### PR TITLE
Layers panel: multi-select, drag-reorder, inline rename

### DIFF
--- a/crates/app/src/panels.rs
+++ b/crates/app/src/panels.rs
@@ -8,7 +8,7 @@
 
 use crate::ui;
 use crate::ui::palette;
-use crate::workspace::{ColorTarget, ContextTarget, Modal, Popup, Workspace};
+use crate::workspace::{ColorTarget, ContextTarget, LayerDrop, Modal, Popup, Workspace};
 use gpui::{
     canvas, deferred, div, img, px, svg, Context, InteractiveElement as _, IntoElement,
     MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement as _, RenderImage,
@@ -1833,6 +1833,8 @@ struct LayerRow {
     name: String,
     visible: bool,
     active: bool,
+    /// In the multi-selection but not the active layer.
+    selected: bool,
     open: bool,
     /// The layer has effects switched on, shown as Photoshop's fx badge.
     fx: bool,
@@ -1850,6 +1852,7 @@ fn flatten_layers(
     layers: &[Layer],
     depth: usize,
     active: Option<LayerId>,
+    selected: &[LayerId],
     out: &mut Vec<LayerRow>,
 ) {
     for layer in layers.iter().rev() {
@@ -1865,13 +1868,14 @@ fn flatten_layers(
             name: layer.name.clone(),
             visible: layer.visible,
             active: Some(layer.id) == active,
+            selected: Some(layer.id) != active && selected.contains(&layer.id),
             open,
             fx: !layer.style.is_empty(),
             smart: layer.smart.is_some(),
         });
         if let LayerKind::Group(g) = &layer.kind {
             if g.open {
-                flatten_layers(&g.children, depth + 1, active, out);
+                flatten_layers(&g.children, depth + 1, active, selected, out);
             }
         }
     }
@@ -1982,8 +1986,17 @@ fn layers_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoEle
     let mut rows = Vec::new();
     let active_layer = ws.doc.as_ref().and_then(|d| d.active_layer);
     if let Some(doc) = &ws.doc {
-        flatten_layers(&doc.tree.layers, 0, doc.active_layer, &mut rows);
+        flatten_layers(
+            &doc.tree.layers,
+            0,
+            doc.active_layer,
+            &doc.selected_layers(),
+            &mut rows,
+        );
     }
+    // Drop indicator while rows are being dragged, and any rename field.
+    let layer_drop = ws.layer_drop;
+    let rename = ws.layer_rename.clone();
     let thumbs: Vec<Option<Arc<RenderImage>>> =
         rows.iter().map(|r| ws.layer_thumbnail(r.id)).collect();
     let opacity_display = active_layer
@@ -2032,7 +2045,10 @@ fn layers_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoEle
                 .children(rows.into_iter().zip(thumbs).map(|(row, thumb)| {
                     let id = row.id;
                     let is_active_row = row.active;
-                    div()
+                    let is_selected_row = row.selected;
+                    let entity = cx.entity();
+                    let mut base = div()
+                        .relative()
                         .flex()
                         .flex_row()
                         .items_center()
@@ -2041,21 +2057,30 @@ fn layers_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoEle
                         .h(px(34.0))
                         .flex_none()
                         .rounded_sm()
-                        .when_active(row.active)
-                        .hover(move |s| {
-                            if is_active_row {
-                                s
-                            } else {
-                                s.bg(gpui::rgb(palette().hover))
-                            }
-                        })
+                        .when_active(row.active);
+                    if row.selected {
+                        base = base.bg(gpui::rgb(palette().selection_bg));
+                    }
+                    base.hover(move |s| {
+                        if is_active_row || is_selected_row {
+                            s
+                        } else {
+                            s.bg(gpui::rgb(palette().hover))
+                        }
+                    })
                         .on_mouse_down(
                             MouseButton::Left,
-                            cx.listener(move |ws, _e, _w, cx| {
-                                if let Some(doc) = &mut ws.doc {
-                                    doc.active_layer = Some(id);
-                                }
-                                cx.notify();
+                            cx.listener(move |ws, ev: &MouseDownEvent, _w, cx| {
+                                ws.layer_row_mouse_down(id, ev, cx);
+                            }),
+                        )
+                        .on_mouse_move(cx.listener(move |ws, ev: &MouseMoveEvent, _w, cx| {
+                            ws.layer_row_mouse_move(id, ev, cx);
+                        }))
+                        .on_mouse_up(
+                            MouseButton::Left,
+                            cx.listener(move |ws, _ev: &MouseUpEvent, _w, cx| {
+                                ws.finish_layer_drag(cx);
                             }),
                         )
                         .on_mouse_down(
@@ -2063,6 +2088,19 @@ fn layers_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoEle
                             cx.listener(move |ws, ev: &MouseDownEvent, _w, cx| {
                                 ws.open_context_menu(ContextTarget::Layer(id), ev.position, cx);
                             }),
+                        )
+                        .child(
+                            // Row bounds, so a drag knows which half of the
+                            // row the pointer is in.
+                            canvas(
+                                move |bounds, _window, cx| {
+                                    entity
+                                        .update(cx, |ws, _| ws.record_layer_row_bounds(id, bounds));
+                                },
+                                |_, _, _, _| {},
+                            )
+                            .absolute()
+                            .size_full(),
                         )
                         .child(
                             // Visibility eye.
@@ -2150,13 +2188,39 @@ fn layers_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoEle
                                     }
                                 }),
                         )
-                        .child(
-                            div()
+                        .child(match &rename {
+                            // Inline rename: an editable field with the
+                            // dialogs' caret convention.
+                            Some((rid, buffer)) if *rid == id => div()
+                                .flex_grow()
+                                .h(px(22.0))
+                                .px_1()
+                                .flex()
+                                .items_center()
+                                .rounded_sm()
+                                .bg(gpui::rgb(palette().field_bg))
+                                .border_1()
+                                .border_color(gpui::rgb(palette().accent))
+                                .text_size(px(12.0))
+                                .text_color(gpui::rgb(palette().text))
+                                .child(format!("{buffer}|"))
+                                .into_any_element(),
+                            _ => div()
                                 .flex_grow()
                                 .text_size(px(12.0))
                                 .overflow_hidden()
-                                .child(row.name),
-                        )
+                                .on_mouse_down(
+                                    MouseButton::Left,
+                                    cx.listener(move |ws, ev: &MouseDownEvent, _w, cx| {
+                                        if ev.click_count >= 2 {
+                                            ws.begin_layer_rename(id, cx);
+                                            cx.stop_propagation();
+                                        }
+                                    }),
+                                )
+                                .child(row.name)
+                                .into_any_element(),
+                        })
                         .children(row.smart.then(|| {
                             div()
                                 .flex_none()
@@ -2177,7 +2241,42 @@ fn layers_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoEle
                                 .bg(gpui::rgb(palette().control_bg))
                                 .child("fx")
                         }))
-                })),
+                        // Drop indicators while a row drag is in flight: a
+                        // bar on the receiving edge, or an outline when the
+                        // drop lands inside a group.
+                        .children((layer_drop == Some(LayerDrop::Above(id))).then(|| {
+                            div()
+                                .absolute()
+                                .top(px(0.0))
+                                .left_0()
+                                .right_0()
+                                .h(px(2.0))
+                                .bg(gpui::rgb(palette().accent))
+                        }))
+                        .children((layer_drop == Some(LayerDrop::Below(id))).then(|| {
+                            div()
+                                .absolute()
+                                .bottom(px(0.0))
+                                .left_0()
+                                .right_0()
+                                .h(px(2.0))
+                                .bg(gpui::rgb(palette().accent))
+                        }))
+                        .children((layer_drop == Some(LayerDrop::Into(id))).then(|| {
+                            div()
+                                .absolute()
+                                .inset_0()
+                                .rounded_sm()
+                                .border_2()
+                                .border_color(gpui::rgb(palette().accent))
+                        }))
+                }))
+                .on_mouse_up(
+                    MouseButton::Left,
+                    cx.listener(|ws, _ev: &MouseUpEvent, _w, cx| {
+                        ws.finish_layer_drag(cx);
+                    }),
+                ),
         )
         .child(
             // Action buttons.

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -164,6 +164,19 @@ pub struct Workspace {
     pub screen_mode: ScreenMode,
     /// A guide being dragged out of a ruler.
     dragging_guide: Option<schist_core::Guide>,
+    /// A layer row press that may become (or already is) a drag-reorder.
+    layer_drag: Option<LayerDrag>,
+    /// Where the dragged rows would land if released now. `Some` only
+    /// while a drag is past the threshold.
+    pub layer_drop: Option<LayerDrop>,
+    /// Live bounds of layer rows, recorded each frame by their canvases.
+    layer_row_bounds: FxHashMap<schist_core::LayerId, Bounds<Pixels>>,
+    /// The row a shift-click range extends from: the last plainly
+    /// clicked row.
+    layer_anchor: Option<schist_core::LayerId>,
+    /// An inline rename in progress in the layers panel: the layer and
+    /// the text typed so far.
+    pub layer_rename: Option<(schist_core::LayerId, String)>,
     /// The selection outline, tagged with the selection generation it was
     /// traced from.
     selection_outline: Option<(u64, SelectionOutline)>,
@@ -543,6 +556,29 @@ pub enum ColorTarget {
     Background,
 }
 
+/// A press on a layer row that may become a drag-reorder.
+struct LayerDrag {
+    /// The row the mouse went down on.
+    layer: schist_core::LayerId,
+    start: Point<Pixels>,
+    /// The pointer has moved past the drag threshold.
+    active: bool,
+    /// The row was already inside a multi-selection when pressed, so the
+    /// selection was kept (to allow dragging it all); releasing without
+    /// dragging collapses it to just this row.
+    collapse: bool,
+}
+
+/// Where dragged layer rows would land, relative to the row under the
+/// cursor. "Above"/"Below" are panel directions (above = later in the
+/// sibling vec, since siblings render top-of-stack first).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LayerDrop {
+    Above(schist_core::LayerId),
+    Below(schist_core::LayerId),
+    Into(schist_core::LayerId),
+}
+
 /// Which part of a colour control the pointer is dragging. Held on the
 /// workspace rather than the modal because the Color panel's ramp has no
 /// modal to live in.
@@ -623,6 +659,11 @@ impl Workspace {
             view: load_view_options(),
             screen_mode: ScreenMode::default(),
             dragging_guide: None,
+            layer_drag: None,
+            layer_drop: None,
+            layer_row_bounds: FxHashMap::default(),
+            layer_anchor: None,
+            layer_rename: None,
             selection_outline: None,
             nav_thumb: None,
             focused_once: false,
@@ -2495,6 +2536,9 @@ impl Workspace {
 
     fn on_mouse_down(&mut self, ev: &MouseDownEvent, window: &mut Window, cx: &mut Context<Self>) {
         window.focus(&self.focus);
+        // Clicking the canvas ends an inline layer rename, keeping what
+        // was typed.
+        self.commit_layer_rename(cx);
         let local = self.to_local(ev.position);
         if ev.button == MouseButton::Middle || self.panning_tool() {
             self.pan_last = Some(ev.position);
@@ -2787,6 +2831,377 @@ impl Workspace {
         self.activate_tool(next, cx);
     }
 
+    // ----- layers panel: selection, drag-reorder, inline rename -----
+
+    /// The rows the layers panel currently shows, top to bottom (closed
+    /// groups hide their children). Shift-click ranges select within this.
+    fn visible_layer_ids(&self) -> Vec<schist_core::LayerId> {
+        fn walk(layers: &[Layer], out: &mut Vec<schist_core::LayerId>) {
+            for layer in layers.iter().rev() {
+                out.push(layer.id);
+                if let schist_core::LayerKind::Group(g) = &layer.kind {
+                    if g.open {
+                        walk(&g.children, out);
+                    }
+                }
+            }
+        }
+        let mut out = Vec::new();
+        if let Some(doc) = &self.doc {
+            walk(&doc.tree.layers, &mut out);
+        }
+        out
+    }
+
+    pub fn record_layer_row_bounds(
+        &mut self,
+        id: schist_core::LayerId,
+        bounds: Bounds<Pixels>,
+    ) {
+        self.layer_row_bounds.insert(id, bounds);
+    }
+
+    /// Mouse down on a layer row: update the selection (plain click,
+    /// shift range or ctrl/cmd toggle) and arm a possible drag.
+    pub fn layer_row_mouse_down(
+        &mut self,
+        id: schist_core::LayerId,
+        ev: &MouseDownEvent,
+        cx: &mut Context<Self>,
+    ) {
+        self.commit_layer_rename(cx);
+        let visible = self.visible_layer_ids();
+        let anchor = self.layer_anchor;
+        let Some(doc) = self.doc.as_mut() else {
+            return;
+        };
+        let mut selection = doc.selected_layers();
+        let mut collapse = false;
+        if ev.modifiers.shift {
+            // Select the range between the anchor (the last plain click)
+            // and this row; the anchor stays put for further shift-clicks.
+            let anchor = anchor
+                .filter(|a| visible.contains(a))
+                .or(doc.active_layer)
+                .unwrap_or(id);
+            let a = visible.iter().position(|&v| v == anchor).unwrap_or(0);
+            let b = visible.iter().position(|&v| v == id).unwrap_or(a);
+            let (lo, hi) = (a.min(b), a.max(b));
+            doc.selected = visible[lo..=hi].to_vec();
+            doc.active_layer = Some(id);
+        } else if ev.modifiers.secondary() {
+            // Toggle this row in or out; never toggle out the last one.
+            if let Some(ix) = selection.iter().position(|&s| s == id) {
+                if selection.len() > 1 {
+                    selection.remove(ix);
+                    if doc.active_layer == Some(id) {
+                        doc.active_layer = selection.last().copied();
+                    }
+                    doc.selected = selection;
+                }
+            } else {
+                selection.push(id);
+                doc.selected = selection;
+                doc.active_layer = Some(id);
+                self.layer_anchor = Some(id);
+            }
+        } else if selection.len() > 1 && selection.contains(&id) {
+            // Pressing inside a multi-selection keeps it, so the whole
+            // thing can be dragged; a plain release collapses it.
+            doc.active_layer = Some(id);
+            collapse = true;
+        } else {
+            doc.selected = vec![id];
+            doc.active_layer = Some(id);
+            self.layer_anchor = Some(id);
+        }
+        self.layer_drag = Some(LayerDrag {
+            layer: id,
+            start: ev.position,
+            active: false,
+            collapse,
+        });
+        self.layer_drop = None;
+        cx.notify();
+    }
+
+    /// The layers a drag moves: the multi-selection when the pressed row
+    /// is part of it, otherwise just the pressed row — in panel order
+    /// (top first), minus any layer whose ancestor is also moving.
+    fn dragged_layers(&self) -> Vec<schist_core::LayerId> {
+        let (Some(drag), Some(doc)) = (&self.layer_drag, &self.doc) else {
+            return Vec::new();
+        };
+        let mut ids = doc.selected_layers();
+        if !ids.contains(&drag.layer) {
+            ids = vec![drag.layer];
+        }
+        let mut paths: Vec<(schist_core::LayerId, schist_core::LayerPath)> = ids
+            .iter()
+            .filter_map(|&id| doc.tree.path_of(id).map(|p| (id, p)))
+            .collect();
+        // Siblings render top-of-stack first, so descending path order
+        // is panel order.
+        paths.sort_by(|a, b| b.1 .0.cmp(&a.1 .0));
+        let roots: Vec<bool> = paths
+            .iter()
+            .map(|(_, p)| {
+                !paths
+                    .iter()
+                    .any(|(_, q)| q.0.len() < p.0.len() && p.0[..q.0.len()] == q.0[..])
+            })
+            .collect();
+        paths
+            .into_iter()
+            .zip(roots)
+            .filter_map(|((id, _), root)| root.then_some(id))
+            .collect()
+    }
+
+    /// Mouse move over a layer row with the button down: past a small
+    /// threshold the press becomes a drag, and the row under the cursor
+    /// becomes the drop target — top half above, bottom half below, and
+    /// the middle of a group row drops into the group.
+    pub fn layer_row_mouse_move(
+        &mut self,
+        id: schist_core::LayerId,
+        ev: &MouseMoveEvent,
+        cx: &mut Context<Self>,
+    ) {
+        if ev.pressed_button != Some(MouseButton::Left) {
+            // The release happened outside the panel; forget the drag.
+            if self.layer_drag.take().is_some() {
+                self.layer_drop = None;
+                cx.notify();
+            }
+            return;
+        }
+        let Some(drag) = self.layer_drag.as_mut() else {
+            return;
+        };
+        if !drag.active {
+            let dx = f32::from(ev.position.x - drag.start.x).abs();
+            let dy = f32::from(ev.position.y - drag.start.y).abs();
+            if dx.max(dy) < 4.0 {
+                return;
+            }
+            drag.active = true;
+        }
+        let drop = if self.dragged_layers().contains(&id) {
+            None
+        } else {
+            let is_group = self
+                .doc
+                .as_ref()
+                .and_then(|d| d.tree.find(id))
+                .is_some_and(|l| matches!(l.kind, schist_core::LayerKind::Group(_)));
+            let frac = self
+                .layer_row_bounds
+                .get(&id)
+                .map(|b| {
+                    (f32::from(ev.position.y) - f32::from(b.origin.y))
+                        / f32::from(b.size.height).max(1.0)
+                })
+                .unwrap_or(0.5);
+            Some(if is_group {
+                if frac < 0.3 {
+                    LayerDrop::Above(id)
+                } else if frac > 0.7 {
+                    LayerDrop::Below(id)
+                } else {
+                    LayerDrop::Into(id)
+                }
+            } else if frac < 0.5 {
+                LayerDrop::Above(id)
+            } else {
+                LayerDrop::Below(id)
+            })
+        };
+        if self.layer_drop != drop {
+            self.layer_drop = drop;
+            cx.notify();
+        }
+    }
+
+    /// Mouse released after a layer-row press: commit the drop if this
+    /// was a drag, otherwise collapse a kept multi-selection down to the
+    /// pressed row.
+    pub fn finish_layer_drag(&mut self, cx: &mut Context<Self>) {
+        let moving = self.dragged_layers();
+        let Some(drag) = self.layer_drag.take() else {
+            return;
+        };
+        let drop = self.layer_drop.take();
+        if drag.active {
+            if let Some(drop) = drop {
+                self.drop_layers(moving, drop, cx);
+            }
+        } else if drag.collapse {
+            if let Some(doc) = self.doc.as_mut() {
+                doc.selected = vec![drag.layer];
+                doc.active_layer = Some(drag.layer);
+            }
+            self.layer_anchor = Some(drag.layer);
+        }
+        cx.notify();
+    }
+
+    /// Move the dragged layers to the drop position, as one undo step.
+    /// Layers keep their panel order: the first lands at the drop point
+    /// and each next one goes directly below the previous.
+    fn drop_layers(
+        &mut self,
+        moving: Vec<schist_core::LayerId>,
+        drop: LayerDrop,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(doc) = self.doc.as_mut() else {
+            return;
+        };
+        let target = match drop {
+            LayerDrop::Above(t) | LayerDrop::Below(t) | LayerDrop::Into(t) => t,
+        };
+        if moving.is_empty() || moving.contains(&target) {
+            return;
+        }
+        let Some(target_path) = doc.tree.path_of(target) else {
+            return;
+        };
+        // A layer cannot move into its own subtree.
+        let dest_parent: &[usize] = match drop {
+            LayerDrop::Into(_) => &target_path.0,
+            _ => &target_path.0[..target_path.0.len() - 1],
+        };
+        for id in &moving {
+            let Some(p) = doc.tree.path_of(*id) else {
+                return;
+            };
+            if dest_parent.len() >= p.0.len() && dest_parent[..p.0.len()] == p.0[..] {
+                return;
+            }
+        }
+        let mut edit = doc.begin_edit(if moving.len() > 1 {
+            "Move Layers"
+        } else {
+            "Move Layer"
+        });
+        let mut prev: Option<schist_core::LayerId> = None;
+        for id in moving {
+            let Some(from) = edit.doc().tree.path_of(id) else {
+                continue;
+            };
+            // Destination in pre-removal coordinates.
+            let mut to = match (prev, drop) {
+                // Each later layer lands directly below the previous one.
+                (Some(p), _) => match edit.doc().tree.path_of(p) {
+                    Some(pp) => pp,
+                    None => continue,
+                },
+                (None, LayerDrop::Above(t)) => {
+                    let Some(mut tp) = edit.doc().tree.path_of(t) else {
+                        break;
+                    };
+                    *tp.0.last_mut().unwrap() += 1;
+                    tp
+                }
+                (None, LayerDrop::Below(t)) => match edit.doc().tree.path_of(t) {
+                    Some(tp) => tp,
+                    None => break,
+                },
+                (None, LayerDrop::Into(g)) => {
+                    let Some(mut gp) = edit.doc().tree.path_of(g) else {
+                        break;
+                    };
+                    let top = edit
+                        .doc()
+                        .tree
+                        .find(g)
+                        .and_then(|l| l.children())
+                        .map_or(0, |c| c.len());
+                    gp.0.push(top);
+                    gp
+                }
+            };
+            // `move_layer` removes then reinserts, so a removal earlier in
+            // the same sibling vec shifts the destination down by one.
+            let d = from.0.len() - 1;
+            if to.0.len() > d && to.0[..d] == from.0[..d] && to.0[d] > from.0[d] {
+                to.0[d] -= 1;
+            }
+            if to != from {
+                edit.move_layer(from, to);
+            }
+            prev = Some(id);
+        }
+        edit.commit();
+        self.after_change(cx);
+    }
+
+    /// Start renaming a layer inline (double-click on its name).
+    pub fn begin_layer_rename(&mut self, id: schist_core::LayerId, cx: &mut Context<Self>) {
+        let Some(name) = self
+            .doc
+            .as_ref()
+            .and_then(|d| d.tree.find(id))
+            .map(|l| l.name.clone())
+        else {
+            return;
+        };
+        self.layer_rename = Some((id, name));
+        self.layer_drag = None;
+        self.layer_drop = None;
+        self.focused_field = None;
+        cx.notify();
+    }
+
+    pub fn commit_layer_rename(&mut self, cx: &mut Context<Self>) {
+        if let Some((id, name)) = self.layer_rename.take() {
+            // An emptied field keeps the old name: rename_layer rejects
+            // blank names.
+            self.rename_layer(id, name, cx);
+            cx.notify();
+        }
+    }
+
+    pub fn cancel_layer_rename(&mut self, cx: &mut Context<Self>) {
+        if self.layer_rename.take().is_some() {
+            cx.notify();
+        }
+    }
+
+    /// Feed a keystroke to an inline layer rename. Consumes every key
+    /// while one is open so shortcuts can't fire mid-typing.
+    pub fn layer_rename_key(&mut self, ev: &gpui::KeyDownEvent, cx: &mut Context<Self>) -> bool {
+        if self.layer_rename.is_none() {
+            return false;
+        }
+        match ev.keystroke.key.as_str() {
+            "enter" | "tab" => self.commit_layer_rename(cx),
+            "escape" => self.cancel_layer_rename(cx),
+            "backspace" => {
+                if let Some((_, name)) = self.layer_rename.as_mut() {
+                    name.pop();
+                }
+            }
+            "space" => {
+                if let Some((_, name)) = self.layer_rename.as_mut() {
+                    name.push(' ');
+                }
+            }
+            _ => {
+                if let (Some((_, name)), Some(t)) =
+                    (self.layer_rename.as_mut(), ev.keystroke.key_char.as_deref())
+                {
+                    if !t.is_empty() && !t.chars().any(char::is_control) {
+                        name.push_str(t);
+                    }
+                }
+            }
+        }
+        cx.notify();
+        true
+    }
+
     // ----- context menus -----
 
     /// Open a right-click menu at `position`.
@@ -2796,7 +3211,10 @@ impl Workspace {
         position: Point<Pixels>,
         cx: &mut Context<Self>,
     ) {
-        // Right-clicking a layer selects it first, like Photoshop.
+        self.commit_layer_rename(cx);
+        // Right-clicking a layer selects it first, like Photoshop. If the
+        // row is already in the multi-selection, the selection is kept
+        // (`selected_layers` sees the active layer still inside it).
         if let (ContextTarget::Layer(id), Some(doc)) = (target, self.doc.as_mut()) {
             doc.active_layer = Some(id);
         }
@@ -3125,6 +3543,12 @@ impl Workspace {
     }
 
     pub fn cancel_gesture(&mut self, cx: &mut Context<Self>) {
+        // Escape reaches here as the CancelGesture action, ahead of the
+        // canvas key listener the rename normally types through.
+        if self.layer_rename.is_some() {
+            self.cancel_layer_rename(cx);
+            return;
+        }
         if self.tool_flyout.is_some() {
             self.close_tool_flyout(cx);
             return;
@@ -4908,6 +5332,10 @@ impl Workspace {
             .on_scroll_wheel(cx.listener(|ws, ev, w, cx| ws.on_scroll(ev, w, cx)))
             .on_pinch(cx.listener(|ws, ev, w, cx| ws.on_pinch(ev, w, cx)))
             .on_key_down(cx.listener(|ws, ev: &gpui::KeyDownEvent, _w, cx| {
+                if ws.layer_rename_key(ev, cx) {
+                    cx.stop_propagation();
+                    return;
+                }
                 if ws.field_key(&ev.keystroke.key, ev.keystroke.key_char.as_deref()) {
                     cx.notify();
                     cx.stop_propagation();
@@ -5101,7 +5529,8 @@ impl Render for Workspace {
         if let Some((id, enabled)) = self.pending_plugin_toggle.take() {
             self.set_plugin_enabled(id, enabled, cx);
         }
-        let captures_keys = self.tool_captures_keys() || self.modal.is_some();
+        let captures_keys =
+            self.tool_captures_keys() || self.modal.is_some() || self.layer_rename.is_some();
         let chrome = self.screen_mode == ScreenMode::Standard;
         let modal = crate::dialogs::render(self, cx);
         let context_menu = panels::context_menu(self, window.viewport_size(), cx);

--- a/crates/core/src/document.rs
+++ b/crates/core/src/document.rs
@@ -47,6 +47,11 @@ pub struct Document {
     pub tree: LayerTree,
     pub selection: Selection,
     pub active_layer: Option<LayerId>,
+    /// The layers-panel multi-selection: every highlighted row, including
+    /// the active layer. UI state like `active_layer`, so not undoable.
+    /// Read it through `selected_layers()`, which prunes stale ids and
+    /// falls back to the active layer when the two disagree.
+    pub selected: Vec<LayerId>,
     pub history: History,
     /// PSD image resources we preserve for round-trip fidelity.
     pub preserved_resources: Vec<PreservedResource>,
@@ -100,6 +105,7 @@ impl Document {
             tree: LayerTree::default(),
             selection: Selection::new(),
             active_layer: None,
+            selected: Vec::new(),
             history: History::new(),
             preserved_resources: Vec::new(),
             revision: 0,
@@ -137,6 +143,25 @@ impl Document {
                 crate::layer::LayerKind::Group(g) => stack.extend(g.children.iter()),
                 crate::layer::LayerKind::Adjustment(_) => {}
             }
+        }
+    }
+
+    /// The effective layers-panel selection. When `selected` still contains
+    /// the active layer it is the multi-selection (minus any ids whose
+    /// layers have since been deleted); when something changed the active
+    /// layer without touching `selected` — a command, a right-click on an
+    /// unselected row — the extras are stale and the selection collapses to
+    /// just the active layer.
+    pub fn selected_layers(&self) -> Vec<LayerId> {
+        match self.active_layer {
+            Some(active) if self.selected.contains(&active) => self
+                .selected
+                .iter()
+                .copied()
+                .filter(|&id| self.tree.find(id).is_some())
+                .collect(),
+            Some(active) => self.tree.find(active).map(|l| l.id).into_iter().collect(),
+            None => Vec::new(),
         }
     }
 

--- a/plugins/commands-core/src/lib.rs
+++ b/plugins/commands-core/src/lib.rs
@@ -559,35 +559,64 @@ impl CommandPlugin for CoreCommandsPlugin {
                 edit.commit();
             }),
             cmd("layer.delete", "Delete Layer", None, |ctx| {
-                let Some(id) = ctx.doc.active_layer else {
+                // Deletes the panel's whole multi-selection as one edit.
+                let ids = selection_roots(ctx.doc);
+                if ids.is_empty() {
                     return;
-                };
-                let mut edit = ctx.doc.begin_edit("Delete Layer");
-                edit.remove_layer(id);
+                }
+                let mut edit = ctx.doc.begin_edit(if ids.len() > 1 {
+                    "Delete Layers"
+                } else {
+                    "Delete Layer"
+                });
+                for id in ids {
+                    edit.remove_layer(id);
+                }
                 edit.commit();
             }),
-            cmd("layer.group", "Group Layer", Some("cmd-g"), |ctx| {
-                // Wraps the active layer in a group (multi-select lands
-                // with the layers-panel selection model).
-                let Some(id) = ctx.doc.active_layer else {
-                    return;
-                };
-                let Some(path) = ctx.doc.tree.path_of(id) else {
+            cmd("layer.group", "Group Layers", Some("cmd-g"), |ctx| {
+                // Wraps the selected layers in a group, which lands where
+                // the topmost of them was.
+                let ids = selection_roots(ctx.doc);
+                let Some(mut insert) = ids.first().and_then(|&id| ctx.doc.tree.path_of(id)) else {
                     return;
                 };
                 let mut group = Layer::new_group("Group");
                 let group_id = group.id;
-                let mut edit = ctx.doc.begin_edit("Group Layer");
-                // Remove the layer, put it inside the group, insert group.
-                let removed = ctx_remove(&mut edit, id);
-                if let Some(layer) = removed {
-                    if let LayerKind::Group(g) = &mut group.kind {
-                        g.children.push(layer);
+                let mut edit = ctx.doc.begin_edit(if ids.len() > 1 {
+                    "Group Layers"
+                } else {
+                    "Group Layer"
+                });
+                let mut children = Vec::new();
+                for id in ids {
+                    let Some(path) = edit.doc().tree.path_of(id) else {
+                        continue;
+                    };
+                    let Some(layer) = ctx_remove(&mut edit, id) else {
+                        continue;
+                    };
+                    children.push(layer);
+                    // A removal earlier in the same sibling vec shifts the
+                    // insertion slot down by one.
+                    let d = path.0.len() - 1;
+                    if insert.0.len() > d && insert.0[..d] == path.0[..d] && insert.0[d] > path.0[d]
+                    {
+                        insert.0[d] -= 1;
                     }
-                    edit.insert_layer(path, group);
+                }
+                if !children.is_empty() {
+                    // Collected topmost first; children are stored
+                    // bottom-to-top.
+                    children.reverse();
+                    if let LayerKind::Group(g) = &mut group.kind {
+                        g.children = children;
+                    }
+                    edit.insert_layer(insert, group);
                 }
                 edit.commit();
                 ctx.doc.active_layer = Some(group_id);
+                ctx.doc.selected = vec![group_id];
             }),
             cmd("select.reselect", "Reselect", Some("cmd-shift-d"), |ctx| {
                 let Some(previous) = ctx.doc.last_selection.clone() else {
@@ -800,6 +829,33 @@ fn move_layer_to_end(ctx: &mut CommandCtx, to_front: bool) {
 /// Remove a layer through the builder but get the removed value back
 /// (EditBuilder::remove_layer records the op; we reconstruct the layer from
 /// the document *before* removal).
+/// The panel's multi-selection reduced to independent roots: descendants
+/// of another selected layer are dropped (the ancestor carries them), and
+/// the result is in panel order, topmost first.
+fn selection_roots(doc: &Document) -> Vec<LayerId> {
+    let mut paths: Vec<(LayerId, LayerPath)> = doc
+        .selected_layers()
+        .into_iter()
+        .filter_map(|id| doc.tree.path_of(id).map(|p| (id, p)))
+        .collect();
+    // Siblings render top-of-stack first, so descending path order is
+    // panel order.
+    paths.sort_by(|a, b| b.1 .0.cmp(&a.1 .0));
+    let roots: Vec<bool> = paths
+        .iter()
+        .map(|(_, p)| {
+            !paths
+                .iter()
+                .any(|(_, q)| q.0.len() < p.0.len() && p.0[..q.0.len()] == q.0[..])
+        })
+        .collect();
+    paths
+        .into_iter()
+        .zip(roots)
+        .filter_map(|((id, _), root)| root.then_some(id))
+        .collect()
+}
+
 fn ctx_remove(edit: &mut schist_core::EditBuilder<'_>, id: LayerId) -> Option<Layer> {
     let layer = edit.doc().tree.find(id)?.clone();
     if edit.remove_layer(id) {
@@ -1055,6 +1111,86 @@ mod m11_tests {
 
         run(&reg, "edit.undo", &mut doc, &mut state);
         assert_eq!(names(&doc), vec!["L1", "L2", "L0"], "ordering undoes");
+    }
+
+    #[test]
+    fn delete_removes_the_whole_multi_selection_as_one_edit() {
+        let reg = registry();
+        let mut doc = doc_with_layers(4);
+        let mut state = EditorState::default();
+        let (l0, l2) = (doc.tree.layers[0].id, doc.tree.layers[2].id);
+        doc.active_layer = Some(l0);
+        doc.selected = vec![l0, l2];
+
+        run(&reg, "layer.delete", &mut doc, &mut state);
+        assert_eq!(names(&doc), vec!["L1", "L3"]);
+        assert_eq!(doc.history.undo_name(), Some("Delete Layers"));
+
+        run(&reg, "edit.undo", &mut doc, &mut state);
+        assert_eq!(names(&doc), vec!["L0", "L1", "L2", "L3"], "one undo step");
+    }
+
+    #[test]
+    fn group_wraps_the_selection_where_the_topmost_layer_was() {
+        let reg = registry();
+        let mut doc = doc_with_layers(4);
+        let mut state = EditorState::default();
+        let (l1, l3) = (doc.tree.layers[1].id, doc.tree.layers[3].id);
+        doc.active_layer = Some(l3);
+        doc.selected = vec![l1, l3];
+
+        run(&reg, "layer.group", &mut doc, &mut state);
+        assert_eq!(names(&doc), vec!["L0", "L2", "Group"]);
+        let group = &doc.tree.layers[2];
+        let children: Vec<&str> = group
+            .children()
+            .unwrap()
+            .iter()
+            .map(|l| l.name.as_str())
+            .collect();
+        assert_eq!(children, vec!["L1", "L3"], "stack order kept");
+        assert_eq!(doc.active_layer, Some(group.id));
+
+        run(&reg, "edit.undo", &mut doc, &mut state);
+        assert_eq!(names(&doc), vec!["L0", "L1", "L2", "L3"]);
+    }
+
+    #[test]
+    fn selected_descendants_ride_along_with_their_group() {
+        let reg = registry();
+        let mut doc = doc_with_layers(2);
+        let mut state = EditorState::default();
+        // Group L1, then select both the group and its child: deleting
+        // must not remove the child twice.
+        doc.active_layer = Some(doc.tree.layers[1].id);
+        run(&reg, "layer.group", &mut doc, &mut state);
+        let group_id = doc.tree.layers[1].id;
+        let child_id = doc.tree.layers[1].children().unwrap()[0].id;
+        doc.active_layer = Some(group_id);
+        doc.selected = vec![group_id, child_id];
+
+        run(&reg, "layer.delete", &mut doc, &mut state);
+        assert_eq!(names(&doc), vec!["L0"]);
+        assert_eq!(doc.history.undo_name(), Some("Delete Layer"));
+    }
+
+    #[test]
+    fn stale_multi_selection_collapses_to_the_active_layer() {
+        let reg = registry();
+        let mut doc = doc_with_layers(3);
+        let mut state = EditorState::default();
+        let (l0, l1, l2) = (
+            doc.tree.layers[0].id,
+            doc.tree.layers[1].id,
+            doc.tree.layers[2].id,
+        );
+        // Something moved the active layer without touching `selected`,
+        // as commands do; the extras no longer apply.
+        doc.selected = vec![l0, l1];
+        doc.active_layer = Some(l2);
+
+        run(&reg, "layer.delete", &mut doc, &mut state);
+        assert_eq!(names(&doc), vec!["L0", "L1"]);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds the three core layer-stack interactions to the layers panel:

- **Drag to reorder** — rows drag past a 4px threshold; an accent bar marks the receiving edge, and the middle of a group row outlines to drop *inside* the group. Dragging any row of a multi-selection moves the whole selection in panel order as a single "Move Layers" undo step. Moves into a dragged layer's own subtree are refused; descendants ride along with selected ancestors.
- **Multi-select** — shift-click extends a range over the visible rows, ctrl/cmd-click toggles rows, and pressing inside a multi-selection keeps it so it can be dragged (plain release collapses it, like Photoshop). Active row keeps the accent; other selected rows use `selection_bg`. `layer.delete` and `layer.group` (Ctrl+G) now act on the whole selection as one undo step.
- **Inline rename** — double-click a layer name to edit in place (dialogs' caret convention). Enter or clicking away commits through the undoable rename path; Escape cancels; an emptied field keeps the old name.

## How

- Selection state is `Document::selected: Vec<LayerId>` beside `active_layer`, read via `selected_layers()`, which prunes stale ids and collapses to the active layer whenever a command moves it without touching the selection — existing single-layer code paths need no changes.
- Drag/drop is the panel's hand-rolled mouse-down/move/up idiom (like sliders/guides), with per-row bounds recorded by `gpui::canvas`. Drop paths are computed in pre-removal coordinates with an index-shift adjustment matching `EditBuilder::move_layer` semantics.
- An open rename joins the `captures_keys` disjunction so the `enter`/`tab`/letter action bindings can't preempt typing (found live: the `enter → CommitGesture` binding was swallowing the commit key); the always-on `escape → CancelGesture` binding cancels the rename first.

## Testing

- New unit tests: multi-delete, multi-group (order + placement), descendant dedup, stale-selection collapse; full `cargo test --workspace` green.
- Verified live under Xvfb/lavapipe: range/toggle selection, single and multi drag with indicators, drop into group, rename commit/cancel, and single-step undo of each operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)