### PR TITLE
Put the menus in the system bar on macOS

### DIFF
--- a/crates/app/src/actions.rs
+++ b/crates/app/src/actions.rs
@@ -25,6 +25,22 @@ pub struct AddAdjustment {
     pub kind: String,
 }
 
+/// Open a registered filter's dialog by id (e.g. "filter.gaussian_blur").
+#[derive(Clone, PartialEq, Debug, serde::Deserialize, gpui::Action)]
+#[action(namespace = schist, no_json)]
+pub struct OpenFilter {
+    pub id: String,
+}
+
+/// Run one of the shell's own menu items. The in-window menu bar calls
+/// `panels::run_app_item` directly; the macOS menu bar can only carry
+/// actions, so it dispatches this.
+#[derive(Clone, PartialEq, Debug, gpui::Action)]
+#[action(namespace = schist, no_json)]
+pub struct RunAppItem {
+    pub item: AppItem,
+}
+
 /// Step to the next tool in a toolbar group (Shift + the group's key).
 #[derive(Clone, PartialEq, Debug, serde::Deserialize, gpui::Action)]
 #[action(namespace = schist, no_json)]
@@ -71,6 +87,153 @@ actions!(
         ClearGuides,
         CycleScreenMode,
         TogglePanels,
+        HideApp,
+        HideOthers,
+        ShowAll,
         Quit,
     ]
 );
+
+/// An item in the menu bar that the shell itself handles, as opposed to a
+/// plugin command, a filter or an adjustment. Named here rather than in
+/// `panels` because [`RunAppItem`] carries one.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum AppItem {
+    New,
+    Open,
+    Close,
+    Save,
+    SaveAs,
+    Quit,
+    ZoomIn,
+    ZoomOut,
+    ZoomFit,
+    ZoomActual,
+    ImageSize,
+    CanvasSize,
+    FreeTransform,
+    Crop,
+    Plugins,
+    Export,
+    AssignProfile,
+    ConvertProfile,
+    ProofColors,
+    ToggleRulers,
+    ToggleGrid,
+    ToggleGuides,
+    ToggleExtras,
+    ToggleSnap,
+    ClearGuides,
+    ScreenModeItem,
+    Preferences,
+    CheckForUpdates,
+    LayerStyleItem,
+    SelectExpand,
+    SelectContract,
+    SelectBorder,
+    SelectSmooth,
+    SelectFeatherItem,
+    ColorRangeItem,
+    ModeRgb,
+    ModeGrayscale,
+    ModeCmyk,
+    ModeLab,
+    ModeIndexed,
+    AutoTone,
+    AutoContrast,
+    AutoColor,
+    RotateCw,
+    RotateCcw,
+    Rotate180,
+    FlipCanvasH,
+    FlipCanvasV,
+    Trim,
+    /// Apply an adjustment to the pixels rather than adding a layer.
+    ApplyAdjustment(schist_core::AdjustmentKind),
+    StrokeItem,
+    FillItem,
+    ContentAwareFill,
+    TransformSelection,
+    ContentAwareScaleItem,
+    FilterGalleryItem,
+    ManageModels,
+    NewLayerComp,
+    ExportArtboards,
+    ExportSlices,
+    RotateViewCw,
+    RotateViewCcw,
+    ResetView,
+    ClearNotes,
+    ClearCounts,
+    ApplyLayerComp(usize),
+    DeleteLayerComp(usize),
+    LiquifyItem,
+    PuppetWarpItem,
+    VanishingPointItem,
+    PathFill,
+    PathStroke,
+    PathToSelection,
+    PathDelete,
+}
+
+/// The string [`AddAdjustment`] carries for each adjustment kind. Kept
+/// stable: these ids appear in the default keymap.
+pub fn adjustment_id(kind: schist_core::AdjustmentKind) -> Option<&'static str> {
+    use schist_core::AdjustmentKind::*;
+    Some(match kind {
+        Levels => "levels",
+        Curves => "curves",
+        HueSaturation => "hue_saturation",
+        BrightnessContrast => "brightness_contrast",
+        BlackWhite => "black_white",
+        SolidColor => "solid_color",
+        GradientFill => "gradient_fill",
+        PatternFill => "pattern_fill",
+        Invert => "invert",
+        Posterize => "posterize",
+        Threshold => "threshold",
+        ColorBalance => "color_balance",
+        Vibrance => "vibrance",
+        Exposure => "exposure",
+        PhotoFilter => "photo_filter",
+        GradientMap => "gradient_map",
+        SelectiveColor => "selective_color",
+        ChannelMixer => "channel_mixer",
+        // A kind read from a PSD we have no editor for; there is nothing
+        // to create one from.
+        Other(_) => return None,
+    })
+}
+
+/// Inverse of [`adjustment_id`].
+pub fn adjustment_from_id(id: &str) -> Option<schist_core::AdjustmentKind> {
+    schist_adjustments::Params::creatable()
+        .iter()
+        .copied()
+        .find(|&kind| adjustment_id(kind) == Some(id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_creatable_adjustment_has_an_id() {
+        // A kind with no id is one the Adjust menu would drop on macOS,
+        // where the item has to be carried by an action rather than a
+        // closure.
+        for &kind in schist_adjustments::Params::creatable() {
+            let id =
+                adjustment_id(kind).unwrap_or_else(|| panic!("{} has no id", kind.display_name()));
+            assert_eq!(adjustment_from_id(id), Some(kind));
+        }
+    }
+
+    #[test]
+    fn default_keymap_adjustment_ids_resolve() {
+        // The ids the built-in ⌘L/⌘M/⌘U/⌘I bindings are written with.
+        for id in ["levels", "curves", "hue_saturation", "invert"] {
+            assert!(adjustment_from_id(id).is_some(), "{id} no longer resolves");
+        }
+    }
+}

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -8,11 +8,13 @@ mod curve_editor;
 mod dialogs;
 mod gallery;
 mod keymap;
+mod native_menu;
 mod panels;
 mod style_dialog;
 mod ui;
 mod workspace;
 
+use actions::{HideApp, HideOthers, Quit, ShowAll};
 use gpui::{px, size, App, AppContext as _, Application, Bounds, WindowBounds, WindowOptions};
 use schist_plugin_api::{CodecPlugin, PluginManifest, PluginRegistry};
 use workspace::Workspace;
@@ -117,6 +119,12 @@ fn main() {
         .with_assets(assets::Assets)
         .run(move |cx: &mut App| {
             cx.bind_keys(keymap::build_bindings(&registry));
+            // The macOS application menu, which is reachable with no window
+            // open, so these are global rather than on the workspace.
+            cx.on_action(|_: &Quit, cx: &mut App| cx.quit());
+            cx.on_action(|_: &HideApp, cx: &mut App| cx.hide());
+            cx.on_action(|_: &HideOthers, cx: &mut App| cx.hide_other_apps());
+            cx.on_action(|_: &ShowAll, cx: &mut App| cx.unhide_other_apps());
             let bounds = Bounds::centered(None, size(px(1440.0), px(900.0)), cx);
             cx.open_window(
                 WindowOptions {

--- a/crates/app/src/native_menu.rs
+++ b/crates/app/src/native_menu.rs
@@ -1,0 +1,270 @@
+//! The macOS menu bar.
+//!
+//! macOS puts an application's menus in the system bar at the top of the
+//! screen rather than inside its windows, so on that platform the in-window
+//! bar `panels::menu_bar` draws is replaced by this one. Both are built from
+//! the same `panels::menus` description, so the two cannot drift apart.
+//!
+//! Everything here compiles on every platform — only `sync` is a no-op off
+//! macOS — so a change to the menus is type-checked wherever Schist builds.
+
+use crate::actions::*;
+use crate::panels::{self, MenuEntry};
+use crate::workspace::Workspace;
+use gpui::{Action, Context, Menu, MenuItem, SystemMenuType};
+
+/// The bold first menu, named after the app.
+const APP_NAME: &str = "Schist";
+
+/// Rebuild the system menu bar, if anything it shows has changed since the
+/// last frame. Cheap to call from `render`: the check is a small string
+/// compare, and `NSMenu` is only rebuilt when a label or an entry differs.
+pub fn sync(ws: &mut Workspace, cx: &mut Context<Workspace>) {
+    if !cfg!(target_os = "macos") {
+        return;
+    }
+    let signature = signature(ws);
+    if ws.native_menu.as_deref() == Some(signature.as_str()) {
+        return;
+    }
+    ws.native_menu = Some(signature);
+    cx.set_menus(build(ws));
+}
+
+/// What the built menus depend on beyond the (fixed) plugin registry: the
+/// toggle labels, and the layer comps the Layer menu lists.
+fn signature(ws: &Workspace) -> String {
+    let v = &ws.view;
+    let mut out = format!(
+        "{}{}{}{}{}{}",
+        v.rulers as u8,
+        v.grid as u8,
+        v.guides as u8,
+        v.extras as u8,
+        v.snap as u8,
+        ws.color.proof.is_some() as u8,
+    );
+    if let Some(doc) = ws.doc.as_ref() {
+        for comp in &doc.layer_comps {
+            out.push('\u{1f}');
+            out.push_str(&comp.name);
+        }
+    }
+    out
+}
+
+fn build(ws: &Workspace) -> Vec<Menu> {
+    let mut menus = vec![app_menu()];
+    menus.extend(panels::menus(ws).into_iter().map(|(title, entries)| Menu {
+        name: title.into(),
+        items: items(ws, entries),
+    }));
+    menus
+}
+
+/// The items macOS expects under the application's own menu. Preferences,
+/// Quit and Check for Updates live here rather than in File/View, and are
+/// dropped from those menus by `item`.
+fn app_menu() -> Menu {
+    Menu {
+        name: APP_NAME.into(),
+        items: vec![
+            // No About box to open yet; the update check is the other item
+            // macOS keeps here.
+            MenuItem::action(
+                "Check for Updates…",
+                RunAppItem {
+                    item: AppItem::CheckForUpdates,
+                },
+            ),
+            MenuItem::separator(),
+            MenuItem::action("Preferences…", ShowPreferences),
+            MenuItem::separator(),
+            MenuItem::os_submenu("Services", SystemMenuType::Services),
+            MenuItem::separator(),
+            // No key equivalents: ⌘H is View ▸ Extras here, as it is in
+            // Photoshop, and the menu would take the keystroke first.
+            MenuItem::action(format!("Hide {APP_NAME}"), HideApp),
+            MenuItem::action("Hide Others", HideOthers),
+            MenuItem::action("Show All", ShowAll),
+            MenuItem::separator(),
+            MenuItem::action(format!("Quit {APP_NAME}"), Quit),
+        ],
+    }
+}
+
+fn items(ws: &Workspace, entries: Vec<MenuEntry>) -> Vec<MenuItem> {
+    let converted = entries.into_iter().filter_map(|e| item(ws, e)).collect();
+    trim_separators(converted)
+}
+
+fn item(ws: &Workspace, entry: MenuEntry) -> Option<MenuItem> {
+    Some(match entry {
+        MenuEntry::Sep => MenuItem::Separator,
+        MenuEntry::Cmd(id) => {
+            let label = ws
+                .registry
+                .command(id)
+                .map(|c| c.title.to_string())
+                .unwrap_or_else(|| id.to_string());
+            action_item(label, Box::new(RunCommand { id: id.to_string() }))
+        }
+        MenuEntry::Adjustment(kind) => action_item(
+            kind.display_name().to_string(),
+            Box::new(AddAdjustment {
+                kind: adjustment_id(kind)?.to_string(),
+            }),
+        ),
+        MenuEntry::Filter(id) => {
+            let name = ws
+                .registry
+                .filters()
+                .find(|f| f.id() == id)
+                .map(|f| format!("{}…", f.name()))
+                .unwrap_or_else(|| id.to_string());
+            action_item(name, Box::new(OpenFilter { id: id.to_string() }))
+        }
+        MenuEntry::Dynamic(label, item) => action_item(label, Box::new(RunAppItem { item })),
+        MenuEntry::App(label, item, _) => {
+            action_item(label_for(ws, label, item), action_for(item)?)
+        }
+        MenuEntry::Sub(label, children) => MenuItem::submenu(Menu {
+            name: label.into(),
+            items: items(ws, children),
+        }),
+    })
+}
+
+fn action_item(name: String, action: Box<dyn Action>) -> MenuItem {
+    MenuItem::Action {
+        name: name.into(),
+        action,
+        // Cut/Copy/Paste are plugin commands operating on the document, not
+        // on a focused text field, so none of them want the OS selector:
+        // that would send them down the responder chain instead.
+        os_action: None,
+    }
+}
+
+/// The action a menu item dispatches. GPUI reads each item's key equivalent
+/// out of the keymap by matching on the action, so items that already have a
+/// binding must name the same action that binding does — otherwise the
+/// shortcut would not show beside them.
+///
+/// `None` drops the item: it belongs in the application menu instead.
+fn action_for(item: AppItem) -> Option<Box<dyn Action>> {
+    Some(match item {
+        AppItem::Quit | AppItem::Preferences | AppItem::CheckForUpdates => return None,
+        AppItem::New => Box::new(NewFile),
+        AppItem::Open => Box::new(OpenFile),
+        AppItem::Close => Box::new(CloseTab),
+        AppItem::Save => Box::new(SaveFile),
+        AppItem::SaveAs => Box::new(SaveFileAs),
+        AppItem::ZoomIn => Box::new(ZoomIn),
+        AppItem::ZoomOut => Box::new(ZoomOut),
+        AppItem::ZoomFit => Box::new(ZoomFit),
+        AppItem::ZoomActual => Box::new(ZoomActual),
+        AppItem::ImageSize => Box::new(ShowImageSize),
+        AppItem::CanvasSize => Box::new(ShowCanvasSize),
+        AppItem::LayerStyleItem => Box::new(ShowLayerStyle),
+        AppItem::FreeTransform => Box::new(ActivateTool {
+            id: "transform".into(),
+        }),
+        AppItem::ToggleRulers => Box::new(ToggleRulers),
+        AppItem::ToggleGrid => Box::new(ToggleGrid),
+        AppItem::ToggleGuides => Box::new(ToggleGuides),
+        AppItem::ToggleExtras => Box::new(ToggleExtras),
+        AppItem::ToggleSnap => Box::new(ToggleSnap),
+        AppItem::ClearGuides => Box::new(ClearGuides),
+        // Deliberately not `CycleScreenMode`: its only binding is a bare
+        // "f", and a key equivalent without modifiers is swallowed by the
+        // menu before the letter can reach a tool that is taking typing.
+        other => Box::new(RunAppItem { item: other }),
+    })
+}
+
+/// GPUI's menus have no check marks, and the macOS convention for a toggle
+/// without one is a label that says what the click will do — Finder's "Hide
+/// Sidebar" / "Show Sidebar". The in-window bar keeps its check marks.
+fn label_for(ws: &Workspace, label: &'static str, item: AppItem) -> String {
+    let toggled = |on: bool, verb: (&str, &str), noun: &str| {
+        format!("{} {noun}", if on { verb.1 } else { verb.0 })
+    };
+    const SHOW: (&str, &str) = ("Show", "Hide");
+    const ENABLE: (&str, &str) = ("Enable", "Disable");
+    match item {
+        AppItem::ToggleRulers => toggled(ws.view.rulers, SHOW, "Rulers"),
+        AppItem::ToggleGrid => toggled(ws.view.grid, SHOW, "Grid"),
+        AppItem::ToggleGuides => toggled(ws.view.guides, SHOW, "Guides"),
+        AppItem::ToggleExtras => toggled(ws.view.extras, SHOW, "Extras"),
+        AppItem::ToggleSnap => toggled(ws.view.snap, ENABLE, "Snapping"),
+        AppItem::ProofColors => toggled(ws.color.proof.is_some(), ENABLE, "Proof Colors"),
+        _ => label.to_string(),
+    }
+}
+
+/// Drop the separators left hanging by items that moved to the application
+/// menu — a menu must not open or close on a divider, or show two in a row.
+fn trim_separators(items: Vec<MenuItem>) -> Vec<MenuItem> {
+    let mut out: Vec<MenuItem> = Vec::with_capacity(items.len());
+    for item in items {
+        let separator = matches!(item, MenuItem::Separator);
+        if separator && matches!(out.last(), None | Some(MenuItem::Separator)) {
+            continue;
+        }
+        out.push(item);
+    }
+    if matches!(out.last(), Some(MenuItem::Separator)) {
+        out.pop();
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn shape(items: &[MenuItem]) -> String {
+        items
+            .iter()
+            .map(|item| match item {
+                MenuItem::Separator => '-',
+                _ => 'x',
+            })
+            .collect()
+    }
+
+    #[test]
+    fn separators_do_not_open_close_or_double_up() {
+        let items = vec![
+            MenuItem::Separator,
+            MenuItem::action("a", Quit),
+            MenuItem::Separator,
+            MenuItem::Separator,
+            MenuItem::action("b", Quit),
+            MenuItem::Separator,
+        ];
+        assert_eq!(shape(&trim_separators(items)), "x-x");
+    }
+
+    #[test]
+    fn a_menu_of_nothing_but_separators_is_empty() {
+        let items = vec![MenuItem::Separator, MenuItem::Separator];
+        assert!(trim_separators(items).is_empty());
+    }
+
+    #[test]
+    fn the_application_menu_holds_what_the_other_menus_drop() {
+        // Quit and Preferences belong in the app menu; `action_for`
+        // returning None is what keeps them out of File and View.
+        for item in [
+            AppItem::Quit,
+            AppItem::Preferences,
+            AppItem::CheckForUpdates,
+        ] {
+            assert!(action_for(item).is_none(), "{item:?} would be duplicated");
+        }
+        assert!(action_for(AppItem::New).is_some());
+        assert_eq!(shape(&app_menu().items), "x-x-x-xxx-x");
+    }
+}

--- a/crates/app/src/panels.rs
+++ b/crates/app/src/panels.rs
@@ -6,6 +6,7 @@
 //! are monochrome SVGs from the embedded asset source, tinted by text
 //! color — no emoji.
 
+use crate::actions::AppItem;
 use crate::ui;
 use crate::ui::palette;
 use crate::workspace::{ColorTarget, ContextTarget, LayerDrop, Modal, Popup, Workspace};
@@ -44,7 +45,7 @@ impl<T: Styled> ActiveExt for T {}
 
 // ===== menu bar =====
 
-enum MenuEntry {
+pub(crate) enum MenuEntry {
     /// A registered plugin command (label + keybind resolved from registry).
     Cmd(&'static str),
     /// An app-level item handled by the shell.
@@ -61,86 +62,7 @@ enum MenuEntry {
     Sep,
 }
 
-#[derive(Clone, Copy)]
-enum AppItem {
-    New,
-    Open,
-    Close,
-    Save,
-    SaveAs,
-    Quit,
-    ZoomIn,
-    ZoomOut,
-    ZoomFit,
-    ZoomActual,
-    ImageSize,
-    CanvasSize,
-    FreeTransform,
-    Crop,
-    Plugins,
-    Export,
-    AssignProfile,
-    ConvertProfile,
-    ProofColors,
-    ToggleRulers,
-    ToggleGrid,
-    ToggleGuides,
-    ToggleExtras,
-    ToggleSnap,
-    ClearGuides,
-    ScreenModeItem,
-    Preferences,
-    CheckForUpdates,
-    LayerStyleItem,
-    SelectExpand,
-    SelectContract,
-    SelectBorder,
-    SelectSmooth,
-    SelectFeatherItem,
-    ColorRangeItem,
-    ModeRgb,
-    ModeGrayscale,
-    ModeCmyk,
-    ModeLab,
-    ModeIndexed,
-    AutoTone,
-    AutoContrast,
-    AutoColor,
-    RotateCw,
-    RotateCcw,
-    Rotate180,
-    FlipCanvasH,
-    FlipCanvasV,
-    Trim,
-    /// Apply an adjustment to the pixels rather than adding a layer.
-    ApplyAdjustment(schist_core::AdjustmentKind),
-    StrokeItem,
-    FillItem,
-    ContentAwareFill,
-    TransformSelection,
-    ContentAwareScaleItem,
-    FilterGalleryItem,
-    ManageModels,
-    NewLayerComp,
-    ExportArtboards,
-    ExportSlices,
-    RotateViewCw,
-    RotateViewCcw,
-    ResetView,
-    ClearNotes,
-    ClearCounts,
-    ApplyLayerComp(usize),
-    DeleteLayerComp(usize),
-    LiquifyItem,
-    PuppetWarpItem,
-    VanishingPointItem,
-    PathFill,
-    PathStroke,
-    PathToSelection,
-    PathDelete,
-}
-
-fn menus(ws: &Workspace) -> Vec<(&'static str, Vec<MenuEntry>)> {
+pub(crate) fn menus(ws: &Workspace) -> Vec<(&'static str, Vec<MenuEntry>)> {
     use AppItem::*;
     use MenuEntry::*;
     vec![
@@ -558,14 +480,17 @@ fn app_item_checked(ws: &Workspace, item: AppItem) -> Option<bool> {
     })
 }
 
-fn run_app_item(
+pub(crate) fn run_app_item(
     ws: &mut Workspace,
     item: AppItem,
     window: &mut Window,
     cx: &mut Context<Workspace>,
 ) {
     match item {
-        AppItem::New => ws.new_document(),
+        AppItem::New => {
+            ws.rebuild_tool_groups();
+            ws.new_document();
+        }
         AppItem::Open => crate::keymap::open_file_dialog(ws, window, cx),
         AppItem::Close => ws.request_close_tab(ws.active_tab(), cx),
         AppItem::Save => ws.save_current(window, cx),
@@ -577,6 +502,7 @@ fn run_app_item(
         AppItem::ZoomActual => {
             ws.zoom = 1.0;
             ws.editor.zoom = 1.0;
+            ws.center();
         }
         AppItem::ImageSize => {
             if let Some(doc) = ws.doc.as_ref() {

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -113,6 +113,9 @@ pub struct Workspace {
     /// Path to the open submenu in the menu bar, e.g. [2, 4] for the fifth
     /// row of the third menu. Empty means none.
     pub open_submenu: Vec<usize>,
+    /// What the macOS menu bar was last built from, so it is only rebuilt
+    /// when a label or an entry has actually changed. `None` off macOS.
+    pub native_menu: Option<String>,
     /// Marching-ants animation step, advanced on a timer.
     /// View rotation in radians. Display only: the pixels are untouched,
     /// so this is a change of viewpoint rather than an edit.
@@ -635,6 +638,7 @@ impl Workspace {
             status: "Ready".into(),
             open_popup: None,
             open_submenu: Vec::new(),
+            native_menu: None,
             rotation: 0.0,
             model_downloads: Vec::new(),
             ant_phase: 0,
@@ -1107,7 +1111,7 @@ impl Workspace {
         self.center();
     }
 
-    fn center(&mut self) {
+    pub fn center(&mut self) {
         let Some(doc) = &self.doc else { return };
         let avail = self.canvas_bounds.size;
         self.offset = point(
@@ -2676,7 +2680,7 @@ impl Workspace {
 
     /// Collect the registry's tools into toolbar groups, preserving
     /// registration order both between and within groups.
-    fn rebuild_tool_groups(&mut self) {
+    pub fn rebuild_tool_groups(&mut self) {
         let mut groups: Vec<(&'static str, Vec<&'static str>)> = Vec::new();
         for tool in self.registry.tools() {
             if !tool.in_toolbar() {
@@ -5520,6 +5524,9 @@ impl Render for Workspace {
         let captures_keys =
             self.tool_captures_keys() || self.modal.is_some() || self.layer_rename.is_some();
         let chrome = self.screen_mode == ScreenMode::Standard;
+        // On macOS the menus live in the system bar, not in the window.
+        crate::native_menu::sync(self, cx);
+        let in_window_menus = chrome && !cfg!(target_os = "macos");
         let modal = crate::dialogs::render(self, cx);
         let context_menu = panels::context_menu(self, window.viewport_size(), cx);
         let tool_flyout = panels::tool_flyout(self, cx);
@@ -5543,6 +5550,21 @@ impl Render for Workspace {
             }))
             .on_action(cx.listener(|ws, action: &ActivateTool, _w, cx| {
                 ws.activate_tool(&action.id.clone(), cx);
+            }))
+            .on_action(cx.listener(|ws, action: &RunAppItem, window, cx| {
+                panels::run_app_item(ws, action.item, window, cx);
+            }))
+            .on_action(cx.listener(|ws, action: &OpenFilter, _w, cx| {
+                // The dialog holds the filter's id for the life of the
+                // modal, so it needs the registry's 'static one.
+                let id = ws
+                    .registry
+                    .filters()
+                    .find(|f| f.id() == action.id)
+                    .map(|f| f.id());
+                if let Some(id) = id {
+                    ws.open_filter_dialog(id, cx);
+                }
             }))
             .on_action(cx.listener(|ws, action: &CycleToolGroup, _w, cx| {
                 // The group ids are 'static strings from the registry; find
@@ -5628,18 +5650,10 @@ impl Render for Workspace {
                 }
             }))
             .on_action(cx.listener(|ws, action: &AddAdjustment, _w, cx| {
-                let kind = match action.kind.as_str() {
-                    "levels" => schist_core::AdjustmentKind::Levels,
-                    "curves" => schist_core::AdjustmentKind::Curves,
-                    "hue_saturation" => schist_core::AdjustmentKind::HueSaturation,
-                    "invert" => schist_core::AdjustmentKind::Invert,
-                    "brightness_contrast" => schist_core::AdjustmentKind::BrightnessContrast,
-                    other => {
-                        log::warn!("unknown adjustment {other}");
-                        return;
-                    }
-                };
-                ws.add_adjustment(kind, cx);
+                match adjustment_from_id(&action.kind) {
+                    Some(kind) => ws.add_adjustment(kind, cx),
+                    None => log::warn!("unknown adjustment {}", action.kind),
+                }
             }))
             .on_action(cx.listener(|ws, _: &ToggleRulers, _w, cx| ws.toggle_rulers(cx)))
             .on_action(cx.listener(|ws, _: &ToggleGrid, _w, cx| ws.toggle_grid(cx)))
@@ -5672,8 +5686,7 @@ impl Render for Workspace {
             }))
             .on_action(cx.listener(|ws, _: &NextTab, _w, cx| ws.cycle_tab(1, cx)))
             .on_action(cx.listener(|ws, _: &PrevTab, _w, cx| ws.cycle_tab(-1, cx)))
-            .on_action(|_: &Quit, _w, cx| cx.quit())
-            .children(chrome.then(|| panels::menu_bar(self, cx)))
+            .children(in_window_menus.then(|| panels::menu_bar(self, cx)))
             .children(chrome.then(|| panels::tool_options_bar(self, cx)))
             .children(chrome.then(|| panels::tab_bar(self, cx)))
             .child(


### PR DESCRIPTION
macOS expects an application's menus at the top of the screen, not inside its windows, so Schist's own bar looked out of place there and left the system bar holding nothing but the app's name.

Both bars are now built from the same panels::menus description. GPUI's menus can only carry actions, so AppItem moves into actions.rs behind a new RunAppItem, filters get an OpenFilter action, and the items that already have a keybinding name the action that binding names -- which is how ⌘N, ⌘T and ⌘0 come to show beside them, GPUI reading each key equivalent out of the keymap.

Three things follow from what GPUI's menu API can express:

- It has no check marks, so View's toggles say what the click will do ("Hide Rulers"), as Finder does. The in-window bar keeps its ticks.
- Screen Mode's only binding is a bare "f", and a key equivalent without modifiers is swallowed before the letter can reach a tool that is taking typing -- so that item dispatches an unbound action instead.
- Quit, Preferences and Check for Updates move to the application menu and are dropped from File and View, rather than appearing twice.

AddAdjustment knew five adjustment ids and warned about the rest, which was invisible while only the keymap built one; the macOS Adjust menu builds sixteen. It now round-trips through adjustment_id.

Cannot be run here: this box has no macOS. The Linux bar is unchanged, ⌘L and ⌘Q were re-tested, and none of the new code is cfg-gated.