### PR TITLE
Associate the PSD and Affinity formats on all three platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ cargo run --release -p schist-app -- [file.psd|file.png|…]
 `cargo test --workspace` runs everything. Packaging scripts for macOS,
 Windows and Linux live in [packaging/](packaging); tagging `vX.Y.Z` builds
 them all in CI, signing and notarizing the macOS bundle when the
-[signing secrets](docs/versioning.md#signing-secrets) are set.
+[signing secrets](docs/versioning.md#signing-secrets) are set. All three
+register `.psd`, `.psb`, `.afphoto`, `.afdesign`, `.afpub` and `.af` as
+openable, never as the default handler: an installed Schist joins the
+"Open with" menu rather than taking files off Photoshop or Affinity.
 
 The logo is generated, not drawn: [`tools/logo.py`](tools/logo.py) holds the
 geometry and `python3 tools/logo.py` re-emits the SVGs and every `.icns`,

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -15,8 +15,14 @@ mod ui;
 mod workspace;
 
 use actions::{HideApp, HideOthers, Quit, ShowAll};
-use gpui::{px, size, App, AppContext as _, Application, Bounds, WindowBounds, WindowOptions};
+use gpui::{
+    px, size, App, AppContext as _, Application, AsyncApp, Bounds, WindowBounds, WindowHandle,
+    WindowOptions,
+};
 use schist_plugin_api::{CodecPlugin, PluginManifest, PluginRegistry};
+use std::cell::RefCell;
+use std::path::PathBuf;
+use std::rc::Rc;
 use workspace::Workspace;
 
 /// PSD/PSB import and export via `schist-codec-psd`.
@@ -108,6 +114,53 @@ fn build_registry() -> (PluginRegistry, schist_plugin_host_wasm::PluginManager) 
     (registry, manager)
 }
 
+/// Documents the platform hands over outside argv, and the window they are
+/// destined for. The handler has to be installed before the app runs, so at
+/// launch the window may not exist yet; anything that arrives that early
+/// waits here until it does.
+#[derive(Default)]
+struct OpenRequests {
+    window: Option<(AsyncApp, WindowHandle<Workspace>)>,
+    queued: Vec<PathBuf>,
+}
+
+/// A `file://` URL as a local path, or `None` for anything that is not one.
+///
+/// macOS opens documents by handing the app percent-encoded URLs; every
+/// other platform Schist is associated on passes a plain path on argv.
+fn path_from_url(url: &str) -> Option<PathBuf> {
+    let rest = url.strip_prefix("file://")?;
+    // An empty authority and "localhost" both mean this machine; anything
+    // else is a remote file we cannot open by path anyway.
+    let rest = rest.strip_prefix("localhost").unwrap_or(rest);
+    if !rest.starts_with('/') {
+        return None;
+    }
+    // "file:///C:/..." -- the drive letter, not the root, starts the path.
+    #[cfg(windows)]
+    let rest = rest.strip_prefix('/').unwrap_or(rest);
+
+    let bytes = rest.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            // A truncated or non-hex escape means this is not a URL we
+            // understand, so decline it rather than guessing at the bytes.
+            let hex = bytes.get(i + 1..i + 3)?;
+            if !hex.iter().all(u8::is_ascii_hexdigit) {
+                return None;
+            }
+            out.push(u8::from_str_radix(std::str::from_utf8(hex).ok()?, 16).ok()?);
+            i += 3;
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+    Some(PathBuf::from(String::from_utf8(out).ok()?))
+}
+
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     // Opt-in: SCHIST_CRASH_REPORTS=1, or the preference file's
@@ -115,18 +168,41 @@ fn main() {
     crash::install_handler(crash_reports_enabled());
     let (registry, plugin_manager) = build_registry();
 
-    Application::new()
-        .with_assets(assets::Assets)
-        .run(move |cx: &mut App| {
-            cx.bind_keys(keymap::build_bindings(&registry));
-            // The macOS application menu, which is reachable with no window
-            // open, so these are global rather than on the workspace.
-            cx.on_action(|_: &Quit, cx: &mut App| cx.quit());
-            cx.on_action(|_: &HideApp, cx: &mut App| cx.hide());
-            cx.on_action(|_: &HideOthers, cx: &mut App| cx.hide_other_apps());
-            cx.on_action(|_: &ShowAll, cx: &mut App| cx.unhide_other_apps());
-            let bounds = Bounds::centered(None, size(px(1440.0), px(900.0)), cx);
-            cx.open_window(
+    let requests: Rc<RefCell<OpenRequests>> = Rc::default();
+    let app = Application::new().with_assets(assets::Assets);
+    // Finder does not use argv: a double-clicked document arrives as an Apple
+    // event, both at launch and while Schist is already running.
+    app.on_open_urls({
+        let requests = requests.clone();
+        move |urls| {
+            let paths: Vec<PathBuf> = urls.iter().filter_map(|u| path_from_url(u)).collect();
+            if paths.is_empty() {
+                return;
+            }
+            let window = requests.borrow().window.clone();
+            match window {
+                Some((async_cx, window)) => {
+                    let opened = async_cx.update(|cx| open_all(paths, window, cx));
+                    if let Err(err) = opened {
+                        log::error!("open failed: {err:#}");
+                    }
+                }
+                None => requests.borrow_mut().queued.extend(paths),
+            }
+        }
+    });
+
+    app.run(move |cx: &mut App| {
+        cx.bind_keys(keymap::build_bindings(&registry));
+        // The macOS application menu, which is reachable with no window
+        // open, so these are global rather than on the workspace.
+        cx.on_action(|_: &Quit, cx: &mut App| cx.quit());
+        cx.on_action(|_: &HideApp, cx: &mut App| cx.hide());
+        cx.on_action(|_: &HideOthers, cx: &mut App| cx.hide_other_apps());
+        cx.on_action(|_: &ShowAll, cx: &mut App| cx.unhide_other_apps());
+        let bounds = Bounds::centered(None, size(px(1440.0), px(900.0)), cx);
+        let window = cx
+            .open_window(
                 WindowOptions {
                     window_bounds: Some(WindowBounds::Windowed(bounds)),
                     ..Default::default()
@@ -147,21 +223,68 @@ fn main() {
                 },
             )
             .expect("failed to open window");
-            cx.activate(true);
-            // Closing the last window ends the session. The X11, Wayland and
-            // Windows backends already stop themselves once no window is left;
-            // AppKit instead keeps a window-less app sitting in the dock, and
-            // Schist has nothing to offer in that state — no menu item opens a
-            // second window. Quitting from anywhere but macOS would panic
-            // besides: `Platform::quit` is synchronous on Linux and re-enters
-            // the client state this callback is already dispatching from.
-            if cfg!(target_os = "macos") {
-                cx.on_window_closed(|cx| {
-                    if cx.windows().is_empty() {
-                        cx.quit();
-                    }
-                })
-                .detach();
-            }
-        });
+
+        let queued = {
+            let mut requests = requests.borrow_mut();
+            requests.window = Some((cx.to_async(), window));
+            std::mem::take(&mut requests.queued)
+        };
+        open_all(queued, window, cx);
+        cx.activate(true);
+        // Closing the last window ends the session. The X11, Wayland and
+        // Windows backends already stop themselves once no window is left;
+        // AppKit instead keeps a window-less app sitting in the dock, and
+        // Schist has nothing to offer in that state — no menu item opens a
+        // second window. Quitting from anywhere but macOS would panic
+        // besides: `Platform::quit` is synchronous on Linux and re-enters
+        // the client state this callback is already dispatching from.
+        if cfg!(target_os = "macos") {
+            cx.on_window_closed(|cx| {
+                if cx.windows().is_empty() {
+                    cx.quit();
+                }
+            })
+            .detach();
+        }
+    });
+}
+
+fn open_all(paths: Vec<PathBuf>, window: WindowHandle<Workspace>, cx: &mut App) {
+    for path in paths {
+        if let Err(err) = window.update(cx, |ws, _window, cx| ws.load_file(path, cx)) {
+            log::error!("open failed: {err:#}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::path_from_url;
+    use std::path::PathBuf;
+
+    #[test]
+    fn finder_urls_become_paths() {
+        assert_eq!(
+            path_from_url("file:///Users/astrid/Pictures/moss.afphoto"),
+            Some(PathBuf::from("/Users/astrid/Pictures/moss.afphoto"))
+        );
+        // Spaces and non-ASCII arrive percent-encoded.
+        assert_eq!(
+            path_from_url("file:///tmp/two%20words/gr%C3%BCn.afdesign"),
+            Some(PathBuf::from("/tmp/two words/grün.afdesign"))
+        );
+        assert_eq!(
+            path_from_url("file://localhost/tmp/a.psb"),
+            Some(PathBuf::from("/tmp/a.psb"))
+        );
+    }
+
+    #[test]
+    fn anything_that_is_not_a_local_file_is_declined() {
+        assert_eq!(path_from_url("https://example.com/a.psd"), None);
+        assert_eq!(path_from_url("schist://open"), None);
+        assert_eq!(path_from_url("file://server/share/a.psd"), None);
+        // A truncated escape is malformed, not a path with a stray '%'.
+        assert_eq!(path_from_url("file:///tmp/a%2"), None);
+    }
 }

--- a/packaging/linux/appimage.sh
+++ b/packaging/linux/appimage.sh
@@ -12,9 +12,14 @@ cargo build --release -p schist-app
 
 rm -rf "$appdir"
 mkdir -p "$appdir/usr/bin" "$appdir/usr/share/applications" \
+         "$appdir/usr/share/mime/packages" \
          "$appdir/usr/share/icons/hicolor/256x256/apps"
 cp "$root/target/release/schist" "$appdir/usr/bin/"
 cp "$root/packaging/linux/schist.desktop" "$appdir/usr/share/applications/"
+# The Affinity MIME types the desktop entry names; a desktop integrator that
+# installs the entry finds them here rather than binding it to nothing.
+cp "$root/packaging/linux/place.astrid.schist.mime.xml" \
+   "$appdir/usr/share/mime/packages/"
 cp "$root/packaging/linux/schist.desktop" "$appdir/schist.desktop"
 # appimagetool looks the icon up by the desktop entry's Icon= key, so both
 # copies have to carry the app ID as their name.

--- a/packaging/linux/place.astrid.schist.mime.xml
+++ b/packaging/linux/place.astrid.schist.mime.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- MIME types shared-mime-info does not ship, so the desktop entry has
+     something real to associate with. Installed to
+     $PREFIX/share/mime/packages/, after which update-mime-database runs. -->
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+
+  <!-- Every Affinity file, whatever the app that wrote it, starts with the
+       same four bytes; only the object graph inside differs. So the magic
+       identifies the family, and the globs pick the member out of it. -->
+  <mime-type type="application/x-affinity-document">
+    <comment>Affinity document</comment>
+    <generic-icon name="image-x-generic"/>
+    <glob pattern="*.af"/>
+    <magic priority="60">
+      <match type="string" value="\x00\xffKA" offset="0"/>
+    </magic>
+  </mime-type>
+
+  <mime-type type="application/x-affinity-photo">
+    <comment>Affinity Photo document</comment>
+    <sub-class-of type="application/x-affinity-document"/>
+    <generic-icon name="image-x-generic"/>
+    <glob pattern="*.afphoto"/>
+  </mime-type>
+
+  <mime-type type="application/x-affinity-designer">
+    <comment>Affinity Designer document</comment>
+    <sub-class-of type="application/x-affinity-document"/>
+    <generic-icon name="image-x-generic"/>
+    <glob pattern="*.afdesign"/>
+  </mime-type>
+
+  <mime-type type="application/x-affinity-publisher">
+    <comment>Affinity Publisher document</comment>
+    <sub-class-of type="application/x-affinity-document"/>
+    <generic-icon name="image-x-generic"/>
+    <glob pattern="*.afpub"/>
+  </mime-type>
+
+  <!-- Large Document Format is a PSD with 64-bit offsets: same type, and
+       the same codec reads it, but shared-mime-info only globs *.psd. -->
+  <mime-type type="image/vnd.adobe.photoshop">
+    <glob pattern="*.psb"/>
+  </mime-type>
+
+</mime-info>

--- a/packaging/linux/place.astrid.schist.yaml
+++ b/packaging/linux/place.astrid.schist.yaml
@@ -27,6 +27,8 @@ modules:
       - install -Dm755 target/release/schist /app/bin/schist
       - install -Dm644 packaging/linux/schist.desktop
           /app/share/applications/place.astrid.schist.desktop
+      - install -Dm644 packaging/linux/place.astrid.schist.mime.xml
+          /app/share/mime/packages/place.astrid.schist.xml
       - install -Dm644 packaging/linux/schist.png
           /app/share/icons/hicolor/256x256/apps/place.astrid.schist.png
     sources:

--- a/packaging/linux/schist.desktop
+++ b/packaging/linux/schist.desktop
@@ -7,4 +7,4 @@ Exec=schist %f
 Icon=place.astrid.schist
 Terminal=false
 Categories=Graphics;2DGraphics;RasterGraphics;
-MimeType=image/vnd.adobe.photoshop;image/png;image/jpeg;image/tiff;image/webp;
+MimeType=image/vnd.adobe.photoshop;application/x-affinity-photo;application/x-affinity-designer;application/x-affinity-publisher;application/x-affinity-document;image/png;image/jpeg;image/tiff;image/webp;

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -12,14 +12,106 @@
     <key>CFBundlePackageType</key><string>APPL</string>
     <key>LSMinimumSystemVersion</key><string>11.0</string>
     <key>NSHighResolutionCapable</key><true/>
+
+    <!-- Types nobody else on the system declares. Launch Services will not
+         bind an extension to the app unless some bundle names the UTI, and
+         only Adobe and Serif ship the ones below, so import them, using
+         the vendors' own identifiers where they are known, rather than
+         minting place.astrid.* types that would shadow the real apps. -->
+    <key>UTImportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeIdentifier</key><string>com.adobe.photoshop-large-image</string>
+            <key>UTTypeDescription</key><string>Photoshop Large Document</string>
+            <key>UTTypeConformsTo</key>
+            <array><string>public.image</string></array>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key><array><string>psb</string></array>
+                <key>public.mime-type</key><array><string>image/vnd.adobe.photoshop</string></array>
+            </dict>
+        </dict>
+        <dict>
+            <key>UTTypeIdentifier</key><string>com.seriflabs.afphoto</string>
+            <key>UTTypeDescription</key><string>Affinity Photo Document</string>
+            <key>UTTypeConformsTo</key>
+            <array><string>public.data</string></array>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key><array><string>afphoto</string></array>
+                <key>public.mime-type</key><array><string>application/x-affinity-photo</string></array>
+            </dict>
+        </dict>
+        <dict>
+            <key>UTTypeIdentifier</key><string>com.seriflabs.afdesign</string>
+            <key>UTTypeDescription</key><string>Affinity Designer Document</string>
+            <key>UTTypeConformsTo</key>
+            <array><string>public.data</string></array>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key><array><string>afdesign</string></array>
+                <key>public.mime-type</key><array><string>application/x-affinity-designer</string></array>
+            </dict>
+        </dict>
+        <dict>
+            <key>UTTypeIdentifier</key><string>com.seriflabs.afpub</string>
+            <key>UTTypeDescription</key><string>Affinity Publisher Document</string>
+            <key>UTTypeConformsTo</key>
+            <array><string>public.data</string></array>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key><array><string>afpub</string></array>
+                <key>public.mime-type</key><array><string>application/x-affinity-publisher</string></array>
+            </dict>
+        </dict>
+        <dict>
+            <!-- The unified extension of Canva-era Affinity. Serif has not
+                 published an identifier for it; this one is ours in all but
+                 name, and costs nothing if they later declare their own. -->
+            <key>UTTypeIdentifier</key><string>com.seriflabs.af</string>
+            <key>UTTypeDescription</key><string>Affinity Document</string>
+            <key>UTTypeConformsTo</key>
+            <array><string>public.data</string></array>
+            <key>UTTypeTagSpecification</key>
+            <dict>
+                <key>public.filename-extension</key><array><string>af</string></array>
+                <key>public.mime-type</key><array><string>application/x-affinity-document</string></array>
+            </dict>
+        </dict>
+    </array>
+
     <key>CFBundleDocumentTypes</key>
     <array>
         <dict>
             <key>CFBundleTypeName</key><string>Photoshop Document</string>
             <key>CFBundleTypeRole</key><string>Editor</string>
+            <key>LSHandlerRank</key><string>Alternate</string>
             <key>LSItemContentTypes</key>
             <array>
                 <string>com.adobe.photoshop-image</string>
+                <string>com.adobe.photoshop-large-image</string>
+            </array>
+        </dict>
+        <dict>
+            <!-- Import-only: there is no way to write a file Affinity would
+                 accept, so Schist opens these but never claims to edit them. -->
+            <key>CFBundleTypeName</key><string>Affinity Document</string>
+            <key>CFBundleTypeRole</key><string>Viewer</string>
+            <key>LSHandlerRank</key><string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
+                <string>com.seriflabs.afphoto</string>
+                <string>com.seriflabs.afdesign</string>
+                <string>com.seriflabs.afpub</string>
+                <string>com.seriflabs.af</string>
+            </array>
+        </dict>
+        <dict>
+            <key>CFBundleTypeName</key><string>Image</string>
+            <key>CFBundleTypeRole</key><string>Editor</string>
+            <key>LSHandlerRank</key><string>Alternate</string>
+            <key>LSItemContentTypes</key>
+            <array>
                 <string>public.png</string>
                 <string>public.jpeg</string>
                 <string>public.tiff</string>

--- a/packaging/windows/installer.nsi
+++ b/packaging/windows/installer.nsi
@@ -14,6 +14,22 @@ Unicode true
 Icon "schist.ico"
 UninstallIcon "schist.ico"
 
+; One ProgID per extension. Registered under the extension's
+; OpenWithProgids rather than as its default handler, so installing Schist
+; never silently steals files from Photoshop or the Affinity apps -- it
+; just joins their "Open with" menu, and Windows offers it as a choice.
+!macro AssociateExt ext desc
+  WriteRegStr HKCR ".${ext}\OpenWithProgids" "Schist.${ext}" ""
+  WriteRegStr HKCR "Schist.${ext}" "" "${desc}"
+  WriteRegStr HKCR "Schist.${ext}\DefaultIcon" "" "$INSTDIR\schist.ico"
+  WriteRegStr HKCR "Schist.${ext}\shell\open\command" "" '"$INSTDIR\schist.exe" "%1"'
+!macroend
+
+!macro UnassociateExt ext
+  DeleteRegValue HKCR ".${ext}\OpenWithProgids" "Schist.${ext}"
+  DeleteRegKey HKCR "Schist.${ext}"
+!macroend
+
 Page directory
 Page instfiles
 UninstPage uninstConfirm
@@ -35,10 +51,18 @@ Section "Schist"
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Schist" \
     "DisplayIcon" "$INSTDIR\schist.ico"
 
-  ; Open .psd files with Schist.
-  WriteRegStr HKCR ".psd\OpenWithProgids" "Schist.psd" ""
-  WriteRegStr HKCR "Schist.psd\shell\open\command" "" '"$INSTDIR\schist.exe" "%1"'
-  WriteRegStr HKCR "Schist.psd\DefaultIcon" "" "$INSTDIR\schist.ico"
+  ; Everything Schist can open that the shell has no better idea about.
+  ; PSB is a PSD with 64-bit offsets, and the Affinity family is
+  ; import-only, but all of them open by double-click just the same.
+  !insertmacro AssociateExt "psd" "Photoshop Document"
+  !insertmacro AssociateExt "psb" "Photoshop Large Document"
+  !insertmacro AssociateExt "afphoto" "Affinity Photo Document"
+  !insertmacro AssociateExt "afdesign" "Affinity Designer Document"
+  !insertmacro AssociateExt "afpub" "Affinity Publisher Document"
+  !insertmacro AssociateExt "af" "Affinity Document"
+  ; SHCNE_ASSOCCHANGED: pick the new associations up now rather than at the
+  ; next sign-in, so the icons and the Open With menu are right immediately.
+  System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, i 0, i 0)'
 
   CreateShortcut "$SMPROGRAMS\Schist.lnk" "$INSTDIR\schist.exe" "" "$INSTDIR\schist.ico"
   WriteUninstaller "$INSTDIR\uninstall.exe"
@@ -52,5 +76,11 @@ Section "Uninstall"
   RMDir "$INSTDIR"
   DeleteRegKey HKLM "Software\Schist"
   DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Schist"
-  DeleteRegKey HKCR "Schist.psd"
+  !insertmacro UnassociateExt "psd"
+  !insertmacro UnassociateExt "psb"
+  !insertmacro UnassociateExt "afphoto"
+  !insertmacro UnassociateExt "afdesign"
+  !insertmacro UnassociateExt "afpub"
+  !insertmacro UnassociateExt "af"
+  System::Call 'shell32::SHChangeNotify(i 0x08000000, i 0, i 0, i 0)'
 SectionEnd


### PR DESCRIPTION
Schist opens `.psd`, `.psb`, `.afphoto`, `.afdesign`, `.afpub` and `.af`, but the packaging only ever told the desktop about `.psd`. This registers the whole set on macOS, Windows and Linux — and never as the default handler, so an installed Schist joins the "Open with" menu rather than taking files off Photoshop or Affinity.

### macOS
Launch Services will not bind an extension unless some bundle declares its UTI, and only Adobe and Serif ship these — so `Info.plist` imports them (`com.adobe.photoshop-large-image`, `com.seriflabs.*`) using the vendors' own identifiers rather than minting `place.astrid.*` types that would shadow the real apps. `CFBundleDocumentTypes` splits into Photoshop (Editor), Affinity (Viewer — the format is import-only, so Editor would be a lie) and Image, each ranked `Alternate`.

### Linux
The Affinity MIME types are not in shared-mime-info, so `place.astrid.schist.mime.xml` defines them: a glob per app over a shared `application/x-affinity-document` parent that carries the family's `\x00\xffKA` magic, which also identifies files arriving with no extension. `*.psb` joins the existing `image/vnd.adobe.photoshop`. Installed by both the Flatpak manifest and `appimage.sh`, and named in the desktop entry.

### Windows
The hand-written `.psd` block becomes `AssociateExt`/`UnassociateExt` macros over all six, plus `SHChangeNotify` so the shell picks the associations up without a sign-out.

### The gap this exposed
macOS delivers double-clicked documents through `application:openURLs:`, not argv — so even the pre-existing `.psd` association only ever opened an empty window. `main.rs` now installs `on_open_urls` before `run` (it is an `Application` method, not an `App` one), queueing anything that lands before the window exists.

### Verification
`cargo test -p schist-app` passes, clippy and fmt are clean, and `cargo check` cross-builds for `x86_64-pc-windows-gnu`. `makensis` compiles the installer. `update-mime-database` builds the MIME package, after which `gio info` reports `application/x-affinity-photo` for a real `.afphoto`, `application/x-affinity-document` for the same bytes stripped of their extension, and `image/vnd.adobe.photoshop` for a `.psb`. The GUI still opens an `.afphoto` layered.

Two things I could not verify from Linux: real Finder/Explorer behaviour, and the vendors' actual UTI strings. If one of those identifiers is wrong the association still works — nothing else on a typical Mac claims these extensions — Schist just would not share the type with the vendor's app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)