### PR TITLE
Quit when the last window closes

### DIFF
--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -148,5 +148,20 @@ fn main() {
             )
             .expect("failed to open window");
             cx.activate(true);
+            // Closing the last window ends the session. The X11, Wayland and
+            // Windows backends already stop themselves once no window is left;
+            // AppKit instead keeps a window-less app sitting in the dock, and
+            // Schist has nothing to offer in that state — no menu item opens a
+            // second window. Quitting from anywhere but macOS would panic
+            // besides: `Platform::quit` is synchronous on Linux and re-enters
+            // the client state this callback is already dispatching from.
+            if cfg!(target_os = "macos") {
+                cx.on_window_closed(|cx| {
+                    if cx.windows().is_empty() {
+                        cx.quit();
+                    }
+                })
+                .detach();
+            }
         });
 }


### PR DESCRIPTION
Closing Schist's only window on macOS left the app running with nothing on screen — still in the dock, still holding the menu bar that #3 just moved up there, and with no route back to a window, since no menu item opens a second one. AppKit keeps a window-less app alive unless told otherwise, so an `on_window_closed` observer now quits once `cx.windows()` is empty.

The observer is macOS-only, for two reasons:

- The other backends already do this. X11 and Wayland stop their event loop when the last window goes, and the Windows backend posts a quit message from the last `close_one_window`.
- Doing it on Linux *breaks* shutdown. `Platform::quit` defers to the main queue on macOS and to the foreground executor on Windows, but on Linux it calls `with_common` straight away, which re-borrows the client state this callback is already being dispatched from. Schist died on `RefCell already borrowed` (exit 101) instead of shutting down, skipping the rest of the quit path.

It is a `cfg!` rather than a `#[cfg]` so the callback stays type-checked wherever Schist builds, matching how `native_menu` handles the same split.

## Testing

- `cargo build -p schist-app`.
- Headless X11 (Xvfb + lavapipe), sending a real `WM_DELETE_WINDOW` to the app window: exits 0 with no panic, same as before this change. The intermediate ungated version is what turned up the `RefCell` panic above.
- The macOS path is reasoned from the backends, not run: closing the window calls `Window::on_close` → `remove_window()`, which drops the window from `cx.windows` before the observers fire, so the emptiness check is accurate, and mac's deferred `quit` means calling it from inside the observer is safe.

One thing to flag, unchanged by this PR but now easier to hit: there is no unsaved-changes prompt on window close (`Workspace` registers no `should_close` handler), so closing the last window discards dirty tabs and quits. Crash-recovery snapshots are still written, exactly as with the existing Quit menu item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)