### PR TITLE
Add an MCP server that drives the editor headless

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5564,6 +5564,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "schist-mcp"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "env_logger",
+ "image",
+ "log",
+ "rustc-hash 2.1.3",
+ "schist-adjustments",
+ "schist-codec-psd",
+ "schist-codecs-common",
+ "schist-commands-core",
+ "schist-compositor",
+ "schist-core",
+ "schist-filters-core",
+ "schist-layer-fx",
+ "schist-plugin-api",
+ "schist-plugin-host-wasm",
+ "schist-tools-basic",
+ "schist-tools-doc",
+ "schist-tools-paint",
+ "schist-tools-retouch",
+ "schist-tools-select",
+ "schist-tools-transform",
+ "schist-tools-type",
+ "schist-tools-vector",
+ "schist-tools-warp",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schist-neural"
 version = "0.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/plugin-host-wasm",
     "crates/plugin-sdk",
     "crates/colormgmt",
+    "crates/mcp",
     "plugins/codecs-common",
     "plugins/tools-basic",
     "plugins/tools-paint",

--- a/README.md
+++ b/README.md
@@ -217,8 +217,17 @@ Drop the `.wasm` in `~/.config/schist/plugins/` — or use **File ▸
 Plugins…**, which also shows why anything failed to load. Full instructions
 and a format example: [docs/plugin-guide.md](docs/plugin-guide.md).
 
+## MCP
+
+`cargo build --release -p schist-mcp` builds a [Model Context
+Protocol](https://modelcontextprotocol.io) server that drives Schist
+headless — sessions instead of windows, with every tool, command, filter
+and codec reachable through the same registry the app uses, plus inline
+PNG rendering. See [docs/mcp.md](docs/mcp.md).
+
 ## Documentation
 
 * [docs/architecture.md](docs/architecture.md) — how the pieces fit
 * [docs/plugin-guide.md](docs/plugin-guide.md) — writing plugins
+* [docs/mcp.md](docs/mcp.md) — the MCP server
 * [docs/versioning.md](docs/versioning.md) — compatibility and releases

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "schist-mcp"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Model Context Protocol server exposing Schist editing sessions over stdio"
+
+[[bin]]
+name = "schist-mcp"
+path = "src/main.rs"
+
+[dependencies]
+schist-core.workspace = true
+schist-plugin-api.workspace = true
+schist-compositor.workspace = true
+schist-layer-fx.workspace = true
+schist-adjustments.workspace = true
+schist-codec-psd.workspace = true
+schist-plugin-host-wasm.workspace = true
+schist-codecs-common.workspace = true
+schist-tools-basic.workspace = true
+schist-tools-paint.workspace = true
+schist-tools-retouch.workspace = true
+schist-tools-warp.workspace = true
+schist-tools-doc.workspace = true
+schist-tools-select.workspace = true
+schist-tools-transform.workspace = true
+schist-tools-vector.workspace = true
+schist-tools-type.workspace = true
+schist-filters-core.workspace = true
+schist-commands-core.workspace = true
+anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+rustc-hash.workspace = true
+image.workspace = true
+log.workspace = true
+env_logger.workspace = true
+base64 = "0.22"

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -1,0 +1,1255 @@
+//! `schist-mcp` — a Model Context Protocol server over stdio.
+//!
+//! Create a session (a blank document or an opened file), then drive it by
+//! session id: every registered tool, menu command, filter, adjustment and
+//! codec — the same plugin registry the GPUI app assembles — plus document
+//! introspection and PNG rendering. JSON-RPC 2.0, newline-delimited, on
+//! stdin/stdout; logs go to stderr so they never corrupt the stream.
+
+mod session;
+
+use anyhow::{anyhow, bail, Result};
+use base64::Engine as _;
+use schist_core::color::{Depth, Rgba};
+use schist_core::{AdjustmentKind, BlendMode, IntRect, Layer, LayerId, LayerKind};
+use schist_plugin_api::{ExportOptions, Modifiers, OptionKind, OptionValue, ToolOption};
+use serde_json::{json, Value};
+use session::Session;
+use std::collections::HashMap;
+use std::io::{BufRead, Write};
+
+fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn"))
+        .target(env_logger::Target::Stderr)
+        .init();
+    let stdin = std::io::stdin();
+    let mut server = Server::default();
+    for line in stdin.lock().lines() {
+        let line = match line {
+            Ok(l) => l,
+            Err(_) => break,
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let message: Value = match serde_json::from_str(&line) {
+            Ok(v) => v,
+            Err(e) => {
+                respond(&json!({
+                    "jsonrpc": "2.0", "id": null,
+                    "error": {"code": -32700, "message": format!("parse error: {e}")}
+                }));
+                continue;
+            }
+        };
+        let id = message.get("id").cloned();
+        let Some(method) = message.get("method").and_then(|m| m.as_str()) else {
+            continue;
+        };
+        let params = message.get("params").cloned().unwrap_or(Value::Null);
+        // Notifications get no reply.
+        let Some(id) = id else {
+            continue;
+        };
+        let reply = match server.handle(method, &params) {
+            Ok(result) => json!({"jsonrpc": "2.0", "id": id, "result": result}),
+            Err(e) => json!({
+                "jsonrpc": "2.0", "id": id,
+                "error": {"code": e.0, "message": e.1}
+            }),
+        };
+        respond(&reply);
+    }
+}
+
+fn respond(value: &Value) {
+    let mut out = std::io::stdout().lock();
+    let _ = serde_json::to_writer(&mut out, value);
+    let _ = out.write_all(b"\n");
+    let _ = out.flush();
+}
+
+/// JSON-RPC error: (code, message).
+struct RpcError(i64, String);
+
+#[derive(Default)]
+struct Server {
+    sessions: HashMap<String, Session>,
+    next_id: u64,
+}
+
+impl Server {
+    fn handle(&mut self, method: &str, params: &Value) -> Result<Value, RpcError> {
+        match method {
+            "initialize" => {
+                let requested = params
+                    .get("protocolVersion")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("2025-03-26");
+                Ok(json!({
+                    "protocolVersion": requested,
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {
+                        "name": "schist-mcp",
+                        "version": env!("CARGO_PKG_VERSION"),
+                    },
+                    "instructions": "Headless Schist image editor. Call create_session first \
+                        (blank document or open a file) and pass the returned session id to every \
+                        other tool. Use describe to enumerate the session's canvas tools, menu \
+                        commands, filters, adjustments and codecs; get_state for the document and \
+                        layer tree; render to see the canvas as a PNG. Edits go through the same \
+                        plugin registry and undo history as the GUI (undo/redo are the edit.undo \
+                        and edit.redo commands).",
+                }))
+            }
+            "ping" => Ok(json!({})),
+            "tools/list" => Ok(json!({"tools": tool_defs()})),
+            "tools/call" => {
+                let name = params
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| RpcError(-32602, "missing tool name".into()))?;
+                let args = params.get("arguments").cloned().unwrap_or(json!({}));
+                match self.call_tool(name, &args) {
+                    Ok(content) => Ok(json!({"content": content})),
+                    Err(e) => Ok(json!({
+                        "content": [{"type": "text", "text": format!("{e:#}")}],
+                        "isError": true,
+                    })),
+                }
+            }
+            _ => Err(RpcError(-32601, format!("method not found: {method}"))),
+        }
+    }
+
+    fn call_tool(&mut self, name: &str, args: &Value) -> Result<Value> {
+        match name {
+            "create_session" => self.create_session(args),
+            "list_sessions" => self.list_sessions(),
+            "close_session" => {
+                let id = arg_str(args, "session")?;
+                self.sessions
+                    .remove(id)
+                    .ok_or_else(|| anyhow!("no session {id:?}"))?;
+                text(format!("closed {id}"))
+            }
+            "describe" => {
+                let sess = self.session(args)?;
+                let what = args.get("what").and_then(|v| v.as_str()).unwrap_or("all");
+                text_json(describe(sess, what)?)
+            }
+            "get_state" => {
+                let id = arg_str(args, "session")?.to_string();
+                let sess = self.session(args)?;
+                text_json(state_json(&id, sess))
+            }
+            "run_command" => {
+                let sess = self.session(args)?;
+                let title = sess.run_command(arg_str(args, "id")?)?;
+                text(title)
+            }
+            "select_tool" => {
+                let sess = self.session(args)?;
+                let id = sess.activate_tool(arg_str(args, "id")?)?;
+                text(format!("active tool: {id}"))
+            }
+            "set_tool_options" => self.set_tool_options(args),
+            "tool_stroke" => self.tool_stroke(args),
+            "tool_input" => {
+                let modifiers = parse_modifiers(args.get("modifiers"));
+                let sess = self.session(args)?;
+                let consumed = sess.tool_input(
+                    arg_str(args, "action")?,
+                    args.get("key").and_then(|v| v.as_str()),
+                    args.get("text").and_then(|v| v.as_str()),
+                    modifiers,
+                )?;
+                text(if consumed { "consumed" } else { "not consumed" }.to_string())
+            }
+            "apply_filter" => {
+                let values: Vec<(String, f64)> = args
+                    .get("params")
+                    .and_then(|v| v.as_object())
+                    .map(|m| {
+                        m.iter()
+                            .map(|(k, v)| {
+                                v.as_f64()
+                                    .map(|n| (k.clone(), n))
+                                    .ok_or_else(|| anyhow!("parameter {k:?} must be a number"))
+                            })
+                            .collect::<Result<Vec<_>>>()
+                    })
+                    .transpose()?
+                    .unwrap_or_default();
+                let sess = self.session(args)?;
+                let name = sess.apply_filter(arg_str(args, "id")?, &values)?;
+                text(format!("applied {name}"))
+            }
+            "apply_adjustment" => {
+                let kind = parse_adjustment_kind(arg_str(args, "kind")?)?;
+                let params = match args.get("params") {
+                    Some(v) if !v.is_null() => Some(
+                        serde_json::from_value::<schist_adjustments::Params>(v.clone())
+                            .map_err(|e| anyhow!("bad adjustment params: {e}"))?,
+                    ),
+                    _ => None,
+                };
+                let sess = self.session(args)?;
+                let name = sess.apply_adjustment(kind, params)?;
+                text(format!("applied {name}"))
+            }
+            "set_active_layer" => {
+                let id = args
+                    .get("id")
+                    .and_then(|v| v.as_u64())
+                    .ok_or_else(|| anyhow!("missing layer id"))?;
+                let sess = self.session(args)?;
+                let id = LayerId(id);
+                let name = sess
+                    .doc
+                    .tree
+                    .find(id)
+                    .map(|l| l.name.clone())
+                    .ok_or_else(|| anyhow!("no layer {}", id.0))?;
+                sess.doc.active_layer = Some(id);
+                sess.doc.selected = vec![id];
+                text(format!("active layer: {name}"))
+            }
+            "set_layer_props" => self.set_layer_props(args),
+            "set_editor" => self.set_editor(args),
+            "render" => self.render(args),
+            "save" => {
+                let path = args.get("path").and_then(|v| v.as_str()).map(String::from);
+                let sess = self.session(args)?;
+                let path = path
+                    .map(std::path::PathBuf::from)
+                    .or_else(|| sess.doc.path.clone())
+                    .ok_or_else(|| anyhow!("document has no path; pass one"))?;
+                sess.save(&path)?;
+                text(format!("saved {}", path.display()))
+            }
+            "export" => {
+                let path = std::path::PathBuf::from(arg_str(args, "path")?);
+                let options = ExportOptions {
+                    quality: args
+                        .get("quality")
+                        .and_then(|v| v.as_u64())
+                        .map(|q| q.clamp(1, 100) as u8)
+                        .unwrap_or(ExportOptions::default().quality),
+                    bit_depth: args
+                        .get("bit_depth")
+                        .and_then(|v| v.as_u64())
+                        .map(|b| b as u8)
+                        .unwrap_or(ExportOptions::default().bit_depth),
+                    dither: args
+                        .get("dither")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(ExportOptions::default().dither),
+                };
+                let sess = self.session(args)?;
+                sess.export(&path, &options)?;
+                text(format!("exported {}", path.display()))
+            }
+            _ => bail!("unknown tool {name:?}"),
+        }
+    }
+
+    fn session(&mut self, args: &Value) -> Result<&mut Session> {
+        let id = arg_str(args, "session")?;
+        self.sessions
+            .get_mut(id)
+            .ok_or_else(|| anyhow!("no session {id:?} — create_session first"))
+    }
+
+    fn create_session(&mut self, args: &Value) -> Result<Value> {
+        let session = match args.get("path").and_then(|v| v.as_str()) {
+            Some(path) => Session::open(std::path::Path::new(path))?,
+            None => {
+                let width = args.get("width").and_then(|v| v.as_u64()).unwrap_or(1280) as u32;
+                let height = args.get("height").and_then(|v| v.as_u64()).unwrap_or(800) as u32;
+                let depth = match args.get("depth").and_then(|v| v.as_u64()).unwrap_or(8) {
+                    8 => Depth::Eight,
+                    16 => Depth::Sixteen,
+                    32 => Depth::ThirtyTwo,
+                    other => bail!("depth must be 8, 16 or 32, not {other}"),
+                };
+                let title = args
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("Untitled");
+                Session::new_blank(title, width, height, depth)?
+            }
+        };
+        self.next_id += 1;
+        let id = format!("s{}", self.next_id);
+        self.sessions.insert(id.clone(), session);
+        let sess = self.sessions.get_mut(&id).unwrap();
+        text_json(state_json(&id, sess))
+    }
+
+    fn list_sessions(&mut self) -> Result<Value> {
+        let mut sessions: Vec<Value> = self
+            .sessions
+            .iter()
+            .map(|(id, s)| {
+                json!({
+                    "session": id,
+                    "title": s.doc.title,
+                    "path": s.doc.path.as_ref().map(|p| p.display().to_string()),
+                    "size": [s.doc.width, s.doc.height],
+                    "dirty": s.doc.dirty,
+                })
+            })
+            .collect();
+        sessions.sort_by(|a, b| a["session"].as_str().cmp(&b["session"].as_str()));
+        text_json(json!({"sessions": sessions}))
+    }
+
+    fn set_tool_options(&mut self, args: &Value) -> Result<Value> {
+        let options = args
+            .get("options")
+            .and_then(|v| v.as_object())
+            .ok_or_else(|| anyhow!("missing options object"))?
+            .clone();
+        let sess = self.session(args)?;
+        let active = sess.state.active_tool;
+        let declared: Vec<ToolOption> = sess
+            .registry
+            .tools()
+            .find(|t| t.id() == active)
+            .map(|t| t.options())
+            .unwrap_or_default();
+        for (key, value) in &options {
+            let kind = declared
+                .iter()
+                .find(|o| o.key == key.as_str())
+                .map(|o| o.kind)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "tool {active:?} has no option {key:?} (has: {:?})",
+                        declared.iter().map(|o| o.key).collect::<Vec<_>>()
+                    )
+                })?;
+            let value = coerce_option(value, kind)?;
+            sess.set_tool_option(key, value)?;
+        }
+        text(format!("set {} option(s) on {active}", options.len()))
+    }
+
+    fn tool_stroke(&mut self, args: &Value) -> Result<Value> {
+        let points: Vec<(f32, f32)> = args
+            .get("points")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| anyhow!("missing points array"))?
+            .iter()
+            .map(|p| {
+                let pair = p.as_array().filter(|a| a.len() == 2).ok_or_else(|| {
+                    anyhow!("each point must be an [x, y] pair in document pixels")
+                })?;
+                Ok((
+                    pair[0].as_f64().unwrap_or(0.0) as f32,
+                    pair[1].as_f64().unwrap_or(0.0) as f32,
+                ))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let pressure = args
+            .get("pressure")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(1.0)
+            .clamp(0.0, 1.0) as f32;
+        let modifiers = parse_modifiers(args.get("modifiers"));
+        let sess = self.session(args)?;
+        let tool = sess.state.active_tool;
+        sess.stroke(&points, pressure, modifiers)?;
+        text(format!("{tool}: stroke of {} point(s)", points.len()))
+    }
+
+    fn set_layer_props(&mut self, args: &Value) -> Result<Value> {
+        let id = args
+            .get("id")
+            .and_then(|v| v.as_u64())
+            .ok_or_else(|| anyhow!("missing layer id"))?;
+        let name = args.get("name").and_then(|v| v.as_str()).map(String::from);
+        let visible = args.get("visible").and_then(|v| v.as_bool());
+        let locked = args.get("locked").and_then(|v| v.as_bool());
+        let clipping = args.get("clipping").and_then(|v| v.as_bool());
+        let opacity = args
+            .get("opacity")
+            .and_then(|v| v.as_f64())
+            .map(|v| v.clamp(0.0, 1.0) as f32);
+        let fill_opacity = args
+            .get("fill_opacity")
+            .and_then(|v| v.as_f64())
+            .map(|v| v.clamp(0.0, 1.0) as f32);
+        let blend = args
+            .get("blend")
+            .and_then(|v| v.as_str())
+            .map(parse_blend_mode)
+            .transpose()?;
+        let sess = self.session(args)?;
+        let id = LayerId(id);
+        if sess.doc.tree.find(id).is_none() {
+            bail!("no layer {}", id.0);
+        }
+        let mut edit = sess.doc.begin_edit("Layer Properties");
+        edit.change_props(id, |layer| {
+            if let Some(name) = name {
+                layer.name = name;
+            }
+            if let Some(v) = visible {
+                layer.visible = v;
+            }
+            if let Some(v) = locked {
+                layer.locked = v;
+            }
+            if let Some(v) = clipping {
+                layer.clipping = v;
+            }
+            if let Some(v) = opacity {
+                layer.opacity = v;
+            }
+            if let Some(v) = fill_opacity {
+                layer.fill_opacity = v;
+            }
+            if let Some(v) = blend {
+                layer.blend = v;
+            }
+        });
+        edit.commit();
+        sess.after_change();
+        text(format!("updated layer {}", id.0))
+    }
+
+    fn set_editor(&mut self, args: &Value) -> Result<Value> {
+        let foreground = args
+            .get("foreground")
+            .and_then(|v| v.as_str())
+            .map(parse_color)
+            .transpose()?;
+        let background = args
+            .get("background")
+            .and_then(|v| v.as_str())
+            .map(parse_color)
+            .transpose()?;
+        let resample = args
+            .get("resample")
+            .and_then(|v| v.as_str())
+            .map(|s| match s.to_ascii_lowercase().as_str() {
+                "nearest" => Ok(schist_core::Filter::Nearest),
+                "bilinear" => Ok(schist_core::Filter::Bilinear),
+                "bicubic" => Ok(schist_core::Filter::Bicubic),
+                other => Err(anyhow!(
+                    "resample must be nearest, bilinear or bicubic, not {other:?}"
+                )),
+            })
+            .transpose()?;
+        let sess = self.session(args)?;
+        if let Some(c) = foreground {
+            sess.state.foreground = c;
+        }
+        if let Some(c) = background {
+            sess.state.background = c;
+        }
+        if let Some(v) = args.get("brush_size").and_then(|v| v.as_f64()) {
+            sess.state.brush_size = (v as f32).max(1.0);
+        }
+        if let Some(v) = args.get("brush_hardness").and_then(|v| v.as_f64()) {
+            sess.state.brush_hardness = (v as f32).clamp(0.0, 1.0);
+        }
+        if let Some(v) = args.get("tool_opacity").and_then(|v| v.as_f64()) {
+            sess.state.tool_opacity = (v as f32).clamp(0.0, 1.0);
+        }
+        if let Some(v) = args.get("tolerance").and_then(|v| v.as_u64()) {
+            sess.state.tolerance = v.min(255) as u8;
+        }
+        if let Some(f) = resample {
+            sess.state.resample = f;
+        }
+        text("editor state updated".to_string())
+    }
+
+    fn render(&mut self, args: &Value) -> Result<Value> {
+        let region = match (
+            args.get("x").and_then(|v| v.as_i64()),
+            args.get("y").and_then(|v| v.as_i64()),
+            args.get("width").and_then(|v| v.as_u64()),
+            args.get("height").and_then(|v| v.as_u64()),
+        ) {
+            (Some(x), Some(y), Some(w), Some(h)) => {
+                Some(IntRect::from_xywh(x as i32, y as i32, w as u32, h as u32))
+            }
+            (None, None, None, None) => None,
+            _ => bail!("pass all of x, y, width, height for a region, or none for the canvas"),
+        };
+        let max_dim = args
+            .get("max_dim")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(1024)
+            .clamp(16, 8192) as u32;
+        let out_path = args.get("path").and_then(|v| v.as_str()).map(String::from);
+        let sess = self.session(args)?;
+        let (region, pixels) = sess.render(region)?;
+        let (w, h) = (region.width() as u32, region.height() as u32);
+        let img = image::RgbaImage::from_raw(w, h, pixels)
+            .ok_or_else(|| anyhow!("composited buffer had the wrong size"))?;
+        let img = image::DynamicImage::ImageRgba8(img);
+        if let Some(path) = &out_path {
+            img.save_with_format(path, image::ImageFormat::Png)?;
+        }
+        let shown = if w.max(h) > max_dim {
+            img.thumbnail(max_dim, max_dim)
+        } else {
+            img
+        };
+        let mut png = Vec::new();
+        shown.write_to(&mut std::io::Cursor::new(&mut png), image::ImageFormat::Png)?;
+        let note =
+            match &out_path {
+                Some(path) => format!(
+                "rendered {w}x{h} at ({}, {}); full resolution written to {path}, preview {}x{}",
+                region.left, region.top, shown.width(), shown.height()
+            ),
+                None => format!(
+                    "rendered {w}x{h} at ({}, {}), shown at {}x{}",
+                    region.left,
+                    region.top,
+                    shown.width(),
+                    shown.height()
+                ),
+            };
+        Ok(json!([
+            {
+                "type": "image",
+                "data": base64::engine::general_purpose::STANDARD.encode(&png),
+                "mimeType": "image/png",
+            },
+            {"type": "text", "text": note},
+        ]))
+    }
+}
+
+// ----- argument helpers -----
+
+fn arg_str<'a>(args: &'a Value, key: &str) -> Result<&'a str> {
+    args.get(key)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("missing required argument {key:?}"))
+}
+
+fn text(s: String) -> Result<Value> {
+    Ok(json!([{"type": "text", "text": s}]))
+}
+
+fn text_json(v: Value) -> Result<Value> {
+    text(serde_json::to_string_pretty(&v)?)
+}
+
+fn parse_modifiers(v: Option<&Value>) -> Modifiers {
+    let get = |key: &str| {
+        v.and_then(|m| m.get(key))
+            .and_then(|b| b.as_bool())
+            .unwrap_or(false)
+    };
+    Modifiers {
+        shift: get("shift"),
+        alt: get("alt"),
+        ctrl_or_cmd: get("ctrl") || get("cmd") || get("ctrl_or_cmd"),
+    }
+}
+
+fn coerce_option(value: &Value, kind: OptionKind) -> Result<OptionValue> {
+    match (value, kind) {
+        (Value::Bool(b), _) => Ok(OptionValue::Bool(*b)),
+        (Value::Number(n), OptionKind::Choice(_)) => {
+            Ok(OptionValue::Choice(n.as_f64().unwrap_or(0.0) as usize))
+        }
+        (Value::Number(n), _) => Ok(OptionValue::Num(n.as_f64().unwrap_or(0.0) as f32)),
+        (Value::String(s), OptionKind::Choice(names)) => names
+            .iter()
+            .position(|n| n.eq_ignore_ascii_case(s))
+            .map(OptionValue::Choice)
+            .ok_or_else(|| anyhow!("no choice {s:?} (choices: {names:?})")),
+        (Value::String(s), _) => s
+            .parse::<f32>()
+            .map(OptionValue::Num)
+            .map_err(|_| anyhow!("option value {s:?} is not a number")),
+        (other, _) => bail!("unsupported option value {other}"),
+    }
+}
+
+fn parse_color(s: &str) -> Result<Rgba> {
+    let hex = s.trim().trim_start_matches('#');
+    let channel = |at: usize, width: usize| -> Result<f32> {
+        let raw = u8::from_str_radix(&hex[at * width..(at + 1) * width], 16)
+            .map_err(|_| anyhow!("bad hex colour {s:?}"))?;
+        let raw = if width == 1 { raw * 17 } else { raw };
+        Ok(raw as f32 / 255.0)
+    };
+    match hex.len() {
+        3 => Ok(Rgba::new(
+            channel(0, 1)?,
+            channel(1, 1)?,
+            channel(2, 1)?,
+            1.0,
+        )),
+        6 => Ok(Rgba::new(
+            channel(0, 2)?,
+            channel(1, 2)?,
+            channel(2, 2)?,
+            1.0,
+        )),
+        8 => Ok(Rgba::new(
+            channel(0, 2)?,
+            channel(1, 2)?,
+            channel(2, 2)?,
+            channel(3, 2)?,
+        )),
+        _ => bail!("colour must be #rgb, #rrggbb or #rrggbbaa, not {s:?}"),
+    }
+}
+
+fn color_hex(c: Rgba) -> String {
+    let byte = |v: f32| (v.clamp(0.0, 1.0) * 255.0).round() as u8;
+    format!(
+        "#{:02x}{:02x}{:02x}{:02x}",
+        byte(c.r),
+        byte(c.g),
+        byte(c.b),
+        byte(c.a)
+    )
+}
+
+/// Names accepted case-insensitively with spaces, slashes and dashes
+/// ignored, so "Hue/Saturation", "hue-saturation" and "huesaturation" all
+/// land on the same kind.
+fn normalize(name: &str) -> String {
+    name.chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .collect::<String>()
+        .to_ascii_lowercase()
+}
+
+const ADJUSTMENT_KINDS: [AdjustmentKind; 18] = [
+    AdjustmentKind::Levels,
+    AdjustmentKind::Curves,
+    AdjustmentKind::HueSaturation,
+    AdjustmentKind::BrightnessContrast,
+    AdjustmentKind::BlackWhite,
+    AdjustmentKind::SolidColor,
+    AdjustmentKind::GradientFill,
+    AdjustmentKind::PatternFill,
+    AdjustmentKind::Invert,
+    AdjustmentKind::Posterize,
+    AdjustmentKind::Threshold,
+    AdjustmentKind::ColorBalance,
+    AdjustmentKind::Vibrance,
+    AdjustmentKind::Exposure,
+    AdjustmentKind::PhotoFilter,
+    AdjustmentKind::GradientMap,
+    AdjustmentKind::SelectiveColor,
+    AdjustmentKind::ChannelMixer,
+];
+
+fn parse_adjustment_kind(name: &str) -> Result<AdjustmentKind> {
+    let wanted = normalize(name);
+    ADJUSTMENT_KINDS
+        .iter()
+        .find(|k| normalize(k.display_name()) == wanted)
+        .copied()
+        .ok_or_else(|| {
+            anyhow!(
+                "unknown adjustment {name:?} (kinds: {})",
+                ADJUSTMENT_KINDS.map(|k| k.display_name()).join(", ")
+            )
+        })
+}
+
+const BLEND_MODES: [BlendMode; 28] = [
+    BlendMode::PassThrough,
+    BlendMode::Normal,
+    BlendMode::Dissolve,
+    BlendMode::Darken,
+    BlendMode::Multiply,
+    BlendMode::ColorBurn,
+    BlendMode::LinearBurn,
+    BlendMode::DarkerColor,
+    BlendMode::Lighten,
+    BlendMode::Screen,
+    BlendMode::ColorDodge,
+    BlendMode::LinearDodge,
+    BlendMode::LighterColor,
+    BlendMode::Overlay,
+    BlendMode::SoftLight,
+    BlendMode::HardLight,
+    BlendMode::VividLight,
+    BlendMode::LinearLight,
+    BlendMode::PinLight,
+    BlendMode::HardMix,
+    BlendMode::Difference,
+    BlendMode::Exclusion,
+    BlendMode::Subtract,
+    BlendMode::Divide,
+    BlendMode::Hue,
+    BlendMode::Saturation,
+    BlendMode::Color,
+    BlendMode::Luminosity,
+];
+
+fn parse_blend_mode(name: &str) -> Result<BlendMode> {
+    let wanted = normalize(name);
+    BLEND_MODES
+        .iter()
+        .find(|m| normalize(&format!("{m:?}")) == wanted)
+        .copied()
+        .ok_or_else(|| anyhow!("unknown blend mode {name:?}"))
+}
+
+// ----- state and capability reporting -----
+
+fn rect_json(r: IntRect) -> Value {
+    json!({"x": r.left, "y": r.top, "width": r.width(), "height": r.height()})
+}
+
+fn layer_json(layer: &Layer, active: Option<LayerId>) -> Value {
+    let kind = match &layer.kind {
+        LayerKind::Raster(_) if layer.shape.is_some() => "shape".to_string(),
+        LayerKind::Raster(_) if layer.smart.is_some() => "smart_object".to_string(),
+        LayerKind::Raster(_) => "raster".to_string(),
+        LayerKind::Group(_) => "group".to_string(),
+        LayerKind::Adjustment(a) => format!("adjustment:{}", a.kind.display_name()),
+    };
+    let mut out = json!({
+        "id": layer.id.0,
+        "name": layer.name,
+        "kind": kind,
+        "visible": layer.visible,
+        "opacity": layer.opacity,
+        "blend": format!("{:?}", layer.blend),
+        "bounds": rect_json(layer.content_bounds()),
+    });
+    let obj = out.as_object_mut().unwrap();
+    if layer.fill_opacity != 1.0 {
+        obj.insert("fill_opacity".into(), json!(layer.fill_opacity));
+    }
+    if layer.clipping {
+        obj.insert("clipping".into(), json!(true));
+    }
+    if layer.locked {
+        obj.insert("locked".into(), json!(true));
+    }
+    if layer.mask.is_some() {
+        obj.insert("has_mask".into(), json!(true));
+    }
+    if !layer.style.is_empty() {
+        obj.insert("has_effects".into(), json!(true));
+    }
+    if active == Some(layer.id) {
+        obj.insert("active".into(), json!(true));
+    }
+    if let Some(children) = layer.children() {
+        obj.insert(
+            "children".into(),
+            Value::Array(children.iter().map(|c| layer_json(c, active)).collect()),
+        );
+    }
+    out
+}
+
+fn option_json(option: &ToolOption) -> Value {
+    let (kind, extra) = match option.kind {
+        OptionKind::Slider { min, max, suffix } => {
+            ("slider", json!({"min": min, "max": max, "suffix": suffix}))
+        }
+        OptionKind::Toggle => ("toggle", json!({})),
+        OptionKind::Choice(names) => ("choice", json!({"choices": names})),
+    };
+    let value = match option.value {
+        OptionValue::Num(v) => json!(v),
+        OptionValue::Bool(b) => json!(b),
+        OptionValue::Choice(i) => match option.kind {
+            OptionKind::Choice(names) => json!(names.get(i).copied().unwrap_or("?")),
+            _ => json!(i),
+        },
+    };
+    let mut out = json!({
+        "key": option.key,
+        "label": option.label,
+        "kind": kind,
+        "value": value,
+    });
+    out.as_object_mut()
+        .unwrap()
+        .extend(extra.as_object().unwrap().clone());
+    out
+}
+
+fn state_json(id: &str, sess: &Session) -> Value {
+    let doc = &sess.doc;
+    let tool_options: Vec<Value> = sess
+        .registry
+        .tools()
+        .find(|t| t.id() == sess.state.active_tool)
+        .map(|t| t.options().iter().map(option_json).collect())
+        .unwrap_or_default();
+    json!({
+        "session": id,
+        "document": {
+            "title": doc.title,
+            "path": doc.path.as_ref().map(|p| p.display().to_string()),
+            "width": doc.width,
+            "height": doc.height,
+            "depth_bits": doc.depth.bytes_per_channel() * 8,
+            "mode": doc.mode.display_name(),
+            "resolution_dpi": doc.resolution_dpi,
+            "dirty": doc.dirty,
+        },
+        "layers": doc
+            .tree
+            .layers
+            .iter()
+            .map(|l| layer_json(l, doc.active_layer))
+            .collect::<Vec<_>>(),
+        "selection": if doc.selection.is_empty() {
+            json!({"empty": true})
+        } else {
+            json!({"empty": false, "bounds": rect_json(doc.selection.bounds())})
+        },
+        "history": {
+            "can_undo": doc.history.can_undo(),
+            "undo": doc.history.undo_name(),
+            "can_redo": doc.history.can_redo(),
+            "redo": doc.history.redo_name(),
+        },
+        "editor": {
+            "active_tool": sess.state.active_tool,
+            "tool_options": tool_options,
+            "foreground": color_hex(sess.state.foreground),
+            "background": color_hex(sess.state.background),
+            "brush_size": sess.state.brush_size,
+            "brush_hardness": sess.state.brush_hardness,
+            "tool_opacity": sess.state.tool_opacity,
+            "tolerance": sess.state.tolerance,
+            "resample": sess.state.resample.display_name(),
+        },
+    })
+}
+
+fn describe(sess: &Session, what: &str) -> Result<Value> {
+    let tools = || -> Value {
+        sess.registry
+            .tools()
+            .map(|t| {
+                json!({
+                    "id": t.id(),
+                    "name": t.name(),
+                    "group": t.group(),
+                    "shortcut": t.shortcut(),
+                    "in_toolbar": t.in_toolbar(),
+                    "options": t.options().iter().map(option_json).collect::<Vec<_>>(),
+                })
+            })
+            .collect()
+    };
+    let commands = || -> Value {
+        sess.registry
+            .commands()
+            .iter()
+            .map(|c| json!({"id": c.id, "title": c.title, "keybind": c.keybind}))
+            .collect()
+    };
+    let filters = || -> Value {
+        sess.registry
+            .filters()
+            .map(|f| {
+                json!({
+                    "id": f.id(),
+                    "name": f.name(),
+                    "category": f.category(),
+                    "info": f.info(),
+                    "params": f
+                        .params()
+                        .iter()
+                        .map(|p| {
+                            json!({
+                                "key": p.key,
+                                "label": p.label,
+                                "min": p.min,
+                                "max": p.max,
+                                "default": p.default,
+                                "suffix": p.suffix,
+                                "choices": p.choices,
+                            })
+                        })
+                        .collect::<Vec<_>>(),
+                })
+            })
+            .collect()
+    };
+    let codecs = || -> Value {
+        sess.registry
+            .codecs()
+            .map(|c| {
+                json!({
+                    "id": c.id(),
+                    "name": c.name(),
+                    "extensions": c.extensions(),
+                    "can_export": c.can_export(),
+                    "supports_quality": c.supports_quality(),
+                })
+            })
+            .collect()
+    };
+    let adjustments = || -> Value {
+        ADJUSTMENT_KINDS
+            .iter()
+            .map(|k| {
+                json!({
+                    "kind": k.display_name(),
+                    "default_params": serde_json::to_value(
+                        schist_adjustments::Params::default_for(*k)
+                    )
+                    .unwrap_or(Value::Null),
+                })
+            })
+            .collect()
+    };
+    let blend_modes = || -> Value {
+        BLEND_MODES
+            .iter()
+            .map(|m| json!(format!("{m:?}")))
+            .collect()
+    };
+    Ok(match what {
+        "tools" => json!({"tools": tools()}),
+        "commands" => json!({"commands": commands()}),
+        "filters" => json!({"filters": filters()}),
+        "codecs" => json!({"codecs": codecs()}),
+        "adjustments" => json!({"adjustments": adjustments()}),
+        "blend_modes" => json!({"blend_modes": blend_modes()}),
+        "all" => json!({
+            "tools": tools(),
+            "commands": commands(),
+            "filters": filters(),
+            "codecs": codecs(),
+            "adjustments": adjustments(),
+            "blend_modes": blend_modes(),
+        }),
+        other => bail!(
+            "unknown section {other:?} (tools, commands, filters, codecs, adjustments, \
+             blend_modes or all)"
+        ),
+    })
+}
+
+// ----- tool definitions -----
+
+fn tool_defs() -> Value {
+    let session_prop = json!({"type": "string", "description": "Session id from create_session"});
+    let modifiers_prop = json!({
+        "type": "object",
+        "description": "Held modifier keys",
+        "properties": {
+            "shift": {"type": "boolean"},
+            "alt": {"type": "boolean"},
+            "ctrl": {"type": "boolean", "description": "Ctrl/Cmd"},
+        },
+    });
+    let def = |name: &str, description: &str, props: Value, required: &[&str]| {
+        json!({
+            "name": name,
+            "description": description,
+            "inputSchema": {
+                "type": "object",
+                "properties": props,
+                "required": required,
+            },
+        })
+    };
+    json!([
+        def(
+            "create_session",
+            "Create an editing session: open an image file (PSD/PSB, PNG, JPEG, WebP, TIFF, \
+             Affinity .af/.afphoto/.afdesign/.afpub) or start a blank document with a white \
+             Background layer. Returns the session id and initial state.",
+            json!({
+                "path": {"type": "string", "description": "File to open; omit for a blank document"},
+                "width": {"type": "integer", "description": "Blank document width (default 1280)"},
+                "height": {"type": "integer", "description": "Blank document height (default 800)"},
+                "depth": {"type": "integer", "enum": [8, 16, 32], "description": "Bits per channel (default 8)"},
+                "title": {"type": "string"},
+            }),
+            &[],
+        ),
+        def("list_sessions", "List open sessions.", json!({}), &[]),
+        def(
+            "close_session",
+            "Close a session, discarding unsaved changes.",
+            json!({"session": session_prop}),
+            &["session"],
+        ),
+        def(
+            "describe",
+            "Enumerate what the session can do: canvas tools (with their options), menu \
+             commands (run with run_command), filters, destructive adjustments (with default \
+             parameter shapes), codecs and blend modes.",
+            json!({
+                "session": session_prop,
+                "what": {
+                    "type": "string",
+                    "enum": ["tools", "commands", "filters", "codecs", "adjustments", "blend_modes", "all"],
+                    "description": "Section to list (default all)",
+                },
+            }),
+            &["session"],
+        ),
+        def(
+            "get_state",
+            "Document info, full layer tree (with layer ids), selection, undo/redo state, and \
+             editor state including the active tool's options.",
+            json!({"session": session_prop}),
+            &["session"],
+        ),
+        def(
+            "run_command",
+            "Run a menu command by id (see describe): edit.undo, edit.redo, select.all, \
+             layer.new, layer.duplicate, image.crop and everything else in the menus.",
+            json!({
+                "session": session_prop,
+                "id": {"type": "string", "description": "Command id, e.g. \"layer.duplicate\""},
+            }),
+            &["session", "id"],
+        ),
+        def(
+            "select_tool",
+            "Activate a canvas tool by id (see describe): brush, eraser, marquee, lasso, wand, \
+             gradient, move, crop, transform, text, shapes, pen…",
+            json!({
+                "session": session_prop,
+                "id": {"type": "string", "description": "Tool id, e.g. \"brush\""},
+            }),
+            &["session", "id"],
+        ),
+        def(
+            "set_tool_options",
+            "Set options-bar values on the active tool. Numbers for sliders, booleans for \
+             toggles, and either an index or the choice's name for dropdowns.",
+            json!({
+                "session": session_prop,
+                "options": {
+                    "type": "object",
+                    "description": "Option key to value, e.g. {\"wand-tolerance\": 40}",
+                    "additionalProperties": true,
+                },
+            }),
+            &["session", "options"],
+        ),
+        def(
+            "tool_stroke",
+            "Drive the active tool through one pointer gesture in document pixels: down on the \
+             first point, drag through the rest, up on the last. One point clicks. A brush \
+             stroke, a marquee drag, a transform-handle drag and a text-layer click are all one \
+             call. Modal tools (crop, transform, text) keep a pending state afterwards — finish \
+             with tool_input.",
+            json!({
+                "session": session_prop,
+                "points": {
+                    "type": "array",
+                    "items": {"type": "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2},
+                    "description": "[[x, y], …] in document pixels",
+                },
+                "pressure": {"type": "number", "description": "Stylus pressure 0..1 (default 1)"},
+                "modifiers": modifiers_prop,
+            }),
+            &["session", "points"],
+        ),
+        def(
+            "tool_input",
+            "Non-pointer input for the active tool: commit (Enter) or cancel (Escape) a pending \
+             crop/transform/text gesture, or send a raw key — the type tool takes text through \
+             action \"key\" with the character in \"text\".",
+            json!({
+                "session": session_prop,
+                "action": {"type": "string", "enum": ["key", "commit", "cancel"]},
+                "key": {"type": "string", "description": "Physical key name for action \"key\", e.g. \"a\", \"enter\", \"backspace\""},
+                "text": {"type": "string", "description": "Character the key types, when it types one"},
+                "modifiers": modifiers_prop,
+            }),
+            &["session", "action"],
+        ),
+        def(
+            "apply_filter",
+            "Run a destructive filter on the active pixel layer (through the selection when one \
+             exists), as one undoable edit. Omitted parameters use their defaults (see describe).",
+            json!({
+                "session": session_prop,
+                "id": {"type": "string", "description": "Filter id, e.g. \"filter.gaussian-blur\""},
+                "params": {
+                    "type": "object",
+                    "description": "Parameter key to number",
+                    "additionalProperties": {"type": "number"},
+                },
+            }),
+            &["session", "id"],
+        ),
+        def(
+            "apply_adjustment",
+            "Image ▸ Adjustments: apply an adjustment destructively to the active layer's \
+             pixels. For a non-destructive adjustment layer use the layer.adjustment.* commands \
+             instead. params follows the shape shown by describe(adjustments); omit for defaults.",
+            json!({
+                "session": session_prop,
+                "kind": {"type": "string", "description": "e.g. \"Levels\", \"Hue/Saturation\", \"Brightness/Contrast\""},
+                "params": {"type": "object", "description": "Serde form of the adjustment's parameters"},
+            }),
+            &["session", "kind"],
+        ),
+        def(
+            "set_active_layer",
+            "Make a layer the target of tools, filters and layer commands (layer ids come from \
+             get_state).",
+            json!({
+                "session": session_prop,
+                "id": {"type": "integer", "description": "Layer id"},
+            }),
+            &["session", "id"],
+        ),
+        def(
+            "set_layer_props",
+            "Change a layer's name, visibility, opacity, fill opacity, blend mode, lock or \
+             clipping flag, as one undoable edit.",
+            json!({
+                "session": session_prop,
+                "id": {"type": "integer"},
+                "name": {"type": "string"},
+                "visible": {"type": "boolean"},
+                "opacity": {"type": "number", "description": "0..1"},
+                "fill_opacity": {"type": "number", "description": "0..1"},
+                "blend": {"type": "string", "description": "Blend mode name, e.g. \"Multiply\""},
+                "locked": {"type": "boolean"},
+                "clipping": {"type": "boolean"},
+            }),
+            &["session", "id"],
+        ),
+        def(
+            "set_editor",
+            "Set shared editor state: foreground/background colours, brush size and hardness, \
+             tool opacity, magic-wand tolerance, transform resampling.",
+            json!({
+                "session": session_prop,
+                "foreground": {"type": "string", "description": "#rrggbb or #rrggbbaa"},
+                "background": {"type": "string"},
+                "brush_size": {"type": "number", "description": "Pixels"},
+                "brush_hardness": {"type": "number", "description": "0 soft .. 1 hard"},
+                "tool_opacity": {"type": "number", "description": "0..1"},
+                "tolerance": {"type": "integer", "description": "0..255"},
+                "resample": {"type": "string", "enum": ["nearest", "bilinear", "bicubic"]},
+            }),
+            &["session"],
+        ),
+        def(
+            "render",
+            "Composite the document (or a region) and return it as a PNG image, downscaled to \
+             max_dim for viewing. Pass path to also write the full-resolution PNG to disk.",
+            json!({
+                "session": session_prop,
+                "x": {"type": "integer"},
+                "y": {"type": "integer"},
+                "width": {"type": "integer"},
+                "height": {"type": "integer"},
+                "max_dim": {"type": "integer", "description": "Longest edge of the returned preview (default 1024)"},
+                "path": {"type": "string", "description": "Also write full-resolution PNG here"},
+            }),
+            &["session"],
+        ),
+        def(
+            "save",
+            "Save the document, codec chosen by extension (.psd/.psb keeps layers; raster \
+             formats flatten). Defaults to the path it was opened from.",
+            json!({
+                "session": session_prop,
+                "path": {"type": "string", "description": "Target path; optional when the document already has one"},
+            }),
+            &["session"],
+        ),
+        def(
+            "export",
+            "Export a flattened copy with encoder settings, leaving the document's own path \
+             untouched.",
+            json!({
+                "session": session_prop,
+                "path": {"type": "string"},
+                "quality": {"type": "integer", "description": "1..100 for lossy formats (default 90)"},
+                "bit_depth": {"type": "integer", "description": "Bits per channel where the format supports a choice (default 8)"},
+                "dither": {"type": "boolean", "description": "Dither when reducing depth (default true)"},
+            }),
+            &["session", "path"],
+        ),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn colours_parse_in_every_hex_form() {
+        assert_eq!(parse_color("#fff").unwrap(), Rgba::new(1.0, 1.0, 1.0, 1.0));
+        assert_eq!(
+            parse_color("#ff0000").unwrap(),
+            Rgba::new(1.0, 0.0, 0.0, 1.0)
+        );
+        assert_eq!(
+            parse_color("00ff0080").unwrap(),
+            Rgba::new(0.0, 1.0, 0.0, 128.0 / 255.0)
+        );
+        assert!(parse_color("#zzz").is_err());
+        assert!(parse_color("#ffff").is_err());
+        assert_eq!(color_hex(Rgba::new(1.0, 0.0, 0.0, 1.0)), "#ff0000ff");
+    }
+
+    #[test]
+    fn names_normalize_to_kinds_and_modes() {
+        assert_eq!(
+            parse_adjustment_kind("Hue/Saturation").unwrap(),
+            AdjustmentKind::HueSaturation
+        );
+        assert_eq!(
+            parse_adjustment_kind("brightness-contrast").unwrap(),
+            AdjustmentKind::BrightnessContrast
+        );
+        assert!(parse_adjustment_kind("sepia").is_err());
+        assert_eq!(
+            parse_blend_mode("soft light").unwrap(),
+            BlendMode::SoftLight
+        );
+        assert_eq!(parse_blend_mode("MULTIPLY").unwrap(), BlendMode::Multiply);
+        assert!(parse_blend_mode("bogus").is_err());
+    }
+
+    #[test]
+    fn option_values_coerce_by_kind() {
+        let choice = OptionKind::Choice(&["Mosaic", "Crystals"]);
+        assert_eq!(
+            coerce_option(&json!("crystals"), choice).unwrap(),
+            OptionValue::Choice(1)
+        );
+        assert_eq!(
+            coerce_option(&json!(1), choice).unwrap(),
+            OptionValue::Choice(1)
+        );
+        assert!(coerce_option(&json!("nope"), choice).is_err());
+        let slider = OptionKind::Slider {
+            min: 0.0,
+            max: 10.0,
+            suffix: "",
+        };
+        assert_eq!(
+            coerce_option(&json!(4.5), slider).unwrap(),
+            OptionValue::Num(4.5)
+        );
+        assert_eq!(
+            coerce_option(&json!(true), OptionKind::Toggle).unwrap(),
+            OptionValue::Bool(true)
+        );
+    }
+}

--- a/crates/mcp/src/session.rs
+++ b/crates/mcp/src/session.rs
@@ -658,13 +658,21 @@ mod tests {
             .unwrap();
         let (_, painted) = session.render(None).unwrap();
         assert!(
-            painted.chunks_exact(4).any(|p| p[0] > 200 && p[1] < 100),
+            painted
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .any(|p| p[0] > 200 && p[1] < 100),
             "the stroke left no red pixels"
         );
         session.run_command("edit.undo").unwrap();
         let (_, restored) = session.render(None).unwrap();
         assert!(
-            restored.chunks_exact(4).all(|p| p[0] > 240 && p[1] > 240),
+            restored
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .all(|p| p[0] > 240 && p[1] > 240),
             "undo did not put the white background back"
         );
     }
@@ -704,7 +712,11 @@ mod tests {
             .unwrap();
         let (_, inverted) = session.render(None).unwrap();
         assert!(
-            inverted.chunks_exact(4).all(|p| p[0] < 15 && p[1] < 15),
+            inverted
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .all(|p| p[0] < 15 && p[1] < 15),
             "inverting white did not give black"
         );
         session.run_command("edit.undo").unwrap();

--- a/crates/mcp/src/session.rs
+++ b/crates/mcp/src/session.rs
@@ -1,0 +1,731 @@
+//! One editing session: a document plus the same plugin registry and
+//! editor state the GPUI shell would hold for a window.
+//!
+//! The methods here are the headless counterparts of `Workspace`'s
+//! document-editing paths — same registry, same history semantics, same
+//! selection-feathered filter writes — minus everything that needs a
+//! window (view transforms, previews, system clipboard, dialogs).
+
+use anyhow::{anyhow, bail, Context as _, Result};
+use schist_core::color::{Depth, Rgba};
+use schist_core::{
+    blit_rgba8, AdjustmentKind, Document, IntRect, Layer, LayerId, LayerKind, TileCoord, TILE_SIZE,
+};
+use schist_plugin_api::{
+    CodecPlugin, CommandCtx, EditorState, ExportOptions, FilterValues, Modifiers, OptionValue,
+    PluginManifest, PluginRegistry, PointerInput, ToolCtx,
+};
+use std::path::{Path, PathBuf};
+
+/// PSD/PSB import and export via `schist-codec-psd` — the same wrapper the
+/// app shell registers.
+struct PsdCodec;
+
+impl CodecPlugin for PsdCodec {
+    fn id(&self) -> &'static str {
+        "codec.psd"
+    }
+    fn name(&self) -> &'static str {
+        "Photoshop PSD"
+    }
+    fn extensions(&self) -> &'static [&'static str] {
+        &["psd", "psb"]
+    }
+    fn probe(&self, bytes: &[u8]) -> bool {
+        schist_codec_psd::is_psd(bytes)
+    }
+    fn import(&self, bytes: &[u8]) -> Result<Document> {
+        Ok(schist_codec_psd::read_psd(bytes)?)
+    }
+    fn can_export(&self) -> bool {
+        true
+    }
+    fn export(&self, doc: &Document) -> Result<Vec<u8>> {
+        Ok(schist_codec_psd::write_psd(doc)?)
+    }
+}
+
+struct PsdPlugin;
+
+impl PluginManifest for PsdPlugin {
+    fn id(&self) -> &'static str {
+        "schist.codec-psd"
+    }
+    fn register(&self, registry: &mut PluginRegistry) {
+        registry.register_codec(Box::new(PsdCodec));
+    }
+}
+
+/// The same first-party plugin set `schist-app` assembles, plus any
+/// installed third-party WebAssembly plugins. Each session gets its own
+/// registry because tools carry per-gesture state.
+fn build_registry() -> (PluginRegistry, schist_plugin_host_wasm::PluginManager) {
+    let mut registry = PluginRegistry::new();
+    let manifests: Vec<Box<dyn PluginManifest>> = vec![
+        Box::new(schist_tools_basic::BasicToolsPlugin),
+        Box::new(schist_tools_paint::PaintToolsPlugin),
+        Box::new(schist_tools_retouch::RetouchToolsPlugin),
+        Box::new(schist_tools_warp::WarpToolsPlugin),
+        Box::new(schist_tools_doc::DocToolsPlugin),
+        Box::new(schist_tools_select::SelectToolsPlugin),
+        Box::new(schist_tools_transform::TransformToolsPlugin),
+        Box::new(schist_tools_vector::VectorToolsPlugin),
+        Box::new(schist_tools_type::TypeToolsPlugin),
+        Box::new(schist_commands_core::CoreCommandsPlugin),
+        Box::new(schist_filters_core::CoreFiltersPlugin),
+        Box::new(schist_codecs_common::CommonCodecsPlugin),
+        Box::new(PsdPlugin),
+    ];
+    for manifest in manifests {
+        manifest.register(&mut registry);
+    }
+    let manager = match schist_plugin_host_wasm::PluginManager::plugin_dir() {
+        Some(dir) => schist_plugin_host_wasm::PluginManager::load_dir(&dir, &mut registry),
+        None => schist_plugin_host_wasm::PluginManager::default(),
+    };
+    (registry, manager)
+}
+
+pub struct Session {
+    pub doc: Document,
+    pub state: EditorState,
+    pub registry: PluginRegistry,
+    /// Keeps loaded WASM plugins alive for the session's lifetime.
+    _wasm: schist_plugin_host_wasm::PluginManager,
+}
+
+impl Session {
+    /// A blank document with a white Background layer, like File ▸ New.
+    pub fn new_blank(title: &str, width: u32, height: u32, depth: Depth) -> Result<Session> {
+        if width == 0 || height == 0 || width > 30_000 || height > 30_000 {
+            bail!("document size must be 1..=30000 in each dimension");
+        }
+        let mut doc = Document::new(title, width, height, depth);
+        let mut bg = Layer::new_raster("Background");
+        let white = vec![255u8; width as usize * height as usize * 4];
+        blit_rgba8(
+            &mut bg.as_raster_mut().unwrap().tiles,
+            depth,
+            IntRect::from_size(width, height),
+            &white,
+        );
+        doc.push_layer(bg);
+        doc.dirty = false;
+        Ok(Session::install(doc))
+    }
+
+    /// Open a file through the codec registry, like File ▸ Open.
+    pub fn open(path: &Path) -> Result<Session> {
+        let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+        let (registry, wasm) = build_registry();
+        let ext = path.extension().and_then(|e| e.to_str());
+        let codec = registry
+            .codec_for(&bytes, ext)
+            .ok_or_else(|| anyhow!("no codec for {}", path.display()))?;
+        let mut doc = codec.import(&bytes)?;
+        doc.title = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "Untitled".into());
+        doc.path = Some(path.to_path_buf());
+        doc.snapshot_history_source();
+        let mut session = Session {
+            doc,
+            state: EditorState::default(),
+            registry,
+            _wasm: wasm,
+        };
+        session.after_change();
+        Ok(session)
+    }
+
+    fn install(mut doc: Document) -> Session {
+        doc.snapshot_history_source();
+        let (registry, wasm) = build_registry();
+        Session {
+            doc,
+            state: EditorState::default(),
+            registry,
+            _wasm: wasm,
+        }
+    }
+
+    // ----- commands -----
+
+    pub fn run_command(&mut self, id: &str) -> Result<String> {
+        // Grow, Similar and Color Range take their tolerance from the
+        // magic wand, exactly as the app does.
+        self.sync_wand_tolerance();
+        let command = self
+            .registry
+            .command(id)
+            .ok_or_else(|| anyhow!("unknown command {id:?}"))?;
+        let mut ctx = CommandCtx {
+            doc: &mut self.doc,
+            state: &mut self.state,
+        };
+        (command.run)(&mut ctx);
+        let title = command.title.to_string();
+        self.after_change();
+        Ok(title)
+    }
+
+    fn sync_wand_tolerance(&mut self) {
+        if let Some(option) = self
+            .registry
+            .tools()
+            .find(|t| t.id() == "wand")
+            .and_then(|t| t.options().into_iter().find(|o| o.key == "wand-tolerance"))
+        {
+            self.state.tolerance = option.value.num().round().clamp(0.0, 255.0) as u8;
+        }
+    }
+
+    // ----- tools -----
+
+    pub fn activate_tool(&mut self, id: &str) -> Result<&'static str> {
+        let previous = self.state.active_tool;
+        if previous != id {
+            if let Some(tool) = self.registry.tool_mut(previous) {
+                let mut ctx = ToolCtx {
+                    doc: &mut self.doc,
+                    state: &mut self.state,
+                };
+                tool.on_deactivate(&mut ctx);
+            }
+        }
+        let static_id = {
+            let tool = self
+                .registry
+                .tool_mut(id)
+                .ok_or_else(|| anyhow!("unknown tool {id:?}"))?;
+            tool.id()
+        };
+        self.state.active_tool = static_id;
+        let tool = self.registry.tool_mut(static_id).unwrap();
+        let mut ctx = ToolCtx {
+            doc: &mut self.doc,
+            state: &mut self.state,
+        };
+        tool.on_activate(&mut ctx);
+        self.after_change();
+        Ok(static_id)
+    }
+
+    pub fn set_tool_option(&mut self, key: &str, value: OptionValue) -> Result<()> {
+        let tool_id = self.state.active_tool;
+        let tool = self
+            .registry
+            .tool_mut(tool_id)
+            .ok_or_else(|| anyhow!("no active tool"))?;
+        let key = tool
+            .options()
+            .iter()
+            .map(|o| o.key)
+            .find(|k| *k == key)
+            .ok_or_else(|| {
+                anyhow!(
+                    "tool {tool_id:?} has no option {key:?} (has: {:?})",
+                    tool.options().iter().map(|o| o.key).collect::<Vec<_>>()
+                )
+            })?;
+        tool.set_option(key, value);
+        let tool = self.registry.tool_mut(tool_id).unwrap();
+        let mut ctx = ToolCtx {
+            doc: &mut self.doc,
+            state: &mut self.state,
+        };
+        tool.on_option_changed(&mut ctx, key);
+        self.after_change();
+        Ok(())
+    }
+
+    /// Drive the active tool through a full gesture: pointer down on the
+    /// first point, moves through the rest, up on the last.
+    pub fn stroke(
+        &mut self,
+        points: &[(f32, f32)],
+        pressure: f32,
+        modifiers: Modifiers,
+    ) -> Result<()> {
+        if points.is_empty() {
+            bail!("stroke needs at least one point");
+        }
+        let tool_id = self.state.active_tool;
+        if self.registry.tool_mut(tool_id).is_none() {
+            bail!("no active tool");
+        }
+        let input = |&(x, y): &(f32, f32)| PointerInput {
+            x,
+            y,
+            pressure,
+            modifiers,
+        };
+        let tool = self.registry.tool_mut(tool_id).unwrap();
+        let mut ctx = ToolCtx {
+            doc: &mut self.doc,
+            state: &mut self.state,
+        };
+        tool.on_pointer_down(&mut ctx, input(&points[0]));
+        for point in &points[1..] {
+            tool.on_pointer_move(&mut ctx, input(point));
+        }
+        tool.on_pointer_up(&mut ctx, input(points.last().unwrap()));
+        self.after_change();
+        Ok(())
+    }
+
+    /// Enter / Escape / raw keys for modal tools (free transform, crop,
+    /// the type tool's text entry).
+    pub fn tool_input(
+        &mut self,
+        action: &str,
+        key: Option<&str>,
+        text: Option<&str>,
+        modifiers: Modifiers,
+    ) -> Result<bool> {
+        let tool_id = self.state.active_tool;
+        let tool = self
+            .registry
+            .tool_mut(tool_id)
+            .ok_or_else(|| anyhow!("no active tool"))?;
+        let mut ctx = ToolCtx {
+            doc: &mut self.doc,
+            state: &mut self.state,
+        };
+        let consumed = match action {
+            "commit" => {
+                tool.on_commit(&mut ctx);
+                true
+            }
+            "cancel" => {
+                tool.on_cancel(&mut ctx);
+                true
+            }
+            "key" => {
+                let key = key.ok_or_else(|| anyhow!("action \"key\" needs a key name"))?;
+                tool.on_key(&mut ctx, key, text, modifiers)
+            }
+            other => bail!("unknown action {other:?} (expected key, commit or cancel)"),
+        };
+        self.after_change();
+        Ok(consumed)
+    }
+
+    // ----- filters and destructive adjustments -----
+
+    pub fn apply_filter(&mut self, id: &str, values: &[(String, f64)]) -> Result<String> {
+        let filter = self
+            .registry
+            .filters()
+            .find(|f| f.id() == id)
+            .ok_or_else(|| anyhow!("unknown filter {id:?}"))?;
+        let params = filter.params();
+        let mut resolved = FilterValues::defaults(&params);
+        for (key, value) in values {
+            let key = params
+                .iter()
+                .map(|p| p.key)
+                .find(|k| k == key)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "filter {id:?} has no parameter {key:?} (has: {:?})",
+                        params.iter().map(|p| p.key).collect::<Vec<_>>()
+                    )
+                })?;
+            resolved.set(key, *value as f32);
+        }
+        let name = filter.name().to_string();
+        let (layer_id, region) = self.filter_target()?;
+        let original = self
+            .read_region(layer_id, region)
+            .ok_or_else(|| anyhow!("layer pixels unreadable"))?;
+        let mut buf = original.clone();
+        let filter = self.registry.filters().find(|f| f.id() == id).unwrap();
+        filter.apply(
+            &mut buf,
+            region.width() as usize,
+            region.height() as usize,
+            &resolved,
+        );
+        self.write_region(layer_id, region, &original, &buf, &name);
+        self.after_change();
+        Ok(name)
+    }
+
+    /// Image ▸ Adjustments: apply an adjustment straight onto the active
+    /// layer's pixels, as one history entry.
+    pub fn apply_adjustment(
+        &mut self,
+        kind: AdjustmentKind,
+        params: Option<schist_adjustments::Params>,
+    ) -> Result<String> {
+        let params = params.unwrap_or_else(|| schist_adjustments::Params::default_for(kind));
+        let (layer_id, region) = self.filter_target()?;
+        let original = self
+            .read_region(layer_id, region)
+            .ok_or_else(|| anyhow!("layer pixels unreadable"))?;
+        let mut buf = original.clone();
+        params.apply_buffer(&mut buf);
+        let name = kind.display_name().to_string();
+        self.write_region(layer_id, region, &original, &buf, &name);
+        self.after_change();
+        Ok(name)
+    }
+
+    /// The active raster layer and the region a filter would touch —
+    /// the selection's bounds when there is one, the layer's otherwise.
+    fn filter_target(&self) -> Result<(LayerId, IntRect)> {
+        let layer_id = self
+            .doc
+            .active_layer
+            .ok_or_else(|| anyhow!("select a layer first"))?;
+        if self
+            .doc
+            .tree
+            .find(layer_id)
+            .and_then(|l| l.as_raster())
+            .is_none()
+        {
+            bail!("filters need a pixel layer");
+        }
+        let canvas = self.doc.canvas_rect();
+        let region = if self.doc.selection.is_empty() {
+            self.doc
+                .tree
+                .find(layer_id)
+                .map(|l| l.content_bounds())
+                .unwrap_or(IntRect::EMPTY)
+                .intersect(&canvas)
+        } else {
+            self.doc.selection.bounds().intersect(&canvas)
+        };
+        if region.is_empty() {
+            bail!("nothing to filter");
+        }
+        Ok((layer_id, region))
+    }
+
+    /// Pull `region` out of a raster layer into a flat straight-alpha
+    /// f32 RGBA buffer, the shape every filter works on.
+    fn read_region(&self, layer_id: LayerId, region: IntRect) -> Option<Vec<f32>> {
+        let raster = self.doc.tree.find(layer_id).and_then(|l| l.as_raster())?;
+        let (w, h) = (region.width() as usize, region.height() as usize);
+        let mut buf = vec![0.0f32; w * h * 4];
+        for y in 0..h {
+            for x in 0..w {
+                let px = raster
+                    .tiles
+                    .pixel(region.left + x as i32, region.top + y as i32);
+                let at = (y * w + x) * 4;
+                buf[at] = px.r;
+                buf[at + 1] = px.g;
+                buf[at + 2] = px.b;
+                buf[at + 3] = px.a;
+            }
+        }
+        Some(buf)
+    }
+
+    /// Blend `filtered` back over `original` through the selection, as one
+    /// history entry, so partial coverage feathers the result.
+    fn write_region(
+        &mut self,
+        layer_id: LayerId,
+        region: IntRect,
+        original: &[f32],
+        filtered: &[f32],
+        label: &str,
+    ) {
+        let selection = self.doc.selection.clone();
+        let coords: Vec<TileCoord> = TileCoord::covering(&region).collect();
+        let mut edit = self.doc.begin_edit(label.to_string());
+        for coord in coords {
+            let clip = coord.rect().intersect(&region);
+            if clip.is_empty() {
+                continue;
+            }
+            let Some(tile) = edit.writable_tile(layer_id, coord) else {
+                break;
+            };
+            let trect = coord.rect();
+            let w = region.width() as usize;
+            for y in clip.top..clip.bottom {
+                for x in clip.left..clip.right {
+                    let cov = selection.coverage(x, y) as f32 / 255.0;
+                    if cov <= 0.0 {
+                        continue;
+                    }
+                    let src = ((y - region.top) as usize * w + (x - region.left) as usize) * 4;
+                    let ix = ((y - trect.top) * TILE_SIZE + (x - trect.left)) as usize;
+                    let mix = |a: f32, b: f32| a + (b - a) * cov;
+                    tile.set(
+                        ix,
+                        Rgba::new(
+                            mix(original[src], filtered[src]),
+                            mix(original[src + 1], filtered[src + 1]),
+                            mix(original[src + 2], filtered[src + 2]),
+                            mix(original[src + 3], filtered[src + 3]),
+                        ),
+                    );
+                }
+            }
+        }
+        edit.commit();
+    }
+
+    // ----- rendering -----
+
+    /// Composite `region` (or the whole canvas) to straight-alpha RGBA8,
+    /// with shape and style caches refreshed first.
+    pub fn render(&mut self, region: Option<IntRect>) -> Result<(IntRect, Vec<u8>)> {
+        self.after_change();
+        let canvas = self.doc.canvas_rect();
+        let region = region.map(|r| r.intersect(&canvas)).unwrap_or(canvas);
+        if region.is_empty() {
+            bail!("render region is empty");
+        }
+        let pixels = schist_compositor::composite_region_rgba8(&self.doc, region);
+        Ok((region, pixels))
+    }
+
+    // ----- saving -----
+
+    fn exporter_for(&self, path: &Path) -> Option<&dyn CodecPlugin> {
+        let ext = path.extension()?.to_str()?.to_ascii_lowercase();
+        self.registry
+            .codecs()
+            .find(|c| c.can_export() && c.extensions().contains(&ext.as_str()))
+    }
+
+    /// File ▸ Save (As): serialize by extension and adopt the path.
+    pub fn save(&mut self, path: &Path) -> Result<()> {
+        // Raster formats flatten through the compositor, which reads the
+        // styled-raster caches — bring them up to date first.
+        self.after_change();
+        let codec = self.exporter_for(path).ok_or_else(|| {
+            anyhow!(
+                "no exporter for .{} — exportable: {}",
+                path.extension().and_then(|e| e.to_str()).unwrap_or(""),
+                self.export_extensions().join(", ")
+            )
+        })?;
+        let bytes = codec.export(&self.doc)?;
+        write_atomically(path, &bytes)?;
+        self.doc.dirty = false;
+        self.doc.path = Some(path.to_path_buf());
+        if let Some(name) = path.file_name() {
+            self.doc.title = name.to_string_lossy().into_owned();
+        }
+        Ok(())
+    }
+
+    /// File ▸ Export: flattened export with encoder settings, leaving the
+    /// document's own path alone.
+    pub fn export(&mut self, path: &Path, options: &ExportOptions) -> Result<()> {
+        self.after_change();
+        let codec = self.exporter_for(path).ok_or_else(|| {
+            anyhow!(
+                "no exporter for .{} — exportable: {}",
+                path.extension().and_then(|e| e.to_str()).unwrap_or(""),
+                self.export_extensions().join(", ")
+            )
+        })?;
+        let bytes = codec.export_with(&self.doc, options)?;
+        write_atomically(path, &bytes)
+    }
+
+    fn export_extensions(&self) -> Vec<String> {
+        self.registry
+            .codecs()
+            .filter(|c| c.can_export())
+            .flat_map(|c| c.extensions().iter().map(|e| e.to_string()))
+            .collect()
+    }
+
+    // ----- derived caches -----
+
+    /// The headless counterpart of the shell's `after_change`: re-rasterize
+    /// stale vector shapes, rebuild stale layer-effect rasters, and drop
+    /// the damage (there is no display cache here to invalidate).
+    pub fn after_change(&mut self) {
+        let depth = self.doc.depth;
+        let canvas = self.doc.canvas_rect();
+        let mut grew = Vec::new();
+        reshape_layers(&mut self.doc.tree.layers, depth, canvas, &mut grew);
+        restyle_layers(&mut self.doc.tree.layers, &mut grew);
+        for rect in grew {
+            self.doc.add_damage(rect);
+        }
+        self.doc.take_damage();
+    }
+}
+
+fn write_atomically(path: &Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)?;
+        }
+    }
+    let tmp: PathBuf = path.with_extension("schist-tmp");
+    std::fs::write(&tmp, bytes)?;
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+/// Re-rasterize any shape layer whose path, fill or stroke has moved.
+fn reshape_layers(layers: &mut [Layer], depth: Depth, canvas: IntRect, damage: &mut Vec<IntRect>) {
+    for layer in layers.iter_mut() {
+        if let LayerKind::Group(g) = &mut layer.kind {
+            reshape_layers(&mut g.children, depth, canvas, damage);
+        }
+        let Some(shape) = layer.shape.as_deref() else {
+            continue;
+        };
+        let key = shape.key();
+        if layer.shape_key == key {
+            continue;
+        }
+        let before = layer.content_bounds();
+        let tiles = schist_tools_vector::render_shape(shape, depth, canvas);
+        if let Some(raster) = layer.as_raster_mut() {
+            raster.tiles = tiles;
+        }
+        layer.shape_key = key;
+        layer.styled = None;
+        damage.push(before);
+        damage.push(layer.content_bounds());
+    }
+}
+
+/// Rebuild stale styled rasters (layer effects), collecting changed areas.
+fn restyle_layers(layers: &mut [Layer], damage: &mut Vec<IntRect>) {
+    for layer in layers.iter_mut() {
+        if let LayerKind::Group(g) = &mut layer.kind {
+            restyle_layers(&mut g.children, damage);
+        }
+        if layer.style.is_empty() {
+            if let Some(old) = layer.styled.take() {
+                damage.push(old.bounds);
+            }
+            continue;
+        }
+        let key = fx_key(layer);
+        if layer.styled.as_ref().map(|s| s.key) == Some(key) {
+            continue;
+        }
+        let before = layer.styled.as_ref().map(|s| s.bounds);
+        layer.styled = schist_layer_fx::render(layer).map(|mut r| {
+            r.key = key;
+            std::sync::Arc::new(r)
+        });
+        if let Some(b) = before {
+            damage.push(b);
+        }
+        if let Some(s) = &layer.styled {
+            damage.push(s.bounds);
+        }
+    }
+}
+
+/// Fingerprint of everything a styled raster depends on.
+fn fx_key(layer: &Layer) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = rustc_hash::FxHasher::default();
+    format!("{:?}", layer.style).hash(&mut h);
+    layer.fill_opacity.to_bits().hash(&mut h);
+    if let Some(r) = layer.as_raster() {
+        r.tiles.fingerprint().hash(&mut h);
+    }
+    h.finish()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn blank() -> Session {
+        Session::new_blank("test", 64, 48, Depth::Eight).unwrap()
+    }
+
+    #[test]
+    fn a_brush_stroke_paints_and_undo_restores() {
+        let mut session = blank();
+        session.state.foreground = Rgba::new(1.0, 0.0, 0.0, 1.0);
+        session.activate_tool("brush").unwrap();
+        session
+            .stroke(&[(10.0, 10.0), (50.0, 30.0)], 1.0, Modifiers::default())
+            .unwrap();
+        let (_, painted) = session.render(None).unwrap();
+        assert!(
+            painted.chunks_exact(4).any(|p| p[0] > 200 && p[1] < 100),
+            "the stroke left no red pixels"
+        );
+        session.run_command("edit.undo").unwrap();
+        let (_, restored) = session.render(None).unwrap();
+        assert!(
+            restored.chunks_exact(4).all(|p| p[0] > 240 && p[1] > 240),
+            "undo did not put the white background back"
+        );
+    }
+
+    #[test]
+    fn commands_and_filters_run_by_registry_id() {
+        let mut session = blank();
+        session.run_command("layer.duplicate").unwrap();
+        assert_eq!(session.doc.tree.layers.len(), 2);
+        assert!(session.run_command("no.such.command").is_err());
+
+        // A blur over a painted layer changes pixels; an unknown filter or
+        // parameter is refused by name.
+        session.state.foreground = Rgba::new(0.0, 0.0, 1.0, 1.0);
+        session.activate_tool("pencil").unwrap();
+        session
+            .stroke(&[(0.0, 24.0), (63.0, 24.0)], 1.0, Modifiers::default())
+            .unwrap();
+        let (_, before) = session.render(None).unwrap();
+        session
+            .apply_filter("filter.gaussian_blur", &[("radius".into(), 4.0)])
+            .unwrap();
+        let (_, after) = session.render(None).unwrap();
+        assert_ne!(before, after);
+        assert!(session.apply_filter("filter.nope", &[]).is_err());
+        assert!(session
+            .apply_filter("filter.gaussian_blur", &[("nope".into(), 1.0)])
+            .is_err());
+    }
+
+    #[test]
+    fn adjustments_apply_destructively_as_one_edit() {
+        let mut session = blank();
+        let (_, before) = session.render(None).unwrap();
+        session
+            .apply_adjustment(AdjustmentKind::Invert, None)
+            .unwrap();
+        let (_, inverted) = session.render(None).unwrap();
+        assert!(
+            inverted.chunks_exact(4).all(|p| p[0] < 15 && p[1] < 15),
+            "inverting white did not give black"
+        );
+        session.run_command("edit.undo").unwrap();
+        let (_, restored) = session.render(None).unwrap();
+        assert_eq!(before, restored);
+    }
+
+    #[test]
+    fn a_selection_confines_a_filter() {
+        let mut session = blank();
+        session.activate_tool("marquee.rect").unwrap();
+        session
+            .stroke(&[(0.0, 0.0), (32.0, 48.0)], 1.0, Modifiers::default())
+            .unwrap();
+        assert!(!session.doc.selection.is_empty());
+        session
+            .apply_adjustment(AdjustmentKind::Invert, None)
+            .unwrap();
+        let (_, pixels) = session.render(None).unwrap();
+        let px = |x: usize, y: usize| &pixels[(y * 64 + x) * 4..(y * 64 + x) * 4 + 4];
+        assert!(px(10, 24)[0] < 15, "inside the selection stays white");
+        assert!(px(50, 24)[0] > 240, "outside the selection went dark");
+    }
+}

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,54 @@
+# The MCP server
+
+`schist-mcp` exposes Schist to [Model Context Protocol] clients — Claude
+Code, Claude Desktop, or anything else that speaks MCP over stdio. It
+links the kernel and the same first-party plugin set the app assembles
+(plus any installed WebAssembly plugins), so it needs no window, no GPU
+and no display: everything runs headless through the same registry,
+undo history and compositor the GUI uses.
+
+[Model Context Protocol]: https://modelcontextprotocol.io
+
+```sh
+cargo build --release -p schist-mcp
+```
+
+Register the binary with your client, e.g. for Claude Code:
+
+```sh
+claude mcp add schist -- /path/to/target/release/schist-mcp
+```
+
+## Sessions
+
+Everything starts with `create_session` — open a file (PSD/PSB, PNG,
+JPEG, WebP, TIFF, or Affinity `.af`/`.afphoto`/`.afdesign`/`.afpub`) or
+create a blank document — and every other call takes the returned
+session id. Sessions are independent documents with their own tool
+state, selection and history, like the app's tabs.
+
+## What a session can do
+
+The surface is deliberately generic rather than one MCP tool per
+feature: `describe` enumerates what is installed, and four invokers
+cover all of it, so a third-party plugin dropped into
+`~/.config/schist/plugins` is as reachable as a built-in.
+
+| MCP tool | covers |
+|---|---|
+| `run_command` | every menu command, `edit.undo`/`edit.redo` included |
+| `select_tool`, `set_tool_options`, `tool_stroke`, `tool_input` | all 55 canvas tools, driven by document-space pointer gestures and commit/cancel/key input |
+| `apply_filter` | every filter, applied through the selection as one history entry |
+| `apply_adjustment` | Image ▸ Adjustments, destructively on the active layer |
+
+Around those: `get_state` (document, layer tree, selection, history,
+editor state), `set_active_layer` and `set_layer_props`, `set_editor`
+(colours, brush, tolerance), `render` (PNG of the canvas or a region,
+returned inline and optionally written to disk), and `save`/`export`
+choosing the codec by extension.
+
+The semantics match the app shell: filters read the active raster
+layer, write back feathered through the selection, and land as single
+undoable edits; tool gestures go through the same `PointerInput`
+document-space path as canvas clicks; vector shapes re-rasterize and
+layer effects rebuild before every render.


### PR DESCRIPTION
## What

`cargo build --release -p schist-mcp` now builds a [Model Context Protocol](https://modelcontextprotocol.io) server over stdio, so MCP clients (Claude Code, Claude Desktop, …) can drive Schist with no window, GPU or display. A client calls `create_session` — opening a file (PSD/PSB, PNG, JPEG, WebP, TIFF, Affinity) or creating a blank document — and passes the returned session id to everything else. Sessions are independent documents with their own tool state, selection and history, like the app's tabs.

## How

Because every feature is a plugin and the kernel never imports GPUI, the server links the exact registry `schist-app` assembles (first-party plugins, the PSD codec, sandboxed WASM plugins from `~/.config/schist/plugins`) and exposes it generically rather than one MCP tool per feature — so everything the app does is reachable by construction, third-party plugins included:

- `describe` enumerates the session's canvas tools (with live options), menu commands, filters, adjustments (with parameter shapes), codecs and blend modes
- `run_command` runs any menu command by id, `edit.undo`/`edit.redo` included
- `select_tool` / `set_tool_options` / `tool_stroke` / `tool_input` drive any tool through document-space pointer gestures plus commit/cancel/key input
- `apply_filter` / `apply_adjustment` mirror the shell's semantics: active raster layer, written back feathered through the selection, one history entry
- plus `get_state` (document, layer tree, selection, history, editor state), `set_active_layer`, `set_layer_props`, `set_editor`, `render` (inline PNG, optional full-res file), `save`/`export` by extension

`session.rs` ports the shell's headless-safe paths, including shape re-rasterization and layer-effects rebuild before every render/save, and the magic-wand tolerance sync.

## Testing

- 7 unit tests: brush stroke paints and undo restores, commands/filters by registry id, destructive adjustments as one edit, selection-confined filters, colour/blend/adjustment-name parsers, option coercion
- Verified end-to-end over the real protocol: painted a stroke, duplicated a layer, undid it, saved a PSD, reopened it, marquee-selected half the canvas, gaussian-blurred and hue-shifted it — the render showed exactly the selected half changed — then undos restored the original pixel-for-pixel
- `cargo clippy --all-targets` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)