### PR TITLE
Make opening large Affinity/PSD files fast and non-blocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5441,9 +5441,12 @@ dependencies = [
 name = "schist-codec-affinity"
 version = "0.3.0"
 dependencies = [
+ "crc32fast",
  "image",
  "log",
  "miniz_oxide",
+ "rayon",
+ "rustc-hash 2.1.3",
  "ruzstd",
  "schist-adjustments",
  "schist-color",
@@ -5465,6 +5468,8 @@ dependencies = [
  "byteorder",
  "log",
  "miniz_oxide",
+ "rayon",
+ "schist-codec-affinity",
  "schist-color",
  "schist-compositor",
  "schist-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ schist-psd-descriptor = { path = "crates/psd-descriptor" }
 miniz_oxide = "0.8"
 # zstd for Affinity 2 files; also pure Rust.
 ruzstd = "0.9"
+# SIMD CRC-32 (pure Rust with std-detected SSE4.2/PCLMUL paths).
+crc32fast = "1.5"
 schist-text-engine = { path = "crates/text-engine" }
 schist-adjustments = { path = "crates/adjustments" }
 schist-plugin-host-wasm = { path = "crates/plugin-host-wasm" }

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -926,25 +926,41 @@ impl Workspace {
         cx.notify();
     }
 
+    /// Open `path` without blocking the window: the read and decode run
+    /// on a background thread and the document is installed when ready.
     pub fn load_file(&mut self, path: PathBuf, cx: &mut Context<Self>) {
-        let result = (|| -> anyhow::Result<Document> {
-            let bytes = std::fs::read(&path)?;
-            let ext = path.extension().and_then(|e| e.to_str());
-            let codec = self
-                .registry
-                .codec_for(&bytes, ext)
-                .ok_or_else(|| anyhow::anyhow!("no codec for {}", path.display()))?;
-            let mut doc = codec.import(&bytes)?;
-            doc.title = path
-                .file_name()
-                .map(|n| n.to_string_lossy().into_owned())
-                .unwrap_or_else(|| "Untitled".into());
-            doc.path = Some(path.clone());
-            Ok(doc)
-        })();
+        self.status = format!("Opening {}\u{2026}", path.display()).into();
+        cx.notify();
+        let codecs = self.registry.shared_codecs();
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move { decode_file(&codecs, &path) })
+                .await;
+            this.update(cx, |ws, cx| {
+                ws.finish_load(result, cx);
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    /// The synchronous version of [`Self::load_file`], for the recovery
+    /// path, which fixes up the document as soon as it is installed.
+    fn load_file_sync(&mut self, path: PathBuf, cx: &mut Context<Self>) {
+        let result = decode_file(&self.registry.shared_codecs(), &path);
+        self.finish_load(result, cx);
+        cx.notify();
+    }
+
+    fn finish_load(&mut self, result: anyhow::Result<Document>, cx: &mut Context<Self>) {
         match result {
             Ok(doc) => {
-                self.status = format!("Opened {}", path.display()).into();
+                self.status = match &doc.path {
+                    Some(p) => format!("Opened {}", p.display()).into(),
+                    None => format!("Opened {}", doc.title).into(),
+                };
                 self.install_document(doc);
                 self.offer_missing_fonts(cx);
             }
@@ -953,7 +969,6 @@ impl Workspace {
                 self.status = format!("Open failed: {err}").into();
             }
         }
-        cx.notify();
     }
 
     /// Serialize the document to `path`, choosing the codec by extension.
@@ -1108,7 +1123,7 @@ impl Workspace {
 
     /// Load a recovery snapshot and mark it dirty (it has no real path).
     pub fn recover_from(&mut self, path: PathBuf, cx: &mut Context<Self>) {
-        self.load_file(path.clone(), cx);
+        self.load_file_sync(path.clone(), cx);
         if let Some(doc) = &mut self.doc {
             doc.path = None;
             doc.dirty = true;
@@ -3819,18 +3834,49 @@ impl Workspace {
             ((doc.width as f32 / scale) as u32).clamp(1, MAX),
             ((doc.height as f32 / scale) as u32).clamp(1, 84),
         );
-        let rgba = schist_compositor::composite_region_rgba8(doc, doc.canvas_rect());
+        // Point-sample through the shared tile cache rather than
+        // compositing the whole canvas at full resolution: tiles the
+        // viewport has already composited are reused, an edit
+        // recomposites only the tiles it damaged, and no canvas-sized
+        // full-resolution buffer ever exists.
+        let sxs: Vec<u32> = (0..w)
+            .map(|tx| (((tx as f32 + 0.5) * scale) as u32).min(doc.width - 1))
+            .collect();
+        let sys: Vec<u32> = (0..h)
+            .map(|ty| (((ty as f32 + 0.5) * scale) as u32).min(doc.height - 1))
+            .collect();
+        let dedup = |v: &[u32]| {
+            let mut t: Vec<i32> = v
+                .iter()
+                .map(|&s| (s as i32).div_euclid(TILE_SIZE))
+                .collect();
+            t.dedup();
+            t
+        };
+        let (tcols, trows) = (dedup(&sxs), dedup(&sys));
+        let coords: Vec<TileCoord> = trows
+            .iter()
+            .flat_map(|&ty| tcols.iter().map(move |&tx| TileCoord { tx, ty }))
+            .collect();
+        self.cache.prewarm(doc, &coords);
         let mut bgra = vec![0u8; (w * h * 4) as usize];
         for ty in 0..h {
             for tx in 0..w {
-                let sx = ((tx as f32 + 0.5) * scale) as u32;
-                let sy = ((ty as f32 + 0.5) * scale) as u32;
-                let s = ((sy.min(doc.height - 1) * doc.width + sx.min(doc.width - 1)) * 4) as usize;
+                let (sx, sy) = (sxs[tx as usize] as i32, sys[ty as usize] as i32);
+                let tile = self.cache.get(
+                    doc,
+                    TileCoord {
+                        tx: sx.div_euclid(TILE_SIZE),
+                        ty: sy.div_euclid(TILE_SIZE),
+                    },
+                );
+                let s = ((sy.rem_euclid(TILE_SIZE) * TILE_SIZE + sx.rem_euclid(TILE_SIZE)) * 4)
+                    as usize;
                 let (r, g, b, a) = (
-                    rgba[s] as u32,
-                    rgba[s + 1] as u32,
-                    rgba[s + 2] as u32,
-                    rgba[s + 3] as u32,
+                    tile[s] as u32,
+                    tile[s + 1] as u32,
+                    tile[s + 2] as u32,
+                    tile[s + 3] as u32,
                 );
                 let bg = if ((tx >> 2) + (ty >> 2)) & 1 == 0 {
                     0xE0
@@ -6015,6 +6061,33 @@ fn install_faces(faces: &[crate::fonts::Face]) -> Result<usize, String> {
         installed += 1;
     }
     Ok(installed)
+}
+
+/// Read and decode a document file. Blocking and potentially seconds of
+/// work for a large layered file, so it runs on a background thread.
+fn decode_file(
+    codecs: &[Arc<dyn schist_plugin_api::CodecPlugin>],
+    path: &std::path::Path,
+) -> anyhow::Result<Document> {
+    let bytes = std::fs::read(path)?;
+    let ext = path.extension().and_then(|e| e.to_str());
+    let codec = codecs
+        .iter()
+        .find(|c| c.probe(&bytes))
+        .or_else(|| {
+            let ext = ext?.to_ascii_lowercase();
+            codecs
+                .iter()
+                .find(|c| c.extensions().contains(&ext.as_str()))
+        })
+        .ok_or_else(|| anyhow::anyhow!("no codec for {}", path.display()))?;
+    let mut doc = codec.import(&bytes)?;
+    doc.title = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "Untitled".into());
+    doc.path = Some(path.to_path_buf());
+    Ok(doc)
 }
 
 /// Fetch a model over HTTP. Blocking, so it runs on a background thread.

--- a/crates/codec-affinity/Cargo.toml
+++ b/crates/codec-affinity/Cargo.toml
@@ -21,6 +21,13 @@ serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 log.workspace = true
+# Tile decompression, channel interleave, and placement resampling are
+# all embarrassingly parallel; large documents decode minutes faster.
+rayon.workspace = true
+rustc-hash.workspace = true
+# SIMD CRC-32; every decompressed entry is checksummed, which adds up
+# to hundreds of megabytes on a large document.
+crc32fast.workspace = true
 
 [dev-dependencies]
 # Geometry tests decode the embedded thumbnail — Affinity's own render

--- a/crates/codec-affinity/examples/afbench.rs
+++ b/crates/codec-affinity/examples/afbench.rs
@@ -1,0 +1,62 @@
+//! Time each stage of an Affinity import: `afbench <file>...`
+//!
+//! Prints per-file wall times for archive parse, doc.dat extraction,
+//! graph parse, and the full import, so codec changes can be measured
+//! against a real corpus.
+
+use std::time::Instant;
+
+fn main() {
+    for path in std::env::args().skip(1) {
+        let bytes = std::fs::read(&path).expect("read file");
+        let t0 = Instant::now();
+        let archive = match schist_codec_affinity::Archive::parse(&bytes) {
+            Ok(a) => a,
+            Err(e) => {
+                println!("{path}: archive parse failed: {e}");
+                continue;
+            }
+        };
+        let t_archive = t0.elapsed();
+
+        let t1 = Instant::now();
+        let entry = archive.head("doc.dat").expect("doc.dat");
+        let doc_bytes = archive.extract(entry).expect("extract doc.dat");
+        let t_doc = t1.elapsed();
+
+        let t2 = Instant::now();
+        let full = schist_codec_affinity::read_affinity(&bytes);
+        let t_full = t2.elapsed();
+
+        if std::env::var_os("AFBENCH_LAYERS").is_some() {
+            if let Ok((doc, _)) = &full {
+                for layer in doc.tree.iter() {
+                    let b = layer.content_bounds();
+                    println!(
+                        "  layer {:?}: {}x{} at ({},{})",
+                        layer.name,
+                        b.width(),
+                        b.height(),
+                        b.left,
+                        b.top
+                    );
+                }
+            }
+        }
+        match full {
+            Ok((doc, report)) => println!(
+                "{path}: {:.1} MiB, archive {:?}, doc.dat {:?} ({} KiB), full import {:?} ({} raster layers, {} skipped, {}x{})",
+                bytes.len() as f64 / (1024.0 * 1024.0),
+                t_archive,
+                t_doc,
+                doc_bytes.len() / 1024,
+                t_full,
+                report.raster_layers,
+                report.skipped.len(),
+                doc.width,
+                doc.height,
+            ),
+            Err(e) => println!("{path}: import failed after {t_full:?}: {e}"),
+        }
+    }
+}

--- a/crates/codec-affinity/src/archive.rs
+++ b/crates/codec-affinity/src/archive.rs
@@ -126,8 +126,14 @@ pub struct Archive<'a> {
     pub creation_date: u64,
     thumb_offset: u64,
     /// Name → id, as introduced by flag-0 entries.
-    names: Vec<(String, u32)>,
+    names: rustc_hash::FxHashMap<String, u32>,
     entries: Vec<Entry>,
+    /// First-appearance order of names, for `names()`.
+    name_order: Vec<String>,
+    /// Id → index in `entries` of its newest revision. Documents hold a
+    /// tile entry per 64 KiB of pixels, and each is looked up by name;
+    /// scanning the entry table per lookup is quadratic in file size.
+    heads: rustc_hash::FxHashMap<u32, usize>,
 }
 
 pub fn is_affinity(bytes: &[u8]) -> bool {
@@ -173,10 +179,26 @@ impl<'a> Archive<'a> {
             class_tag,
             creation_date,
             thumb_offset,
-            names: Vec::new(),
+            names: Default::default(),
             entries: Vec::new(),
+            name_order: Vec::new(),
+            heads: Default::default(),
         };
         archive.parse_fats(&mut c, fat_offset)?;
+        for (at, entry) in archive.entries.iter().enumerate() {
+            match archive.heads.entry(entry.id) {
+                std::collections::hash_map::Entry::Occupied(mut o) => {
+                    // `>=` so that of two revisions in equally-dated
+                    // savepoints, the later-listed one wins.
+                    if entry.savepoint >= archive.entries[*o.get()].savepoint {
+                        o.insert(at);
+                    }
+                }
+                std::collections::hash_map::Entry::Vacant(v) => {
+                    v.insert(at);
+                }
+            }
+        }
         Ok(archive)
     }
 
@@ -249,12 +271,15 @@ impl<'a> Archive<'a> {
                 if flag == 0 {
                     let len = c.u16()? as usize;
                     let name = String::from_utf8_lossy(c.take(len)?).into_owned();
-                    match self.names.iter().find(|(n, _)| *n == name) {
-                        Some((_, existing)) if *existing != id => {
+                    match self.names.get(&name) {
+                        Some(existing) if *existing != id => {
                             return Err(malformed(format!("name {name:?} maps to two ids")));
                         }
                         Some(_) => {}
-                        None => self.names.push((name, id)),
+                        None => {
+                            self.name_order.push(name.clone());
+                            self.names.insert(name, id);
+                        }
                     }
                 }
                 self.entries.push(entry);
@@ -303,17 +328,14 @@ impl<'a> Archive<'a> {
 
     /// Names of every entry ever stored, in first-appearance order.
     pub fn names(&self) -> impl Iterator<Item = &str> {
-        self.names.iter().map(|(n, _)| n.as_str())
+        self.name_order.iter().map(|n| n.as_str())
     }
 
     /// The newest revision of `name`, if it exists and is not deleted.
     pub fn head(&self, name: &str) -> Option<&Entry> {
-        let id = self.names.iter().find(|(n, _)| n == name)?.1;
-        self.entries
-            .iter()
-            .filter(|e| e.id == id)
-            .max_by_key(|e| e.savepoint)
-            .filter(|e| e.flag != 2)
+        let id = self.names.get(name)?;
+        let entry = &self.entries[*self.heads.get(id)?];
+        (entry.flag != 2).then_some(entry)
     }
 
     /// Decode one entry: decompress, undo prediction, verify the CRC.
@@ -428,18 +450,10 @@ fn undo_deinterleave_16(data: &mut [u8]) {
     data.copy_from_slice(&out);
 }
 
-/// Standard IEEE CRC-32 (the zlib polynomial), bitwise; entries are small
-/// enough that a table isn't worth the cache.
+/// Standard IEEE CRC-32 (the zlib polynomial). Every tile of every
+/// raster layer is checksummed, so this sits on the import hot path.
 pub(crate) fn crc32(data: &[u8]) -> u32 {
-    let mut crc = 0xFFFF_FFFFu32;
-    for &b in data {
-        crc ^= b as u32;
-        for _ in 0..8 {
-            let mask = (crc & 1).wrapping_neg();
-            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
-        }
-    }
-    !crc
+    crc32fast::hash(data)
 }
 
 #[cfg(test)]

--- a/crates/codec-affinity/src/import.rs
+++ b/crates/codec-affinity/src/import.rs
@@ -19,6 +19,7 @@
 use crate::archive::Archive;
 use crate::error::{malformed, AffinityError};
 use crate::graph::{self, tag_name, Graph, Node, Value};
+use rayon::prelude::*;
 use schist_color::Depth;
 use schist_core::{blit_rgba8, Document, IntRect, Layer};
 
@@ -47,6 +48,17 @@ impl ImportReport {
     /// layered import shows the same picture Affinity would.
     pub fn complete(&self) -> bool {
         self.skipped.is_empty()
+    }
+
+    /// Fold in the report of a subtree imported on another thread.
+    fn absorb(&mut self, other: ImportReport) {
+        self.raster_layers += other.raster_layers;
+        self.groups += other.groups;
+        self.masks += other.masks;
+        self.text_layers += other.text_layers;
+        self.shapes += other.shapes;
+        self.adjustments += other.adjustments;
+        self.skipped.extend(other.skipped);
     }
 }
 
@@ -200,10 +212,11 @@ fn build(archive: &Archive, graph: &Graph) -> Result<(Document, ImportReport), A
         }
     }
 
-    for child in graph.children(spread, b"Chld") {
-        for layer in walker.layer_stack(child) {
-            doc.push_layer(layer);
-        }
+    let children = graph.children(spread, b"Chld");
+    let (layers, subreport) = walker.layer_stacks_par(&children, walker.ctm);
+    walker.report.absorb(subreport);
+    for layer in layers {
+        doc.push_layer(layer);
     }
 
     doc.damage_all();
@@ -361,6 +374,33 @@ impl Walker<'_> {
         out
     }
 
+    /// Walk sibling subtrees in parallel — decoding a layer's pixels is
+    /// the bulk of an import, and siblings are independent. Each worker
+    /// gets its own report; the merged result keeps file order.
+    fn layer_stacks_par(&self, nodes: &[&Node], ctm: Mat) -> (Vec<Layer>, ImportReport) {
+        let results: Vec<(Vec<Layer>, ImportReport)> = nodes
+            .par_iter()
+            .map(|node| {
+                let mut report = ImportReport::default();
+                let mut walker = Walker {
+                    archive: self.archive,
+                    graph: self.graph,
+                    report: &mut report,
+                    ctm,
+                };
+                let layers = walker.layer_stack(node);
+                (layers, report)
+            })
+            .collect();
+        let mut layers = Vec::new();
+        let mut report = ImportReport::default();
+        for (subtree, subreport) in results {
+            layers.extend(subtree);
+            report.absorb(subreport);
+        }
+        (layers, report)
+    }
+
     fn layer(&mut self, node: &Node) -> Option<Layer> {
         let kind = node.type_tag();
         let name = str_of(node, b"Desc").unwrap_or_default().to_string();
@@ -396,15 +436,9 @@ impl Walker<'_> {
                 self.report.groups += 1;
                 let mut group = Layer::new_group(display);
                 // Children live in the group's coordinate space.
-                let saved = self.ctm;
-                self.ctm = self.node_ctm(node);
-                let children: Vec<Layer> = self
-                    .graph
-                    .children(node, b"Chld")
-                    .into_iter()
-                    .flat_map(|c| self.layer_stack(c))
-                    .collect();
-                self.ctm = saved;
+                let nodes = self.graph.children(node, b"Chld");
+                let (children, subreport) = self.layer_stacks_par(&nodes, self.node_ctm(node));
+                self.report.absorb(subreport);
                 if let schist_core::LayerKind::Group(g) = &mut group.kind {
                     g.children = children;
                 }
@@ -1426,50 +1460,109 @@ fn affine_resample(img: &RgbaImage, map: &Mat) -> Option<(IntRect, RgbaImage)> {
     }
 
     let (iw, ih) = (img.width as i64, img.height as i64);
+    // Taps are premultiplied (so transparent neighbours don't drag
+    // colour in) but kept on the 0–255 scale; the unpremultiply ratio
+    // and the alpha write-out below are scale-invariant.
     let fetch = |x: i64, y: i64| -> [f32; 4] {
         if x < 0 || y < 0 || x >= iw || y >= ih {
             return [0.0; 4];
         }
         let at = ((y as usize * iw as usize) + x as usize) * 4;
         let p = &img.pixels[at..at + 4];
-        // Premultiplied, so transparent neighbours don't drag colour in.
-        let a = p[3] as f32 / 255.0;
+        let a = p[3] as f32;
         [p[0] as f32 * a, p[1] as f32 * a, p[2] as f32 * a, a]
     };
     let mut pixels = vec![0u8; dw * dh * 4];
-    for y in 0..dh {
-        for x in 0..dw {
-            let (sx, sy) = inv.apply(
-                rect.left as f64 + x as f64 + 0.5,
-                rect.top as f64 + y as f64 + 0.5,
+    let m = &inv.0;
+    // Fully opaque sources (photos, most pasted images) need no
+    // premultiply/unpremultiply when the whole 2×2 neighbourhood is
+    // inside the image: the taps are opaque, so a straight lerp of the
+    // raw channels gives the same result without twelve multiplies and
+    // a divide per pixel.
+    let opaque = img
+        .pixels
+        .as_chunks::<4>()
+        .0
+        .par_iter()
+        .all(|p| p[3] == 0xFF);
+    pixels
+        .par_chunks_exact_mut(dw * 4)
+        .enumerate()
+        .for_each(|(y, row)| {
+            // The inverse map is affine, so along a row the source point
+            // advances by a constant (m[0], m[3]) per pixel.
+            let py = rect.top as f64 + y as f64 + 0.5;
+            let (row_sx, row_sy) = (
+                m[1] * py + m[2] + m[0] * (rect.left as f64 + 0.5),
+                m[4] * py + m[5] + m[3] * (rect.left as f64 + 0.5),
             );
-            let (fx, fy) = (sx - 0.5, sy - 0.5);
-            if fx < -1.0 || fy < -1.0 || fx > sw || fy > sh {
-                continue;
-            }
-            let (x0, y0) = (fx.floor() as i64, fy.floor() as i64);
-            let (wx, wy) = ((fx - x0 as f64) as f32, (fy - y0 as f64) as f32);
-            let mut acc = [0.0f32; 4];
-            for (dxy, wgt) in [
-                ((0, 0), (1.0 - wx) * (1.0 - wy)),
-                ((1, 0), wx * (1.0 - wy)),
-                ((0, 1), (1.0 - wx) * wy),
-                ((1, 1), wx * wy),
-            ] {
-                let p = fetch(x0 + dxy.0, y0 + dxy.1);
-                for (a, v) in acc.iter_mut().zip(p) {
-                    *a += v * wgt;
+            for (x, out) in row.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+                let (sx, sy) = (row_sx + m[0] * x as f64, row_sy + m[3] * x as f64);
+                let (fx, fy) = (sx - 0.5, sy - 0.5);
+                if fx < -1.0 || fy < -1.0 || fx > sw || fy > sh {
+                    continue;
+                }
+                // Branch-free floor: `as` truncates toward zero, so
+                // adjust down for negative non-integers. (Landing one
+                // texel low on a negative integer just moves all the
+                // weight to the other tap — same sample.)
+                let (tx, ty) = (fx as i64, fy as i64);
+                let x0 = tx - (tx as f64 > fx) as i64;
+                let y0 = ty - (ty as f64 > fy) as i64;
+                let (wx, wy) = ((fx - x0 as f64) as f32, (fy - y0 as f64) as f32);
+                if opaque && x0 >= 0 && y0 >= 0 && x0 + 1 < iw && y0 + 1 < ih {
+                    let row0 = &img.pixels[(y0 as usize * iw as usize + x0 as usize) * 4..][..8];
+                    let row1 =
+                        &img.pixels[((y0 + 1) as usize * iw as usize + x0 as usize) * 4..][..8];
+                    for c in 0..3 {
+                        let top = row0[c] as f32 * (1.0 - wx) + row0[c + 4] as f32 * wx;
+                        let bot = row1[c] as f32 * (1.0 - wx) + row1[c + 4] as f32 * wx;
+                        out[c] = (top * (1.0 - wy) + bot * wy + 0.5) as u8;
+                    }
+                    out[3] = 0xFF;
+                    continue;
+                }
+                let acc = if x0 >= 0 && y0 >= 0 && x0 + 1 < iw && y0 + 1 < ih {
+                    // Whole 2×2 neighbourhood inside: read the two row
+                    // pairs directly, skipping the per-tap bounds test.
+                    let at = |px: i64, py: i64| -> [f32; 4] {
+                        let p = &img.pixels[((py as usize * iw as usize) + px as usize) * 4..][..4];
+                        let a = p[3] as f32;
+                        [p[0] as f32 * a, p[1] as f32 * a, p[2] as f32 * a, a]
+                    };
+                    let (p00, p10) = (at(x0, y0), at(x0 + 1, y0));
+                    let (p01, p11) = (at(x0, y0 + 1), at(x0 + 1, y0 + 1));
+                    let mut acc = [0.0f32; 4];
+                    for c in 0..4 {
+                        let top = p00[c] * (1.0 - wx) + p10[c] * wx;
+                        let bot = p01[c] * (1.0 - wx) + p11[c] * wx;
+                        acc[c] = top * (1.0 - wy) + bot * wy;
+                    }
+                    acc
+                } else {
+                    let mut acc = [0.0f32; 4];
+                    for (dxy, wgt) in [
+                        ((0, 0), (1.0 - wx) * (1.0 - wy)),
+                        ((1, 0), wx * (1.0 - wy)),
+                        ((0, 1), (1.0 - wx) * wy),
+                        ((1, 1), wx * wy),
+                    ] {
+                        let p = fetch(x0 + dxy.0, y0 + dxy.1);
+                        for (a, v) in acc.iter_mut().zip(p) {
+                            *a += v * wgt;
+                        }
+                    }
+                    acc
+                };
+                if acc[3] > f32::EPSILON {
+                    let unpremul = 1.0 / acc[3];
+                    for i in 0..3 {
+                        out[i] = (acc[i] * unpremul + 0.5).clamp(0.0, 255.0) as u8;
+                    }
+                    out[3] = (acc[3] + 0.5).clamp(0.0, 255.0) as u8;
                 }
             }
-            let out = &mut pixels[(y * dw + x) * 4..][..4];
-            if acc[3] > f32::EPSILON {
-                for i in 0..3 {
-                    out[i] = (acc[i] / acc[3] + 0.5).clamp(0.0, 255.0) as u8;
-                }
-                out[3] = (acc[3] * 255.0 + 0.5).clamp(0.0, 255.0) as u8;
-            }
-        }
-    }
+        });
     Some((
         rect,
         RgbaImage {
@@ -1580,28 +1673,30 @@ fn decode_bitmap(
     let sta_names: [&[u8; 4]; 5] = [b"Sta1", b"Sta2", b"Sta3", b"Sta4", b"Sta5"];
     let idx_names: [&[u8; 4]; 5] = [b"Idx1", b"Idx2", b"Idx3", b"Idx4", b"Idx5"];
     let twi_names: [&[u8; 4]; 5] = [b"TWi1", b"TWi2", b"TWi3", b"TWi4", b"TWi5"];
-    let mut planes = Vec::with_capacity(fmt.channels);
-    for channel in 0..fmt.channels {
-        planes.push(load_plane(PlaneJob {
-            archive,
-            graph,
-            bitm,
-            sta: sta_names[channel],
-            idx: idx_names[channel],
-            // Affinity rounds the tile grid up past the pixels it
-            // needs, so the status array's row stride is the declared
-            // `TWi`, not `ceil(row_bytes / 256)`. Reading it as the
-            // tight grid shears every row after the first.
-            grid_width: i32_of(bitm, twi_names[channel])
-                .filter(|w| *w > 0)
-                .map_or(row_bytes.div_ceil(256), |w| w as usize),
-            pitch,
-            rows,
-            height,
-            bytes_per_sample: fmt.bytes_per_sample,
-            source: source.as_ref().map(|s| (s, channel)),
-        })?);
-    }
+    let planes = (0..fmt.channels)
+        .into_par_iter()
+        .map(|channel| {
+            load_plane(PlaneJob {
+                archive,
+                graph,
+                bitm,
+                sta: sta_names[channel],
+                idx: idx_names[channel],
+                // Affinity rounds the tile grid up past the pixels it
+                // needs, so the status array's row stride is the declared
+                // `TWi`, not `ceil(row_bytes / 256)`. Reading it as the
+                // tight grid shears every row after the first.
+                grid_width: i32_of(bitm, twi_names[channel])
+                    .filter(|w| *w > 0)
+                    .map_or(row_bytes.div_ceil(256), |w| w as usize),
+                pitch,
+                rows,
+                height,
+                bytes_per_sample: fmt.bytes_per_sample,
+                source: source.as_ref().map(|s| (s, channel)),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     // Interleave planes into straight-alpha RGBA8. Higher depths are
     // reduced to 8 bits here; precision, not placement, is what's lost.
@@ -1615,52 +1710,115 @@ fn decode_bitmap(
     };
 
     let mut pixels = vec![0u8; width * height * 4];
-    for y in 0..height {
-        for x in 0..width {
-            let out = &mut pixels[(y * width + x) * 4..][..4];
-            let (r, g, b, a) = match fmt.kind {
-                FormatKind::Rgba => (
-                    sample(&planes[0], x, y),
-                    sample(&planes[1], x, y),
-                    sample(&planes[2], x, y),
-                    sample(&planes[3], x, y),
-                ),
-                FormatKind::Gray => {
-                    let g = sample(&planes[0], x, y);
-                    (g, g, g, sample(&planes[1], x, y))
-                }
-                FormatKind::Mask => {
-                    let v = sample(&planes[0], x, y);
-                    (v, v, v, 1.0)
-                }
-                FormatKind::Cmyk => {
-                    let (c, m, yl, k) = (
+    match (fmt.bytes_per_sample, &fmt.kind) {
+        // 8-bit samples map to output bytes unchanged; interleave the
+        // planes directly instead of round-tripping through f32.
+        (1, FormatKind::Rgba) => {
+            pixels
+                .par_chunks_exact_mut(width * 4)
+                .enumerate()
+                .for_each(|(y, out_row)| {
+                    let at = y * pitch;
+                    let (r, g, b, a) = (
+                        &planes[0][at..at + width],
+                        &planes[1][at..at + width],
+                        &planes[2][at..at + width],
+                        &planes[3][at..at + width],
+                    );
+                    for (x, px) in out_row.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+                        *px = [r[x], g[x], b[x], a[x]];
+                    }
+                });
+            return Ok(RgbaImage {
+                width: width as u32,
+                height: height as u32,
+                pixels,
+            });
+        }
+        (1, FormatKind::Gray) => {
+            pixels
+                .par_chunks_exact_mut(width * 4)
+                .enumerate()
+                .for_each(|(y, out_row)| {
+                    let at = y * pitch;
+                    let (g, a) = (&planes[0][at..at + width], &planes[1][at..at + width]);
+                    for (x, px) in out_row.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+                        *px = [g[x], g[x], g[x], a[x]];
+                    }
+                });
+            return Ok(RgbaImage {
+                width: width as u32,
+                height: height as u32,
+                pixels,
+            });
+        }
+        (1, FormatKind::Mask) => {
+            pixels
+                .par_chunks_exact_mut(width * 4)
+                .enumerate()
+                .for_each(|(y, out_row)| {
+                    let at = y * pitch;
+                    let v = &planes[0][at..at + width];
+                    for (x, px) in out_row.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+                        *px = [v[x], v[x], v[x], 0xFF];
+                    }
+                });
+            return Ok(RgbaImage {
+                width: width as u32,
+                height: height as u32,
+                pixels,
+            });
+        }
+        _ => {}
+    }
+    pixels
+        .par_chunks_exact_mut(width * 4)
+        .enumerate()
+        .for_each(|(y, out_row)| {
+            for (x, out) in out_row.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+                let (r, g, b, a) = match fmt.kind {
+                    FormatKind::Rgba => (
                         sample(&planes[0], x, y),
                         sample(&planes[1], x, y),
                         sample(&planes[2], x, y),
                         sample(&planes[3], x, y),
-                    );
-                    (
-                        (1.0 - c) * (1.0 - k),
-                        (1.0 - m) * (1.0 - k),
-                        (1.0 - yl) * (1.0 - k),
-                        sample(&planes[4], x, y),
-                    )
-                }
-                FormatKind::Lab => {
-                    let l = sample(&planes[0], x, y) * 100.0;
-                    let a_c = sample(&planes[1], x, y) * 255.0 - 128.0;
-                    let b_c = sample(&planes[2], x, y) * 255.0 - 128.0;
-                    let (r, g, b) = lab_to_srgb(l, a_c, b_c);
-                    (r, g, b, sample(&planes[3], x, y))
-                }
-            };
-            out[0] = (r * 255.0 + 0.5) as u8;
-            out[1] = (g * 255.0 + 0.5) as u8;
-            out[2] = (b * 255.0 + 0.5) as u8;
-            out[3] = (a * 255.0 + 0.5) as u8;
-        }
-    }
+                    ),
+                    FormatKind::Gray => {
+                        let g = sample(&planes[0], x, y);
+                        (g, g, g, sample(&planes[1], x, y))
+                    }
+                    FormatKind::Mask => {
+                        let v = sample(&planes[0], x, y);
+                        (v, v, v, 1.0)
+                    }
+                    FormatKind::Cmyk => {
+                        let (c, m, yl, k) = (
+                            sample(&planes[0], x, y),
+                            sample(&planes[1], x, y),
+                            sample(&planes[2], x, y),
+                            sample(&planes[3], x, y),
+                        );
+                        (
+                            (1.0 - c) * (1.0 - k),
+                            (1.0 - m) * (1.0 - k),
+                            (1.0 - yl) * (1.0 - k),
+                            sample(&planes[4], x, y),
+                        )
+                    }
+                    FormatKind::Lab => {
+                        let l = sample(&planes[0], x, y) * 100.0;
+                        let a_c = sample(&planes[1], x, y) * 255.0 - 128.0;
+                        let b_c = sample(&planes[2], x, y) * 255.0 - 128.0;
+                        let (r, g, b) = lab_to_srgb(l, a_c, b_c);
+                        (r, g, b, sample(&planes[3], x, y))
+                    }
+                };
+                out[0] = (r * 255.0 + 0.5) as u8;
+                out[1] = (g * 255.0 + 0.5) as u8;
+                out[2] = (b * 255.0 + 0.5) as u8;
+                out[3] = (a * 255.0 + 0.5) as u8;
+            }
+        });
     Ok(RgbaImage {
         width: width as u32,
         height: height as u32,
@@ -1703,6 +1861,10 @@ fn load_plane(job: PlaneJob) -> Result<Vec<u8>, AffinityError> {
 
     let mut plane = vec![0u8; job.pitch * job.rows];
     let places = tile_offsets(job.grid_width, job.height);
+    // Pair each stored tile with its destination first; decompressing
+    // and CRC-checking the payloads is the bulk of the work and every
+    // tile is independent, so that part fans out across cores.
+    let mut stored: Vec<(usize, usize, [i32; 4], &str)> = Vec::new();
     for (&status, (x, y)) in statuses.iter().zip(places) {
         match status {
             0 | 1 => {}
@@ -1722,29 +1884,7 @@ fn load_plane(job: PlaneJob) -> Result<Vec<u8>, AffinityError> {
                     Some(Value::Embedded { name, .. }) => name,
                     _ => return Err(malformed("block has no data reference")),
                 };
-                let entry = job
-                    .archive
-                    .head(name)
-                    .ok_or_else(|| malformed(format!("missing tile entry {name:?}")))?;
-                let tile = tile_payload(job.archive.extract(entry)?)
-                    .ok_or_else(|| malformed(format!("tile {name:?} has no 64 KiB payload")))?;
-                let (x0, y0) = (
-                    rect[0].clamp(0, 256) as usize,
-                    rect[1].clamp(0, 256) as usize,
-                );
-                let (x1, y1) = (
-                    rect[2].clamp(0, 256) as usize,
-                    rect[3].clamp(0, 256) as usize,
-                );
-                for ty in y0..y1 {
-                    if y + ty >= job.rows {
-                        break;
-                    }
-                    let dst = (y + ty) * job.pitch + x + x0;
-                    let src = ty * 256 + x0;
-                    let n = x1.saturating_sub(x0).min(job.pitch - (x + x0));
-                    plane[dst..dst + n].copy_from_slice(&tile[src..src + n]);
-                }
+                stored.push((x, y, rect, name));
             }
             // Source-backed: the pixels live in the bitmap's original
             // file (Bckg), not in tile entries.
@@ -1755,6 +1895,36 @@ fn load_plane(job: PlaneJob) -> Result<Vec<u8>, AffinityError> {
                 copy_source_tile(&mut plane, &job, source, channel, x, y)?;
             }
             other => return Err(malformed(format!("unknown tile status {other}"))),
+        }
+    }
+    let tiles = stored
+        .par_iter()
+        .map(|&(_, _, _, name)| {
+            let entry = job
+                .archive
+                .head(name)
+                .ok_or_else(|| malformed(format!("missing tile entry {name:?}")))?;
+            tile_payload(job.archive.extract(entry)?)
+                .ok_or_else(|| malformed(format!("tile {name:?} has no 64 KiB payload")))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    for ((x, y, rect, _), tile) in stored.iter().zip(&tiles) {
+        let (x0, y0) = (
+            rect[0].clamp(0, 256) as usize,
+            rect[1].clamp(0, 256) as usize,
+        );
+        let (x1, y1) = (
+            rect[2].clamp(0, 256) as usize,
+            rect[3].clamp(0, 256) as usize,
+        );
+        for ty in y0..y1 {
+            if y + ty >= job.rows {
+                break;
+            }
+            let dst = (y + ty) * job.pitch + x + x0;
+            let src = ty * 256 + x0;
+            let n = x1.saturating_sub(x0).min(job.pitch - (x + x0));
+            plane[dst..dst + n].copy_from_slice(&tile[src..src + n]);
         }
     }
     Ok(plane)
@@ -2542,29 +2712,40 @@ fn resample_to(img: RgbaImage, dw: u32, dh: u32) -> RgbaImage {
         return img;
     }
     let (sw, sh) = (img.width as usize, img.height as usize);
-    let mut pixels = vec![0u8; dw as usize * dh as usize * 4];
-    for y in 0..dh as usize {
-        let fy = (y as f32 + 0.5) * sh as f32 / dh as f32 - 0.5;
-        let y0 = (fy.floor().max(0.0) as usize).min(sh - 1);
-        let y1 = (y0 + 1).min(sh - 1);
-        let wy = (fy - y0 as f32).clamp(0.0, 1.0);
-        for x in 0..dw as usize {
+    let (dw, dh) = (dw as usize, dh as usize);
+    // The horizontal taps are the same for every row; compute them once
+    // as byte offsets into a source row.
+    let xtaps: Vec<(usize, usize, f32)> = (0..dw)
+        .map(|x| {
             let fx = (x as f32 + 0.5) * sw as f32 / dw as f32 - 0.5;
             let x0 = (fx.floor().max(0.0) as usize).min(sw - 1);
             let x1 = (x0 + 1).min(sw - 1);
             let wx = (fx - x0 as f32).clamp(0.0, 1.0);
-            let at = |px: usize, py: usize, c: usize| img.pixels[(py * sw + px) * 4 + c] as f32;
-            let out = &mut pixels[(y * dw as usize + x) * 4..][..4];
-            for (c, slot) in out.iter_mut().enumerate() {
-                let top = at(x0, y0, c) * (1.0 - wx) + at(x1, y0, c) * wx;
-                let bot = at(x0, y1, c) * (1.0 - wx) + at(x1, y1, c) * wx;
-                *slot = (top * (1.0 - wy) + bot * wy + 0.5) as u8;
+            (x0 * 4, x1 * 4, wx)
+        })
+        .collect();
+    let mut pixels = vec![0u8; dw * dh * 4];
+    pixels
+        .par_chunks_exact_mut(dw * 4)
+        .enumerate()
+        .for_each(|(y, out_row)| {
+            let fy = (y as f32 + 0.5) * sh as f32 / dh as f32 - 0.5;
+            let y0 = (fy.floor().max(0.0) as usize).min(sh - 1);
+            let y1 = (y0 + 1).min(sh - 1);
+            let wy = (fy - y0 as f32).clamp(0.0, 1.0);
+            let row0 = &img.pixels[y0 * sw * 4..][..sw * 4];
+            let row1 = &img.pixels[y1 * sw * 4..][..sw * 4];
+            for (out, &(x0, x1, wx)) in out_row.as_chunks_mut::<4>().0.iter_mut().zip(&xtaps) {
+                for c in 0..4 {
+                    let top = row0[x0 + c] as f32 * (1.0 - wx) + row0[x1 + c] as f32 * wx;
+                    let bot = row1[x0 + c] as f32 * (1.0 - wx) + row1[x1 + c] as f32 * wx;
+                    out[c] = (top * (1.0 - wy) + bot * wy + 0.5) as u8;
+                }
             }
-        }
-    }
+        });
     RgbaImage {
-        width: dw,
-        height: dh,
+        width: dw as u32,
+        height: dh as u32,
         pixels,
     }
 }

--- a/crates/codec-psd/Cargo.toml
+++ b/crates/codec-psd/Cargo.toml
@@ -11,6 +11,14 @@ schist-color.workspace = true
 schist-psd-descriptor.workspace = true
 miniz_oxide.workspace = true
 anyhow.workspace = true
+# Layers' channel data decompresses independently; large documents
+# decode in parallel.
+rayon.workspace = true
 byteorder.workspace = true
 thiserror.workspace = true
 log.workspace = true
+
+[dev-dependencies]
+# The psdbench example converts corpus Affinity files to PSD to get
+# realistically large inputs for timing the reader and writer.
+schist-codec-affinity.workspace = true

--- a/crates/codec-psd/examples/psdbench.rs
+++ b/crates/codec-psd/examples/psdbench.rs
@@ -1,0 +1,48 @@
+//! Time PSD read/write on realistic inputs: `psdbench <file>...`
+//!
+//! A `.psd`/`.psb` argument is timed directly. An Affinity argument is
+//! imported and written out as PSD first (cached next to /tmp) so the
+//! corpus of large real documents can exercise this codec too.
+
+use std::time::Instant;
+
+fn main() {
+    for path in std::env::args().skip(1) {
+        let bytes = std::fs::read(&path).expect("read file");
+        let psd = if schist_codec_psd::is_psd(&bytes) {
+            bytes
+        } else {
+            let stem = std::path::Path::new(&path)
+                .file_stem()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned();
+            let cache = std::env::temp_dir().join(format!("psdbench-{stem}.psd"));
+            if let Ok(cached) = std::fs::read(&cache) {
+                cached
+            } else {
+                let (doc, _) = schist_codec_affinity::read_affinity(&bytes).expect("affinity");
+                let t = Instant::now();
+                let out = schist_codec_psd::write_psd(&doc).expect("write_psd");
+                println!(
+                    "{path}: write_psd {:?} ({:.1} MiB)",
+                    t.elapsed(),
+                    out.len() as f64 / (1024.0 * 1024.0)
+                );
+                std::fs::write(&cache, &out).expect("cache psd");
+                out
+            }
+        };
+        let t = Instant::now();
+        match schist_codec_psd::read_psd(&psd) {
+            Ok(doc) => println!(
+                "{path}: {:.1} MiB psd, read_psd {:?} ({}x{})",
+                psd.len() as f64 / (1024.0 * 1024.0),
+                t.elapsed(),
+                doc.width,
+                doc.height
+            ),
+            Err(e) => println!("{path}: read_psd failed after {:?}: {e}", t.elapsed()),
+        }
+    }
+}

--- a/crates/codec-psd/src/reader/layers.rs
+++ b/crates/codec-psd/src/reader/layers.rs
@@ -3,10 +3,11 @@
 
 use super::cursor::Cursor;
 use super::header::Header;
-use super::pixels::{fill_mask_tiles, fill_tiles, plane_to_f32, ColorPlanes};
+use super::pixels::{fill_mask_tiles, fill_tiles, fill_tiles_u8, plane_to_f32, ColorPlanes};
 use super::rle::unpack_channel;
 use crate::error::PsdError;
-use schist_color::ColorMode;
+use rayon::prelude::*;
+use schist_color::{ColorMode, Depth};
 use schist_core::{
     AdjustmentData, AdjustmentKind, BlendMode, GroupLayer, IntRect, Layer, LayerId, LayerKind,
     LayerMask, MaskTileMap, RasterLayer, RawBlock, TileMap,
@@ -146,11 +147,28 @@ fn parse_layer_info(cur: &mut Cursor, header: &Header) -> Result<(Vec<Layer>, bo
     }
 
     // Channel image data follows all records, per layer in record order.
-    let mut parsed = Vec::with_capacity(recs.len());
-    for rec in recs {
-        let (tiles, mask_tiles) = decode_layer_channels(cur, &rec, header)?;
-        parsed.push((rec, tiles, mask_tiles));
+    // Each layer's share is the sum of its declared channel lengths, so
+    // the layers can be sliced up front and decoded in parallel —
+    // decompressing channel data is the bulk of opening a PSD.
+    let mut slices = Vec::with_capacity(recs.len());
+    for rec in &recs {
+        let total: u64 = rec
+            .channels
+            .iter()
+            .try_fold(0u64, |acc, &(_, len)| acc.checked_add(len))
+            .ok_or_else(|| PsdError::Corrupt("channel lengths overflow".into()))?;
+        let total = cur.checked_len(total)?;
+        slices.push(cur.take(total)?);
     }
+    let parsed = recs
+        .into_par_iter()
+        .zip(slices)
+        .map(|(rec, slice)| {
+            let mut ch_cur = Cursor::new(slice);
+            let (tiles, mask_tiles) = decode_layer_channels(&mut ch_cur, &rec, header)?;
+            Ok((rec, tiles, mask_tiles))
+        })
+        .collect::<Result<Vec<_>, PsdError>>()?;
 
     Ok((fold_groups(parsed, header), merged_alpha))
 }
@@ -361,10 +379,14 @@ fn decode_layer_channels(
     rec: &Rec,
     header: &Header,
 ) -> Result<(TileMap, Option<MaskTileMap>), PsdError> {
-    let mut planes = ColorPlanes::default();
+    // Channels are collected as the raw decompressed planes; conversion
+    // to f32 happens only on the paths that need it (16/32-bit depth,
+    // CMYK/Lab modes). 8-bit RGB/Gray — the overwhelmingly common case —
+    // interleaves the bytes directly.
+    let mut raw: [Option<Vec<u8>>; 4] = Default::default();
     let mut mask_bytes: Option<Vec<u8>> = None;
     // CMYK's black plane, which has no slot in `ColorPlanes`.
-    let mut key: Option<Vec<f32>> = None;
+    let mut key_bytes: Option<Vec<u8>> = None;
 
     for &(id, declared_len) in &rec.channels {
         let declared_len = cur.checked_len(declared_len)?;
@@ -440,28 +462,54 @@ fn decode_layer_channels(
 
         match target {
             Target::Mask => mask_bytes = Some(bytes),
-            Target::Alpha => planes.a = Some(plane_to_f32(&bytes, header.depth)),
-            Target::Color(0) => planes.r = Some(plane_to_f32(&bytes, header.depth)),
-            Target::Color(1) => planes.g = Some(plane_to_f32(&bytes, header.depth)),
-            Target::Color(2) => planes.b = Some(plane_to_f32(&bytes, header.depth)),
-            Target::Color(_) => key = Some(plane_to_f32(&bytes, header.depth)),
+            Target::Alpha => raw[3] = Some(bytes),
+            Target::Color(c @ 0..=2) => raw[c as usize] = Some(bytes),
+            Target::Color(_) => key_bytes = Some(bytes),
         }
-    }
-
-    // Convert whatever the file's mode stores into the RGBA everything
-    // downstream works in.
-    match header.mode {
-        ColorMode::Grayscale | ColorMode::Indexed => {
-            planes.g.clone_from(&planes.r);
-            planes.b.clone_from(&planes.r);
-        }
-        ColorMode::Cmyk => convert_cmyk_planes(&mut planes, key.as_deref()),
-        ColorMode::Lab => convert_lab_planes(&mut planes),
-        ColorMode::Rgb => {}
     }
 
     let mut tiles = TileMap::new();
-    fill_tiles(&mut tiles, header.depth, rec.rect, &planes);
+    if header.depth == Depth::Eight
+        && matches!(
+            header.mode,
+            ColorMode::Rgb | ColorMode::Grayscale | ColorMode::Indexed
+        )
+    {
+        let gray = !matches!(header.mode, ColorMode::Rgb);
+        let (g, b) = if gray {
+            (raw[0].as_deref(), raw[0].as_deref())
+        } else {
+            (raw[1].as_deref(), raw[2].as_deref())
+        };
+        fill_tiles_u8(
+            &mut tiles,
+            rec.rect,
+            [raw[0].as_deref(), g, b, raw[3].as_deref()],
+        );
+    } else {
+        let to_f32 = |p: &Option<Vec<u8>>| p.as_deref().map(|b| plane_to_f32(b, header.depth));
+        let mut planes = ColorPlanes {
+            r: to_f32(&raw[0]),
+            g: to_f32(&raw[1]),
+            b: to_f32(&raw[2]),
+            a: to_f32(&raw[3]),
+        };
+        let key = to_f32(&key_bytes);
+
+        // Convert whatever the file's mode stores into the RGBA everything
+        // downstream works in.
+        match header.mode {
+            ColorMode::Grayscale | ColorMode::Indexed => {
+                planes.g.clone_from(&planes.r);
+                planes.b.clone_from(&planes.r);
+            }
+            ColorMode::Cmyk => convert_cmyk_planes(&mut planes, key.as_deref()),
+            ColorMode::Lab => convert_lab_planes(&mut planes),
+            ColorMode::Rgb => {}
+        }
+
+        fill_tiles(&mut tiles, header.depth, rec.rect, &planes);
+    }
 
     let mask_tiles = match (&rec.mask, mask_bytes) {
         (Some(m), Some(bytes)) => {

--- a/crates/codec-psd/src/reader/mod.rs
+++ b/crates/codec-psd/src/reader/mod.rs
@@ -93,6 +93,32 @@ fn background_from_composite(
     merged_alpha: bool,
 ) -> Layer {
     let base = header.base_channels() as usize;
+
+    // 8-bit RGB/Gray flattened files — the common bulk export — skip the
+    // f32 round-trip and interleave the raw planes directly.
+    if header.depth == schist_color::Depth::Eight
+        && matches!(
+            header.mode,
+            ColorMode::Rgb | ColorMode::Grayscale | ColorMode::Indexed
+        )
+    {
+        let plane = |i: usize| composite.planes.get(i).map(|p| p.as_slice());
+        let (g, b) = if matches!(header.mode, ColorMode::Rgb) {
+            (plane(1), plane(2))
+        } else {
+            (plane(0), plane(0))
+        };
+        let alpha = (merged_alpha && header.channels as usize > base)
+            .then(|| plane(base))
+            .flatten();
+        let mut layer = Layer::new_raster("Background");
+        let rect = IntRect::from_size(header.width, header.height);
+        if let schist_core::LayerKind::Raster(RasterLayer { tiles }) = &mut layer.kind {
+            pixels::fill_tiles_u8(tiles, rect, [plane(0), g, b, alpha]);
+        }
+        return layer;
+    }
+
     let to_f32 = |i: usize| {
         composite
             .planes

--- a/crates/codec-psd/src/reader/pixels.rs
+++ b/crates/codec-psd/src/reader/pixels.rs
@@ -1,7 +1,7 @@
 //! Converting decompressed planar channel bytes into tile maps.
 
 use schist_color::{Depth, Rgba};
-use schist_core::{IntRect, MaskTileMap, TileCoord, TileMap, TILE_SIZE};
+use schist_core::{IntRect, MaskTileMap, TileBuf, TileCoord, TileMap, TILE_SIZE};
 
 /// Convert one decompressed big-endian channel plane to normalized f32.
 ///
@@ -86,6 +86,57 @@ pub fn fill_tiles(tiles: &mut TileMap, depth: Depth, rect: IntRect, planes: &Col
     tiles.prune_blank();
 }
 
+/// 8-bit fast path of [`fill_tiles`]: interleave raw `[r, g, b, a]` u8
+/// channel planes straight into `U8` tiles, skipping the f32 round-trip
+/// (which is the identity at this depth). Missing colour planes read as
+/// 0 and a missing alpha plane as opaque, matching `ColorPlanes::pixel`;
+/// so does a short plane past its end.
+pub fn fill_tiles_u8(tiles: &mut TileMap, rect: IntRect, planes: [Option<&[u8]>; 4]) {
+    if rect.is_empty() || planes.iter().all(|p| p.is_none()) {
+        return;
+    }
+    let w = rect.width() as usize;
+    let n = w * rect.height() as usize;
+    fn plane<'p>(n: usize, p: Option<&'p [u8]>, default: u8) -> std::borrow::Cow<'p, [u8]> {
+        match p {
+            Some(s) if s.len() >= n => std::borrow::Cow::Borrowed(s),
+            Some(s) => {
+                let mut v = s.to_vec();
+                v.resize(n, default);
+                std::borrow::Cow::Owned(v)
+            }
+            None => std::borrow::Cow::Owned(vec![default; n]),
+        }
+    }
+    let (r, g, b, a) = (
+        plane(n, planes[0], 0),
+        plane(n, planes[1], 0),
+        plane(n, planes[2], 0),
+        plane(n, planes[3], 0xFF),
+    );
+    for coord in TileCoord::covering(&rect) {
+        let trect = coord.rect();
+        let clip = trect.intersect(&rect);
+        if clip.is_empty() {
+            continue;
+        }
+        let TileBuf::U8(d) = tiles.get_mut_or_insert(coord, Depth::Eight) else {
+            unreachable!("freshly inserted tile is U8");
+        };
+        let cols = (clip.right - clip.left) as usize;
+        for y in clip.top..clip.bottom {
+            let s0 = (y - rect.top) as usize * w + (clip.left - rect.left) as usize;
+            let l0 =
+                (y - trect.top) as usize * TILE_SIZE as usize + (clip.left - trect.left) as usize;
+            let dst = &mut d[l0 * 4..(l0 + cols) * 4];
+            for (i, px) in dst.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+                *px = [r[s0 + i], g[s0 + i], b[s0 + i], a[s0 + i]];
+            }
+        }
+    }
+    tiles.prune_blank();
+}
+
 /// Write an 8-bit coverage plane (row-major over `rect`) into a mask tile
 /// map. PSD mask channels are 8-bit regardless of document depth.
 pub fn fill_mask_tiles(tiles: &mut MaskTileMap, rect: IntRect, bytes: &[u8]) {
@@ -100,13 +151,18 @@ pub fn fill_mask_tiles(tiles: &mut MaskTileMap, rect: IntRect, bytes: &[u8]) {
             continue;
         }
         let buf = tiles.get_mut_or_insert(coord);
+        let cols = (clip.right - clip.left) as usize;
         for y in clip.top..clip.bottom {
-            let sy = (y - rect.top) as usize;
-            let ly = (y - trect.top) as usize;
-            for x in clip.left..clip.right {
-                let sx = (x - rect.left) as usize;
-                let lx = (x - trect.left) as usize;
-                buf[ly * TILE_SIZE as usize + lx] = bytes.get(sy * w + sx).copied().unwrap_or(0);
+            let s0 = (y - rect.top) as usize * w + (clip.left - rect.left) as usize;
+            let l0 =
+                (y - trect.top) as usize * TILE_SIZE as usize + (clip.left - trect.left) as usize;
+            if let Some(src) = bytes.get(s0..s0 + cols) {
+                buf[l0..l0 + cols].copy_from_slice(src);
+            } else {
+                // Short plane (corrupt file): whatever exists, then zeros.
+                for (i, dst) in buf[l0..l0 + cols].iter_mut().enumerate() {
+                    *dst = bytes.get(s0 + i).copied().unwrap_or(0);
+                }
             }
         }
     }

--- a/crates/core/src/document.rs
+++ b/crates/core/src/document.rs
@@ -1023,6 +1023,18 @@ pub fn blit_rgba8(tiles: &mut TileMap, depth: Depth, rect: IntRect, rgba: &[u8])
             continue;
         }
         let buf = tiles.get_mut_or_insert(coord, depth);
+        if let crate::tile::TileBuf::U8(d) = buf {
+            // 8-bit tiles share the source's layout; the f32 round-trip
+            // below is the identity on them, so copy whole rows.
+            let n = (clip.right - clip.left) as usize * 4;
+            for y in clip.top..clip.bottom {
+                let s = ((y - rect.top) as usize * w + (clip.left - rect.left) as usize) * 4;
+                let l = (y - trect.top) as usize * TILE_SIZE as usize
+                    + (clip.left - trect.left) as usize;
+                d[l * 4..l * 4 + n].copy_from_slice(&rgba[s..s + n]);
+            }
+            continue;
+        }
         for y in clip.top..clip.bottom {
             let sy = (y - rect.top) as usize;
             let ly = (y - trect.top) as usize;

--- a/crates/plugin-api/src/registry.rs
+++ b/crates/plugin-api/src/registry.rs
@@ -1,13 +1,16 @@
 //! Plugin registries — the kernel's catalog of everything installed.
 
 use crate::{CodecPlugin, Command, CommandPlugin, FilterPlugin, ToolPlugin};
+use std::sync::Arc;
 
 /// All registered plugins, assembled at startup by the app shell from each
 /// enabled `PluginManifest`.
 #[derive(Default)]
 pub struct PluginRegistry {
     tools: Vec<Box<dyn ToolPlugin>>,
-    codecs: Vec<Box<dyn CodecPlugin>>,
+    /// `Arc`, not `Box`: decoding runs on background threads, which need
+    /// to hold the codec beyond the registry borrow.
+    codecs: Vec<Arc<dyn CodecPlugin>>,
     commands: Vec<Command>,
     filters: Vec<Box<dyn FilterPlugin>>,
 }
@@ -27,7 +30,7 @@ impl PluginRegistry {
     }
 
     pub fn register_codec(&mut self, codec: Box<dyn CodecPlugin>) {
-        self.codecs.push(codec);
+        self.codecs.push(Arc::from(codec));
     }
 
     pub fn register_commands(&mut self, plugin: &dyn CommandPlugin) {
@@ -66,6 +69,11 @@ impl PluginRegistry {
                     .find(|c| c.extensions().contains(&ext.as_str()))
             })
             .map(|c| c.as_ref())
+    }
+
+    /// Clones of every codec, for decoding on a background thread.
+    pub fn shared_codecs(&self) -> Vec<Arc<dyn CodecPlugin>> {
+        self.codecs.clone()
     }
 
     pub fn commands(&self) -> &[Command] {


### PR DESCRIPTION
Opening a 58 MiB .af file took 38 seconds with the window frozen for the duration. This makes the import roughly 10x faster across the corpus and moves the decode off the UI thread.

## Measured (16-vCPU box, release, best-of-3)

| File | Before | After |
|---|---|---|
| wewon_defcon.af (58 MiB, 43 layers) | 37.9 s | 3.5 s |
| Untitled.af (13 MiB, 35 layers) | 25.8 s | 2.3 s |
| theoq.af (35 MiB) | 5.7 s | 0.66 s |
| typical stream .afphoto (~10 MiB) | ~0.6 s | ~0.1 s |
| 132 MiB flattened-ish PSD | 2.5 s | 0.15 s |

## Affinity codec

- **Parallelism (rayon)** at every independent level: sibling layer subtrees (each worker gets its own `ImportReport`, merged back in file order), channel planes, stored-tile decompression, and the row loops of both resamplers and the channel interleave.
- **`Archive::head` was quadratic**: a linear scan of all names and all entries, called once per 64 KiB tile. Name and head-revision hash indexes are now built at parse time.
- **CRC-32** was bitwise (8 steps/byte over every decompressed entry); now crc32fast.
- **Scalar hot loops**: the 8-bit interleave skipped its u8→f32→u8 round-trip (an identity), `resample_to` precomputes its horizontal taps once, and `affine_resample` gets an opaque-source fast path (no premultiply, no per-pixel divide) plus a branch-free floor.

## PSD codec

- Each layer's channel data has a declared length, so the section is pre-sliced and **layers decode in parallel**.
- 8-bit RGB/Gray files (layered and flattened) interleave raw planes straight into U8 tiles instead of converting every sample to f32 and back through per-pixel `Option` checks; mask planes copy whole rows.

## App shell

- `Workspace::load_file` read and decoded synchronously on the UI thread (on the CLI path, before first paint). It now runs on the background executor with an "Opening…" status and installs the document when ready. Crash recovery keeps the synchronous variant it depends on; codecs are stored as `Arc` so a clone can cross threads.
- `blit_rgba8` copies whole rows into 8-bit tiles.
- The navigator thumbnail composited the **entire canvas at full resolution** on every revision bump; it now point-samples through the shared `TileCache`, reusing viewport work and recompositing only damaged tiles after edits.

New examples: `afbench` (per-stage Affinity import timings, `AFBENCH_LAYERS=1` dumps layer bounds) and `psdbench` (converts corpus Affinity files to PSD to time the PSD reader on realistically large inputs).

## Verification

- Full workspace suite: 74 suites, 503 tests, 0 failures; clippy clean on touched crates.
- Fixture sweep over the private corpus (`SCHIST_AFFINITY_CORPUS`), including the IoU checks of imports against Affinity's own embedded thumbnails.
- Every corpus file imports with identical layer counts and skip reports to before.
- Headless GUI open of the largest file: canvas, layers panel, and navigator all render correctly through the async path.

Known follow-ups: the scalar bilinear in `affine_resample` is still the top CPU user for rotated multi-megapixel layers (SIMD is the next lever); `write_psd` and the low-zoom preview path are untouched. One behavior nuance: opening several files at once may create tabs in completion order rather than argument order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)