### PR TITLE
Make Liquify redraw the brush, not the layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5771,6 +5771,9 @@ dependencies = [
 [[package]]
 name = "schist-fx"
 version = "0.3.0"
+dependencies = [
+ "rayon",
+]
 
 [[package]]
 name = "schist-layer-fx"
@@ -5973,6 +5976,7 @@ dependencies = [
 name = "schist-tools-warp"
 version = "0.3.0"
 dependencies = [
+ "rayon",
  "schist-color",
  "schist-core",
  "schist-fx",

--- a/crates/compositor-gpu/src/fx.rs
+++ b/crates/compositor-gpu/src/fx.rs
@@ -4,8 +4,8 @@
 //! are a per-device stack, so an fx submission running beside a composite
 //! batch would pop the other's scope. Each job is one upload, a short
 //! chain of dispatches and one readback, except the warp, whose source
-//! plane stays resident between calls (a Liquify drag re-warps the same
-//! snapshot on every pointer move).
+//! plane stays resident between calls (a Puppet Warp drag re-warps the
+//! same snapshot on every pointer move).
 
 use crate::exec::GpuContext;
 use schist_fx::{BlurJob, CarveJob, Carved, FxBackend, LensJob, WarpParams};
@@ -101,7 +101,9 @@ impl FxBackend for GpuFx {
         // Four bilinear taps plus the grid lookup: thin work per pixel, so
         // this only pays when the source stays resident across a drag and
         // a pointer move costs one dispatch and one readback rather than
-        // two transfers of the whole layer.
+        // two transfers of the whole layer. A tool that re-renders only
+        // what its brush touched declines the deal by passing no token —
+        // its jobs are too small to leave the CPU.
         let pixels = params.dst_width * params.dst_height;
         if params.src_token == 0 || !schist_fx::worth_offloading(pixels, 24) {
             return None;

--- a/crates/fx/Cargo.toml
+++ b/crates/fx/Cargo.toml
@@ -5,3 +5,4 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+rayon.workspace = true

--- a/crates/fx/src/lib.rs
+++ b/crates/fx/src/lib.rs
@@ -2,18 +2,21 @@
 //!
 //! These are the filter and warp kernels that sweep an entire selection
 //! per keystroke of a dialog — blurs with a large kernel, and the
-//! displacement resample Liquify and Puppet Warp re-run on every pointer
-//! move — plus Content-Aware Scale, which sweeps it once per carved seam
-//! and so does hundreds of passes for one command. They are the only
-//! pixel work in the editor where a round trip to a second wgpu device
-//! can pay for itself; brush-footprint tools do a few thousand pixels per
-//! dab and stay on the CPU, where the latency is.
+//! displacement resample Puppet Warp re-runs on every pointer move —
+//! plus Content-Aware Scale, which sweeps it once per carved seam and so
+//! does hundreds of passes for one command. They are the only pixel work
+//! in the editor where a round trip to a second wgpu device can pay for
+//! itself; brush-footprint tools do a few thousand pixels per dab and stay
+//! on the CPU, where the latency is. Liquify is the one that goes both
+//! ways: a dab resamples only the footprint of the brush and stays here,
+//! but the warp it runs is the same one.
 //!
 //! The functions here are the entry points callers use. Each dispatches to
 //! the installed [`FxBackend`] and falls back to the `*_cpu` reference —
 //! which is the semantic contract, exactly as `schist-compositor`'s CPU
 //! compositor is for compositing.
 
+use rayon::prelude::*;
 use std::sync::{Arc, OnceLock, RwLock};
 
 /// A separable box blur: `passes` rounds of one horizontal and one
@@ -66,9 +69,10 @@ pub struct WarpParams<'a> {
     /// Document position of mesh vertex (0, 0).
     pub mesh_origin: (i32, i32),
     /// Identifies the source plane across calls so a backend can keep it
-    /// resident between them — a Liquify drag re-warps the same snapshot
-    /// on every pointer move. Any change to the source pixels must change
-    /// the token; 0 means "do not cache".
+    /// resident between them — a Puppet Warp drag re-warps the same
+    /// snapshot on every pointer move. Any change to the source pixels must
+    /// change the token; 0 means "do not cache", and is also how a caller
+    /// says this plane is a one-off it cropped for a single call.
     pub src_token: u64,
 }
 
@@ -349,17 +353,26 @@ pub fn warp(params: &WarpParams<'_>, src: impl FnOnce() -> Vec<f32>) -> Vec<f32>
 
 pub fn warp_cpu(job: &WarpParams<'_>, src: &[f32]) -> Vec<f32> {
     let mut out = vec![0.0f32; job.dst_width * job.dst_height * 4];
-    for row in 0..job.dst_height {
-        for col in 0..job.dst_width {
-            let x = job.dst_origin.0 + col as i32;
-            let y = job.dst_origin.1 + row as i32;
-            let (fx, fy) = (x as f32 + 0.5, y as f32 + 0.5);
-            let (dx, dy) = mesh_sample(job, fx, fy);
-            let px = fetch(job, src, fx + dx - 0.5, fy + dy - 0.5);
-            let i = (row * job.dst_width + col) * 4;
-            out[i..i + 4].copy_from_slice(&px);
-        }
+    if job.dst_width == 0 {
+        return out;
     }
+    // A row of the result depends on nothing but the source and the grid,
+    // so they go out across the cores. This is the one kernel here that a
+    // gesture waits on directly — a Liquify dab re-renders the footprint of
+    // the brush between one pointer move and the next — and the offload
+    // threshold keeps a footprint-sized job on this path.
+    out.par_chunks_mut(job.dst_width * 4)
+        .enumerate()
+        .for_each(|(row, dst)| {
+            for col in 0..job.dst_width {
+                let x = job.dst_origin.0 + col as i32;
+                let y = job.dst_origin.1 + row as i32;
+                let (fx, fy) = (x as f32 + 0.5, y as f32 + 0.5);
+                let (dx, dy) = mesh_sample(job, fx, fy);
+                let px = fetch(job, src, fx + dx - 0.5, fy + dy - 0.5);
+                dst[col * 4..col * 4 + 4].copy_from_slice(&px);
+            }
+        });
     out
 }
 

--- a/plugins/tools-warp/Cargo.toml
+++ b/plugins/tools-warp/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
+rayon.workspace = true
 schist-core.workspace = true
 schist-color.workspace = true
 schist-fx.workspace = true

--- a/plugins/tools-warp/examples/liquifybench.rs
+++ b/plugins/tools-warp/examples/liquifybench.rs
@@ -1,0 +1,89 @@
+//! What a Liquify stroke costs per pointer event. Run with
+//! `cargo run --release -p schist-tools-warp --example liquifybench`.
+//!
+//! A dab only moves the mesh under the brush, so what matters is that the
+//! numbers track the brush and not the layer: the 12-megapixel row should
+//! cost about what the 0.8-megapixel one does at the same size.
+
+use schist_color::{Depth, Rgba};
+use schist_core::{Document, Layer, TileCoord, TILE_PIXELS};
+use schist_plugin_api::{EditorState, OptionValue, PointerInput, ToolCtx, ToolPlugin};
+use schist_tools_warp::liquify::LiquifyTool;
+use std::time::Instant;
+
+fn at(x: f32, y: f32) -> PointerInput {
+    PointerInput {
+        x,
+        y,
+        pressure: 1.0,
+        modifiers: Default::default(),
+    }
+}
+
+fn document(w: u32, h: u32) -> Document {
+    let mut doc = Document::new("bench", w, h, Depth::Eight);
+    let mut layer = Layer::new_raster("art");
+    let rect = doc.canvas_rect();
+    if let Some(raster) = layer.as_raster_mut() {
+        let mut state = 0x2545F4914F6CDD1Du64;
+        for coord in TileCoord::covering(&rect) {
+            let buf = raster.tiles.get_mut_or_insert(coord, Depth::Eight);
+            for i in 0..TILE_PIXELS {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                let n = (state >> 40) as f32 / 16777216.0;
+                buf.set(i, Rgba::new(n, 1.0 - n, 0.5, 1.0));
+            }
+        }
+    }
+    doc.active_layer = Some(layer.id);
+    doc.tree.layers.push(layer);
+    doc
+}
+
+fn main() {
+    let ms = |start: Instant| start.elapsed().as_secs_f64() * 1000.0;
+    println!(
+        "{:>14}  {:>5}  {:>8}  {:>13}  {:>8}",
+        "layer", "brush", "pick up", "pointer move", "commit"
+    );
+    for (w, h, size) in [
+        (1024u32, 768u32, 100.0f32),
+        (4000, 3000, 100.0),
+        (4000, 3000, 1000.0),
+    ] {
+        let mut doc = document(w, h);
+        let mut state = EditorState::default();
+        let mut tool = LiquifyTool::new();
+        tool.set_option("liquify-size", OptionValue::Num(size));
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+
+        let start = Instant::now();
+        tool.on_activate(&mut ctx);
+        let begin_ms = ms(start);
+
+        let (cx, cy) = (w as f32 / 2.0, h as f32 / 2.0);
+        tool.on_pointer_down(&mut ctx, at(cx, cy));
+        let moves = 40;
+        let start = Instant::now();
+        for i in 1..=moves {
+            tool.on_pointer_move(&mut ctx, at(cx + i as f32 * 3.0, cy + i as f32));
+        }
+        let move_ms = ms(start) / moves as f64;
+        tool.on_pointer_up(&mut ctx, at(cx, cy));
+        ctx.doc.take_damage();
+
+        let start = Instant::now();
+        tool.on_deactivate(&mut ctx);
+        let commit_ms = ms(start);
+
+        println!(
+            "{:>9}x{:<4} {size:>5.0}  {begin_ms:>6.1} ms  {move_ms:>10.2} ms  {commit_ms:>6.1} ms",
+            w, h
+        );
+    }
+}

--- a/plugins/tools-warp/src/liquify.rs
+++ b/plugins/tools-warp/src/liquify.rs
@@ -10,7 +10,7 @@ use schist_plugin_api::{
     EditorState, OptionValue, Overlay, PointerInput, ToolCtx, ToolOption, ToolPlugin,
 };
 
-use crate::mesh::{warp_tiles, Mesh};
+use crate::mesh::{warp_into, Mesh};
 
 /// Photoshop's Liquify brushes.
 const MODES: &[&str] = &[
@@ -65,9 +65,6 @@ struct Session {
     /// The layer as it was before any warping. Every render goes from
     /// here, so the mesh is applied once rather than compounding.
     original: TileMap,
-    /// Names `original` for a backend that can keep it resident: the
-    /// snapshot is fixed for the whole drag, only the mesh moves.
-    token: u64,
     mesh: Mesh,
     last: Option<(f32, f32)>,
 }
@@ -105,10 +102,14 @@ impl LiquifyTool {
             return;
         };
         // Warp over the artwork grown by one brush, so pixels can be
-        // pushed outwards past the original edge.
+        // pushed outwards past the original edge. Tile-granular bounds
+        // rather than pixel-tight ones: this runs when the tool is picked
+        // up and after every Enter, and scanning twelve megapixels for
+        // their alpha to save a fringe of mesh nobody warps is not a trade
+        // worth making.
         let rect = raster
             .tiles
-            .content_bounds()
+            .tile_bounds()
             .inflated(self.size.ceil() as i32)
             .intersect(&ctx.doc.canvas_rect());
         if rect.is_empty() {
@@ -117,39 +118,52 @@ impl LiquifyTool {
         self.session = Some(Session {
             layer: id,
             original: raster.tiles.clone(),
-            token: crate::mesh::next_source_token(),
             mesh: Mesh::new(rect),
             last: None,
         });
     }
 
-    /// Re-render the layer from the snapshot through the current mesh.
-    fn render(&self, doc: &mut Document) {
+    /// Re-render `region` of the layer from the snapshot through the
+    /// current mesh.
+    ///
+    /// Only the pixels a dab could have changed are redone. Everywhere else
+    /// the layer already holds the right answer: a render always goes from
+    /// the frozen snapshot through the mesh, and a dab only moves the
+    /// vertices under the brush, so the rest of the layer was warped
+    /// through offsets that still stand.
+    fn render(&self, doc: &mut Document, region: IntRect) {
         let Some(session) = &self.session else { return };
-        let depth = doc.depth;
-        let clip = doc.canvas_rect();
-        let warped = warp_tiles(&session.original, &session.mesh, depth, clip, session.token);
-        // Anything the mesh does not cover keeps its original pixels.
-        let mut tiles = session.original.clone();
-        for (coord, buf) in warped.iter() {
-            *tiles.get_mut_or_insert(*coord, depth) = (**buf).clone();
+        let region = region.intersect(&doc.canvas_rect());
+        if region.is_empty() {
+            return;
         }
-        if let Some(raster) = doc
+        let depth = doc.depth;
+        let Some(raster) = doc
             .tree
             .find_mut(session.layer)
             .and_then(|l| l.as_raster_mut())
-        {
-            raster.tiles = tiles;
-        }
-        doc.add_damage(session.mesh.rect);
-    }
-
-    /// Apply one dab of the current brush to the mesh.
-    fn dab(&mut self, x: f32, y: f32, dx: f32, dy: f32) {
-        let Some(session) = &mut self.session else {
+        else {
             return;
         };
+        warp_into(
+            &mut raster.tiles,
+            &session.original,
+            &session.mesh,
+            depth,
+            region,
+            0,
+        );
+        doc.add_damage(region);
+    }
+
+    /// Apply one dab of the current brush to the mesh, returning the
+    /// destination pixels it changed.
+    fn dab(&mut self, x: f32, y: f32, dx: f32, dy: f32) -> IntRect {
+        let Some(session) = &mut self.session else {
+            return IntRect::EMPTY;
+        };
         let radius = self.size / 2.0;
+        let dirty = session.mesh.dab_rect(x, y, radius);
         let strength = (self.pressure / 100.0).clamp(0.0, 1.0);
         match self.mode {
             Mode::Forward => {
@@ -163,7 +177,7 @@ impl LiquifyTool {
                 // Perpendicular to the drag: pixels slide to its left.
                 let len = dx.hypot(dy);
                 if len < 1e-4 {
-                    return;
+                    return IntRect::EMPTY;
                 }
                 let (px, py) = (dy / len, -dx / len);
                 let push = len * strength;
@@ -200,6 +214,7 @@ impl LiquifyTool {
                 });
             }
         }
+        dirty
     }
 
     fn commit(&mut self, ctx: &mut ToolCtx) {
@@ -210,25 +225,24 @@ impl LiquifyTool {
         if session.mesh.is_identity() {
             return;
         }
-        // Put the original back so the recorded edit has the right before,
-        // then write the warped result as one entry.
-        let depth = ctx.doc.depth;
-        let clip = ctx.doc.canvas_rect();
-        let warped = warp_tiles(&session.original, &session.mesh, depth, clip, session.token);
-        let mut tiles = session.original.clone();
-        for (coord, buf) in warped.iter() {
-            *tiles.get_mut_or_insert(*coord, depth) = (**buf).clone();
-        }
-        if let Some(raster) = ctx
+        // The layer already holds the finished warp: every dab re-rendered
+        // the pixels it touched, from the snapshot, through the mesh. So
+        // this is not another sweep of the artwork — it is taking the
+        // result out, putting the snapshot back so the recorded edit has
+        // the right before, and writing the result as one entry. Tiles no
+        // dab reached are still shared with the snapshot, and the edit
+        // compares by pointer, so history only carries what moved.
+        let Some(raster) = ctx
             .doc
             .tree
             .find_mut(session.layer)
             .and_then(|l| l.as_raster_mut())
-        {
-            raster.tiles = session.original.clone();
-        }
+        else {
+            return;
+        };
+        let warped = std::mem::replace(&mut raster.tiles, session.original);
         let mut edit = ctx.doc.begin_edit("Liquify");
-        edit.replace_layer_tiles(session.layer, tiles);
+        edit.replace_layer_tiles(session.layer, warped);
         edit.commit();
     }
 }
@@ -289,8 +303,8 @@ impl ToolPlugin for LiquifyTool {
             session.last = Some((input.x, input.y));
         }
         // A click with no drag still applies the radial brushes.
-        self.dab(input.x, input.y, 0.0, 0.0);
-        self.render(ctx.doc);
+        let dirty = self.dab(input.x, input.y, 0.0, 0.0);
+        self.render(ctx.doc, dirty);
     }
 
     fn on_pointer_move(&mut self, ctx: &mut ToolCtx, input: PointerInput) {
@@ -302,11 +316,11 @@ impl ToolPlugin for LiquifyTool {
         if dx.hypot(dy) < 1.0 {
             return;
         }
-        self.dab(input.x, input.y, dx, dy);
+        let dirty = self.dab(input.x, input.y, dx, dy);
         if let Some(session) = &mut self.session {
             session.last = Some((input.x, input.y));
         }
-        self.render(ctx.doc);
+        self.render(ctx.doc, dirty);
     }
 
     fn on_pointer_up(&mut self, _ctx: &mut ToolCtx, _input: PointerInput) {
@@ -359,5 +373,5 @@ pub fn liquify_region(
     mesh: &Mesh,
     depth: schist_color::Depth,
 ) -> TileMap {
-    warp_tiles(src, mesh, depth, rect, 0)
+    crate::mesh::warp_tiles(src, mesh, depth, rect, 0)
 }

--- a/plugins/tools-warp/src/mesh.rs
+++ b/plugins/tools-warp/src/mesh.rs
@@ -6,6 +6,7 @@
 //! grid and interpolated, because storing it per pixel would cost
 //! 96 MB on a 12-megapixel layer for no visible gain.
 
+use rayon::prelude::*;
 use schist_color::{Depth, Rgba};
 use schist_core::{IntRect, TileCoord, TileMap, TILE_SIZE};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -24,6 +25,16 @@ pub struct Mesh {
     /// `(dx, dy)` per vertex: where this point's colour is fetched *from*,
     /// relative to itself. Zero everywhere means the identity.
     pub offsets: Vec<(f32, f32)>,
+}
+
+/// A rectangular slice of a [`Mesh`], in the flat form the kernel takes.
+pub struct Subgrid {
+    /// `(dx, dy)` per vertex, interleaved, row major.
+    pub offsets: Vec<f32>,
+    pub cols: usize,
+    pub rows: usize,
+    /// Document position of this slice's vertex (0, 0).
+    pub origin: (i32, i32),
 }
 
 impl Mesh {
@@ -95,6 +106,73 @@ impl Mesh {
         }
     }
 
+    /// The destination pixels a dab at `(cx, cy)` can change.
+    ///
+    /// A dab only moves vertices inside its radius, and a destination
+    /// pixel interpolates the four vertices around it, so the influence
+    /// stops one cell past the outermost vertex the brush reached. This is
+    /// what lets a stroke re-render its own footprint instead of the whole
+    /// layer.
+    pub fn dab_rect(&self, cx: f32, cy: f32, radius: f32) -> IntRect {
+        let reach = radius + CELL;
+        IntRect::new(
+            (cx - reach).floor() as i32,
+            (cy - reach).floor() as i32,
+            (cx + reach).ceil() as i32 + 1,
+            (cy + reach).ceil() as i32 + 1,
+        )
+        .intersect(&self.rect)
+    }
+
+    /// The vertices `rect` samples, interleaved `(dx, dy)`, with the grid
+    /// shape and origin that go with them.
+    ///
+    /// A dab re-renders a disc, and handing the kernel the whole grid for
+    /// it would copy far more offsets than the disc reads — a megabyte and
+    /// a half per pointer move on a 12-megapixel layer. The slice keeps a
+    /// cell of margin on every side, so a pixel inside `rect` interpolates
+    /// the same four vertices it would have in the full grid, and where the
+    /// margin runs out it is because the full grid ends there too, which
+    /// makes clamping agree as well.
+    pub fn subgrid(&self, rect: IntRect) -> Subgrid {
+        if self.cols < 2 || self.rows < 2 || rect.is_empty() {
+            return Subgrid {
+                offsets: self.offsets.iter().flat_map(|(x, y)| [*x, *y]).collect(),
+                cols: self.cols,
+                rows: self.rows,
+                origin: (self.rect.left, self.rect.top),
+            };
+        }
+        let lo = |v: i32, origin: i32| {
+            (((v - origin) as f32 / CELL).floor() as i64 - 1).clamp(0, i64::MAX) as usize
+        };
+        let hi = |v: i32, origin: i32, n: usize| {
+            (((v - origin) as f32 / CELL).ceil() as i64 + 1).clamp(0, n as i64 - 1) as usize
+        };
+        let lo_c = lo(rect.left, self.rect.left).min(self.cols - 1);
+        let lo_r = lo(rect.top, self.rect.top).min(self.rows - 1);
+        let hi_c = hi(rect.right, self.rect.left, self.cols).max(lo_c);
+        let hi_r = hi(rect.bottom, self.rect.top, self.rows).max(lo_r);
+        let (cols, rows) = (hi_c - lo_c + 1, hi_r - lo_r + 1);
+        let mut offsets = Vec::with_capacity(cols * rows * 2);
+        for row in lo_r..=hi_r {
+            let base = row * self.cols;
+            for &(dx, dy) in &self.offsets[base + lo_c..=base + hi_c] {
+                offsets.push(dx);
+                offsets.push(dy);
+            }
+        }
+        Subgrid {
+            offsets,
+            cols,
+            rows,
+            origin: (
+                self.rect.left + (lo_c as f32 * CELL) as i32,
+                self.rect.top + (lo_r as f32 * CELL) as i32,
+            ),
+        }
+    }
+
     /// Bilinear displacement at a document position.
     pub fn sample(&self, x: f32, y: f32) -> (f32, f32) {
         if self.cols < 2 || self.rows < 2 {
@@ -128,11 +206,13 @@ impl Mesh {
 
 /// Identify one warp source for the life of a drag.
 ///
-/// Liquify and Puppet Warp both re-render from a snapshot taken when the
-/// gesture started, so the pixels never change while the mesh does — which
-/// is exactly what lets an accelerated backend keep the source plane
-/// resident and pay only for the result coming back. Anything that hands
-/// out a token is promising the pixels behind it are frozen.
+/// Puppet Warp re-renders everything its mesh covers from a snapshot taken
+/// when the gesture started, so the pixels never change while the mesh
+/// does — which is exactly what lets an accelerated backend keep the source
+/// plane resident and pay only for the result coming back. Anything that
+/// hands out a token is promising the pixels behind it are frozen. (Liquify
+/// wants no token: a dab redoes its own footprint, which is small enough
+/// that the transfer would cost more than the work.)
 pub fn next_source_token() -> u64 {
     static NEXT: AtomicU64 = AtomicU64::new(1);
     NEXT.fetch_add(1, Ordering::Relaxed)
@@ -151,20 +231,46 @@ pub fn warp_tiles(
     src_token: u64,
 ) -> TileMap {
     let mut out = TileMap::new();
+    warp_into(&mut out, src, mesh, depth, clip, src_token);
+    out
+}
+
+/// Resample `src` through `mesh` into `dst`, touching only pixels inside
+/// `clip`.
+///
+/// Splitting this out is what lets a Liquify stroke re-render just the
+/// footprint of the dab it has applied: everything outside `clip` in `dst`
+/// was warped through the same mesh values by an earlier call and is still
+/// current, because a dab only moves the vertices under the brush.
+pub fn warp_into(
+    dst: &mut TileMap,
+    src: &TileMap,
+    mesh: &Mesh,
+    depth: Depth,
+    clip: IntRect,
+    src_token: u64,
+) {
     let region = mesh.rect.intersect(&clip);
     if region.is_empty() {
-        return out;
+        return;
     }
-    // The source plane is the whole snapshot, not just what this mesh
-    // reaches: it has to stay the same across a drag for the token to mean
-    // anything, and outside the stored tiles the map reads as transparent
-    // anyway.
-    let plane = src.tile_bounds();
-    let offsets: Vec<f32> = mesh
-        .offsets
-        .iter()
-        .flat_map(|(dx, dy)| [*dx, *dy])
-        .collect();
+    let stored = src.tile_bounds();
+    let grid = mesh.subgrid(region);
+    // Which source pixels to put in front of the kernel, and it follows
+    // from the token. A token promises a fixed plane across a drag, so a
+    // backend can keep it resident and a sweep of the whole layer pays for
+    // the transfer once; the plane is then the entire snapshot, because
+    // cropping it would make the token name different pixels on different
+    // calls. No token means a one-off — in practice the footprint of a
+    // single dab — and flattening megabytes of layer to resample a disc of
+    // it costs far more than the resample, so the plane shrinks to what the
+    // displacement over this region can actually reach.
+    let plane = if src_token != 0 {
+        stored
+    } else {
+        let reach = grid.offsets.iter().fold(0.0f32, |m, v| m.max(v.abs()));
+        region.inflated(reach.ceil() as i32 + 2).intersect(&stored)
+    };
     let params = schist_fx::WarpParams {
         src_width: plane.width().max(0) as usize,
         src_height: plane.height().max(0) as usize,
@@ -172,11 +278,11 @@ pub fn warp_tiles(
         dst_origin: (region.left, region.top),
         dst_width: region.width().max(0) as usize,
         dst_height: region.height().max(0) as usize,
-        mesh: &offsets,
-        mesh_cols: mesh.cols,
-        mesh_rows: mesh.rows,
+        mesh: &grid.offsets,
+        mesh_cols: grid.cols,
+        mesh_rows: grid.rows,
         cell: CELL,
-        mesh_origin: (mesh.rect.left, mesh.rect.top),
+        mesh_origin: grid.origin,
         src_token,
     };
     let warped = schist_fx::warp(&params, || flatten(src, plane));
@@ -188,7 +294,7 @@ pub fn warp_tiles(
         if cliprect.is_empty() {
             continue;
         }
-        let buf = out.get_mut_or_insert(coord, depth);
+        let buf = dst.get_mut_or_insert(coord, depth);
         for y in cliprect.top..cliprect.bottom {
             for x in cliprect.left..cliprect.right {
                 let i = ((y - region.top) as usize * stride + (x - region.left) as usize) * 4;
@@ -200,20 +306,40 @@ pub fn warp_tiles(
             }
         }
     }
-    out
 }
 
 /// Copy a tile map's stored region out into one flat straight-alpha plane.
+///
+/// A row at a time across the cores, and within a row a tile at a time: a
+/// map lookup per pixel costs about as much as the resample this is
+/// feeding. A tile the map does not store is transparent, which the buffer
+/// already is.
 fn flatten(src: &TileMap, rect: IntRect) -> Vec<f32> {
     let (w, h) = (rect.width().max(0) as usize, rect.height().max(0) as usize);
     let mut out = vec![0.0f32; w * h * 4];
-    for row in 0..h {
-        for col in 0..w {
-            let p = src.pixel(rect.left + col as i32, rect.top + row as i32);
-            let i = (row * w + col) * 4;
-            out[i..i + 4].copy_from_slice(&[p.r, p.g, p.b, p.a]);
-        }
+    if w == 0 || h == 0 {
+        return out;
     }
+    out.par_chunks_mut(w * 4)
+        .enumerate()
+        .for_each(|(row, dst)| {
+            let y = rect.top + row as i32;
+            let ty = y.div_euclid(TILE_SIZE);
+            let ly = y.rem_euclid(TILE_SIZE) * TILE_SIZE;
+            let mut x = rect.left;
+            while x < rect.right {
+                let tx = x.div_euclid(TILE_SIZE);
+                let end = ((tx + 1) * TILE_SIZE).min(rect.right);
+                if let Some(tile) = src.get(TileCoord { tx, ty }) {
+                    for x in x..end {
+                        let p = tile.get((ly + x.rem_euclid(TILE_SIZE)) as usize);
+                        let i = (x - rect.left) as usize * 4;
+                        dst[i..i + 4].copy_from_slice(&[p.r, p.g, p.b, p.a]);
+                    }
+                }
+                x = end;
+            }
+        });
     out
 }
 

--- a/plugins/tools-warp/tests/incremental_warp.rs
+++ b/plugins/tools-warp/tests/incremental_warp.rs
@@ -1,0 +1,276 @@
+//! A stroke that re-renders only what each dab touched has to land on the
+//! same pixels as one sweep of the whole mesh, or Liquify's speed would be
+//! bought with seams and stale patches.
+
+use schist_color::{Depth, Rgba};
+use schist_core::{IntRect, TileCoord, TileMap};
+use schist_tools_warp::mesh::{warp_into, warp_tiles, Mesh};
+
+const RECT: IntRect = IntRect {
+    left: 0,
+    top: 0,
+    right: 300,
+    bottom: 220,
+};
+
+fn artwork() -> TileMap {
+    let mut tiles = TileMap::new();
+    for coord in TileCoord::covering(&RECT) {
+        let trect = coord.rect();
+        let buf = tiles.get_mut_or_insert(coord, Depth::ThirtyTwo);
+        for ly in 0..schist_core::TILE_SIZE {
+            for lx in 0..schist_core::TILE_SIZE {
+                let (x, y) = (trect.left + lx, trect.top + ly);
+                // A pattern with detail at every scale, so a stale patch
+                // or a fetch from the wrong place shows up as a mismatch.
+                let v = (((x * 7) ^ (y * 13)) % 255) as f32 / 255.0;
+                buf.set(
+                    (ly * schist_core::TILE_SIZE + lx) as usize,
+                    Rgba::new(v, 1.0 - v, (x % 32) as f32 / 32.0, 1.0),
+                );
+            }
+        }
+    }
+    tiles
+}
+
+/// The dabs of one stroke: a forward push, a twirl and a bloat, so the
+/// mesh ends up with offsets of both signs on both axes.
+fn dabs(mesh: &mut Mesh, i: usize) -> IntRect {
+    let (x, y) = (60.0 + i as f32 * 9.0, 70.0 + (i as f32 * 5.0).sin() * 30.0);
+    let radius = 24.0 + (i % 3) as f32 * 12.0;
+    let dirty = mesh.dab_rect(x, y, radius);
+    match i % 3 {
+        0 => mesh.for_each_near(x, y, radius, |off, w, _, _| {
+            off.0 -= 9.0 * w;
+            off.1 -= 4.0 * w;
+        }),
+        1 => mesh.for_each_near(x, y, radius, |off, w, rx, ry| {
+            let (s, c) = (0.3 * w).sin_cos();
+            let (fx, fy) = (rx + off.0, ry + off.1);
+            off.0 = fx * c - fy * s - rx;
+            off.1 = fx * s + fy * c - ry;
+        }),
+        _ => mesh.for_each_near(x, y, radius, |off, w, rx, ry| {
+            let (fx, fy) = (rx + off.0, ry + off.1);
+            off.0 -= fx * 0.2 * w;
+            off.1 -= fy * 0.2 * w;
+        }),
+    }
+    dirty
+}
+
+#[test]
+fn rendering_dab_by_dab_matches_one_sweep_of_the_whole_mesh() {
+    let src = artwork();
+    let mut mesh = Mesh::new(RECT);
+    // The stroke, each dab re-rendering only its own footprint on top of
+    // what the last one left, which is what the tool does.
+    let mut running = src.clone();
+    for i in 0..24 {
+        let dirty = dabs(&mut mesh, i);
+        warp_into(&mut running, &src, &mesh, Depth::ThirtyTwo, dirty, 0);
+    }
+    // The same mesh, applied in one pass over everything, with the source
+    // handed over whole under a token.
+    let swept = warp_tiles(&src, &mesh, Depth::ThirtyTwo, RECT, 7);
+
+    for y in RECT.top..RECT.bottom {
+        for x in RECT.left..RECT.right {
+            let (a, b) = (running.pixel(x, y), swept.pixel(x, y));
+            assert!(
+                (a.r - b.r).abs() < 1e-6
+                    && (a.g - b.g).abs() < 1e-6
+                    && (a.b - b.b).abs() < 1e-6
+                    && (a.a - b.a).abs() < 1e-6,
+                "({x}, {y}) drifted: incremental {a:?}, swept {b:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn a_dab_leaves_everything_outside_its_footprint_alone() {
+    let src = artwork();
+    let mut mesh = Mesh::new(RECT);
+    let mut out = src.clone();
+    let dirty = dabs(&mut mesh, 0);
+    warp_into(&mut out, &src, &mesh, Depth::ThirtyTwo, dirty, 0);
+    for y in RECT.top..RECT.bottom {
+        for x in RECT.left..RECT.right {
+            if dirty.contains(x, y) {
+                continue;
+            }
+            assert_eq!(
+                (out.pixel(x, y).r, out.pixel(x, y).a),
+                (src.pixel(x, y).r, src.pixel(x, y).a),
+                "({x}, {y}) changed outside the dab"
+            );
+        }
+    }
+}
+
+#[test]
+fn a_cropped_source_plane_reaches_as_far_as_the_displacement_does() {
+    // One big push, rendered through a window far smaller than the throw,
+    // so the resample has to read well outside the window it is filling.
+    let src = artwork();
+    let mut mesh = Mesh::new(RECT);
+    mesh.for_each_near(150.0, 110.0, 100.0, |off, w, _, _| off.0 -= 60.0 * w);
+    let window = IntRect::new(140, 100, 160, 120);
+    let mut cropped = TileMap::new();
+    warp_into(&mut cropped, &src, &mesh, Depth::ThirtyTwo, window, 0);
+    let whole = warp_tiles(&src, &mesh, Depth::ThirtyTwo, RECT, 11);
+    for y in window.top..window.bottom {
+        for x in window.left..window.right {
+            let (a, b) = (cropped.pixel(x, y), whole.pixel(x, y));
+            assert!(
+                (a.r - b.r).abs() < 1e-6 && (a.a - b.a).abs() < 1e-6,
+                "({x}, {y}) lost pixels the crop should have covered: {a:?} vs {b:?}"
+            );
+        }
+    }
+}
+
+// ===== the tool itself =====
+
+use schist_core::{Document, Layer};
+use schist_plugin_api::{EditorState, PointerInput, ToolCtx, ToolPlugin};
+use schist_tools_warp::liquify::LiquifyTool;
+
+fn document() -> (Document, schist_core::LayerId) {
+    let mut doc = Document::new("t", 300, 220, Depth::ThirtyTwo);
+    let mut layer = Layer::new_raster("art");
+    if let Some(raster) = layer.as_raster_mut() {
+        raster.tiles = artwork();
+    }
+    let id = layer.id;
+    doc.tree.layers.push(layer);
+    doc.active_layer = Some(id);
+    (doc, id)
+}
+
+fn at(x: f32, y: f32) -> PointerInput {
+    PointerInput {
+        x,
+        y,
+        pressure: 1.0,
+        modifiers: Default::default(),
+    }
+}
+
+fn tiles_of(doc: &Document, id: schist_core::LayerId) -> TileMap {
+    doc.tree
+        .find(id)
+        .and_then(|l| l.as_raster())
+        .map(|r| r.tiles.clone())
+        .unwrap()
+}
+
+fn stroke(tool: &mut LiquifyTool, ctx: &mut ToolCtx) {
+    tool.on_pointer_down(ctx, at(100.0, 110.0));
+    for i in 1..=20 {
+        tool.on_pointer_move(ctx, at(100.0 + i as f32 * 4.0, 110.0));
+    }
+    tool.on_pointer_up(ctx, at(180.0, 110.0));
+}
+
+#[test]
+fn a_pointer_move_damages_the_brush_and_not_the_layer() {
+    let (mut doc, _) = document();
+    let mut state = EditorState::default();
+    let mut tool = LiquifyTool::new();
+    let mut ctx = ToolCtx {
+        doc: &mut doc,
+        state: &mut state,
+    };
+    tool.on_activate(&mut ctx);
+    tool.on_pointer_down(&mut ctx, at(100.0, 110.0));
+    ctx.doc.take_damage();
+    tool.on_pointer_move(&mut ctx, at(112.0, 110.0));
+    let damage = ctx.doc.take_damage();
+    let area: i64 = damage
+        .iter()
+        .map(|r| r.width() as i64 * r.height() as i64)
+        .sum();
+    // The default brush is 100 across; a footprint plus a cell of slop is
+    // around 12 000 pixels, where the whole layer is 66 000.
+    assert!(
+        area < 20_000,
+        "a dab repainted {area} pixels, which is most of the layer"
+    );
+}
+
+#[test]
+fn committing_writes_the_warp_and_undo_takes_it_back() {
+    let (mut doc, id) = document();
+    let before = tiles_of(&doc, id);
+    let mut state = EditorState::default();
+    let mut tool = LiquifyTool::new();
+    {
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        tool.on_activate(&mut ctx);
+        stroke(&mut tool, &mut ctx);
+        tool.on_commit(&mut ctx);
+    }
+    let after = tiles_of(&doc, id);
+    let moved = (0..220)
+        .flat_map(|y| (0..300).map(move |x| (x, y)))
+        .filter(|&(x, y)| (after.pixel(x, y).r - before.pixel(x, y).r).abs() > 1e-4)
+        .count();
+    assert!(moved > 1000, "the stroke barely changed anything: {moved}");
+    // Nothing outside the brush's reach along the stroke moved. (Inside
+    // it, even a pixel the mesh did not displace comes back through the
+    // resample, which costs it a bit of float.)
+    for y in 0..220 {
+        for x in 0..300 {
+            if (40..=240).contains(&x) && (50..=175).contains(&y) {
+                continue;
+            }
+            assert_eq!(
+                after.pixel(x, y).r,
+                before.pixel(x, y).r,
+                "({x}, {y}) changed, far from the stroke"
+            );
+        }
+    }
+    assert_eq!(doc.undo().as_deref(), Some("Liquify"));
+    let undone = tiles_of(&doc, id);
+    for y in 0..220 {
+        for x in 0..300 {
+            assert_eq!(
+                undone.pixel(x, y).r,
+                before.pixel(x, y).r,
+                "undo left ({x}, {y}) warped"
+            );
+        }
+    }
+}
+
+#[test]
+fn escape_puts_the_pixels_back() {
+    let (mut doc, id) = document();
+    let before = tiles_of(&doc, id);
+    let mut state = EditorState::default();
+    let mut tool = LiquifyTool::new();
+    let mut ctx = ToolCtx {
+        doc: &mut doc,
+        state: &mut state,
+    };
+    tool.on_activate(&mut ctx);
+    stroke(&mut tool, &mut ctx);
+    tool.on_cancel(&mut ctx);
+    let after = tiles_of(ctx.doc, id);
+    for y in 0..220 {
+        for x in 0..300 {
+            assert_eq!(
+                after.pixel(x, y).r,
+                before.pixel(x, y).r,
+                "cancel left ({x}, {y}) warped"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Liquify felt laggy because every pointer move re-warped the whole layer: flatten the entire snapshot to f32, resample all of it, clone the tile map, write every tile back, and damage the layer rect so the compositor recomposited the canvas. On a 12-megapixel layer that was ~1 s per mouse move, and Enter cost another 1.3 s.

## What changed

- **Render the dab's footprint, not the layer.** A dab only moves the mesh vertices under the brush, and a destination pixel interpolates the four vertices around it, so nothing outside `radius + one cell` can change. `Mesh::dab_rect` returns that rect; `warp_into` resamples into the layer's own tiles instead of rebuilding them from a clone; damage shrinks to the same rect, so the compositor invalidates a handful of tiles.
- **Crop what the kernel is handed.** `src_token != 0` still means "the whole snapshot, keep it resident" — Puppet Warp's case, and the one an accelerated backend can use. No token now also means the plane is cropped to what the displacement over the region can reach. `Mesh::subgrid` does the same for the offsets, which were a megabyte and a half copied per pointer move.
- **Commit stops re-sweeping.** The layer already holds the finished warp, so Enter moves the tiles out and puts the snapshot back. Tiles no dab reached are still `Arc`-shared with the snapshot and `replace_layer_tiles` diffs by pointer, so undo history carries only what moved.
- **The conversions either side of the kernel**, which dominate a big dab once the sweep is gone: `flatten` goes tile-wise and parallel instead of a map lookup per pixel, `warp_cpu` puts its rows across the cores (both also help Puppet Warp and any GPU-declined fallback), and picking the tool up takes tile-granular bounds rather than scanning twelve megapixels of alpha.

## Numbers

`cargo run --release -p schist-tools-warp --example liquifybench` (new):

| layer | brush | pick up | pointer move | commit |
|---|---|---|---|---|
| 1024×768 | 100 | 3.8 → 0.0 ms | 50.7 → **0.9 ms** | 52.4 → 0.2 ms |
| 4000×3000 | 100 | 51 → 0.1 ms | 1045 → **0.8 ms** | 1356 → 1.0 ms |
| 4000×3000 | 1000 | 97 → 0.3 ms | 1318 → **21.5 ms** | 1320 → 0.3 ms |

## Testing

`tests/incremental_warp.rs` holds the invariant the speedup rests on: a stroke rendered dab by dab is pixel-identical to one sweep of the final mesh. Plus a dab touching nothing outside its footprint, a cropped plane reaching as far as the displacement does, and tool-level tests for damage size, commit/undo and Escape. Workspace tests and clippy are clean, and the GPU warp-parity tests still pass.

Also driven end to end through the headless MCP server on a real image — smooth warp, no seams or stale patches, undo restored the file byte-identically.

## Notes

- Liquify no longer goes near the GPU warp; a dab is far below what a round trip pays for. The comments naming it as the resident-source client now name Puppet Warp, which still is.
- Pre-existing edge case, left alone: if another edit changes the layer while a Liquify session is open but idle, the snapshot goes stale. Before, the next dab reverted the whole layer; now it reverts only the dab's footprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)