### PR TITLE
Open the Color Picker from every colour swatch

### DIFF
--- a/crates/app/src/color_picker.rs
+++ b/crates/app/src/color_picker.rs
@@ -276,8 +276,13 @@ pub fn render(
 
     ui::modal_frame(
         match target {
-            ColorTarget::Foreground => "Color Picker (Foreground Color)",
-            ColorTarget::Background => "Color Picker (Background Color)",
+            ColorTarget::Foreground => SharedString::from("Color Picker (Foreground Color)"),
+            ColorTarget::Background => SharedString::from("Color Picker (Background Color)"),
+            ColorTarget::StyleEffect(effect) => SharedString::from(format!(
+                "Color Picker ({} Color)",
+                crate::style_dialog::effect_label(effect)
+            )),
+            ColorTarget::ColorRange => SharedString::from("Color Picker (Color Range)"),
         },
         620.0,
         body,

--- a/crates/app/src/dialogs.rs
+++ b/crates/app/src/dialogs.rs
@@ -2,7 +2,7 @@
 //! adjustments, export options and preferences.
 
 use crate::ui;
-use crate::workspace::{Modal, Popup, Workspace};
+use crate::workspace::{ColorTarget, Modal, Popup, Workspace};
 use gpui::{
     div, px, Context, InteractiveElement as _, IntoElement, ParentElement as _, SharedString,
     StatefulInteractiveElement as _, Styled as _,
@@ -1354,11 +1354,23 @@ fn color_range_dialog(
                 .gap_2()
                 .child(
                     div()
+                        .id("color-range-swatch")
                         .size(px(18.0))
+                        .flex_none()
                         .rounded_sm()
                         .border_1()
                         .border_color(gpui::rgb(ui::palette().edge))
-                        .bg(gpui::rgb(swatch)),
+                        .bg(gpui::rgb(swatch))
+                        .cursor_pointer()
+                        .hover(|s| s.border_color(gpui::rgb(ui::palette().text)))
+                        .on_mouse_down(
+                            gpui::MouseButton::Left,
+                            cx.listener(move |ws, _e, _w, cx| {
+                                // This dialog stays open underneath the
+                                // picker and takes the colour on OK.
+                                ws.open_color_picker_on(ColorTarget::ColorRange, target, cx);
+                            }),
+                        ),
                 )
                 .child(ui::button(
                     "Use Foreground",

--- a/crates/app/src/style_dialog.rs
+++ b/crates/app/src/style_dialog.rs
@@ -8,7 +8,7 @@
 
 use crate::dialogs::{param_slider, SliderSpec};
 use crate::ui;
-use crate::workspace::{Modal, Popup, Workspace};
+use crate::workspace::{ColorTarget, Modal, Popup, Workspace};
 use gpui::{
     div, px, Context, InteractiveElement as _, IntoElement, MouseButton, MouseDownEvent,
     ParentElement as _, SharedString, StatefulInteractiveElement as _, Styled,
@@ -266,7 +266,21 @@ fn color_of(style: &LayerStyle, effect: &str) -> Option<Rgba> {
     })
 }
 
-fn set_color(style: &mut LayerStyle, effect: &str, c: Rgba) {
+/// The display name of a colour this dialog owns, for the Color Picker's
+/// title bar.
+pub fn effect_label(effect: &str) -> &'static str {
+    match effect {
+        "gradient_overlay.from" => "Gradient Overlay From",
+        "gradient_overlay.to" => "Gradient Overlay To",
+        _ => EFFECTS
+            .iter()
+            .find(|(key, _)| *key == effect)
+            .map(|(_, label)| *label)
+            .unwrap_or("Layer Style"),
+    }
+}
+
+pub fn set_color(style: &mut LayerStyle, effect: &str, c: Rgba) {
     match effect {
         "drop_shadow" => style.drop_shadow.settings.color = c,
         "inner_shadow" => style.inner_shadow.settings.color = c,
@@ -275,8 +289,38 @@ fn set_color(style: &mut LayerStyle, effect: &str, c: Rgba) {
         "stroke" => style.stroke.settings.color = c,
         "color_overlay" => style.color_overlay.settings.color = c,
         "satin" => style.satin.settings.color = c,
+        // The gradient's two ends are not "the effect's colour", so they
+        // get their own keys rather than a slot in `color_of`.
+        "gradient_overlay.from" => style.gradient_overlay.settings.from = c,
+        "gradient_overlay.to" => style.gradient_overlay.settings.to = c,
         _ => {}
     }
+}
+
+/// A colour swatch that opens the Color Picker on `key`. The Layer Style
+/// dialog stays open underneath it and takes the colour on OK.
+fn color_swatch(
+    id: &'static str,
+    key: &'static str,
+    c: Rgba,
+    cx: &mut Context<Workspace>,
+) -> impl IntoElement {
+    div()
+        .id(id)
+        .size(px(18.0))
+        .flex_none()
+        .rounded_sm()
+        .border_1()
+        .border_color(gpui::rgb(ui::palette().edge))
+        .bg(gpui::rgb(rgb_of(c)))
+        .cursor_pointer()
+        .hover(|s| s.border_color(gpui::rgb(ui::palette().text)))
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
+                ws.open_color_picker_on(ColorTarget::StyleEffect(key), c, cx);
+            }),
+        )
 }
 
 fn blend_of(style: &LayerStyle, effect: &str) -> Option<BlendMode> {
@@ -423,14 +467,7 @@ pub fn render(
                 .flex_row()
                 .items_center()
                 .gap_2()
-                .child(
-                    div()
-                        .size(px(18.0))
-                        .rounded_sm()
-                        .border_1()
-                        .border_color(gpui::rgb(ui::palette().edge))
-                        .bg(gpui::rgb(rgb_of(c))),
-                )
+                .child(color_swatch("style-color-swatch", active, c, cx))
                 .child(ui::button(
                     "Use Foreground",
                     false,
@@ -585,7 +622,14 @@ pub fn render(
                     div()
                         .flex()
                         .flex_row()
+                        .items_center()
                         .gap_2()
+                        .child(color_swatch(
+                            "style-gradient-from",
+                            "gradient_overlay.from",
+                            style.gradient_overlay.settings.from,
+                            cx,
+                        ))
                         .child(ui::button(
                             "From = FG",
                             false,
@@ -593,6 +637,12 @@ pub fn render(
                                 let fg = ws.editor.foreground;
                                 edit(ws, cx, |s| s.gradient_overlay.settings.from = fg);
                             },
+                            cx,
+                        ))
+                        .child(color_swatch(
+                            "style-gradient-to",
+                            "gradient_overlay.to",
+                            style.gradient_overlay.settings.to,
                             cx,
                         ))
                         .child(ui::button(

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -170,6 +170,10 @@ pub struct Workspace {
     pub context_menu: Option<ContextMenu>,
     /// The open modal dialog, if any.
     pub modal: Option<Modal>,
+    /// Dialogs suspended underneath `modal`, innermost last. Only the
+    /// Color Picker stacks: it opens on top of a dialog that owns a colour
+    /// swatch, and closing it puts that dialog back exactly as it was.
+    modal_stack: Vec<Modal>,
     /// Numeric field currently accepting digits, and its edit buffer.
     pub focused_field: Option<&'static str>,
     pub field_buffer: String,
@@ -611,11 +615,18 @@ pub enum Modal {
     },
 }
 
-/// Which of the two editor colours a picker is editing.
+/// What a picker is editing.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ColorTarget {
     Foreground,
     Background,
+    /// A colour belonging to one Layer Style effect, keyed as in
+    /// `style_dialog::EFFECTS`. That dialog stays open underneath the
+    /// picker and receives the colour on OK.
+    StyleEffect(&'static str),
+    /// The colour Select ▸ Color Range matches against, with that
+    /// dialog left open underneath the picker.
+    ColorRange,
 }
 
 /// A press on a layer row that may become a drag-reorder.
@@ -717,6 +728,7 @@ impl Workspace {
             tool_press: None,
             context_menu: None,
             modal: None,
+            modal_stack: Vec::new(),
             focused_field: None,
             field_buffer: String::new(),
             plugins,
@@ -3333,6 +3345,9 @@ impl Workspace {
     // ----- modals and numeric fields -----
 
     pub fn open_modal(&mut self, modal: Modal, cx: &mut Context<Self>) {
+        // A dialog opened from the menus replaces whatever was up,
+        // suspended parents included; only `open_color_picker_on` stacks.
+        self.modal_stack.clear();
         self.modal = Some(modal);
         self.context_menu = None;
         self.focused_field = None;
@@ -3346,8 +3361,25 @@ impl Workspace {
         let original = match target {
             ColorTarget::Foreground => self.editor.foreground,
             ColorTarget::Background => self.editor.background,
+            // Not reachable from the editor colour wells: these belong to
+            // a dialog, which opens the picker through
+            // `open_color_picker_on` and supplies the colour itself.
+            ColorTarget::StyleEffect(_) | ColorTarget::ColorRange => return,
         };
+        self.open_color_picker_on(target, original, cx);
+    }
+
+    /// Open the picker over the dialog that is already up, which is
+    /// suspended rather than closed: `close_modal` brings it back whether
+    /// the picker is OK'd or cancelled.
+    pub fn open_color_picker_on(
+        &mut self,
+        target: ColorTarget,
+        original: Rgba,
+        cx: &mut Context<Self>,
+    ) {
         let hsv = crate::color_picker::rgb_to_hsv(original.r, original.g, original.b);
+        let parent = self.modal.take();
         self.open_modal(
             Modal::ColorPicker {
                 target,
@@ -3356,6 +3388,10 @@ impl Workspace {
             },
             cx,
         );
+        // After `open_modal`, which clears the stack.
+        if let Some(parent) = parent {
+            self.modal_stack.push(parent);
+        }
     }
 
     /// Take the picker's colour and close it. Cancel does nothing, because
@@ -3370,8 +3406,34 @@ impl Workspace {
         match target {
             ColorTarget::Foreground => self.editor.foreground = colour,
             ColorTarget::Background => self.editor.background = colour,
+            // Written below, once `close_modal` has put the dialog the
+            // picker was opened from back in `self.modal`.
+            ColorTarget::StyleEffect(_) | ColorTarget::ColorRange => {}
         }
         self.close_modal(cx);
+        match target {
+            ColorTarget::StyleEffect(effect) => {
+                let mut next = None;
+                self.update_modal(|m| {
+                    if let Modal::LayerStyle { style, layer, .. } = m {
+                        crate::style_dialog::set_color(style, effect, colour);
+                        next = Some((*layer, **style));
+                    }
+                });
+                if let Some((layer, style)) = next {
+                    self.preview_layer_style(layer, style, cx);
+                }
+            }
+            ColorTarget::ColorRange => {
+                self.update_modal(|m| {
+                    if let Modal::ColorRange { target, .. } = m {
+                        *target = colour;
+                    }
+                });
+                cx.notify();
+            }
+            ColorTarget::Foreground | ColorTarget::Background => {}
+        }
     }
 
     /// The ± buttons beside a picker component.
@@ -3391,7 +3453,8 @@ impl Workspace {
         // Same for a cancelled Layer Style session: OK clears the modal
         // itself before it gets here, so reaching this means Cancel.
         self.revert_layer_style();
-        self.modal = None;
+        // Closing the picker uncovers the dialog it was opened from.
+        self.modal = self.modal_stack.pop();
         self.focused_field = None;
         self.field_buffer.clear();
         self.open_popup = None;


### PR DESCRIPTION
Clicking the swatch on Layer Style's Color row did nothing, which is the one thing the control looks like it should do.

The reason it did nothing is that `Workspace::modal` is a single `Option<Modal>` and the picker is itself a `Modal`, so opening it would have thrown away the Layer Style session mid-edit. So modals get a suspend stack: `open_color_picker_on` pushes the dialog that is already up, and `close_modal` pops it back rather than clearing, whether the picker was OK'd or cancelled. `modal` stays the top of the stack, so the dozen places that read it -- the renderer, the key routing, the "is a dialog up" guards -- carry on unchanged. `open_modal` clears the stack, so a dialog launched from the menus still replaces everything.

Three swatches wanted this, not one:

- Layer Style's per-effect Color, via `ColorTarget::StyleEffect(key)`. OK writes through `set_color` and re-previews the layer, the same path the sliders use, so the canvas keeps up.
- Gradient Overlay's From and To, which had no swatches at all -- only the "From = FG" / "To = FG" buttons, so the two colours were reachable only by way of the foreground. They ride the same variant under dotted keys, `gradient_overlay.from` and `.to`, since they are ends of a gradient rather than "the effect's colour" and have no slot in `color_of`.
- Select > Color Range's Sampled, which needs its own variant because it writes back to a different modal.

Driven headlessly to check the parts that are easy to get wrong: OK restores the parent dialog with every other control intact, Cancel and Escape restore it with the colour unchanged, and the parent's own OK/Cancel still commit and revert.