### PR TITLE
Strip debug sections from the shipped Linux binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,11 @@ jobs:
       - name: Package (Linux)
         if: runner.os == 'Linux'
         run: |
+          # The release profile compiles with debug = 1 for readable local
+          # backtraces, and ELF is the one format that embeds that info in the
+          # executable itself -- strip it here so neither the AppImage payload
+          # nor the loose binaries ship it. Symbols stay; only DWARF goes.
+          strip --strip-debug target/release/schist target/release/schist-mcp
           sudo apt-get install -y libfuse2 || true
           curl -sSL -o /tmp/appimagetool \
             https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage


### PR DESCRIPTION
## Summary
- The release profile compiles with `debug = 1` so local release builds get readable backtraces, and ELF is the one binary format that embeds the resulting DWARF in the executable itself — the Linux release artifacts were shipping it (macOS/Windows put it in dSYM/PDB side files that are never packaged).
- Run `strip --strip-debug` on `target/release/schist` and `target/release/schist-mcp` in the Linux packaging step, before `appimage.sh` and the `dist/` copies, so the AppImage payload and both loose binaries ship without debug sections.
- `--strip-debug` leaves the symbol table intact, so shipped binaries still symbolicate panics by function name, and `debug = 1` keeps working for local builds.

## Testing
- Verified cargo's freshness check tolerates the strip: `appimage.sh` re-runs `cargo build --release` afterwards, and a local test confirmed that build is a no-op that leaves the stripped output untouched.
- Workflow YAML parses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)