### PR TITLE
fix: emit u64 lengths for psb widened keys

### DIFF
--- a/crates/codec-psd/src/lib.rs
+++ b/crates/codec-psd/src/lib.rs
@@ -21,6 +21,15 @@ pub mod vector;
 mod writer;
 pub mod zip;
 
+/// Additional-layer-info keys whose length field widens to u64 in PSB files
+/// (per the spec's "Photoshop Big" notes). All other keys stay u32 even in
+/// PSB. Shared by the reader and the writer so the two cannot disagree
+/// about which keys are widened.
+pub(crate) const PSB_U64_KEYS: [[u8; 4]; 13] = [
+    *b"LMsk", *b"Lr16", *b"Lr32", *b"Layr", *b"Mt16", *b"Mt32", *b"Mtrn", *b"Alph", *b"FMsk",
+    *b"lnk2", *b"FEid", *b"FXid", *b"PxSD",
+];
+
 pub use error::PsdError;
 pub use reader::read_psd;
 pub use writer::{write_psd, write_psd_with, PSB_MAX_DIM, PSD_MAX_DIM};

--- a/crates/codec-psd/src/reader/layers.rs
+++ b/crates/codec-psd/src/reader/layers.rs
@@ -6,20 +6,13 @@ use super::header::Header;
 use super::pixels::{fill_mask_tiles, fill_tiles, fill_tiles_u8, plane_to_f32, ColorPlanes};
 use super::rle::unpack_channel;
 use crate::error::PsdError;
+use crate::PSB_U64_KEYS;
 use rayon::prelude::*;
 use schist_color::{ColorMode, Depth};
 use schist_core::{
     AdjustmentData, AdjustmentKind, BlendMode, GroupLayer, IntRect, Layer, LayerId, LayerKind,
     LayerMask, MaskTileMap, RasterLayer, RawBlock, TileMap,
 };
-
-/// Additional-layer-info keys whose length field widens to u64 in PSB files
-/// (per the spec's "Photoshop Big" notes). All other keys stay u32 even in
-/// PSB.
-const PSB_U64_KEYS: [[u8; 4]; 13] = [
-    *b"LMsk", *b"Lr16", *b"Lr32", *b"Layr", *b"Mt16", *b"Mt32", *b"Mtrn", *b"Alph", *b"FMsk",
-    *b"lnk2", *b"FEid", *b"FXid", *b"PxSD",
-];
 
 /// Sanity cap on a single layer dimension — PSB canvases max out at 300,000
 /// px; allow slack for layers extending past the canvas, but reject absurd

--- a/crates/codec-psd/src/writer/mod.rs
+++ b/crates/codec-psd/src/writer/mod.rs
@@ -297,8 +297,15 @@ fn write_layer_record(b: &mut Buf, p: &Prepared, psb: bool) {
     for (key, payload) in &p.extras {
         b.bytes(b"8BIM");
         b.bytes(key);
-        // Only the PSB-widened keys use u64 lengths; ours never do.
-        b.u32(payload.len() as u32);
+        // In PSB these keys carry a u64 length. `p.extras` includes blocks
+        // preserved from the source file, so they really can appear here;
+        // emitting u32 for one produced a file the reader (and Photoshop)
+        // then read four bytes short.
+        if psb && crate::PSB_U64_KEYS.contains(key) {
+            b.u64(payload.len() as u64);
+        } else {
+            b.u32(payload.len() as u32);
+        }
         b.bytes(payload);
         if payload.len() % 2 == 1 {
             b.u8(0);

--- a/crates/codec-psd/tests/writer.rs
+++ b/crates/codec-psd/tests/writer.rs
@@ -217,6 +217,66 @@ fn preserves_unknown_layer_blocks_verbatim() {
 }
 
 #[test]
+fn psb_widened_keys_round_trip() {
+    // In PSB these keys carry a u64 length. The writer emitted u32 for all
+    // of them, so the reader consumed four bytes of payload as part of the
+    // length and the file became unreadable by Schist and Photoshop alike.
+    for key in [*b"LMsk", *b"lnk2", *b"PxSD", *b"Layr"] {
+        let mut doc = base_doc();
+        let mut layer = solid_layer(
+            "psb extras",
+            IntRect::from_xywh(0, 0, 8, 8),
+            [7, 8, 9, 255],
+            Depth::Eight,
+        );
+        layer.extras.push(RawBlock {
+            key,
+            data: b"preserved payload".to_vec(),
+        });
+        doc.push_layer(layer);
+
+        let bytes = write_psd_with(&doc, true).expect("psb write");
+        let back = read_psd(&bytes).unwrap_or_else(|e| {
+            panic!(
+                "psb with {:?} failed to read back: {e}",
+                std::str::from_utf8(&key)
+            )
+        });
+        let block = back.tree.layers[0]
+            .extras
+            .iter()
+            .find(|b| b.key == key)
+            .unwrap_or_else(|| panic!("{:?} kept", std::str::from_utf8(&key)));
+        assert_eq!(block.data, b"preserved payload");
+    }
+}
+
+#[test]
+fn psd_keeps_u32_lengths_for_the_same_keys() {
+    // The widening is PSB-only; a plain PSD must be unaffected.
+    let mut doc = base_doc();
+    let mut layer = solid_layer(
+        "psd extras",
+        IntRect::from_xywh(0, 0, 8, 8),
+        [7, 8, 9, 255],
+        Depth::Eight,
+    );
+    layer.extras.push(RawBlock {
+        key: *b"LMsk",
+        data: b"preserved payload".to_vec(),
+    });
+    doc.push_layer(layer);
+
+    let back = read_psd(&write_psd(&doc).unwrap()).unwrap();
+    let block = back.tree.layers[0]
+        .extras
+        .iter()
+        .find(|b| &b.key == b"LMsk")
+        .expect("LMsk kept");
+    assert_eq!(block.data, b"preserved payload");
+}
+
+#[test]
 fn preserves_image_resources_and_resolution() {
     let mut doc = base_doc();
     doc.resolution_dpi = 144.0;


### PR DESCRIPTION
fixes #25

emit a u64 length in psb for exactly the thirteen widened keys, u32 for everything else.

the key list now lives at the crate root and both sides import it, so the reader and writer cannot drift apart again. it was previously a private const in the reader with the writer hardcoding an assumption about it.

tests cover all four widened keys round-tripping through psb, plus a psd control proving the widening stays psb-only.

## before

![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr07-before.png)

## after

![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr07-after.png)
