### PR TITLE
fix: separate key contexts for text entry and modals

### DIFF
--- a/crates/app/src/keymap.rs
+++ b/crates/app/src/keymap.rs
@@ -11,10 +11,18 @@ use gpui::{Context, KeyBinding, PathPromptOptions, Window};
 use schist_plugin_api::PluginRegistry;
 use std::path::PathBuf;
 
-const CONTEXT: Option<&str> = Some("Workspace");
-/// Context for bindings without modifiers: suppressed while a tool is
-/// capturing typing (see `Workspace::tool_captures_keys`).
+/// Commands that act on the document. Suppressed while typing and while a
+/// modal is open: GPUI dispatches a matching binding *before* the
+/// element's `on_key_down`, and actions stop propagation by default, so a
+/// bound keystroke never reaches the text-entry code at all. Excluding the
+/// binding is the only way to let the keystroke through.
+const CONTEXT: Option<&str> = Some("Workspace && !text_entry && !modal");
+/// Context for bindings without modifiers, i.e. the single-letter tool
+/// shortcuts. `editable` is present only in the ordinary state.
 const TYPING_SAFE: Option<&str> = Some("Workspace && editable");
+/// Bindings that must stay live in every state. Escape is how you leave a
+/// text session or a dialog, so it cannot be suppressed by either.
+const ALWAYS: Option<&str> = Some("Workspace");
 
 fn translate(binding: &str) -> String {
     if cfg!(target_os = "macos") {
@@ -82,7 +90,7 @@ pub fn build_bindings(registry: &PluginRegistry) -> Vec<KeyBinding> {
         KeyBinding::new("]", BrushLarger, TYPING_SAFE),
         KeyBinding::new("x", SwapColors, TYPING_SAFE),
         KeyBinding::new("d", DefaultColors, TYPING_SAFE),
-        KeyBinding::new("escape", CancelGesture, CONTEXT),
+        KeyBinding::new("escape", CancelGesture, ALWAYS),
         KeyBinding::new("enter", CommitGesture, TYPING_SAFE),
         KeyBinding::new(
             &translate("cmd-t"),
@@ -270,4 +278,77 @@ pub fn save_file_dialog(ws: &mut Workspace, window: &mut Window, cx: &mut Contex
         }
     })
     .detach();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ALWAYS, CONTEXT, TYPING_SAFE};
+    use gpui::{KeyBindingContextPredicate, KeyContext};
+
+    /// Does a binding registered with `predicate` fire in `state`?
+    fn fires(predicate: Option<&str>, state: &str) -> bool {
+        let context = [KeyContext::parse(state).expect("context parses")];
+        KeyBindingContextPredicate::parse(predicate.unwrap())
+            .expect("predicate parses")
+            .eval_inner(&context, &context)
+    }
+
+    const ORDINARY: &str = "Workspace editable";
+    const TYPING: &str = "Workspace text_entry";
+    const MODAL: &str = "Workspace modal";
+
+    #[test]
+    fn document_commands_do_not_fire_while_typing_or_in_a_modal() {
+        // The reported bug: ctrl+a ran the canvas Select All while the
+        // caret was in a text layer, because every command was bound
+        // against plain "Workspace", which matched in all three states.
+        assert!(fires(CONTEXT, ORDINARY), "must work normally");
+        assert!(!fires(CONTEXT, TYPING), "ctrl+a must reach the text");
+        assert!(
+            !fires(CONTEXT, MODAL),
+            "ctrl+z must not undo under a dialog"
+        );
+    }
+
+    #[test]
+    fn single_letter_shortcuts_stay_suppressed_while_typing() {
+        // These were already correct; the fix must not regress them.
+        assert!(fires(TYPING_SAFE, ORDINARY));
+        assert!(!fires(TYPING_SAFE, TYPING));
+        assert!(!fires(TYPING_SAFE, MODAL));
+    }
+
+    #[test]
+    fn escape_survives_every_state() {
+        // Escape is the way out of a text session and out of a dialog, so
+        // suppressing it would trap the user in both.
+        assert!(fires(ALWAYS, ORDINARY));
+        assert!(fires(ALWAYS, TYPING));
+        assert!(fires(ALWAYS, MODAL));
+    }
+
+    #[test]
+    fn the_three_states_are_mutually_exclusive() {
+        // Exactly one of the three tokens is present at a time, which is
+        // what lets a predicate name a state by excluding the others.
+        for (state, expected) in [
+            (ORDINARY, ["editable"].as_slice()),
+            (TYPING, ["text_entry"].as_slice()),
+            (MODAL, ["modal"].as_slice()),
+        ] {
+            for token in ["editable", "text_entry", "modal"] {
+                let present = fires(Some(token), state);
+                assert_eq!(
+                    present,
+                    expected.contains(&token),
+                    "{state:?} should{} carry {token:?}",
+                    if expected.contains(&token) {
+                        ""
+                    } else {
+                        " not"
+                    }
+                );
+            }
+        }
+    }
 }

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -6214,8 +6214,17 @@ impl Render for Workspace {
         if let Some((id, enabled)) = self.pending_plugin_toggle.take() {
             self.set_plugin_enabled(id, enabled, cx);
         }
-        let captures_keys =
-            self.tool_captures_keys() || self.modal.is_some() || self.layer_rename.is_some();
+        // Three mutually exclusive input states. A single "is something
+        // capturing keys" flag was not enough: the document commands were
+        // bound against plain "Workspace", which matches in every state, so
+        // only the unmodified single-letter bindings were ever suppressed.
+        let key_context = if self.modal.is_some() {
+            "Workspace modal"
+        } else if self.tool_captures_keys() || self.layer_rename.is_some() {
+            "Workspace text_entry"
+        } else {
+            "Workspace editable"
+        };
         let chrome = self.screen_mode == ScreenMode::Standard;
         // On macOS the menus live in the system bar, not in the window.
         crate::native_menu::sync(self, cx);
@@ -6233,11 +6242,7 @@ impl Render for Workspace {
             // While a tool is capturing typing the context loses "editable",
             // which is what single-letter shortcuts are bound against — so
             // letters reach the tool instead of switching tools.
-            .key_context(if captures_keys {
-                "Workspace"
-            } else {
-                "Workspace editable"
-            })
+            .key_context(key_context)
             // Files dragged in from the OS: anywhere in the window works.
             .on_drop(cx.listener(|ws, paths: &ExternalPaths, _w, cx| {
                 ws.handle_dropped_paths(paths.paths().to_vec(), cx);


### PR DESCRIPTION
fixes #35

replace the single `captures_keys` flag with three mutually exclusive states: `Workspace editable`, `Workspace text_entry`, `Workspace modal`. document commands bind against `Workspace && !text_entry && !modal`, so they simply do not match while typing or under a dialog and the keystroke reaches the text.

adding a token while leaving the commands on the broad `Workspace` predicate would have changed nothing, since that predicate matches in every state. the exclusion has to be in the binding.

escape moves to its own always-on context. it is the way out of both a text session and a dialog, so suppressing it would trap the user.

four tests evaluate the real predicates against each state, including the reported case. the first fails on main with `ctrl+a must reach the text`.

verified by hand in a running window: ctrl+a reaches the text instead of running the canvas select all, escape still leaves a text session and a dialog, and the single-letter tool shortcuts still switch tools.

![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr13-before.png)

![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr13-after.png)
