### PR TITLE
Pick up the gpui fork's Wayland tablet and touchpad-pinch work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2587,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/IAmJSD/gpui?rev=7fa666d3f19cd2372f9eaaa36674b8809f7de808#7fa666d3f19cd2372f9eaaa36674b8809f7de808"
+source = "git+https://github.com/IAmJSD/gpui?rev=84bdb01b29887ca09b6c437dad9a0ae838fe48e8#84bdb01b29887ca09b6c437dad9a0ae838fe48e8"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,7 @@ schist-commands-core = { path = "plugins/commands-core" }
 # mouse events, which upstream has no equivalent of; needed for trackpad
 # pinch-to-zoom and pressure-sensitive painting on the canvas.
 # Pinned by rev so a push to the fork cannot silently change builds.
-gpui = { git = "https://github.com/IAmJSD/gpui", rev = "7fa666d3f19cd2372f9eaaa36674b8809f7de808" }
+gpui = { git = "https://github.com/IAmJSD/gpui", rev = "84bdb01b29887ca09b6c437dad9a0ae838fe48e8" }
 anyhow = "1"
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -173,16 +173,23 @@ swaps them, so plain scrolling zooms and the modifier pans.
 
 **Pinch-to-zoom** works on macOS, Linux — Wayland, and X11 on
 xorg-server 21.1+ (XI 2.4) — and Windows touchscreens, zooming about the
-centre of the gesture, and **stylus pressure** drives brush size on
-macOS, Linux/X11 and Windows. Upstream GPUI surfaces neither, so both
-come from a fork — [IAmJSD/gpui](https://github.com/IAmJSD/gpui), which
-adds `PinchEvent`, `on_pinch` and a `pressure` field on the mouse events
-on top of gpui 0.2.2 — pinned by revision in the workspace `Cargo.toml`.
+centre of the gesture, and **stylus pressure** drives brush size on all
+four backends. Upstream GPUI surfaces neither, so both come from a fork —
+[IAmJSD/gpui](https://github.com/IAmJSD/gpui), which adds `PinchEvent`,
+`on_pinch` and a `pressure` field on the mouse events on top of
+gpui 0.2.2 — pinned by revision in the workspace `Cargo.toml`.
 
-The one pinch gap left is Windows precision touchpads: Windows delivers
-their pinches as Ctrl+scroll rather than a gesture — which is already a
-zoom here anyway. Ctrl+scroll, the zoom-with-scroll preference,
-⌘+/⌘-, and the navigator's zoom slider work everywhere.
+The one pinch gap left is Windows precision touchpads, and it is a gap by
+choice. Windows delivers their pinches as Ctrl+scroll rather than as a
+gesture — which is already a zoom here anyway — and the only way to see
+the real gesture is Direct Manipulation, which cannot be claimed for
+pinches alone: the same claim covers two-finger pans and takes over
+scrolling with them. The fork implements it, behind
+`GPUI_ENABLE_DIRECT_MANIPULATION=1`, but it is untested on hardware and
+off by default rather than put in the path of ordinary scrolling. On a
+pre-21.1 X11 server there is no pinch at all. Ctrl+scroll, the
+zoom-with-scroll preference, ⌘+/⌘-, and the navigator's zoom slider work
+everywhere.
 
 Remap anything in `~/.config/schist/keymap.json`:
 
@@ -192,13 +199,15 @@ Remap anything in `~/.config/schist/keymap.json`:
 
 ## Not there yet
 
-- **Tablet pressure on Wayland.** The pipeline carries pressure end to
-  end, and macOS (`NSEvent`), X11 (the XInput2 pressure valuator) and
-  Windows (pen pointer messages) all feed it; Wayland still needs
-  `zwp_tablet_v2` and hardware to develop against, so it reports full
-  pressure. The X11 and Windows paths are new and verified against the
-  platform documentation rather than a physical tablet — reports from
-  real hardware welcome.
+- **Tablet pressure has never met a tablet.** The pipeline carries
+  pressure end to end and all four backends now feed it — macOS
+  (`NSEvent`), X11 (the XInput2 pressure valuator), Windows (pen pointer
+  messages) and Wayland (`zwp_tablet_v2`) — but every one of those paths
+  was written against the platform documentation rather than a physical
+  stylus. Wayland is the one to be most suspicious of: tablet input there
+  is a protocol of its own rather than an axis on the pointer, so binding
+  it means synthesising the whole mouse event stream from the tool, tip
+  and barrel buttons included. Reports from real hardware welcome.
 - **Only two Neural Filters run a network.** Super Zoom uses a small
   residual CNN trained for this application (`tools/train/detail.py`,
   39k parameters and 153 KB, shipped in the binary); Style Transfer uses


### PR DESCRIPTION
Bumps the pinned `gpui` rev to [`84bdb01`](https://github.com/IAmJSD/gpui/commit/84bdb01b29887ca09b6c437dad9a0ae838fe48e8), which closes both of the fork's outstanding backend gaps, and brings the README in line with it. No other schist code changes.

## What the fork gained

**Wayland stylus pressure, via `zwp_tablet_v2`.** Wayland was the last backend reporting a constant `1.0`, so pressure-sensitive painting silently did nothing there. It isn't a matter of reading an extra axis the way X11's is: tablet input on Wayland is a protocol of its own, and binding it makes the compositor *stop* emulating pointer events for the tool. The backend now synthesises the whole mouse event stream from `zwp_tablet_tool_v2` — tip as the left button, barrel buttons as right/middle, proximity as enter/exit — with pressure on the three events that carry it. A hovering stylus reports a true zero, matching X11; a tool with no pressure axis reports `1.0`, matching a mouse.

**Windows precision-touchpad pinch, via Direct Manipulation — opt-in, off by default.** `WM_GESTURE` only ever covered touchscreens. `DM_POINTERHITTEST` arrives *before* Windows has classified the gesture, so claiming the contact to get a pinch also claims two-finger pans and suppresses the `WM_MOUSEWHEEL` they used to produce; the fork consequently synthesises the scrolling too. That is a replacement for Windows touchpad scrolling written against a cross-compile, on a platform none of us can run, so it stays behind `GPUI_ENABLE_DIRECT_MANIPULATION` until someone has driven it on real hardware. Unset, the window keeps the Ctrl+scroll fallback and behaves exactly as it does today.

Nothing in this repo sets that variable, so on this branch the Windows half is inert.

## README

"Mouse and touchpad" now says pressure works on all four backends, and says why the Windows touchpad pinch gap is a decision rather than an omission. The "not there yet" entry for Wayland pressure is replaced rather than deleted — the honest caveat is no longer "Wayland is missing" but "all four paths were written against platform documentation and none has met a physical stylus".

## Verification

- `cargo check --workspace` clean against the new rev.
- In the fork: `cargo test --features test-support --test pinch` (5 pass), new `wayland/client.rs` unit tests (2 pass), `cargo check --target x86_64-pc-windows-gnu` clean, `cargo fmt --check` clean, and the `hello_world` example renders correctly under Xvfb.
- Wayland and Windows have no runtime path on this box; both backends are compile-reviewed only, as the fork's `UPSTREAM.md` records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)