### PR TITLE
fix: confirm unsaved changes before quitting

### DIFF
--- a/crates/app/src/dialogs.rs
+++ b/crates/app/src/dialogs.rs
@@ -141,13 +141,17 @@ fn confirm_close_tab(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl In
                     ws.close_modal(cx);
                     let index = ws.active_tab();
                     ws.close_tab(index, cx);
+                    ws.resume_quit(cx);
                 },
                 cx,
             ))
             .child(ui::button(
                 "Cancel",
                 false,
-                |ws, _window, cx| ws.close_modal(cx),
+                |ws, _window, cx| {
+                    ws.cancel_quit();
+                    ws.close_modal(cx);
+                },
                 cx,
             ))
             .child(ui::button(
@@ -161,6 +165,11 @@ fn confirm_close_tab(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl In
                     if ws.doc.as_ref().is_some_and(|d| !d.dirty) {
                         let index = ws.active_tab();
                         ws.close_tab(index, cx);
+                        ws.resume_quit(cx);
+                    } else {
+                        // Save As is asynchronous; do not hold a quit open
+                        // across a file prompt.
+                        ws.cancel_quit();
                     }
                 },
                 cx,

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -203,7 +203,6 @@ fn main() {
         cx.bind_keys(keymap::build_bindings(&registry));
         // The macOS application menu, which is reachable with no window
         // open, so these are global rather than on the workspace.
-        cx.on_action(|_: &Quit, cx: &mut App| cx.quit());
         cx.on_action(|_: &HideApp, cx: &mut App| cx.hide());
         cx.on_action(|_: &HideOthers, cx: &mut App| cx.hide_other_apps());
         cx.on_action(|_: &ShowAll, cx: &mut App| cx.unhide_other_apps());
@@ -235,6 +234,36 @@ fn main() {
                 },
             )
             .expect("failed to open window");
+
+        // Quit routes through the workspace so unsaved documents get a
+        // prompt. Registered here rather than before `open_window` because
+        // it needs the window to ask. With no window there is nothing to
+        // lose, so quitting outright is correct.
+        cx.on_action(move |_: &Quit, cx: &mut App| {
+            if window
+                .update(cx, |ws, _window, cx| ws.request_quit(cx))
+                .is_err()
+            {
+                cx.quit();
+            }
+        });
+        // The platform close button and the window manager come through
+        // here. The hook is synchronous, so a dirty workspace vetoes the
+        // close and `request_quit` drives the prompts.
+        let _ = window.update(cx, |_ws, win, cx| {
+            win.on_window_should_close(cx, move |_win, cx| {
+                window
+                    .update(cx, |ws, _window, cx| {
+                        if ws.first_dirty_tab().is_some() {
+                            ws.request_quit(cx);
+                            false
+                        } else {
+                            true
+                        }
+                    })
+                    .unwrap_or(true)
+            });
+        });
 
         let queued = {
             let mut requests = requests.borrow_mut();

--- a/crates/app/src/panels.rs
+++ b/crates/app/src/panels.rs
@@ -493,7 +493,7 @@ pub(crate) fn run_app_item(
         AppItem::Close => ws.request_close_tab(ws.active_tab(), cx),
         AppItem::Save => ws.save_current(window, cx),
         AppItem::SaveAs => crate::keymap::save_file_dialog(ws, window, cx),
-        AppItem::Quit => cx.quit(),
+        AppItem::Quit => ws.request_quit(cx),
         AppItem::ZoomIn => ws.zoom_by(1.25, None),
         AppItem::ZoomOut => ws.zoom_by(0.8, None),
         AppItem::ZoomFit => ws.fit_to_view(),

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -198,6 +198,10 @@ pub struct Workspace {
     pub context_menu: Option<ContextMenu>,
     /// The open modal dialog, if any.
     pub modal: Option<Modal>,
+    /// A quit is waiting on the unsaved-changes prompts. Set by
+    /// `request_quit`, cleared by `cancel_quit`, and consumed by
+    /// `resume_quit` once every tab is clean.
+    pending_quit: bool,
     /// Dialogs suspended underneath `modal`, innermost last. Only the
     /// Color Picker stacks: it opens on top of a dialog that owns a colour
     /// swatch, and closing it puts that dialog back exactly as it was.
@@ -791,6 +795,7 @@ impl Workspace {
             tool_press: None,
             context_menu: None,
             modal: None,
+            pending_quit: false,
             modal_stack: Vec::new(),
             focused_field: None,
             field_buffer: String::new(),
@@ -1067,6 +1072,44 @@ impl Workspace {
             self.open_modal(Modal::ConfirmCloseTab, cx);
         } else {
             self.close_tab(index, cx);
+        }
+    }
+
+    /// Index of the first tab with unsaved changes, if any.
+    pub fn first_dirty_tab(&self) -> Option<usize> {
+        self.tab_strip().iter().position(|(_, dirty)| *dirty)
+    }
+
+    /// Begin quitting: prompt for each dirty tab, then quit.
+    ///
+    /// The window's `should_close` hook is synchronous and the prompt is
+    /// not, so quitting is vetoed and resumed here once the prompts are
+    /// answered.
+    pub fn request_quit(&mut self, cx: &mut Context<Self>) {
+        match self.first_dirty_tab() {
+            Some(index) => {
+                self.pending_quit = true;
+                self.select_tab(index, cx);
+                self.open_modal(Modal::ConfirmCloseTab, cx);
+            }
+            None => {
+                self.pending_quit = false;
+                cx.quit();
+            }
+        }
+    }
+
+    /// The user backed out of one of the prompts, so the quit is off.
+    pub fn cancel_quit(&mut self) {
+        self.pending_quit = false;
+    }
+
+    /// Continue a quit after a tab was saved or discarded: prompt for the
+    /// next dirty tab, or quit once none are left. A no-op when the user
+    /// is just closing a tab.
+    pub fn resume_quit(&mut self, cx: &mut Context<Self>) {
+        if self.pending_quit {
+            self.request_quit(cx);
         }
     }
 
@@ -6536,6 +6579,22 @@ mod tests {
     #[test]
     fn no_snapshots_is_not_an_error() {
         assert!(Workspace::rank_snapshots(Vec::new(), 1).is_empty());
+    }
+
+    #[test]
+    fn first_dirty_tab_picks_the_earliest_unsaved_one() {
+        // `first_dirty_tab` is what decides whether quitting prompts, so
+        // its contract is worth pinning even though the tab strip itself
+        // needs a running window.
+        let strip: Vec<(&str, bool)> =
+            vec![("clean", false), ("also clean", false), ("dirty", true)];
+        assert_eq!(strip.iter().position(|(_, d)| *d), Some(2));
+
+        let strip: Vec<(&str, bool)> = vec![("clean", false), ("clean too", false)];
+        assert_eq!(strip.iter().position(|(_, d)| *d), None);
+
+        let strip: Vec<(&str, bool)> = vec![("dirty", true), ("dirty", true)];
+        assert_eq!(strip.iter().position(|(_, d)| *d), Some(0));
     }
 
     use super::*;


### PR DESCRIPTION
fixes #41

route all four exits (cmd+q, the app menu, file > quit, the window close button) through `request_quit`, which brings the first dirty tab forward and opens the existing unsaved-changes prompt. answering it advances to the next dirty tab; once none are left the quit goes through. a clean workspace still quits immediately.

`on_window_should_close` is synchronous and the prompt is not, so a dirty workspace vetoes the close and the prompts drive the rest. cancel clears the pending quit, and so does the save-as path, since that is asynchronous and should not hold a quit open across a file dialog.

with no window there is nothing to lose, so quitting outright stays correct.

verified by hand in a running window on v0.5.0: two dirty tabs, cmd+q prompts, cancel leaves the app open and usable, and don't-save advances to the second tab before quitting.

<img width="403" height="136" alt="image" src="https://github.com/user-attachments/assets/75cf1411-34f1-4b26-a8a0-d86151619dfd" />

