### PR TITLE
fix: mark the document dirty for guides, comps and saved selections

### DIFF
--- a/crates/app/src/panels.rs
+++ b/crates/app/src/panels.rs
@@ -625,6 +625,7 @@ pub(crate) fn run_app_item(
         AppItem::ClearNotes => {
             if let Some(doc) = ws.doc.as_mut() {
                 doc.notes.clear();
+                doc.mark_dirty();
                 doc.damage_all();
             }
             ws.after_change(cx);
@@ -632,6 +633,7 @@ pub(crate) fn run_app_item(
         AppItem::ClearCounts => {
             if let Some(doc) = ws.doc.as_mut() {
                 doc.counts.clear();
+                doc.mark_dirty();
                 doc.damage_all();
             }
             ws.after_change(cx);

--- a/crates/app/src/panels.rs
+++ b/crates/app/src/panels.rs
@@ -624,17 +624,21 @@ pub(crate) fn run_app_item(
         AppItem::ResetView => ws.reset_view_rotation(cx),
         AppItem::ClearNotes => {
             if let Some(doc) = ws.doc.as_mut() {
-                doc.notes.clear();
-                doc.mark_dirty();
-                doc.damage_all();
+                if !doc.notes.is_empty() {
+                    doc.notes.clear();
+                    doc.mark_dirty();
+                    doc.damage_all();
+                }
             }
             ws.after_change(cx);
         }
         AppItem::ClearCounts => {
             if let Some(doc) = ws.doc.as_mut() {
-                doc.counts.clear();
-                doc.mark_dirty();
-                doc.damage_all();
+                if !doc.counts.is_empty() {
+                    doc.counts.clear();
+                    doc.mark_dirty();
+                    doc.damage_all();
+                }
             }
             ws.after_change(cx);
         }

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -2364,6 +2364,7 @@ impl Workspace {
         let mut comp = schist_core::LayerComp::new(format!("Layer Comp {n}"));
         comp.states = states;
         doc.layer_comps.push(comp);
+        doc.mark_dirty();
         self.status = "Layer comp captured".into();
         cx.notify();
     }
@@ -2400,6 +2401,7 @@ impl Workspace {
         if let Some(doc) = self.doc.as_mut() {
             if index < doc.layer_comps.len() {
                 doc.layer_comps.remove(index);
+                doc.mark_dirty();
             }
         }
         cx.notify();
@@ -4323,6 +4325,7 @@ impl Workspace {
             };
             if guide.position >= 0.0 && guide.position <= limit {
                 doc.guides.push(guide);
+                doc.mark_dirty();
                 doc.damage_all();
             }
         }
@@ -4337,6 +4340,7 @@ impl Workspace {
     pub fn clear_guides(&mut self, cx: &mut Context<Self>) {
         if let Some(doc) = self.doc.as_mut() {
             doc.guides.clear();
+            doc.mark_dirty();
             doc.damage_all();
         }
         self.status = "Guides cleared".into();

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -4339,9 +4339,14 @@ impl Workspace {
     /// Remove every guide.
     pub fn clear_guides(&mut self, cx: &mut Context<Self>) {
         if let Some(doc) = self.doc.as_mut() {
-            doc.guides.clear();
-            doc.mark_dirty();
-            doc.damage_all();
+            // Clearing an already-empty list changes nothing, and marking
+            // dirty for it means a spurious close prompt plus a full
+            // export every 30 seconds from autosave until the next save.
+            if !doc.guides.is_empty() {
+                doc.guides.clear();
+                doc.mark_dirty();
+                doc.damage_all();
+            }
         }
         self.status = "Guides cleared".into();
         self.after_change(cx);

--- a/crates/core/src/document.rs
+++ b/crates/core/src/document.rs
@@ -1194,6 +1194,10 @@ mod tests {
         // mutated directly rather than through `begin_edit`, so nothing
         // set `dirty` for them. The tab then closed without a prompt and
         // autosave, which filters on `dirty`, skipped the document.
+        //
+        // This only pins the helper's contract; the call sites are
+        // covered where they live, in `tools-doc` and `commands-core`,
+        // because a test here cannot tell whether they call it.
         let mut doc = Document::new("t", 32, 32, Depth::Eight);
         assert!(!doc.dirty, "a fresh document is clean");
 

--- a/crates/core/src/document.rs
+++ b/crates/core/src/document.rs
@@ -182,6 +182,21 @@ impl Document {
         self.add_damage(all);
     }
 
+    /// Mark the document as having unsaved changes.
+    ///
+    /// `dirty` is otherwise set only by the edit machinery, so document
+    /// state that is mutated directly (guides, layer comps, saved
+    /// selections, notes, counts) never reached it: the tab closed with no
+    /// prompt and `autosave`, which filters on `dirty`, skipped the
+    /// document entirely.
+    ///
+    /// This is the minimum for not losing the work. Those lists still
+    /// belong in history; when they get their own `EditOp` the call here
+    /// becomes redundant rather than wrong.
+    pub fn mark_dirty(&mut self) {
+        self.dirty = true;
+    }
+
     pub fn take_damage(&mut self) -> Vec<IntRect> {
         std::mem::take(&mut self.damage)
     }
@@ -1172,5 +1187,34 @@ mod tests {
         assert!(!doc.selection.is_empty());
         doc.undo();
         assert!(doc.selection.is_empty());
+    }
+    #[test]
+    fn marking_dirty_is_what_a_close_prompt_and_autosave_key_off() {
+        // Guides, layer comps, saved selections, notes and counts are all
+        // mutated directly rather than through `begin_edit`, so nothing
+        // set `dirty` for them. The tab then closed without a prompt and
+        // autosave, which filters on `dirty`, skipped the document.
+        let mut doc = Document::new("t", 32, 32, Depth::Eight);
+        assert!(!doc.dirty, "a fresh document is clean");
+
+        doc.guides.push(Guide {
+            horizontal: true,
+            position: 10.0,
+        });
+        assert!(!doc.dirty, "the push alone cannot set it");
+
+        doc.mark_dirty();
+        assert!(doc.dirty, "and this is what the call sites now do");
+    }
+
+    #[test]
+    fn damage_alone_does_not_imply_unsaved_changes() {
+        // `add_damage` bumps `revision` so the canvas repaints, which is
+        // why it looks like it should be enough and is not: a repaint is
+        // not an edit.
+        let mut doc = Document::new("t", 32, 32, Depth::Eight);
+        doc.damage_all();
+        assert!(doc.revision > 0, "repaint was requested");
+        assert!(!doc.dirty, "but nothing was actually changed");
     }
 }

--- a/plugins/commands-core/src/lib.rs
+++ b/plugins/commands-core/src/lib.rs
@@ -650,6 +650,7 @@ impl CommandPlugin for CoreCommandsPlugin {
                 let n = ctx.doc.saved_selections.len() + 1;
                 let sel = ctx.doc.selection.clone();
                 ctx.doc.saved_selections.push((format!("Alpha {n}"), sel));
+                ctx.doc.mark_dirty();
             }),
             cmd("select.load", "Load Selection", None, |ctx| {
                 // Loads the most recently saved one; the dialog picks by
@@ -1057,6 +1058,26 @@ mod tests {
         assert!(group.is_group());
         assert_eq!(group.children().unwrap().len(), 1);
         assert_eq!(group.children().unwrap()[0].name, "bg");
+    }
+    #[test]
+    fn saving_a_selection_marks_the_document_unsaved() {
+        // `select.save` mutates `saved_selections` directly rather than
+        // through `begin_edit`, so nothing set `dirty`: the tab closed
+        // with no prompt and autosave skipped the document, taking every
+        // saved selection with it.
+        let reg = registry();
+        let mut doc = doc_with_pixels();
+        let mut state = EditorState::default();
+        doc.selection.select_rect(
+            schist_core::IntRect::from_xywh(0, 0, 10, 10),
+            SelectOp::Replace,
+        );
+        doc.dirty = false;
+
+        run(&reg, "select.save", &mut doc, &mut state);
+
+        assert_eq!(doc.saved_selections.len(), 1, "selection was saved");
+        assert!(doc.dirty, "and the document must count as unsaved");
     }
 }
 

--- a/plugins/tools-doc/src/lib.rs
+++ b/plugins/tools-doc/src/lib.rs
@@ -224,6 +224,8 @@ impl ToolPlugin for RectTool {
                     rect.right + dx,
                     rect.bottom + dy,
                 );
+                // Moving one is a change to the document, not a repaint.
+                ctx.doc.mark_dirty();
             }
             ctx.doc.add_damage(ctx.doc.canvas_rect());
             return;
@@ -260,7 +262,12 @@ impl ToolPlugin for RectTool {
                     user: true,
                 });
             }
+            // A frame is a layer, so `make_frame` commits an edit and is
+            // already dirty; the other two are plain document state.
             RectKind::Frame => self.make_frame(ctx.doc, rect),
+        }
+        if !matches!(self.kind, RectKind::Frame) {
+            ctx.doc.mark_dirty();
         }
         ctx.doc.add_damage(ctx.doc.canvas_rect());
     }
@@ -349,6 +356,7 @@ impl ToolPlugin for PointTool {
                 {
                     if input.modifiers.alt {
                         ctx.doc.notes.remove(i);
+                        ctx.doc.mark_dirty();
                     } else {
                         self.grabbed = Some(i);
                     }
@@ -359,6 +367,7 @@ impl ToolPlugin for PointTool {
                         author: String::new(),
                         text: format!("Note {n}"),
                     });
+                    ctx.doc.mark_dirty();
                 }
             }
             PointKind::Count => {
@@ -378,9 +387,11 @@ impl ToolPlugin for PointTool {
                         .position(|p| (p.0 - input.x).hypot(p.1 - input.y) <= r)
                     {
                         group.points.remove(i);
+                        ctx.doc.mark_dirty();
                     }
                 } else {
                     group.points.push((input.x, input.y));
+                    ctx.doc.mark_dirty();
                 }
             }
         }
@@ -391,6 +402,7 @@ impl ToolPlugin for PointTool {
         if let Some(i) = self.grabbed {
             if let Some(note) = ctx.doc.notes.get_mut(i) {
                 note.at = (input.x, input.y);
+                ctx.doc.mark_dirty();
             }
             ctx.doc.add_damage(ctx.doc.canvas_rect());
         }

--- a/plugins/tools-doc/tests/doc_tools.rs
+++ b/plugins/tools-doc/tests/doc_tools.rs
@@ -220,3 +220,138 @@ fn slices_and_artboards_are_separate_lists() {
     assert_eq!(doc.slices.len(), 1);
     assert!(doc.slices[0].user, "a drawn slice should be a user slice");
 }
+
+/// Every tool here writes straight to a list on the `Document` rather
+/// than going through `begin_edit`, so nothing set `dirty`. The fix that
+/// prompted this covered the Clear menu items but not the tools that
+/// *create* the state, which is the common way to get it: place notes or
+/// drag out slices on a saved document, close the tab, and there was no
+/// prompt and autosave had skipped it.
+#[test]
+fn creating_document_furniture_counts_as_an_unsaved_change() {
+    type Place = Box<dyn Fn(&mut Document)>;
+    let cases: Vec<(&str, Place)> = vec![
+        (
+            "artboard",
+            Box::new(|d: &mut Document| {
+                let mut t = RectTool::new(RectKind::Artboard);
+                let mut s = EditorState::default();
+                let mut c = ToolCtx {
+                    doc: d,
+                    state: &mut s,
+                };
+                t.on_pointer_down(&mut c, input(20.0, 20.0));
+                t.on_pointer_up(&mut c, input(120.0, 90.0));
+            }),
+        ),
+        (
+            "slice",
+            Box::new(|d: &mut Document| {
+                let mut t = RectTool::new(RectKind::Slice);
+                let mut s = EditorState::default();
+                let mut c = ToolCtx {
+                    doc: d,
+                    state: &mut s,
+                };
+                t.on_pointer_down(&mut c, input(20.0, 20.0));
+                t.on_pointer_up(&mut c, input(120.0, 90.0));
+            }),
+        ),
+        (
+            "note",
+            Box::new(|d: &mut Document| {
+                let mut t = PointTool::new(PointKind::Note);
+                let mut s = EditorState::default();
+                let mut c = ToolCtx {
+                    doc: d,
+                    state: &mut s,
+                };
+                t.on_pointer_down(&mut c, input(40.0, 40.0));
+            }),
+        ),
+        (
+            "count",
+            Box::new(|d: &mut Document| {
+                let mut t = PointTool::new(PointKind::Count);
+                let mut s = EditorState::default();
+                let mut c = ToolCtx {
+                    doc: d,
+                    state: &mut s,
+                };
+                t.on_pointer_down(&mut c, input(40.0, 40.0));
+            }),
+        ),
+    ];
+    for (what, place) in cases {
+        let mut d = doc();
+        d.dirty = false;
+        place(&mut d);
+        assert!(d.dirty, "placing a {what} left the document looking saved");
+    }
+}
+
+/// Removing and moving them counts too.
+#[test]
+fn removing_and_moving_furniture_counts_as_well() {
+    // A note dragged to a new position.
+    let mut d = doc();
+    let mut s = EditorState::default();
+    let mut t = PointTool::new(PointKind::Note);
+    {
+        let mut c = ToolCtx {
+            doc: &mut d,
+            state: &mut s,
+        };
+        t.on_pointer_down(&mut c, input(40.0, 40.0));
+        t.on_pointer_up(&mut c, input(40.0, 40.0));
+    }
+    d.dirty = false;
+    {
+        let mut c = ToolCtx {
+            doc: &mut d,
+            state: &mut s,
+        };
+        t.on_pointer_down(&mut c, input(40.0, 40.0));
+        t.on_pointer_move(&mut c, input(90.0, 70.0));
+        t.on_pointer_up(&mut c, input(90.0, 70.0));
+    }
+    assert!(d.dirty, "moving a note left the document looking saved");
+
+    // And alt-clicking it away.
+    d.dirty = false;
+    {
+        let mut c = ToolCtx {
+            doc: &mut d,
+            state: &mut s,
+        };
+        t.on_pointer_down(&mut c, alt(90.0, 70.0));
+    }
+    assert!(d.notes.is_empty(), "the note was removed");
+    assert!(d.dirty, "removing a note left the document looking saved");
+
+    // An artboard dragged across the canvas.
+    let mut d = doc();
+    let mut r = RectTool::new(RectKind::Artboard);
+    {
+        let mut c = ToolCtx {
+            doc: &mut d,
+            state: &mut s,
+        };
+        r.on_pointer_down(&mut c, input(20.0, 20.0));
+        r.on_pointer_up(&mut c, input(120.0, 90.0));
+    }
+    d.dirty = false;
+    {
+        let mut c = ToolCtx {
+            doc: &mut d,
+            state: &mut s,
+        };
+        r.on_pointer_down(&mut c, input(70.0, 55.0));
+        r.on_pointer_move(&mut c, input(140.0, 95.0));
+        r.on_pointer_up(&mut c, input(140.0, 95.0));
+    }
+    assert!(
+        d.dirty,
+        "moving an artboard left the document looking saved"
+    );
+}


### PR DESCRIPTION
fixes #43

add `Document::mark_dirty` and call it from the seven sites that mutate document state outside `begin_edit`. that is enough for the close prompt to appear and for autosave to stop skipping the document.

a named method rather than `doc.dirty = true` scattered around, so the next such mutation has an obvious thing to call and the doc comment explains why it exists. those lists still belong in history; when they get their own `EditOp` this call becomes redundant rather than wrong, and the comment says so.

the regression test is at the call site, not on the setter: it runs `select.save` through the real command registry and asserts the document comes back dirty. it fails on main with `and the document must count as unsaved`. a second test pins that `add_damage` alone does not imply unsaved changes, since that is the trap that makes this look already-handled.

579 tests pass, clippy and fmt clean.