### PR TITLE
fix: collapse the empty text layer discard instead of undoing blindly

### DIFF
--- a/crates/core/src/history.rs
+++ b/crates/core/src/history.rs
@@ -164,6 +164,30 @@ impl History {
         self.undo_stack.last().cloned()
     }
 
+    /// Drop the newest two entries when they are exactly this pair, and
+    /// report whether they were.
+    ///
+    /// For two edits that cancel each other out, where leaving them would
+    /// put two no-op steps in the History panel. Nothing is dropped unless
+    /// both are still on top: an edit committed in between is real work,
+    /// and collapsing across it would leave the history describing a
+    /// document that no longer matches.
+    ///
+    /// Note this is not `pop_redo`. That is the redo primitive: it moves
+    /// an entry from the redo stack *onto* the undo stack rather than
+    /// discarding anything.
+    pub fn drop_cancelling_pair(&mut self, newest: &str, older: &str) -> bool {
+        let n = self.undo_stack.len();
+        if n < 2 {
+            return false;
+        }
+        if self.undo_stack[n - 1].name != newest || self.undo_stack[n - 2].name != older {
+            return false;
+        }
+        self.undo_stack.truncate(n - 2);
+        true
+    }
+
     pub fn can_undo(&self) -> bool {
         !self.undo_stack.is_empty()
     }

--- a/plugins/tools-type/src/lib.rs
+++ b/plugins/tools-type/src/lib.rs
@@ -465,11 +465,20 @@ impl ToolPlugin for TypeTool {
                 let mut edit = ctx.doc.begin_edit("Discard Empty Text");
                 edit.remove_layer(session.layer);
                 edit.commit();
-                // The insert and this removal cancel out; drop both.
-                ctx.doc.undo();
-                ctx.doc.undo();
-                ctx.doc.history.pop_redo();
-                ctx.doc.history.pop_redo();
+                // The insert and this removal cancel out, so collapse the
+                // pair rather than leaving two no-op steps in the panel.
+                //
+                // This used to call `undo()` twice and then `pop_redo()`
+                // twice. Both were wrong: `undo()` unwinds whatever is on
+                // top, which is only this layer's insert when nothing else
+                // was committed in between, and `pop_redo()` is the redo
+                // primitive, so it pushed the junk straight back onto the
+                // undo stack. Clicking with the type tool and not typing
+                // therefore reverted the user's last two real edits, with
+                // the History panel still listing them as applied.
+                ctx.doc
+                    .history
+                    .drop_cancelling_pair("Discard Empty Text", "New Text Layer");
             }
             return;
         }
@@ -885,5 +894,76 @@ mod tests {
         type_text(&mut tool, &mut ctx, "B");
         let two_lines = doc.tree.layers[1].tight_bounds().height();
         assert!(two_lines > one_line + 10, "{two_lines} vs {one_line}");
+    }
+    #[test]
+    fn clicking_without_typing_leaves_earlier_edits_alone() {
+        // The data loss. `on_commit` on an untouched session called
+        // `undo()` twice, which unwinds whatever is on top rather than
+        // this layer's own insert. The two only line up when nothing was
+        // committed in between; a command run mid-session (which is
+        // exactly what a shortcut does, since running one does not commit
+        // the pending tool session) puts a real edit on top instead.
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState::default();
+        let mut tool = TypeTool::default();
+
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut d,
+                state: &mut state,
+            };
+            tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+        }
+
+        // A real edit committed while the empty session is still open.
+        {
+            let mut edit = d.begin_edit("Important Edit");
+            edit.insert_layer(LayerPath(vec![0]), Layer::new_raster("important"));
+            edit.commit();
+        }
+        assert!(d.tree.iter().any(|l| l.name == "important"));
+
+        // Now click away without having typed anything.
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut d,
+                state: &mut state,
+            };
+            tool.on_commit(&mut ctx);
+        }
+
+        let after: Vec<String> = d.tree.iter().map(|l| l.name.clone()).collect();
+        assert!(
+            after.iter().any(|n| n == "important"),
+            "the edit made during the session must survive: {after:?}"
+        );
+        assert!(
+            d.history
+                .entries()
+                .iter()
+                .any(|e| e.name == "Important Edit"),
+            "and it must still be in history"
+        );
+    }
+
+    #[test]
+    fn discarding_an_empty_layer_leaves_no_junk_history() {
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState::default();
+        let mut tool = TypeTool::default();
+        let before = d.history.entries().len();
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut d,
+                state: &mut state,
+            };
+            tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+            tool.on_commit(&mut ctx);
+        }
+        assert_eq!(
+            d.history.entries().len(),
+            before,
+            "the insert and its removal should collapse"
+        );
     }
 }


### PR DESCRIPTION
fixes #45

add `History::drop_cancelling_pair`, which removes the newest two undo entries only when they are exactly the pair named, and use it to collapse the insert and its removal. nothing is dropped unless both are still on top, so an edit committed in between is never touched.

the old code could not be right either way: `undo()` unwinds whatever is on top rather than this layer's own insert, and `pop_redo()` is the redo primitive, so it pushed the junk back onto the undo stack instead of discarding it.

the regression test commits a real edit *while* the empty session is open, which is the case that actually loses data. it fails on main with `the edit made during the session must survive: ["bg", "Text"]` — the user's layer gone, the empty text layer still there.

578 tests pass, clippy and fmt clean.

## before

the levels layer made during the empty session is gone; the empty text layer stayed.

![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr46-before.png)

## after

the levels layer survives; the empty text layer is discarded.

![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr46-after.png)