### PR TITLE
fix: honor PNG/JPEG color metadata on import and export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5668,8 +5668,10 @@ name = "schist-codecs-common"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "crc32fast",
  "image",
  "log",
+ "moxcms",
  "schist-codec-affinity",
  "schist-color",
  "schist-colormgmt",

--- a/crates/colormgmt/src/lib.rs
+++ b/crates/colormgmt/src/lib.rs
@@ -15,7 +15,10 @@
 //! Profiles are parsed by `moxcms` (pure Rust, no C toolchain).
 
 use anyhow::{anyhow, Result};
-use moxcms::{ColorProfile, Layout, RenderingIntent, TransformExecutor, TransformOptions};
+use moxcms::{
+    CicpColorPrimaries, CicpProfile, ColorProfile, Layout, MatrixCoefficients, RenderingIntent,
+    TransferCharacteristics, TransformExecutor, TransformOptions,
+};
 use std::sync::Arc;
 
 /// How out-of-gamut colours are handled.
@@ -268,6 +271,78 @@ impl ColorSettings {
     }
 }
 
+/// Bake BT.2100 HDR pixels (PQ or HLG signal, straight-alpha RGBA f32)
+/// down to sRGB in place.
+///
+/// `primaries` and `transfer` are H.273/cICP code points; `transfer` must
+/// be PQ (16) or HLG (18). Graphic ("diffuse") white — 203 nits, per
+/// BT.2408 — maps to 1.0, and the specular range above it rolls off
+/// through an exponential shoulder rather than clipping, approximating
+/// the SDR rendition cameras bake for HDR captures.
+pub fn bake_hdr_to_srgb(pixels: &mut [f32], primaries: u8, transfer: u8) -> Result<()> {
+    const REF_WHITE_NITS: f32 = 203.0;
+    /// Where the shoulder starts, in diffuse-white-relative linear light.
+    const KNEE: f32 = 0.9;
+
+    let signal_to_nits: fn(f32) -> f32 = match transfer {
+        16 => |v: f32| pq_eotf(v) * 10_000.0,
+        // Per-channel HLG approximation: 1000-nit nominal display, with
+        // the BT.2100 OOTF's system gamma of 1.2 applied channel-wise
+        // rather than to luminance.
+        18 => |v: f32| hlg_inverse_oetf(v).powf(1.2) * 1_000.0,
+        other => return Err(anyhow!("cICP transfer {other} is not PQ or HLG")),
+    };
+    let primaries = CicpColorPrimaries::try_from(primaries)
+        .map_err(|e| anyhow!("bad cICP primaries: {e:?}"))?;
+    let source = Profile {
+        profile: Arc::new(ColorProfile::new_from_cicp(CicpProfile {
+            color_primaries: primaries,
+            transfer_characteristics: TransferCharacteristics::Linear,
+            matrix_coefficients: MatrixCoefficients::Identity,
+            full_range: true,
+        })),
+        bytes: None,
+        name: "HDR source".into(),
+    };
+    for px in pixels.as_chunks_mut::<4>().0 {
+        for c in px.iter_mut().take(3) {
+            let s = signal_to_nits(c.clamp(0.0, 1.0)) / REF_WHITE_NITS;
+            *c = if s <= KNEE {
+                s
+            } else {
+                KNEE + (1.0 - KNEE) * (1.0 - (-(s - KNEE) / (1.0 - KNEE)).exp())
+            };
+        }
+    }
+    ColorTransform::new(&source, &Profile::srgb(), Intent::RelativeColorimetric)?.apply(pixels);
+    Ok(())
+}
+
+/// BT.2100 PQ EOTF: signal 0..1 to display light as a fraction of the
+/// 10 000-nit peak.
+fn pq_eotf(v: f32) -> f32 {
+    const M1: f32 = 1305.0 / 8192.0;
+    const M2: f32 = 2523.0 / 32.0;
+    const C1: f32 = 107.0 / 128.0;
+    const C2: f32 = 2413.0 / 128.0;
+    const C3: f32 = 2392.0 / 128.0;
+    let p = v.max(0.0).powf(1.0 / M2);
+    ((p - C1).max(0.0) / (C2 - C3 * p).max(f32::EPSILON)).powf(1.0 / M1)
+}
+
+/// BT.2100 HLG inverse OETF: signal 0..1 to scene light 0..1.
+fn hlg_inverse_oetf(v: f32) -> f32 {
+    const A: f32 = 0.178_832_77;
+    const B: f32 = 0.284_668_92;
+    const C: f32 = 0.559_910_7;
+    let v = v.max(0.0);
+    if v <= 0.5 {
+        v * v / 3.0
+    } else {
+        (((v - C) / A).exp() + B) / 12.0
+    }
+}
+
 /// Convert pixels from one profile to another, preserving appearance
 /// (Image ▸ Convert to Profile).
 pub fn convert_pixels(
@@ -463,6 +538,61 @@ mod tests {
         dither_to_depth(&mut pixels, 2, 256);
         assert_eq!(pixels[0], 0.0);
         assert_eq!(pixels[4], 1.0);
+    }
+
+    #[test]
+    fn pq_reference_white_bakes_near_srgb_white() {
+        // PQ signal for 203 nits — HDR graphics white — must land close
+        // to full white, not the murky grey a naive 10 000-nit-relative
+        // transform would produce.
+        let mut px = rgba(0.5806, 0.5806, 0.5806);
+        bake_hdr_to_srgb(&mut px, 9, 16).unwrap();
+        assert!(px[0] > 0.93, "reference white stays white: {px:?}");
+        assert!((px[0] - px[1]).abs() < 0.01 && (px[1] - px[2]).abs() < 0.01);
+        assert_eq!(px[3], 1.0, "alpha untouched");
+    }
+
+    #[test]
+    fn pq_blacks_stay_black_and_speculars_stay_bounded() {
+        let mut px = vec![0.0f32, 0.0, 0.0, 1.0, 0.9, 0.9, 0.9, 1.0];
+        bake_hdr_to_srgb(&mut px, 9, 16).unwrap();
+        assert!(px[0] < 0.02, "black stays black: {}", px[0]);
+        // A ~1000-nit specular compresses into the shoulder above
+        // reference white but never exceeds 1.0.
+        assert!(
+            px[4] > 0.95 && px[4] <= 1.0,
+            "specular rolls off: {}",
+            px[4]
+        );
+    }
+
+    #[test]
+    fn pq_bake_is_monotone() {
+        let mut px: Vec<f32> = (0..64)
+            .flat_map(|i| [i as f32 / 63.0, i as f32 / 63.0, i as f32 / 63.0, 1.0])
+            .collect();
+        bake_hdr_to_srgb(&mut px, 9, 16).unwrap();
+        let greys: Vec<f32> = px.as_chunks::<4>().0.iter().map(|p| p[0]).collect();
+        assert!(
+            greys.windows(2).all(|w| w[1] >= w[0]),
+            "monotone: {greys:?}"
+        );
+    }
+
+    #[test]
+    fn hlg_mid_grey_bakes_sensibly() {
+        // HLG 0.5 signal is scene light 1/12 → ~26 nits after the OOTF,
+        // well below reference white but clearly not black.
+        let mut px = rgba(0.5, 0.5, 0.5);
+        bake_hdr_to_srgb(&mut px, 9, 18).unwrap();
+        assert!(px[0] > 0.2 && px[0] < 0.6, "HLG mid-grey: {px:?}");
+    }
+
+    #[test]
+    fn bake_rejects_sdr_transfers() {
+        let mut px = rgba(0.5, 0.5, 0.5);
+        assert!(bake_hdr_to_srgb(&mut px, 9, 1).is_err());
+        assert!(bake_hdr_to_srgb(&mut px, 9, 13).is_err());
     }
 
     #[test]

--- a/plugins/codecs-common/Cargo.toml
+++ b/plugins/codecs-common/Cargo.toml
@@ -14,3 +14,7 @@ image.workspace = true
 schist-color.workspace = true
 schist-colormgmt.workspace = true
 schist-compositor.workspace = true
+
+[dev-dependencies]
+crc32fast.workspace = true
+moxcms = "0.8"

--- a/plugins/codecs-common/src/lib.rs
+++ b/plugins/codecs-common/src/lib.rs
@@ -12,13 +12,71 @@ use schist_plugin_api::{CodecPlugin, ExportOptions, PluginManifest, PluginRegist
 
 mod affinity;
 
+/// The four cICP fields (primaries, transfer, matrix, full-range) from a
+/// PNG's cICP chunk, if one is present before the image data.
+fn png_cicp(bytes: &[u8]) -> Option<[u8; 4]> {
+    let mut rest = bytes.get(8..)?;
+    while rest.len() >= 12 {
+        let len = u32::from_be_bytes(rest[0..4].try_into().ok()?) as usize;
+        let kind = &rest[4..8];
+        if kind == b"cICP" {
+            return <[u8; 4]>::try_from(rest.get(8..8 + len)?).ok();
+        }
+        if kind == b"IDAT" || kind == b"IEND" {
+            return None;
+        }
+        rest = rest.get(8 + len + 4..)?;
+    }
+    None
+}
+
 fn import_with(format: ImageFormat, bytes: &[u8], title: &str) -> anyhow::Result<Document> {
-    let img = image::load_from_memory_with_format(bytes, format)
+    let mut decoder = image::ImageReader::with_format(std::io::Cursor::new(bytes), format)
+        .into_decoder()
         .with_context(|| format!("decoding {title}"))?;
-    let rgba = img.to_rgba8();
-    let (w, h) = rgba.dimensions();
+    use image::ImageDecoder as _;
+    let mut icc = decoder
+        .icc_profile()
+        .ok()
+        .flatten()
+        .filter(|b| !b.is_empty());
+    let img =
+        image::DynamicImage::from_decoder(decoder).with_context(|| format!("decoding {title}"))?;
+    let (w, h) = (img.width(), img.height());
     anyhow::ensure!(w > 0 && h > 0, "zero-sized image");
+
+    // HDR PNGs (iPhone captures, HDR screenshots) mark BT.2100 PQ/HLG in
+    // a cICP chunk, which overrides any iCCP profile; shown raw those
+    // pixels come out flat and grey, so bake them down to sRGB. Everything
+    // else keeps its embedded ICC profile for the display transform.
+    let cicp = (format == ImageFormat::Png)
+        .then(|| png_cicp(bytes))
+        .flatten();
+    let rgba = match cicp {
+        Some([primaries, transfer @ (16 | 18), 0, 1]) => {
+            // Bake from the decoder's full precision: HDR PNGs are
+            // usually 16-bit and the shadows band if quantised first.
+            let mut pixels = img.to_rgba32f().into_raw();
+            match schist_colormgmt::bake_hdr_to_srgb(&mut pixels, primaries, transfer) {
+                Ok(()) => {
+                    icc = None; // the pixels are sRGB now
+                    let bytes: Vec<u8> = pixels
+                        .iter()
+                        .map(|v| (v.clamp(0.0, 1.0) * 255.0 + 0.5) as u8)
+                        .collect();
+                    image::RgbaImage::from_raw(w, h, bytes).context("buffer size")?
+                }
+                Err(err) => {
+                    log::warn!("displaying HDR {title} unmapped: {err:#}");
+                    img.to_rgba8()
+                }
+            }
+        }
+        _ => img.to_rgba8(),
+    };
+
     let mut doc = Document::new(title, w, h, Depth::Eight);
+    doc.icc_profile = icc;
     let mut layer = Layer::new_raster("Background");
     blit_rgba8(
         &mut layer.as_raster_mut().unwrap().tiles,
@@ -51,6 +109,10 @@ fn export_flat(
     let img: image::RgbaImage =
         image::ImageBuffer::from_raw(doc.width, doc.height, rgba).context("buffer size")?;
     let mut out = std::io::Cursor::new(Vec::new());
+    // A document profile changes what the numbers mean; a file without it
+    // reads as sRGB elsewhere, so embed it wherever the format can.
+    let icc = doc.icc_profile.clone();
+    use image::ImageEncoder as _;
     match format {
         // JPEG has no alpha and takes a quality setting.
         ImageFormat::Jpeg => {
@@ -59,7 +121,22 @@ fn export_flat(
                 &mut out,
                 options.quality.clamp(1, 100),
             );
+            if let Some(icc) = icc {
+                let _ = encoder.set_icc_profile(icc);
+            }
             encoder.encode_image(&rgb)?;
+        }
+        ImageFormat::Png => {
+            let mut encoder = image::codecs::png::PngEncoder::new(&mut out);
+            if let Some(icc) = icc {
+                let _ = encoder.set_icc_profile(icc);
+            }
+            encoder.write_image(
+                img.as_raw(),
+                doc.width,
+                doc.height,
+                image::ExtendedColorType::Rgba8,
+            )?;
         }
         _ => img.write_to(&mut out, format)?,
     }
@@ -188,6 +265,95 @@ mod tests {
             .pixel(3, 0)
             .to_u8();
         assert_eq!(px2, [30, 100, 200, 255]);
+    }
+
+    /// Insert a chunk right after IHDR (13-byte data + 12 bytes framing
+    /// after the 8-byte signature).
+    fn splice_chunk(png: &[u8], kind: &[u8; 4], data: &[u8]) -> Vec<u8> {
+        let at = 8 + 12 + 13;
+        let mut out = png[..at].to_vec();
+        out.extend((data.len() as u32).to_be_bytes());
+        out.extend(kind);
+        out.extend(data);
+        let mut crc = crc32fast::Hasher::new();
+        crc.update(kind);
+        crc.update(data);
+        out.extend(crc.finalize().to_be_bytes());
+        out.extend(&png[at..]);
+        out
+    }
+
+    #[test]
+    fn png_iccp_profile_survives_import_and_export() {
+        let display_p3 = moxcms::ColorProfile::new_display_p3().encode().unwrap();
+
+        let img = image::RgbaImage::from_pixel(4, 4, image::Rgba([200, 30, 40, 255]));
+        let mut bytes = std::io::Cursor::new(Vec::new());
+        let mut encoder = image::codecs::png::PngEncoder::new(&mut bytes);
+        image::ImageEncoder::set_icc_profile(&mut encoder, display_p3.clone()).unwrap();
+        image::ImageEncoder::write_image(
+            encoder,
+            img.as_raw(),
+            4,
+            4,
+            image::ExtendedColorType::Rgba8,
+        )
+        .unwrap();
+
+        let doc = PngCodec.import(&bytes.into_inner()).unwrap();
+        assert_eq!(doc.icc_profile.as_deref(), Some(display_p3.as_slice()));
+        // Assigning a profile reinterprets the numbers; it must not touch them.
+        let px = doc.tree.layers[0]
+            .as_raster()
+            .unwrap()
+            .tiles
+            .pixel(0, 0)
+            .to_u8();
+        assert_eq!(px, [200, 30, 40, 255]);
+
+        let out = PngCodec.export(&doc).unwrap();
+        let doc2 = PngCodec.import(&out).unwrap();
+        assert_eq!(doc2.icc_profile.as_deref(), Some(display_p3.as_slice()));
+    }
+
+    #[test]
+    fn png_cicp_pq_bakes_to_srgb() {
+        // Three PQ greys: black, ~203-nit reference white, ~1000 nits.
+        let mut img = image::RgbaImage::new(3, 1);
+        for (x, v) in [0u8, 148, 195].into_iter().enumerate() {
+            img.put_pixel(x as u32, 0, image::Rgba([v, v, v, 255]));
+        }
+        let mut bytes = std::io::Cursor::new(Vec::new());
+        img.write_to(&mut bytes, ImageFormat::Png).unwrap();
+        // BT.2020 primaries, PQ transfer, RGB, full-range.
+        let bytes = splice_chunk(&bytes.into_inner(), b"cICP", &[9, 16, 0, 1]);
+        assert_eq!(super::png_cicp(&bytes), Some([9, 16, 0, 1]));
+
+        let doc = PngCodec.import(&bytes).unwrap();
+        assert!(doc.icc_profile.is_none(), "baked pixels are sRGB");
+        let tiles = &doc.tree.layers[0].as_raster().unwrap().tiles;
+        let black = tiles.pixel(0, 0).to_u8()[0];
+        let white = tiles.pixel(1, 0).to_u8()[0];
+        let spec = tiles.pixel(2, 0).to_u8()[0];
+        assert!(black < 5, "PQ black stays black: {black}");
+        assert!(white > 240, "reference white bakes near white: {white}");
+        assert!(spec >= white, "speculars roll off above white: {spec}");
+    }
+
+    #[test]
+    fn plain_png_has_no_profile_and_exact_pixels() {
+        let img = image::RgbaImage::from_pixel(2, 2, image::Rgba([10, 20, 30, 255]));
+        let mut bytes = std::io::Cursor::new(Vec::new());
+        img.write_to(&mut bytes, ImageFormat::Png).unwrap();
+        let doc = PngCodec.import(&bytes.into_inner()).unwrap();
+        assert!(doc.icc_profile.is_none());
+        let px = doc.tree.layers[0]
+            .as_raster()
+            .unwrap()
+            .tiles
+            .pixel(1, 1)
+            .to_u8();
+        assert_eq!(px, [10, 20, 30, 255]);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

iPhone HDR PNGs (\"pngs look shittier\") carry a `cICP` chunk marking BT.2100 PQ over BT.2020 primaries. The simple codecs decoded the raw samples and dropped every color chunk, so the PQ signal was displayed as if it were sRGB — shadows lifted (8→30), white crushed (255→148), the whole image flat and washed out. Preview honors the chunk, hence the side-by-side mismatch. Ordinary wide-gamut photos also lost their `iCCP` profile (rendered as sRGB → desaturated), and PNG/JPEG export wrote untagged files.

## Fix

- `import_with` now extracts the decoder's embedded ICC profile into `doc.icc_profile` for PNG/JPEG/WebP/TIFF; the existing moxcms document→display transform does the rest.
- PNGs with a `cICP` PQ/HLG chunk are baked to sRGB at import via a new `schist_colormgmt::bake_hdr_to_srgb`: BT.2100 EOTF from the decoder's full (16-bit) precision, 203-nit diffuse white (BT.2408) mapped to 1.0, exponential shoulder above 0.9 for speculars, BT.2020→sRGB gamut via moxcms `new_from_cicp`. cICP takes precedence over iCCP per the PNG spec.
- PNG and JPEG export embed the document profile.

## Verification

- New unit tests: PQ reference white/black/monotonicity, HLG mid-grey, SDR-transfer rejection, iCCP survives import→export→import, cICP bake end-to-end through the codec, plain PNGs stay byte-exact.
- Headless GUI check (Xvfb + lavapipe): a synthetic 16-bit PQ PNG of bands 0/8/16/32/64/128/192/255 rendered as 0/30/39/54/77/109/131/148 before, and 0/8/16/32/64/128/192/251 after (251 = intended specular rolloff above the knee).
- `cargo check --workspace --all-targets` clean, clippy clean, 100 tests pass across the touched and neighboring crates.

Not covered here: WebP/TIFF export still don't embed ICC, Affinity import doesn't set `doc.icc_profile` (PSD does), gain maps are ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)