### PR TITLE
fix: make the type tool and layout engine handle real text

### DIFF
--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -3883,6 +3883,11 @@ impl Workspace {
             "backspace" => {
                 self.field_buffer.pop();
             }
+            // Escape is handled in `cancel_gesture`, which runs first:
+            // it is bound to `CancelGesture` in the always-matching
+            // "Workspace" context, so nothing escape-shaped ever reaches
+            // here. Kept as a fallback for a build with that binding
+            // removed rather than left as a dead arm that looks live.
             "escape" => {
                 self.focused_field = None;
                 self.field_buffer.clear();
@@ -4106,6 +4111,17 @@ impl Workspace {
         }
         if self.context_menu.is_some() {
             self.close_context_menu(cx);
+            return;
+        }
+        // A focused field takes the escape first: it drops focus and
+        // leaves the dialog up, which is what `field_key`'s "escape" arm
+        // meant to do before `CancelGesture` -- bound in the
+        // always-matching "Workspace" context -- got there ahead of it
+        // and closed the whole dialog instead.
+        if self.modal.is_some() && self.focused_field.is_some() {
+            self.focused_field = None;
+            self.field_buffer.clear();
+            cx.notify();
             return;
         }
         if self.modal.is_some() {
@@ -5097,11 +5113,16 @@ impl Workspace {
                         // The engine caches parsed faces and the family
                         // list; both are stale until it re-scans.
                         schist_text_engine::refresh();
-                        let redrawn = ws
+                        // Parked tabs too: they were left with the
+                        // substituted glyphs until they were reopened.
+                        let mut redrawn = ws
                             .doc
                             .as_mut()
                             .map(|doc| schist_tools_type::rerender_family(doc, &family))
                             .unwrap_or(0);
+                        for tab in ws.background_tabs.iter_mut() {
+                            redrawn += schist_tools_type::rerender_family(&mut tab.doc, &family);
+                        }
                         ws.refresh_missing_fonts();
                         format!(
                             "Installed {target} ({n} faces) \u{b7} re-set {redrawn} text layer(s)"

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -3027,8 +3027,14 @@ impl Workspace {
                 _ => None,
             },
         };
-        if let Some(text) = text.filter(|t| !t.is_empty()) {
-            cx.write_to_clipboard(gpui::ClipboardItem::new_string(text));
+        match text.filter(|t| !t.is_empty()) {
+            Some(text) => cx.write_to_clipboard(gpui::ClipboardItem::new_string(text)),
+            // A type session with nothing in it has nothing to copy. It
+            // used to claim the keystroke anyway, so clicking to place
+            // text and then pressing copy silently did nothing instead of
+            // copying the selection.
+            None if matches!(sink, Sink::Tool) => return false,
+            None => {}
         }
         self.after_change(cx);
         true
@@ -4013,11 +4019,6 @@ impl Workspace {
             "backspace" => {
                 self.field_buffer.pop();
             }
-            // Escape is handled in `cancel_gesture`, which runs first:
-            // it is bound to `CancelGesture` in the always-matching
-            // "Workspace" context, so nothing escape-shaped ever reaches
-            // here. Kept as a fallback for a build with that binding
-            // removed rather than left as a dead arm that looks live.
             "escape" => {
                 self.focused_field = None;
                 self.field_buffer.clear();
@@ -4241,17 +4242,6 @@ impl Workspace {
         }
         if self.context_menu.is_some() {
             self.close_context_menu(cx);
-            return;
-        }
-        // A focused field takes the escape first: it drops focus and
-        // leaves the dialog up, which is what `field_key`'s "escape" arm
-        // meant to do before `CancelGesture` -- bound in the
-        // always-matching "Workspace" context -- got there ahead of it
-        // and closed the whole dialog instead.
-        if self.modal.is_some() && self.focused_field.is_some() {
-            self.focused_field = None;
-            self.field_buffer.clear();
-            cx.notify();
             return;
         }
         if self.modal.is_some() {

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -2889,6 +2889,18 @@ impl Workspace {
     }
 
     pub fn run_command(&mut self, id: &str, cx: &mut Context<Self>) {
+        // Copy, cut and paste mean text when something is taking typing.
+        // The clipboard held pixels and nothing else, so ctrl-V while
+        // typing into a text layer pasted a "Pasted Layer" of pixels on
+        // top of the text rather than the string that had been copied,
+        // and ctrl-C copied the selection's pixels instead of the words.
+        if matches!(
+            id,
+            "edit.copy" | "edit.copy_merged" | "edit.cut" | "edit.paste"
+        ) && self.text_clipboard(id, cx)
+        {
+            return;
+        }
         // Grow, Similar and Color Range take their tolerance from the
         // magic wand, exactly as Photoshop does.
         self.sync_wand_tolerance();
@@ -2914,6 +2926,124 @@ impl Workspace {
             log::warn!("unknown command {id}");
         }
         self.after_change(cx);
+    }
+
+    /// Handle copy / cut / paste as text when a text sink has focus.
+    ///
+    /// Returns true when it did, so the pixel commands are skipped.
+    fn text_clipboard(&mut self, id: &str, cx: &mut Context<Self>) -> bool {
+        /// Which sink, in the order the key listeners try them.
+        enum Sink {
+            Rename,
+            Field,
+            Tool,
+        }
+        let tool_id = self.editor.active_tool;
+        let sink = if self.layer_rename.is_some() {
+            Sink::Rename
+        } else if self.focused_field.is_some() {
+            Sink::Field
+        } else if self
+            .registry
+            .tool_mut(tool_id)
+            .is_some_and(|t| t.editing_text().is_some())
+        {
+            Sink::Tool
+        } else {
+            return false;
+        };
+
+        if id == "edit.paste" {
+            let Some(text) = Self::clipboard_text(cx) else {
+                // Nothing textual on the clipboard: say so rather than
+                // pasting pixels over the words.
+                self.status = "Nothing on the clipboard to paste as text".into();
+                cx.notify();
+                return true;
+            };
+            let one_line = text.trim_end_matches('\n');
+            match sink {
+                Sink::Rename => {
+                    if let Some((_, name)) = self.layer_rename.as_mut() {
+                        name.push_str(one_line);
+                    }
+                }
+                Sink::Field => {
+                    self.field_buffer.push_str(one_line);
+                    if let Some(field) = self.focused_field {
+                        self.commit_field_value(field);
+                    }
+                }
+                Sink::Tool => {
+                    if let (Some(doc), Some(tool)) =
+                        (self.doc.as_mut(), self.registry.tool_mut(tool_id))
+                    {
+                        let mut ctx = ToolCtx {
+                            doc,
+                            state: &mut self.editor,
+                        };
+                        tool.insert_text(&mut ctx, &text);
+                    }
+                }
+            }
+            self.after_change(cx);
+            return true;
+        }
+
+        // Copy or cut.
+        let cut = id == "edit.cut";
+        let text = match sink {
+            Sink::Rename => {
+                let text = self.layer_rename.as_ref().map(|(_, n)| n.clone());
+                if cut {
+                    if let Some((_, name)) = self.layer_rename.as_mut() {
+                        name.clear();
+                    }
+                }
+                text
+            }
+            Sink::Field => {
+                let text = Some(self.field_buffer.clone());
+                if cut {
+                    self.field_buffer.clear();
+                    if let Some(field) = self.focused_field {
+                        self.commit_field_value(field);
+                    }
+                }
+                text
+            }
+            Sink::Tool => match (self.doc.as_mut(), self.registry.tool_mut(tool_id)) {
+                (Some(doc), Some(tool)) => {
+                    if cut {
+                        let mut ctx = ToolCtx {
+                            doc,
+                            state: &mut self.editor,
+                        };
+                        tool.take_text(&mut ctx)
+                    } else {
+                        tool.editing_text().map(str::to_string)
+                    }
+                }
+                _ => None,
+            },
+        };
+        if let Some(text) = text.filter(|t| !t.is_empty()) {
+            cx.write_to_clipboard(gpui::ClipboardItem::new_string(text));
+        }
+        self.after_change(cx);
+        true
+    }
+
+    /// A string from the system clipboard, if there is one.
+    ///
+    /// `sync_clipboard_in` walks the same entries but `continue`s on
+    /// anything that is not an image, so text was simply never seen.
+    fn clipboard_text(cx: &mut Context<Self>) -> Option<String> {
+        let item = cx.read_from_clipboard()?;
+        item.entries().iter().find_map(|entry| match entry {
+            gpui::ClipboardEntry::String(s) if !s.text().is_empty() => Some(s.text().to_string()),
+            _ => None,
+        })
     }
 
     /// Mirror the magic wand's tolerance into the shared editor state.

--- a/crates/plugin-api/src/lib.rs
+++ b/crates/plugin-api/src/lib.rs
@@ -157,6 +157,27 @@ pub trait ToolPlugin: Send {
         false
     }
 
+    /// The text this tool is editing, if it edits text at all.
+    ///
+    /// Copy, cut and paste have to mean *text* when something is taking
+    /// typing, and the shell should not have to know which concrete tool
+    /// that is. A tool that says nothing here is not a text sink, and the
+    /// pixel clipboard runs as before.
+    fn editing_text(&self) -> Option<&str> {
+        None
+    }
+
+    /// Insert text into the tool's edit session, returning whether it
+    /// took it.
+    fn insert_text(&mut self, _ctx: &mut ToolCtx, _text: &str) -> bool {
+        false
+    }
+
+    /// Remove the edited text, for a cut. Returns what was removed.
+    fn take_text(&mut self, _ctx: &mut ToolCtx) -> Option<String> {
+        None
+    }
+
     /// The user switched to this tool. Modal tools (free transform, crop)
     /// start their session here.
     fn on_activate(&mut self, _ctx: &mut ToolCtx) {}

--- a/crates/text-engine/src/lib.rs
+++ b/crates/text-engine/src/lib.rs
@@ -137,6 +137,15 @@ pub fn refresh() {
     if let Ok(mut cache) = font_cache().lock() {
         cache.clear();
     }
+    // Both fallback caches too: installing a CJK font is exactly when a
+    // remembered "nothing covers this" stops being true, and that is the
+    // flow this exists for.
+    if let Ok(mut cache) = fallback_cache().lock() {
+        cache.clear();
+    }
+    if let Ok(mut cache) = uncovered_cache().lock() {
+        cache.clear();
+    }
     if let Ok(mut names) = family_name_cache().write() {
         *names = leak_family_names();
     }
@@ -449,8 +458,22 @@ fn fallback_for(ch: char, primary: &LoadedFace, bold: bool, italic: bool) -> Opt
         return None;
     }
     let key = (fallback_key(ch), bold, italic);
-    if let Some(hit) = fallback_cache().lock().ok()?.get(&key) {
-        return hit.clone();
+    // A bucket is a hint about where to look first, not a promise that
+    // one face serves the whole range -- and bucket 0 is a catch-all for
+    // every script without an entry. Taking a hit unverified meant one
+    // symbols-only face cached for an arrow rendered Cyrillic as that
+    // face's tofu, and a cached miss for a single Private Use codepoint
+    // blacked the whole bucket out for the session.
+    if let Some(Some(face)) = fallback_cache().lock().ok()?.get(&key) {
+        if face.font.has_glyph(ch) {
+            return Some(face.clone());
+        }
+    }
+    // Misses are remembered per character, for the same reason.
+    if let Ok(c) = uncovered_cache().lock() {
+        if c.contains(&(ch, bold, italic)) {
+            return None;
+        }
     }
     // Named preferences first -- they are what a person would pick, and
     // they avoid a scan in the cases that actually come up.
@@ -492,8 +515,17 @@ fn fallback_for(ch: char, primary: &LoadedFace, bold: bool, italic: bool) -> Opt
     if found.is_none() {
         log::debug!("text-engine: no installed face covers U+{:04X}", ch as u32);
     }
-    if let Ok(mut c) = fallback_cache().lock() {
-        c.insert(key, found.clone());
+    match &found {
+        Some(_) => {
+            if let Ok(mut c) = fallback_cache().lock() {
+                c.insert(key, found.clone());
+            }
+        }
+        None => {
+            if let Ok(mut c) = uncovered_cache().lock() {
+                c.insert((ch, bold, italic));
+            }
+        }
     }
     found
 }
@@ -518,6 +550,11 @@ fn fallback_key(ch: char) -> u32 {
 /// Families worth trying for a character before scanning everything.
 fn preferred_families(ch: char) -> &'static [&'static str] {
     match fallback_key(ch) {
+        // Emoji land here for their *metrics*: fontdue rasterizes
+        // outlines, and the colour emoji faces are bitmap (CBDT/sbix) or
+        // COLR, so a matched face advances correctly but draws nothing.
+        // Better than a row of tofu at the wrong widths, and the place to
+        // start from when colour glyphs get a renderer.
         1 => &["Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji"],
         2 | 3 => &[
             "Noto Sans CJK JP",
@@ -544,6 +581,14 @@ fn fallback_cache(
         std::sync::Mutex<std::collections::HashMap<FallbackKey, Option<LoadedFace>>>,
     > = OnceLock::new();
     CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Characters no installed face covers, so the whole-database scan runs
+/// once each rather than once per layout.
+fn uncovered_cache() -> &'static std::sync::Mutex<std::collections::HashSet<(char, bool, bool)>> {
+    static CACHE: OnceLock<std::sync::Mutex<std::collections::HashSet<(char, bool, bool)>>> =
+        OnceLock::new();
+    CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
 }
 
 /// The GPOS `kern`-feature pair adjustments of a face, resolved once per
@@ -781,10 +826,6 @@ fn layout(spec: &TextSpec, face: &LoadedFace) -> Layout {
         line_start = at + 1;
     }
 
-    // Alignment measures the *visible* line. `split_inclusive(' ')` keeps
-    // each word's trailing space, so a line ending in one measured wider
-    // than its ink and right- and centre-aligned text hung short of the
-    // edge by exactly that space.
     // Alignment measures the *visible* line. `split_inclusive(' ')` keeps
     // each word's trailing space, so a line ending in one measured wider
     // than its ink and right- and centre-aligned text hung short of the
@@ -1047,6 +1088,20 @@ mod tests {
 
     fn ink(r: &TextRaster) -> usize {
         r.coverage.iter().filter(|&&v| v > 0).count()
+    }
+
+    /// Whether this machine can actually draw `ch` at all.
+    ///
+    /// A face with no coverage still rasterizes `.notdef`, and that box
+    /// has ink, so "the raster is empty" never became true on a runner
+    /// with no CJK font -- the fallback tests failed there instead of
+    /// skipping. Ask the resolver the question directly.
+    fn resolvable(ch: char) -> bool {
+        let spec = spec("");
+        let Some(primary) = load_font(&spec.family, spec.bold, spec.italic) else {
+            return false;
+        };
+        primary.font.has_glyph(ch) || fallback_for(ch, &primary, spec.bold, spec.italic).is_some()
     }
 
     #[test]
@@ -1356,13 +1411,13 @@ mod tests {
     /// the same empty rectangle repeated.
     #[test]
     fn characters_outside_the_chosen_face_are_not_all_the_same_box() {
-        let hiragana = rasterize(&spec("\u{3053}\u{3093}\u{306b}")).expect("font loads");
-        let han = rasterize(&spec("\u{4e2d}\u{6587}\u{5b57}")).expect("font loads");
-        if hiragana.is_empty() || han.is_empty() {
-            // A machine with no CJK face installed has nothing to fall
-            // back to, and drawing tofu is then the honest answer.
+        // A machine with no CJK face installed has nothing to fall back
+        // to, and drawing tofu is then the honest answer.
+        if !resolvable('\u{3053}') || !resolvable('\u{4e2d}') {
             return;
         }
+        let hiragana = rasterize(&spec("\u{3053}\u{3093}\u{306b}")).expect("font loads");
+        let han = rasterize(&spec("\u{4e2d}\u{6587}\u{5b57}")).expect("font loads");
         let per_glyph = |r: &TextRaster| ink(r) as f32 / 3.0;
         let (a, b) = (per_glyph(&hiragana), per_glyph(&han));
         assert!(
@@ -1372,16 +1427,56 @@ mod tests {
         );
     }
 
+    /// The cache is keyed by script bucket, and bucket 0 is a catch-all:
+    /// the face found for one of its characters need not cover the next,
+    /// and a character nothing covers must not answer for the rest.
+    #[test]
+    fn one_bucket_zero_character_does_not_answer_for_another() {
+        let spec = spec("");
+        let Some(primary) = load_font(&spec.family, spec.bold, spec.italic) else {
+            return;
+        };
+        // Cyrillic, an arrow and a Private Use codepoint all land in
+        // bucket 0.
+        let cyrillic = '\u{0416}';
+        let before = fallback_for(cyrillic, &primary, false, false);
+        if let Some(face) = &before {
+            assert!(face.font.has_glyph(cyrillic), "a face that cannot draw it");
+        }
+        // Nothing covers this, so it caches a miss.
+        let pua = fallback_for('\u{E000}', &primary, false, false);
+        assert!(pua.is_none() || pua.unwrap().font.has_glyph('\u{E000}'));
+        // Which must not have blanked the bucket.
+        let after = fallback_for(cyrillic, &primary, false, false);
+        assert_eq!(
+            before.is_some(),
+            after.is_some(),
+            "a cached miss for one character swallowed another"
+        );
+        // Nor may a face cached for the arrow answer for Cyrillic.
+        let arrow = '\u{2192}';
+        if let Some(face) = fallback_for(arrow, &primary, false, false) {
+            assert!(face.font.has_glyph(arrow));
+        }
+        if let Some(face) = fallback_for(cyrillic, &primary, false, false) {
+            assert!(
+                face.font.has_glyph(cyrillic),
+                "the arrow's face was handed back for Cyrillic"
+            );
+        }
+    }
+
     /// And the fallback's advance is used, so the layout is not measured
     /// against the box it is not drawing.
     #[test]
     fn a_fallback_glyph_advances_by_its_own_width() {
-        let narrow = rasterize(&spec("AA")).expect("font loads");
-        let cjk = rasterize(&spec("\u{4e2d}\u{6587}"));
-        let Some(cjk) = cjk else { return };
-        if cjk.is_empty() {
+        if !resolvable('\u{4e2d}') {
             return;
         }
+        let narrow = rasterize(&spec("AA")).expect("font loads");
+        let Some(cjk) = rasterize(&spec("\u{4e2d}\u{6587}")) else {
+            return;
+        };
         // Han glyphs are full-width; two of them are wider than two
         // latin capitals at the same size.
         assert!(

--- a/crates/text-engine/src/lib.rs
+++ b/crates/text-engine/src/lib.rs
@@ -649,15 +649,40 @@ fn layout(spec: &TextSpec, face: &LoadedFace) -> Layout {
         line_start = at + 1;
     }
 
-    let max_width = lines.iter().map(|l| l.width).fold(0.0f32, f32::max);
+    // Alignment measures the *visible* line. `split_inclusive(' ')` keeps
+    // each word's trailing space, so a line ending in one measured wider
+    // than its ink and right- and centre-aligned text hung short of the
+    // edge by exactly that space.
+    let visible = |line: &str, width: f32| -> f32 {
+        let trailing: f32 = line
+            .chars()
+            .rev()
+            .take_while(|c| c.is_whitespace())
+            .scan(None, |prev: &mut Option<char>, c| {
+                let w = advance(c, *prev);
+                *prev = Some(c);
+                Some(w)
+            })
+            .sum();
+        (width - trailing).max(0.0)
+    };
+    let widths: Vec<f32> = lines.iter().map(|l| visible(&l.text, l.width)).collect();
+    // Wrapped text aligns to its own box, not to whichever line happens to
+    // be longest.
+    let max_width = spec
+        .wrap_width
+        .unwrap_or_else(|| widths.iter().copied().fold(0.0f32, f32::max));
     let mut placed = Vec::new();
     let mut spans = Vec::with_capacity(lines.len());
     for (i, line) in lines.iter().enumerate() {
+        // The span keeps the full width -- the caret and the selection
+        // highlight run to the end of the text, trailing space included.
+        let width = widths[i];
         let baseline = ascent + i as f32 * line_advance;
         let start_x = match spec.align {
             Align::Left => 0.0,
-            Align::Center => (max_width - line.width) / 2.0,
-            Align::Right => max_width - line.width,
+            Align::Center => (max_width - width) / 2.0,
+            Align::Right => max_width - width,
         };
         spans.push(LineSpan {
             start: line.start,
@@ -1006,6 +1031,7 @@ mod tests {
         assert!(r.is_some(), "should fall back to a system sans");
         assert!(!r.unwrap().is_empty());
     }
+
     #[test]
     fn caret_advances_along_a_line() {
         let s = spec("abc");
@@ -1065,5 +1091,52 @@ mod tests {
         assert!(caret_at(&s, 999).is_some());
         // Byte 2 is inside the two-byte 'é'.
         assert!(caret_at(&s, 2).is_some());
+    }
+
+    /// Right edge of the rendered ink.
+    fn right_edge(r: &TextRaster) -> i32 {
+        r.bounds.right
+    }
+
+    #[test]
+    fn a_trailing_space_does_not_shift_aligned_text() {
+        // `split_inclusive(' ')` keeps each word's trailing space, and the
+        // alignment offset was computed from that padded width, so a line
+        // ending in a space hung short of the edge by exactly one space.
+        let render = |text: &str| {
+            rasterize(&TextSpec {
+                text: text.into(),
+                size: 32.0,
+                align: Align::Right,
+                ..Default::default()
+            })
+            .expect("rasterized")
+        };
+        let without = render("mmmm\nX");
+        let with = render("mmmm\nX ");
+        assert_eq!(
+            right_edge(&without),
+            right_edge(&with),
+            "a trailing space must not move the ink"
+        );
+    }
+
+    #[test]
+    fn wrapped_text_aligns_to_its_box_not_its_longest_line() {
+        // `max_width` was the widest *rendered* line, so right-aligned
+        // paragraph text sat inside its own frame by however much the
+        // longest line fell short of the wrap width.
+        let spec = TextSpec {
+            text: "aaa bbb ccc ddd eee fff".into(),
+            size: 24.0,
+            align: Align::Right,
+            wrap_width: Some(400.0),
+            ..Default::default()
+        };
+        let r = rasterize(&spec).expect("rasterized");
+        assert_eq!(
+            r.layout_width, 400.0,
+            "the alignment box is the wrap width, not the longest line"
+        );
     }
 }

--- a/crates/text-engine/src/lib.rs
+++ b/crates/text-engine/src/lib.rs
@@ -575,7 +575,19 @@ fn layout(spec: &TextSpec, face: &LoadedFace) -> Layout {
     // A face with GPOS kerning speaks through it alone; the legacy
     // `kern` table is only consulted when there is no GPOS to read.
     let gpos = GposKern::new(&face.data, face.index, spec.size);
-    let advance = |ch: char, prev: Option<char>| -> f32 {
+    // A tab is a stop, not a glyph. Four spaces wide, as every editor
+    // and word processor has settled on. The Type tool turns a Tab
+    // keypress into four spaces, but text arriving from a PSD's `PsTx`
+    // block can contain a real `\t`, and asking the font for the tab
+    // glyph's advance gave it a single ~11 px step -- so imported tabbed
+    // text did not line up in any column.
+    let tab_stop = (font.metrics(' ', spec.size).advance_width * 4.0).max(1.0);
+    // `pen` is the position along the line, measured from the line's own
+    // start, which is what a tab stop is relative to.
+    let advance = |ch: char, prev: Option<char>, pen: f32| -> f32 {
+        if ch == '\t' {
+            return ((pen / tab_stop).floor() + 1.0) * tab_stop - pen;
+        }
         let m = font.metrics(ch, spec.size);
         let kern = prev
             .and_then(|p| match &gpos {
@@ -610,7 +622,7 @@ fn layout(spec: &TextSpec, face: &LoadedFace) -> Layout {
             let mut word_width = 0.0;
             let mut p = prev;
             for ch in word.chars() {
-                word_width += advance(ch, p);
+                word_width += advance(ch, p, width + word_width);
                 p = Some(ch);
             }
             let wraps = spec
@@ -630,7 +642,7 @@ fn layout(spec: &TextSpec, face: &LoadedFace) -> Layout {
                 let mut p = None;
                 word_width = 0.0;
                 for ch in word.chars() {
-                    word_width += advance(ch, p);
+                    word_width += advance(ch, p, word_width);
                     p = Some(ch);
                 }
             }
@@ -653,20 +665,28 @@ fn layout(spec: &TextSpec, face: &LoadedFace) -> Layout {
     // each word's trailing space, so a line ending in one measured wider
     // than its ink and right- and centre-aligned text hung short of the
     // edge by exactly that space.
-    let visible = |line: &str, width: f32| -> f32 {
-        let trailing: f32 = line
-            .chars()
-            .rev()
-            .take_while(|c| c.is_whitespace())
-            .scan(None, |prev: &mut Option<char>, c| {
-                let w = advance(c, *prev);
-                *prev = Some(c);
-                Some(w)
-            })
-            .sum();
-        (width - trailing).max(0.0)
+    // Alignment measures the *visible* line. `split_inclusive(' ')` keeps
+    // each word's trailing space, so a line ending in one measured wider
+    // than its ink and right- and centre-aligned text hung short of the
+    // edge by exactly that space.
+    //
+    // Walking the pen rather than subtracting a trailing run also gets
+    // tabs right: a tab's width depends on where it starts, so it cannot
+    // be measured in isolation.
+    let visible = |line: &str| -> f32 {
+        let mut pen = 0.0f32;
+        let mut ink_end = 0.0f32;
+        let mut prev: Option<char> = None;
+        for ch in line.chars() {
+            pen += advance(ch, prev, pen);
+            if !ch.is_whitespace() {
+                ink_end = pen;
+            }
+            prev = Some(ch);
+        }
+        ink_end
     };
-    let widths: Vec<f32> = lines.iter().map(|l| visible(&l.text, l.width)).collect();
+    let widths: Vec<f32> = lines.iter().map(|l| visible(&l.text)).collect();
     // Wrapped text aligns to its own box, not to whichever line happens to
     // be longest.
     let max_width = spec
@@ -692,13 +712,19 @@ fn layout(spec: &TextSpec, face: &LoadedFace) -> Layout {
             top: i as f32 * line_advance,
             height: line_advance,
         });
-        let mut x = start_x;
         let mut prev: Option<char> = None;
+        // The pen, not a running x: a tab's width depends on where in the
+        // line it starts, so it cannot be measured in isolation.
+        let mut pen = 0.0f32;
         for ch in line.text.chars() {
             if !ch.is_whitespace() {
-                placed.push(PlacedGlyph { ch, x, baseline });
+                placed.push(PlacedGlyph {
+                    ch,
+                    x: start_x + pen,
+                    baseline,
+                });
             }
-            x += advance(ch, prev);
+            pen += advance(ch, prev, pen);
             prev = Some(ch);
         }
     }
@@ -1138,5 +1164,67 @@ mod tests {
             r.layout_width, 400.0,
             "the alignment box is the wrap width, not the longest line"
         );
+    }
+
+    /// A tab is a stop, not a glyph.
+    ///
+    /// `advance` had no `'\t'` case, so it asked the font for the tab
+    /// glyph's advance and got a single ~11 px step. The Type tool turns
+    /// a Tab keypress into four spaces, but text arriving from a PSD's
+    /// `PsTx` block can hold a real tab, and tabbed text imported that
+    /// way lined up in no column at all.
+    #[test]
+    fn a_tab_aligns_prefixes_that_share_a_stop() {
+        // Full stops are narrow enough that one, two and three of them
+        // all sit inside the first stop, which is where a tab is
+        // supposed to hide the difference.
+        let one = rasterize(&spec(".\tX")).expect("font loads");
+        let two = rasterize(&spec("..\tX")).expect("font loads");
+        let three = rasterize(&spec("...\tX")).expect("font loads");
+        assert!(
+            (one.layout_width - two.layout_width).abs() < 0.5
+                && (one.layout_width - three.layout_width).abs() < 0.5,
+            "the tab did not align the column: {} / {} / {}",
+            one.layout_width,
+            two.layout_width,
+            three.layout_width
+        );
+        // Without the tab they differ, so the test is measuring the tab
+        // rather than a font that renders every prefix the same width.
+        let plain_one = rasterize(&spec(".X")).expect("font loads");
+        let plain_three = rasterize(&spec("...X")).expect("font loads");
+        assert!(plain_three.layout_width > plain_one.layout_width + 1.0);
+    }
+
+    /// A prefix past the first stop reaches the next one, so the stops
+    /// are a grid rather than a fixed pad.
+    #[test]
+    fn a_long_prefix_reaches_the_next_stop() {
+        let short = rasterize(&spec(".\tX")).expect("font loads");
+        let long = rasterize(&spec("MMMMMM\tX")).expect("font loads");
+        assert!(
+            long.layout_width > short.layout_width + 1.0,
+            "{} did not clear the first stop ({})",
+            long.layout_width,
+            short.layout_width
+        );
+    }
+
+    /// Stops are measured from each line's own start, so a wide line does
+    /// not drag the line below it out of column.
+    #[test]
+    fn tab_stops_are_per_line() {
+        let alone = rasterize(&spec(".\tX")).expect("font loads");
+        let under = rasterize(&spec("MMMMMM\tX\n.\tX")).expect("font loads");
+        // The second line still sits on the first stop, so the block is
+        // exactly as wide as its widest line -- the long one.
+        let long = rasterize(&spec("MMMMMM\tX")).expect("font loads");
+        assert!(
+            (under.layout_width - long.layout_width).abs() < 0.5,
+            "the short line drifted: {} vs {}",
+            under.layout_width,
+            long.layout_width
+        );
+        assert!(long.layout_width > alone.layout_width);
     }
 }

--- a/crates/text-engine/src/lib.rs
+++ b/crates/text-engine/src/lib.rs
@@ -432,6 +432,120 @@ fn load_font(family: &str, bold: bool, italic: bool) -> Option<LoadedFace> {
     font
 }
 
+/// A face that actually has the glyph for `ch`.
+///
+/// `load_font` resolves one face for the whole spec and every glyph is
+/// rasterized from it. fontdue maps a codepoint the face does not cover
+/// to glyph 0, so `.notdef` -- the tofu box -- is drawn. Typing Japanese
+/// or an emoji gave a row of empty rectangles even with Noto CJK and
+/// Noto Color Emoji installed.
+///
+/// Returns `None` when the primary face already covers `ch`, so the
+/// common path allocates and locks nothing.
+fn fallback_for(ch: char, primary: &LoadedFace, bold: bool, italic: bool) -> Option<LoadedFace> {
+    // Whitespace has no ink; asking for a face for it would pick one at
+    // random and drag its metrics in.
+    if ch.is_whitespace() || primary.font.has_glyph(ch) {
+        return None;
+    }
+    let key = (fallback_key(ch), bold, italic);
+    if let Some(hit) = fallback_cache().lock().ok()?.get(&key) {
+        return hit.clone();
+    }
+    // Named preferences first -- they are what a person would pick, and
+    // they avoid a scan in the cases that actually come up.
+    let mut found = None;
+    for name in preferred_families(ch) {
+        if let Some(face) = load_font(name, bold, italic) {
+            if face.font.has_glyph(ch) {
+                found = Some(face);
+                break;
+            }
+        }
+    }
+    // Otherwise ask every installed face, once per script bucket.
+    if found.is_none() {
+        let ids: Vec<fontdb::ID> = db().faces().map(|f| f.id).collect();
+        for id in ids {
+            let covers = db()
+                .with_face_data(id, |data, index| {
+                    ttf_parser::Face::parse(data, index)
+                        .ok()
+                        .and_then(|f| f.glyph_index(ch))
+                        .is_some()
+                })
+                .unwrap_or(false);
+            if !covers {
+                continue;
+            }
+            let family = db()
+                .face(id)
+                .and_then(|f| f.families.first().map(|(n, _)| n.clone()));
+            if let Some(face) = family.and_then(|n| load_font(&n, bold, italic)) {
+                if face.font.has_glyph(ch) {
+                    found = Some(face);
+                    break;
+                }
+            }
+        }
+    }
+    if found.is_none() {
+        log::debug!("text-engine: no installed face covers U+{:04X}", ch as u32);
+    }
+    if let Ok(mut c) = fallback_cache().lock() {
+        c.insert(key, found.clone());
+    }
+    found
+}
+
+/// Which script bucket a character falls in, so the fallback is resolved
+/// once per script rather than once per character.
+fn fallback_key(ch: char) -> u32 {
+    let c = ch as u32;
+    match c {
+        0x1F000..=0x1FAFF | 0x2600..=0x27BF | 0xFE00..=0xFE0F => 1, // emoji and symbols
+        0x3000..=0x30FF | 0x31F0..=0x31FF | 0xFF00..=0xFFEF => 2,   // kana and CJK punctuation
+        0x4E00..=0x9FFF | 0x3400..=0x4DBF | 0xF900..=0xFAFF => 3,   // han
+        0xAC00..=0xD7AF | 0x1100..=0x11FF => 4,                     // hangul
+        0x0590..=0x05FF => 5,                                       // hebrew
+        0x0600..=0x06FF | 0x0750..=0x077F => 6,                     // arabic
+        0x0900..=0x097F => 7,                                       // devanagari
+        0x0E00..=0x0E7F => 8,                                       // thai
+        _ => 0,
+    }
+}
+
+/// Families worth trying for a character before scanning everything.
+fn preferred_families(ch: char) -> &'static [&'static str] {
+    match fallback_key(ch) {
+        1 => &["Noto Color Emoji", "Apple Color Emoji", "Segoe UI Emoji"],
+        2 | 3 => &[
+            "Noto Sans CJK JP",
+            "Noto Sans CJK SC",
+            "Noto Sans JP",
+            "Source Han Sans",
+            "Hiragino Sans",
+            "Yu Gothic",
+        ],
+        4 => &["Noto Sans CJK KR", "Noto Sans KR", "Malgun Gothic"],
+        5 => &["Noto Sans Hebrew", "David"],
+        6 => &["Noto Sans Arabic", "Geeza Pro"],
+        7 => &["Noto Sans Devanagari", "Mangal"],
+        8 => &["Noto Sans Thai", "Thonburi"],
+        _ => &[],
+    }
+}
+
+type FallbackKey = (u32, bool, bool);
+
+fn fallback_cache(
+) -> &'static std::sync::Mutex<std::collections::HashMap<FallbackKey, Option<LoadedFace>>> {
+    static CACHE: OnceLock<
+        std::sync::Mutex<std::collections::HashMap<FallbackKey, Option<LoadedFace>>>,
+    > = OnceLock::new();
+    CACHE.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
 /// The GPOS `kern`-feature pair adjustments of a face, resolved once per
 /// layout. fontdue reads only the legacy `kern` table; most modern faces
 /// keep their kerning here instead, and Affinity applies it, so matching
@@ -587,6 +701,12 @@ fn layout(spec: &TextSpec, face: &LoadedFace) -> Layout {
     let advance = |ch: char, prev: Option<char>, pen: f32| -> f32 {
         if ch == '\t' {
             return ((pen / tab_stop).floor() + 1.0) * tab_stop - pen;
+        }
+        // A glyph the chosen face does not cover is drawn from a
+        // fallback, so its advance has to come from there too or the
+        // text would be laid out against the .notdef box's width.
+        if let Some(fb) = fallback_for(ch, face, spec.bold, spec.italic) {
+            return fb.font.metrics(ch, spec.size).advance_width + spec.tracking;
         }
         let m = font.metrics(ch, spec.size);
         let kern = prev
@@ -862,7 +982,9 @@ pub fn rasterize(spec: &TextSpec) -> Option<TextRaster> {
     let mut rasterized = Vec::with_capacity(placed.len());
     let mut bounds = IntRect::EMPTY;
     for g in &placed {
-        let (metrics, bitmap) = font.rasterize(g.ch, spec.size);
+        let fb = fallback_for(g.ch, &face, spec.bold, spec.italic);
+        let glyph_font = fb.as_ref().map_or(font, |f| &f.font);
+        let (metrics, bitmap) = glyph_font.rasterize(g.ch, spec.size);
         if metrics.width == 0 || metrics.height == 0 {
             continue;
         }
@@ -1226,5 +1348,60 @@ mod tests {
             long.layout_width
         );
         assert!(long.layout_width > alone.layout_width);
+    }
+
+    /// Every glyph was rasterized from one face, and fontdue maps a
+    /// codepoint that face does not cover to glyph 0 — the .notdef box.
+    /// The tell is identical ink per glyph across unrelated characters:
+    /// the same empty rectangle repeated.
+    #[test]
+    fn characters_outside_the_chosen_face_are_not_all_the_same_box() {
+        let hiragana = rasterize(&spec("\u{3053}\u{3093}\u{306b}")).expect("font loads");
+        let han = rasterize(&spec("\u{4e2d}\u{6587}\u{5b57}")).expect("font loads");
+        if hiragana.is_empty() || han.is_empty() {
+            // A machine with no CJK face installed has nothing to fall
+            // back to, and drawing tofu is then the honest answer.
+            return;
+        }
+        let per_glyph = |r: &TextRaster| ink(r) as f32 / 3.0;
+        let (a, b) = (per_glyph(&hiragana), per_glyph(&han));
+        assert!(
+            (a - b).abs() > 1.0,
+            "hiragana and han have identical ink per glyph ({a} vs {b}), \
+             which is the .notdef box repeated"
+        );
+    }
+
+    /// And the fallback's advance is used, so the layout is not measured
+    /// against the box it is not drawing.
+    #[test]
+    fn a_fallback_glyph_advances_by_its_own_width() {
+        let narrow = rasterize(&spec("AA")).expect("font loads");
+        let cjk = rasterize(&spec("\u{4e2d}\u{6587}"));
+        let Some(cjk) = cjk else { return };
+        if cjk.is_empty() {
+            return;
+        }
+        // Han glyphs are full-width; two of them are wider than two
+        // latin capitals at the same size.
+        assert!(
+            cjk.layout_width > narrow.layout_width,
+            "{} should exceed {}",
+            cjk.layout_width,
+            narrow.layout_width
+        );
+    }
+
+    /// Characters the chosen face does cover keep using it, so nothing
+    /// about ordinary latin text changes.
+    #[test]
+    fn covered_characters_do_not_go_through_the_fallback() {
+        let face = load_font(&default_family(), false, false).expect("a default face");
+        for ch in "Hello, world! 123".chars() {
+            assert!(
+                fallback_for(ch, &face, false, false).is_none(),
+                "{ch:?} should not need a fallback"
+            );
+        }
     }
 }

--- a/plugins/tools-type/src/lib.rs
+++ b/plugins/tools-type/src/lib.rs
@@ -182,6 +182,9 @@ struct Editing {
     /// The other end of the selection. Equal to `caret` when nothing is
     /// selected, so the two together describe both states.
     anchor: usize,
+    /// True while the layer's name is still the auto-generated one, so
+    /// typing may keep updating it.
+    name_is_auto: bool,
 }
 
 /// Does this char hang off the one before it, rather than standing alone?
@@ -228,7 +231,14 @@ impl TypeTool {
             if let Some(raster) = layer.as_raster_mut() {
                 raster.tiles = tiles;
             }
-            layer.name = display_name(&session.stored.spec.text);
+            // Only auto-name while the name still looks auto-generated.
+            // Renaming a text layer to "Headline" and then editing its
+            // text reverted the name on the next keystroke, and no
+            // `LayerProps` op was recorded, so undo could not bring it
+            // back either.
+            if session.name_is_auto {
+                layer.name = display_name(&session.stored.spec.text);
+            }
             write_stored(layer, &session.stored);
         }
         doc.add_damage(before.union(&bounds));
@@ -265,6 +275,7 @@ impl TypeTool {
             dirty: false,
             caret: 0,
             anchor: 0,
+            name_is_auto: true,
         });
     }
 
@@ -273,6 +284,14 @@ impl TypeTool {
         let (px, py) = (x.round() as i32, y.round() as i32);
         let mut hit = None;
         for layer in doc.tree.iter() {
+            // Every other tool filters these; the type tool did not, so
+            // clicking where a hidden text layer used to be silently
+            // started editing it (caret over nothing, keystrokes changing
+            // an invisible layer), and a locked one could be edited
+            // despite the lock.
+            if !layer.visible || layer.locked {
+                continue;
+            }
             let Some(stored) = read_stored(layer) else {
                 continue;
             };
@@ -332,6 +351,11 @@ impl ToolPlugin for TypeTool {
                     ..stored.spec.clone()
                 };
                 let end = stored.spec.text.len();
+                let name_is_auto = ctx
+                    .doc
+                    .tree
+                    .find(layer)
+                    .is_some_and(|l| l.name == display_name(&stored.spec.text));
                 self.editing = Some(Editing {
                     layer,
                     stored,
@@ -340,6 +364,7 @@ impl ToolPlugin for TypeTool {
                     dirty: false,
                     caret: end,
                     anchor: end,
+                    name_is_auto,
                 });
             }
             None => self.start_new(ctx, input.x, input.y),
@@ -1260,6 +1285,44 @@ mod tests {
     }
 
     #[test]
+    fn a_user_set_layer_name_survives_editing_its_text() {
+        // `refresh` reset the name to the first line of the text on every
+        // keystroke, outside any edit, so a name the user had set was
+        // reverted by typing and undo could not bring it back: no
+        // `LayerProps` op was ever recorded for it.
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState::default();
+        let mut tool = TypeTool::default();
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut d,
+                state: &mut state,
+            };
+            tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+            type_text(&mut tool, &mut ctx, "Hi");
+        }
+        let id = tool.editing.as_ref().unwrap().layer;
+
+        // The user renames the layer, which makes the name no longer the
+        // auto-generated one.
+        d.tree.find_mut(id).unwrap().name = "Headline".into();
+        tool.editing.as_mut().unwrap().name_is_auto = false;
+
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut d,
+                state: &mut state,
+            };
+            type_text(&mut tool, &mut ctx, "!");
+        }
+        assert_eq!(
+            d.tree.find(id).unwrap().name,
+            "Headline",
+            "typing must not overwrite a name the user set"
+        );
+    }
+
+    #[test]
     fn discarding_an_empty_layer_leaves_no_junk_history() {
         let mut d = doc();
         let mut state = schist_plugin_api::EditorState::default();
@@ -1456,5 +1519,57 @@ mod tests {
         let mut d = doc();
         let mut tool = editing(&mut d, "hi");
         assert!(!key(&mut tool, &mut d, "s", ctrl()));
+    }
+
+    #[test]
+    fn an_auto_named_layer_still_follows_its_text() {
+        // The other direction: while the name is still the generated one,
+        // it should keep tracking what is typed.
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState::default();
+        let mut tool = TypeTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+        type_text(&mut tool, &mut ctx, "Hi");
+        let id = tool.editing.as_ref().unwrap().layer;
+        assert_eq!(ctx.doc.tree.find(id).unwrap().name, "Hi");
+    }
+
+    #[test]
+    fn a_hidden_or_locked_text_layer_is_not_entered() {
+        // Every other tool filters these. Clicking where a hidden text
+        // layer used to be silently started editing it.
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState::default();
+        let mut tool = TypeTool::default();
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut d,
+                state: &mut state,
+            };
+            tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+            type_text(&mut tool, &mut ctx, "Hi");
+            tool.on_commit(&mut ctx);
+        }
+        let id = d.tree.iter().find(|l| l.name == "Hi").unwrap().id;
+        let layers_before = d.tree.len();
+        let b = d.tree.find(id).unwrap().tight_bounds();
+        d.tree.find_mut(id).unwrap().visible = false;
+
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut d,
+                state: &mut state,
+            };
+            // Clicking the hidden layer must start a *new* layer instead
+            // of resuming the invisible one.
+            tool.on_pointer_down(&mut ctx, input(b.left as f32 + 2.0, b.top as f32 + 2.0));
+        }
+        let session = tool.editing.as_ref().expect("a session started");
+        assert_ne!(session.layer, id, "must not resume the hidden layer");
+        assert!(d.tree.len() > layers_before, "a new layer was created");
     }
 }

--- a/plugins/tools-type/src/lib.rs
+++ b/plugins/tools-type/src/lib.rs
@@ -143,26 +143,37 @@ pub fn rerender_family(doc: &mut Document, family: &str) -> usize {
     }
     let mut ids = Vec::new();
     collect(&doc.tree.layers, family, &mut ids);
-    let mut changed = 0;
-    for id in ids {
-        let Some(stored) = doc.tree.find(id).and_then(read_stored) else {
+    if ids.is_empty() {
+        return 0;
+    }
+    // One undoable edit for the lot. These pixels used to be assigned
+    // straight onto the raster with nothing but an `add_damage` call --
+    // no `begin_edit`, so "Installed Inter (2 faces) - re-set 7 text
+    // layer(s)" changed seven layers with no way to undo it, and the
+    // document was not even marked dirty, so it could be closed without
+    // a save prompt.
+    let mut rendered = Vec::new();
+    for id in &ids {
+        let Some(stored) = doc.tree.find(*id).and_then(read_stored) else {
             continue;
         };
-        let before = doc
-            .tree
-            .find(id)
-            .map(|l| l.content_bounds())
-            .unwrap_or(IntRect::EMPTY);
-        let (tiles, bounds) = render_tiles(doc, &stored);
+        let (tiles, _bounds) = render_tiles(doc, &stored);
+        rendered.push((*id, tiles));
+    }
+    if rendered.is_empty() {
+        return 0;
+    }
+    let changed = rendered.len();
+    let mut edit = doc.begin_edit("Update Fonts");
+    for (id, tiles) in rendered {
+        edit.replace_layer_tiles(id, tiles);
+    }
+    edit.commit();
+    // The style caches were built from the old glyphs.
+    for id in ids {
         if let Some(layer) = doc.tree.find_mut(id) {
-            if let Some(raster) = layer.as_raster_mut() {
-                raster.tiles = tiles;
-            }
-            // The style cache was built from the old glyphs.
             layer.styled = None;
-            changed += 1;
         }
-        doc.add_damage(before.union(&bounds));
     }
     changed
 }
@@ -205,13 +216,32 @@ fn is_continuation(ch: char) -> bool {
 const STYLES: &[&str] = &["Regular", "Bold", "Italic", "Bold Italic"];
 const ALIGNMENTS: &[&str] = &["Left", "Center", "Right"];
 
-#[derive(Default)]
 pub struct TypeTool {
     editing: Option<Editing>,
     /// What new text starts as, and what the options bar shows when
     /// nothing is being edited. Editing a layer adopts its spec, so the
     /// bar always describes the text you are looking at.
     spec: TextSpec,
+    /// Whether the text being edited tracks the foreground swatch.
+    ///
+    /// `StoredText.color` was written once in `start_new` and never
+    /// again -- `TextSpec` has no colour field, so nothing in the options
+    /// bar could reach it. Set the foreground to red, place text, switch
+    /// to blue and click back in: it stayed red, and the only way to
+    /// change it was to delete and retype. On (the default) the edited
+    /// text follows the swatch; off keeps whatever colour the layer
+    /// already had, for editing wording without restyling it.
+    follow_foreground: bool,
+}
+
+impl Default for TypeTool {
+    fn default() -> Self {
+        TypeTool {
+            editing: None,
+            spec: TextSpec::default(),
+            follow_foreground: true,
+        }
+    }
 }
 
 impl TypeTool {
@@ -533,6 +563,11 @@ impl ToolPlugin for TypeTool {
                 80.0,
                 " px",
             ),
+            ToolOption::toggle(
+                "type-follow-fg",
+                "Foreground Colour",
+                self.follow_foreground,
+            ),
         ]
     }
 
@@ -558,6 +593,7 @@ impl ToolPlugin for TypeTool {
             }
             "type-leading" => self.spec.line_height = value.num().clamp(0.5, 3.0),
             "type-tracking" => self.spec.tracking = value.num(),
+            "type-follow-fg" => self.follow_foreground = value.bool(),
             _ => {}
         }
     }
@@ -565,6 +601,7 @@ impl ToolPlugin for TypeTool {
     /// Push the bar's settings onto the text being edited, so a font or
     /// size change shows up immediately rather than on the next click.
     fn on_option_changed(&mut self, ctx: &mut ToolCtx, _key: &str) {
+        let foreground = ctx.state.foreground.to_u8();
         let Some(session) = &mut self.editing else {
             return;
         };
@@ -573,6 +610,9 @@ impl ToolPlugin for TypeTool {
             text,
             ..self.spec.clone()
         };
+        if self.follow_foreground {
+            session.stored.color = foreground;
+        }
         session.dirty = true;
         self.refresh(ctx.doc);
     }
@@ -1571,5 +1611,119 @@ mod tests {
         let session = tool.editing.as_ref().expect("a session started");
         assert_ne!(session.layer, id, "must not resume the hidden layer");
         assert!(d.tree.len() > layers_before, "a new layer was created");
+    }
+
+    /// `StoredText.color` was written once in `start_new` and never
+    /// again: `TextSpec` has no colour field, so nothing in the options
+    /// bar could reach it. Set the foreground to red, place text, switch
+    /// to blue and click back in — it stayed red, and the only way to
+    /// change it was to delete and retype.
+    #[test]
+    fn the_edited_text_follows_the_foreground_swatch() {
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState {
+            foreground: schist_color::Rgba::new(1.0, 0.0, 0.0, 1.0),
+            ..Default::default()
+        };
+        let mut tool = TypeTool::default();
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut d,
+                state: &mut state,
+            };
+            tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+            tool.on_pointer_up(&mut ctx, input(20.0, 60.0));
+            type_text(&mut tool, &mut ctx, "Hi");
+            assert_eq!(
+                tool.editing.as_ref().unwrap().stored.color,
+                [255, 0, 0, 255]
+            );
+        }
+
+        state.foreground = schist_color::Rgba::new(0.0, 0.0, 1.0, 1.0);
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+        tool.set_option("type-size", OptionValue::Num(40.0));
+        tool.on_option_changed(&mut ctx, "type-size");
+        assert_eq!(
+            tool.editing.as_ref().unwrap().stored.color,
+            [0, 0, 255, 255],
+            "the text did not pick up the new foreground"
+        );
+    }
+
+    /// And turning the toggle off keeps the layer's own colour, for
+    /// editing the wording without restyling it.
+    #[test]
+    fn the_colour_can_be_pinned_to_the_layer() {
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState {
+            foreground: schist_color::Rgba::new(1.0, 0.0, 0.0, 1.0),
+            ..Default::default()
+        };
+        let mut tool = TypeTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+        tool.on_pointer_up(&mut ctx, input(20.0, 60.0));
+        type_text(&mut tool, &mut ctx, "Hi");
+
+        tool.set_option("type-follow-fg", OptionValue::Bool(false));
+        ctx.state.foreground = schist_color::Rgba::new(0.0, 0.0, 1.0, 1.0);
+        tool.set_option("type-size", OptionValue::Num(40.0));
+        tool.on_option_changed(&mut ctx, "type-size");
+        assert_eq!(
+            tool.editing.as_ref().unwrap().stored.color,
+            [255, 0, 0, 255]
+        );
+    }
+
+    /// Installing a font re-rendered every layer set in it by assigning
+    /// straight onto the raster — no `begin_edit`, so the change was not
+    /// undoable and the document was not even marked dirty, meaning it
+    /// could be closed without a save prompt.
+    #[test]
+    fn a_font_re_render_is_one_undoable_edit() {
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState::default();
+        let mut tool = TypeTool::default();
+        let family = {
+            let mut ctx = ToolCtx {
+                doc: &mut d,
+                state: &mut state,
+            };
+            tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+            tool.on_pointer_up(&mut ctx, input(20.0, 60.0));
+            type_text(&mut tool, &mut ctx, "Hi");
+            let family = tool.editing.as_ref().unwrap().stored.spec.family.clone();
+            tool.on_commit(&mut ctx);
+            family
+        };
+        d.dirty = false;
+        let steps_before = d.history.undo_name().map(String::from);
+
+        let changed = rerender_family(&mut d, &family);
+        assert_eq!(changed, 1, "the text layer should have been re-rendered");
+        assert_eq!(d.history.undo_name(), Some("Update Fonts"));
+        assert!(d.dirty, "a re-render is an unsaved change");
+
+        d.undo();
+        assert_eq!(
+            d.history.undo_name().map(String::from),
+            steps_before,
+            "the re-render left more than one entry"
+        );
+    }
+
+    /// A family nothing is set in changes nothing, and records nothing.
+    #[test]
+    fn a_font_nothing_uses_records_no_edit() {
+        let mut d = doc();
+        assert_eq!(rerender_family(&mut d, "Definitely Not Installed"), 0);
+        assert!(!d.history.can_undo());
     }
 }

--- a/plugins/tools-type/src/lib.rs
+++ b/plugins/tools-type/src/lib.rs
@@ -216,6 +216,12 @@ fn is_continuation(ch: char) -> bool {
 const STYLES: &[&str] = &["Regular", "Bold", "Italic", "Bold Italic"];
 const ALIGNMENTS: &[&str] = &["Left", "Center", "Right"];
 
+/// Narrower than this and a drag was meant as a click.
+const MIN_AREA_WIDTH: f32 = 8.0;
+
+/// The widest wrap the options slider offers.
+const MAX_AREA_WIDTH: f32 = 4000.0;
+
 pub struct TypeTool {
     editing: Option<Editing>,
     /// What new text starts as, and what the options bar shows when
@@ -232,6 +238,13 @@ pub struct TypeTool {
     /// text follows the swatch; off keeps whatever colour the layer
     /// already had, for editing wording without restyling it.
     follow_foreground: bool,
+    /// A press that has not been released yet, which will make point
+    /// text if it was a click and an area-text box if it was a drag.
+    ///
+    /// `TextSpec::wrap_width` existed and the engine honoured it, but
+    /// nothing in the ui could set it, so every layer was point text and
+    /// paragraph text was unreachable.
+    pending: Option<(f32, f32)>,
 }
 
 impl Default for TypeTool {
@@ -240,6 +253,7 @@ impl Default for TypeTool {
             editing: None,
             spec: TextSpec::default(),
             follow_foreground: true,
+            pending: None,
         }
     }
 }
@@ -346,6 +360,22 @@ impl ToolPlugin for TypeTool {
     fn id(&self) -> &'static str {
         "type"
     }
+
+    fn editing_text(&self) -> Option<&str> {
+        self.editing.as_ref().map(|s| s.stored.spec.text.as_str())
+    }
+
+    fn insert_text(&mut self, ctx: &mut ToolCtx, text: &str) -> bool {
+        insert_text(self, ctx.doc, text)
+    }
+
+    fn take_text(&mut self, ctx: &mut ToolCtx) -> Option<String> {
+        let taken = self.editing.as_ref()?.stored.spec.text.clone();
+        if taken.is_empty() {
+            return None;
+        }
+        clear_text(self, ctx.doc).then_some(taken)
+    }
     fn name(&self) -> &'static str {
         "Type"
     }
@@ -397,12 +427,37 @@ impl ToolPlugin for TypeTool {
                     name_is_auto,
                 });
             }
-            None => self.start_new(ctx, input.x, input.y),
+            None => {
+                // The layer is created here as it always was, so a click
+                // and a keystroke still works with no release in
+                // between. A drag turns it into an area-text box on
+                // release.
+                self.pending = Some((input.x, input.y));
+                self.start_new(ctx, input.x, input.y);
+            }
         }
     }
 
     fn on_pointer_move(&mut self, _ctx: &mut ToolCtx, _input: PointerInput) {}
-    fn on_pointer_up(&mut self, _ctx: &mut ToolCtx, _input: PointerInput) {}
+
+    fn on_pointer_up(&mut self, ctx: &mut ToolCtx, input: PointerInput) {
+        let Some((ax, _ay)) = self.pending.take() else {
+            return;
+        };
+        // A drag defines the box paragraph text wraps inside; a click
+        // leaves point text, which is all this could make before.
+        let width = (input.x - ax).abs();
+        if width < MIN_AREA_WIDTH {
+            return;
+        }
+        let wrap = width.min(MAX_AREA_WIDTH);
+        self.spec.wrap_width = Some(wrap);
+        if let Some(session) = &mut self.editing {
+            session.stored.spec.wrap_width = Some(wrap);
+            session.dirty = true;
+            self.refresh(ctx.doc);
+        }
+    }
 
     fn on_key(
         &mut self,
@@ -568,6 +623,14 @@ impl ToolPlugin for TypeTool {
                 "Foreground Colour",
                 self.follow_foreground,
             ),
+            ToolOption::slider(
+                "type-wrap",
+                "Wrap",
+                self.spec.wrap_width.unwrap_or(0.0),
+                0.0,
+                MAX_AREA_WIDTH,
+                " px",
+            ),
         ]
     }
 
@@ -594,6 +657,12 @@ impl ToolPlugin for TypeTool {
             "type-leading" => self.spec.line_height = value.num().clamp(0.5, 3.0),
             "type-tracking" => self.spec.tracking = value.num(),
             "type-follow-fg" => self.follow_foreground = value.bool(),
+            // Zero means "no box": point text, which is what every layer
+            // was before there was any way to set this.
+            "type-wrap" => {
+                let w = value.num();
+                self.spec.wrap_width = (w >= MIN_AREA_WIDTH).then_some(w.min(MAX_AREA_WIDTH));
+            }
             _ => {}
         }
     }
@@ -981,6 +1050,51 @@ pub fn set_family(tool: &mut TypeTool, doc: &mut Document, family: String) {
 /// True while a text layer is open for editing.
 pub fn is_editing(tool: &TypeTool) -> bool {
     tool.editing.is_some()
+}
+
+/// The text of the layer being edited, if one is.
+pub fn current_text(tool: &TypeTool) -> Option<&str> {
+    tool.editing.as_ref().map(|s| s.stored.spec.text.as_str())
+}
+
+/// Append text to the layer being edited and re-render.
+///
+/// The clipboard held pixels and nothing else, so ctrl-V while typing
+/// pasted a "Pasted Layer" of pixels on top of the text instead of the
+/// string that had been copied.
+pub fn insert_text(tool: &mut TypeTool, doc: &mut Document, text: &str) -> bool {
+    let Some(session) = &mut tool.editing else {
+        return false;
+    };
+    if text.is_empty() {
+        return false;
+    }
+    // Newlines are meaningful; other control characters are not.
+    let cleaned: String = text
+        .chars()
+        .filter(|c| *c == '\n' || !c.is_control())
+        .collect();
+    if cleaned.is_empty() {
+        return false;
+    }
+    session.stored.spec.text.push_str(&cleaned);
+    session.dirty = true;
+    tool.refresh(doc);
+    true
+}
+
+/// Replace the edited layer's text, for a cut.
+pub fn clear_text(tool: &mut TypeTool, doc: &mut Document) -> bool {
+    let Some(session) = &mut tool.editing else {
+        return false;
+    };
+    if session.stored.spec.text.is_empty() {
+        return false;
+    }
+    session.stored.spec.text.clear();
+    session.dirty = true;
+    tool.refresh(doc);
+    true
 }
 
 pub struct TypeToolsPlugin;
@@ -1725,5 +1839,121 @@ mod tests {
         let mut d = doc();
         assert_eq!(rerender_family(&mut d, "Definitely Not Installed"), 0);
         assert!(!d.history.can_undo());
+    }
+
+    /// Copy, cut and paste meant pixels and nothing else: ctrl-V while
+    /// typing into a text layer pasted a "Pasted Layer" of pixels on top
+    /// of the text rather than the string that had been copied.
+    #[test]
+    fn the_type_tool_is_a_text_sink() {
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState::default();
+        let mut tool = TypeTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+
+        // Not editing: the tool is not a text sink, so the pixel
+        // clipboard keeps working.
+        assert_eq!(tool.editing_text(), None);
+        assert!(!tool.insert_text(&mut ctx, "hello"));
+        assert_eq!(tool.take_text(&mut ctx), None);
+
+        tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+        tool.on_pointer_up(&mut ctx, input(20.0, 60.0));
+        type_text(&mut tool, &mut ctx, "Hi");
+        assert_eq!(tool.editing_text(), Some("Hi"));
+
+        assert!(tool.insert_text(&mut ctx, " there"));
+        assert_eq!(tool.editing_text(), Some("Hi there"));
+
+        // Newlines survive a paste; other control characters do not.
+        assert!(tool.insert_text(&mut ctx, "\nline\u{7}two"));
+        assert_eq!(tool.editing_text(), Some("Hi there\nlinetwo"));
+
+        assert_eq!(
+            tool.take_text(&mut ctx).as_deref(),
+            Some("Hi there\nlinetwo")
+        );
+        assert_eq!(tool.editing_text(), Some(""));
+        // Nothing left to cut.
+        assert_eq!(tool.take_text(&mut ctx), None);
+    }
+
+    /// Pasting nothing leaves the text alone rather than marking the
+    /// session dirty for no reason.
+    #[test]
+    fn pasting_nothing_changes_nothing() {
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState::default();
+        let mut tool = TypeTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+        tool.on_pointer_up(&mut ctx, input(20.0, 60.0));
+        type_text(&mut tool, &mut ctx, "Hi");
+
+        assert!(!tool.insert_text(&mut ctx, ""));
+        assert!(!tool.insert_text(&mut ctx, "\u{7}\u{1b}"));
+        assert_eq!(tool.editing_text(), Some("Hi"));
+    }
+
+    /// `TextSpec::wrap_width` existed and the engine honoured it, but
+    /// nothing in the ui could set it, so every layer was point text and
+    /// paragraph text was unreachable.
+    #[test]
+    fn dragging_the_type_tool_makes_an_area_text_box() {
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState::default();
+        let mut tool = TypeTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+
+        tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+        tool.on_pointer_up(&mut ctx, input(140.0, 100.0));
+        let wrap = tool.editing.as_ref().unwrap().stored.spec.wrap_width;
+        assert_eq!(wrap, Some(120.0), "the drag did not set a wrap box");
+
+        // And the text wraps inside it: a long line becomes several.
+        type_text(&mut tool, &mut ctx, "wrapping text needs several words");
+        let tall = layer_height(ctx.doc);
+        tool.set_option("type-wrap", OptionValue::Num(0.0));
+        tool.on_option_changed(&mut ctx, "type-wrap");
+        let flat = layer_height(ctx.doc);
+        assert!(
+            tall > flat,
+            "wrapped text should be taller than one line: {tall} vs {flat}"
+        );
+    }
+
+    /// A click still makes point text, and does so on the press, so a
+    /// click and a keystroke with no release in between still works.
+    #[test]
+    fn clicking_still_makes_point_text() {
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState::default();
+        let mut tool = TypeTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+        assert!(tool.editing.is_some(), "no layer on press");
+        // A jitter of a pixel or two is a click, not a drag.
+        tool.on_pointer_up(&mut ctx, input(22.0, 61.0));
+        assert_eq!(tool.editing.as_ref().unwrap().stored.spec.wrap_width, None);
+    }
+
+    fn layer_height(doc: &Document) -> i32 {
+        doc.tree
+            .iter()
+            .last()
+            .map(|l| l.content_bounds().height())
+            .unwrap_or(0)
     }
 }

--- a/plugins/tools-type/src/lib.rs
+++ b/plugins/tools-type/src/lib.rs
@@ -245,6 +245,14 @@ pub struct TypeTool {
     /// nothing in the ui could set it, so every layer was point text and
     /// paragraph text was unreachable.
     pending: Option<(f32, f32)>,
+    /// The Wrap slider's own value, and the only thing a fresh click
+    /// inherits.
+    ///
+    /// `spec.wrap_width` also picks up the width of whatever layer is
+    /// being edited, so it cannot double as the default for the next
+    /// one: after a single area-text drag -- or just clicking into an
+    /// existing box -- every later click made a box of that width.
+    wrap_default: Option<f32>,
 }
 
 impl Default for TypeTool {
@@ -254,11 +262,36 @@ impl Default for TypeTool {
             spec: TextSpec::default(),
             follow_foreground: true,
             pending: None,
+            wrap_default: None,
         }
     }
 }
 
 impl TypeTool {
+    /// Take the current foreground swatch, if the text is set to follow
+    /// it.
+    ///
+    /// This used to run only from `on_option_changed`, so the swatch
+    /// could be changed and the text kept its old colour until some
+    /// unrelated control was nudged -- and nudging one then recoloured a
+    /// layer the user had only meant to resize. Every moment the tool
+    /// touches a layer goes through here instead.
+    fn adopt_foreground(&mut self, ctx: &mut ToolCtx) {
+        if !self.follow_foreground {
+            return;
+        }
+        let fg = ctx.state.foreground.to_u8();
+        let Some(session) = &mut self.editing else {
+            return;
+        };
+        if session.stored.color == fg {
+            return;
+        }
+        session.stored.color = fg;
+        session.dirty = true;
+        self.refresh(ctx.doc);
+    }
+
     /// Live-render the session's text into its layer without touching
     /// history (the whole session commits as one edit).
     fn refresh(&mut self, doc: &mut Document) {
@@ -292,6 +325,7 @@ impl TypeTool {
         let stored = StoredText {
             spec: TextSpec {
                 text: String::new(),
+                wrap_width: self.wrap_default,
                 ..self.spec.clone()
             },
             origin: (x.round() as i32, y.round() as i32),
@@ -436,6 +470,10 @@ impl ToolPlugin for TypeTool {
                 self.start_new(ctx, input.x, input.y);
             }
         }
+        // Clicking into a layer is when the swatch takes effect: set the
+        // foreground to red, place text, switch to blue and click back
+        // in, and it turns blue.
+        self.adopt_foreground(ctx);
     }
 
     fn on_pointer_move(&mut self, _ctx: &mut ToolCtx, _input: PointerInput) {}
@@ -451,6 +489,8 @@ impl ToolPlugin for TypeTool {
             return;
         }
         let wrap = width.min(MAX_AREA_WIDTH);
+        // The bar shows the box that was just drawn, but this width
+        // belongs to this layer: it is not what the next click makes.
         self.spec.wrap_width = Some(wrap);
         if let Some(session) = &mut self.editing {
             session.stored.spec.wrap_width = Some(wrap);
@@ -471,6 +511,15 @@ impl ToolPlugin for TypeTool {
         }
         let shift = modifiers.shift;
         let word = modifiers.ctrl_or_cmd;
+        // What is typed next comes out in the current colour. Only for
+        // keystrokes that actually put something in: an arrow key has no
+        // business recolouring the layer.
+        let inserts = !modifiers.ctrl_or_cmd
+            && (matches!(key, "enter" | "tab" | "space")
+                || text.is_some_and(|t| !t.is_empty() && !t.chars().any(char::is_control)));
+        if inserts {
+            self.adopt_foreground(ctx);
+        }
         let mut changed = false;
         let mut handled = true;
         {
@@ -662,6 +711,9 @@ impl ToolPlugin for TypeTool {
             "type-wrap" => {
                 let w = value.num();
                 self.spec.wrap_width = (w >= MIN_AREA_WIDTH).then_some(w.min(MAX_AREA_WIDTH));
+                // Asked for by hand, so it is what the next new layer
+                // starts as too.
+                self.wrap_default = self.spec.wrap_width;
             }
             _ => {}
         }
@@ -670,20 +722,19 @@ impl ToolPlugin for TypeTool {
     /// Push the bar's settings onto the text being edited, so a font or
     /// size change shows up immediately rather than on the next click.
     fn on_option_changed(&mut self, ctx: &mut ToolCtx, _key: &str) {
-        let foreground = ctx.state.foreground.to_u8();
-        let Some(session) = &mut self.editing else {
-            return;
-        };
-        let text = std::mem::take(&mut session.stored.spec.text);
-        session.stored.spec = TextSpec {
-            text,
-            ..self.spec.clone()
-        };
-        if self.follow_foreground {
-            session.stored.color = foreground;
+        {
+            let Some(session) = &mut self.editing else {
+                return;
+            };
+            let text = std::mem::take(&mut session.stored.spec.text);
+            session.stored.spec = TextSpec {
+                text,
+                ..self.spec.clone()
+            };
+            session.dirty = true;
         }
-        session.dirty = true;
         self.refresh(ctx.doc);
+        self.adopt_foreground(ctx);
     }
 
     fn on_commit(&mut self, ctx: &mut ToolCtx) {
@@ -1069,10 +1120,12 @@ pub fn insert_text(tool: &mut TypeTool, doc: &mut Document, text: &str) -> bool 
     if text.is_empty() {
         return false;
     }
-    // Newlines are meaningful; other control characters are not.
+    // Newlines and tabs are meaningful -- tabs advance to the next stop,
+    // so stripping them collapsed the columns of anything pasted out of
+    // a PSD-imported layer. Other control characters are not.
     let cleaned: String = text
         .chars()
-        .filter(|c| *c == '\n' || !c.is_control())
+        .filter(|c| *c == '\n' || *c == '\t' || !c.is_control())
         .collect();
     if cleaned.is_empty() {
         return false;
@@ -1947,6 +2000,107 @@ mod tests {
         // A jitter of a pixel or two is a click, not a drag.
         tool.on_pointer_up(&mut ctx, input(22.0, 61.0));
         assert_eq!(tool.editing.as_ref().unwrap().stored.spec.wrap_width, None);
+    }
+
+    /// The width a drag defined belongs to that layer, not to the tool:
+    /// after one area-text box, every later click made a box of the same
+    /// width and there was no way back to point text.
+    #[test]
+    fn a_drag_does_not_make_every_later_click_a_box() {
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState::default();
+        let mut tool = TypeTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+
+        tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+        tool.on_pointer_up(&mut ctx, input(140.0, 100.0));
+        type_text(&mut tool, &mut ctx, "box");
+        assert_eq!(
+            tool.editing.as_ref().unwrap().stored.spec.wrap_width,
+            Some(120.0)
+        );
+
+        // A plain click somewhere else is point text again.
+        tool.on_pointer_down(&mut ctx, input(20.0, 160.0));
+        tool.on_pointer_up(&mut ctx, input(20.0, 160.0));
+        assert_eq!(tool.editing.as_ref().unwrap().stored.spec.wrap_width, None);
+
+        // And so is a click after editing an existing box.
+        tool.on_pointer_down(&mut ctx, input(30.0, 65.0));
+        assert_eq!(
+            tool.editing.as_ref().unwrap().stored.spec.wrap_width,
+            Some(120.0),
+            "clicking into the box should re-open it as a box"
+        );
+        tool.on_pointer_up(&mut ctx, input(30.0, 65.0));
+        tool.on_pointer_down(&mut ctx, input(250.0, 180.0));
+        tool.on_pointer_up(&mut ctx, input(250.0, 180.0));
+        assert_eq!(tool.editing.as_ref().unwrap().stored.spec.wrap_width, None);
+
+        // Dialling the Wrap slider in by hand is the way to ask for a box
+        // up front, and that does carry to the next click.
+        tool.set_option("type-wrap", OptionValue::Num(90.0));
+        tool.on_option_changed(&mut ctx, "type-wrap");
+        tool.on_pointer_down(&mut ctx, input(40.0, 20.0));
+        tool.on_pointer_up(&mut ctx, input(40.0, 20.0));
+        assert_eq!(
+            tool.editing.as_ref().unwrap().stored.spec.wrap_width,
+            Some(90.0)
+        );
+    }
+
+    /// The swatch reaches the text when the tool touches a layer, not
+    /// only when an options-bar control happens to move.
+    #[test]
+    fn clicking_back_in_takes_the_current_foreground() {
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState {
+            foreground: schist_color::Rgba::new(1.0, 0.0, 0.0, 1.0),
+            ..Default::default()
+        };
+        let mut tool = TypeTool::default();
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut d,
+                state: &mut state,
+            };
+            tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+            tool.on_pointer_up(&mut ctx, input(20.0, 60.0));
+            type_text(&mut tool, &mut ctx, "Hi");
+            assert_eq!(tool.editing.as_ref().unwrap().stored.color[0], 255);
+            tool.on_commit(&mut ctx);
+        }
+
+        // Switch to blue and click back into the same text.
+        state.foreground = schist_color::Rgba::new(0.0, 0.0, 1.0, 1.0);
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(22.0, 55.0));
+        let color = tool.editing.as_ref().expect("re-opened").stored.color;
+        assert_eq!(color[2], 255, "the text stayed its old colour: {color:?}");
+        assert_eq!(color[0], 0);
+    }
+
+    /// Tabs are layout characters here, so pasting a tabbed table keeps
+    /// its columns.
+    #[test]
+    fn pasting_keeps_tabs() {
+        let mut d = doc();
+        let mut state = schist_plugin_api::EditorState::default();
+        let mut tool = TypeTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+        tool.on_pointer_up(&mut ctx, input(20.0, 60.0));
+        assert!(tool.insert_text(&mut ctx, "a\tb\nc\td"));
+        assert_eq!(tool.editing_text(), Some("a\tb\nc\td"));
     }
 
     fn layer_height(doc: &Document) -> i32 {


### PR DESCRIPTION

groups five branches: the type tool and the layout engine.

**text rendered as tofu for most of the world**

one face was resolved for the whole spec and every glyph rasterized from it, so any codepoint that face lacked drew `.notdef`. typing japanese or an emoji gave a row of empty rectangles even with noto cjk and noto color emoji installed.

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr60-before.png) | ![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr60-after.png) |

a glyph the chosen face does not have is now drawn from one that does, and advances by *its* width — otherwise the line is laid out against the box it is not drawing.

emoji get as far as the metrics and no further: fontdue rasterizes outlines, and the colour emoji faces are bitmap or COLR, so a matched face advances correctly and draws nothing. better than tofu at the wrong widths, and the place to start from when colour glyphs get a renderer.

**a text layer's colour could never be changed**

`StoredText.color` was written once at creation and `TextSpec` has no colour field, so nothing in the options bar could reach it. set the foreground to red, place text, switch to blue and click back in: it stayed red.

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr48-before.png) | ![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr48-after.png) |

**the clipboard held pixels and nothing else**

ctrl-V while typing pasted a "Pasted Layer" of pixels on top of the text instead of the string that was copied; ctrl-C copied the selection's pixels. rather than the shell downcasting to `TypeTool`, `ToolPlugin` gains three defaulted methods so any text-ish tool participates.

**paragraph text was unreachable**

`TextSpec::wrap_width` existed and the engine honoured it, but nothing in the ui could set it. dragging with the type tool now defines the box; a click still makes point text, and still on the press, so click-then-type is unchanged.

dragging a box with the type tool, then typing into it:

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr-areatext-before.png) | ![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr-areatext-after.png) |

**and four smaller ones**

right- and centre-aligned text counted trailing spaces and hung short of the edge; wrapped text aligned to its longest line rather than its wrap box; a real tab from a psd's `PsTx` block rendered as one glyph advance rather than a stop; installing a font rewrote text layers with no undo entry and left parked tabs on the substituted glyphs; and the type tool overwrote user layer names on every keystroke and entered hidden and locked layers.

---

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` — 643 passed, 0 failed.
---

**how this relates to my other open prs**

these seven are independent of each other — each branches off `main` and each is green on its own. they do share files with my five open prs (#36, #38, #42, #44, #46), mostly `workspace.rs`, so whichever lands first will leave the others needing a rebase. happy to rebase in whatever order suits you, or to split any of these further if one is too big to review in a sitting.

