### PR TITLE
fix: canvas tool correctness, modifiers and missing controls

### DIFF
--- a/crates/app/src/workspace/commands.rs
+++ b/crates/app/src/workspace/commands.rs
@@ -102,16 +102,35 @@ impl Workspace {
         }
     }
 
+    /// Commit or cancel the active tool's in-flight session against the
+    /// document currently on the canvas.
+    pub(super) fn deactivate_tool(&mut self) {
+        let active = self.editor.active_tool;
+        if let (Some(doc), Some(tool)) = (self.doc.as_mut(), self.registry.tool_mut(active)) {
+            let mut ctx = ToolCtx {
+                doc,
+                state: &mut self.editor,
+            };
+            tool.on_deactivate(&mut ctx);
+        }
+    }
+
+    /// Start the active tool afresh against the document now on the canvas.
+    pub(super) fn activate_tool_for_current_doc(&mut self) {
+        let active = self.editor.active_tool;
+        if let (Some(doc), Some(tool)) = (self.doc.as_mut(), self.registry.tool_mut(active)) {
+            let mut ctx = ToolCtx {
+                doc,
+                state: &mut self.editor,
+            };
+            tool.on_activate(&mut ctx);
+        }
+    }
+
     pub fn activate_tool(&mut self, id: &str, cx: &mut Context<Self>) {
         let previous = self.editor.active_tool;
         if previous != id {
-            if let (Some(doc), Some(tool)) = (self.doc.as_mut(), self.registry.tool_mut(previous)) {
-                let mut ctx = ToolCtx {
-                    doc,
-                    state: &mut self.editor,
-                };
-                tool.on_deactivate(&mut ctx);
-            }
+            self.deactivate_tool();
         }
         if let Some(tool) = self.registry.tool_mut(id) {
             let id = tool.id();
@@ -120,13 +139,7 @@ impl Workspace {
             self.group_active.insert(group, id);
             self.editor.active_tool = id;
             self.status = format!("Tool: {name}").into();
-            if let (Some(doc), Some(tool)) = (self.doc.as_mut(), self.registry.tool_mut(id)) {
-                let mut ctx = ToolCtx {
-                    doc,
-                    state: &mut self.editor,
-                };
-                tool.on_activate(&mut ctx);
-            }
+            self.activate_tool_for_current_doc();
         }
         self.after_change(cx);
     }

--- a/crates/app/src/workspace/docs.rs
+++ b/crates/app/src/workspace/docs.rs
@@ -165,6 +165,10 @@ impl Workspace {
     /// Park the active document, view transform and all, back into the
     /// tab list at its current position.
     pub(super) fn stash_active_tab(&mut self) {
+        // Finish the tool against the document it belongs to before that
+        // document leaves the canvas. Live-preview tools retain layer ids;
+        // carrying one into another tab strands unrecorded preview pixels.
+        self.deactivate_tool();
         if let Some(doc) = self.doc.take() {
             let at = self.active_tab.min(self.background_tabs.len());
             self.background_tabs.insert(
@@ -187,6 +191,7 @@ impl Workspace {
         self.offset = tab.offset;
         self.rotation = tab.rotation;
         self.reset_per_document_caches();
+        self.activate_tool_for_current_doc();
     }
 
     /// Drop every cache keyed by document state. Revision and selection

--- a/crates/app/src/workspace/image_ops.rs
+++ b/crates/app/src/workspace/image_ops.rs
@@ -384,17 +384,19 @@ pub(super) fn transform_document(doc: &mut Document, op: CanvasTransform) {
         .collect();
     let mut edit = doc.begin_edit(op.title());
     edit.set_canvas_size(nw, nh);
-    // Guides, artboards, slices, notes, counts and paths are not layer
-    // content, so the pixel loop below leaves them at the old
-    // coordinates. Turn them with the canvas.
+    // Document furniture is not layer content, so rotate and flip it with
+    // the pixels. Quarter turns also swap horizontal and vertical guides.
     let (fw, fh) = (w as f32, h as f32);
-    edit.map_geometry(|x, y| match op {
-        CanvasTransform::Cw90 => (fh - y, x),
-        CanvasTransform::Ccw90 => (y, fw - x),
-        CanvasTransform::Rotate180 => (fw - x, fh - y),
-        CanvasTransform::FlipH => (fw - x, y),
-        CanvasTransform::FlipV => (x, fh - y),
-    });
+    edit.map_geometry(
+        |x, y| match op {
+            CanvasTransform::Cw90 => (fh - y, x),
+            CanvasTransform::Ccw90 => (y, fw - x),
+            CanvasTransform::Rotate180 => (fw - x, fh - y),
+            CanvasTransform::FlipH => (fw - x, y),
+            CanvasTransform::FlipV => (x, fh - y),
+        },
+        swaps,
+    );
     for (id, src) in &sources {
         for coord in TileCoord::covering(&IntRect::from_size(nw, nh)) {
             let trect = coord.rect();

--- a/crates/app/src/workspace/image_ops.rs
+++ b/crates/app/src/workspace/image_ops.rs
@@ -384,6 +384,17 @@ pub(super) fn transform_document(doc: &mut Document, op: CanvasTransform) {
         .collect();
     let mut edit = doc.begin_edit(op.title());
     edit.set_canvas_size(nw, nh);
+    // Guides, artboards, slices, notes, counts and paths are not layer
+    // content, so the pixel loop below leaves them at the old
+    // coordinates. Turn them with the canvas.
+    let (fw, fh) = (w as f32, h as f32);
+    edit.map_geometry(|x, y| match op {
+        CanvasTransform::Cw90 => (fh - y, x),
+        CanvasTransform::Ccw90 => (y, fw - x),
+        CanvasTransform::Rotate180 => (fw - x, fh - y),
+        CanvasTransform::FlipH => (fw - x, y),
+        CanvasTransform::FlipV => (x, fh - y),
+    });
     for (id, src) in &sources {
         for coord in TileCoord::covering(&IntRect::from_size(nw, nh)) {
             let trect = coord.rect();

--- a/crates/core/src/document.rs
+++ b/crates/core/src/document.rs
@@ -297,9 +297,12 @@ impl Document {
                     if let Some(mask) = &mut l.mask {
                         match target {
                             Some(buf) => mask.tiles.insert(*coord, buf.clone()),
-                            None => {
-                                mask.tiles.prune_blank();
-                            }
+                            // The tile did not exist before, so undo has
+                            // to drop it. `prune_blank` could not: it only
+                            // removes all-zero tiles, so anything the
+                            // stroke left with coverage survived the undo
+                            // while unrelated blank tiles were deleted.
+                            None => mask.tiles.remove(*coord),
                         }
                     }
                 }
@@ -1191,8 +1194,12 @@ impl StrokeEdit {
         for ((layer, coord), before) in self.mask_befores {
             if let Some(l) = doc.tree.find_mut(layer) {
                 if let Some(m) = &mut l.mask {
-                    if let Some(buf) = before {
-                        m.tiles.insert(coord, buf);
+                    // Mirrors the raster branch above: `None` means the
+                    // tile did not exist, so rolling back removes it
+                    // rather than leaving the cancelled paint behind.
+                    match before {
+                        Some(buf) => m.tiles.insert(coord, buf),
+                        None => m.tiles.remove(coord),
                     }
                 }
             }
@@ -1667,5 +1674,62 @@ mod tests {
         assert_eq!(doc.tree.find(id).unwrap().raw.as_deref(), Some(&original));
         assert_eq!(doc.redo().as_deref(), Some("Camera Raw Development"));
         assert_eq!(doc.tree.find(id).unwrap().raw.as_deref(), Some(&changed));
+    }
+
+    #[test]
+    fn undoing_a_mask_write_removes_a_tile_it_created() {
+        // `prune_blank` could not remove a tile the stroke created with
+        // any coverage, so the paint survived the undo, and it deleted
+        // unrelated blank tiles as collateral.
+        use crate::layer::LayerMask;
+        let mut doc = Document::new("t", 64, 64, Depth::Eight);
+        let mut layer = Layer::new_raster("l");
+        layer.mask = Some(LayerMask::new_revealing());
+        let id = layer.id;
+        doc.push_layer(layer);
+
+        let coord = TileCoord::containing(0, 0);
+        assert!(doc
+            .tree
+            .find(id)
+            .unwrap()
+            .mask
+            .as_ref()
+            .unwrap()
+            .tiles
+            .get(coord)
+            .is_none());
+
+        let mut edit = doc.begin_edit("Paint Mask");
+        if let Some(buf) = edit.writable_mask_tile(id, coord) {
+            buf[0] = 200;
+        }
+        edit.commit();
+        assert!(
+            doc.tree
+                .find(id)
+                .unwrap()
+                .mask
+                .as_ref()
+                .unwrap()
+                .tiles
+                .get(coord)
+                .is_some(),
+            "the stroke created a tile"
+        );
+
+        doc.undo();
+        assert!(
+            doc.tree
+                .find(id)
+                .unwrap()
+                .mask
+                .as_ref()
+                .unwrap()
+                .tiles
+                .get(coord)
+                .is_none(),
+            "undo must remove a tile that did not exist before"
+        );
     }
 }

--- a/crates/core/src/document.rs
+++ b/crates/core/src/document.rs
@@ -5,7 +5,7 @@ use crate::history::{Edit, EditOp, History, LayerProps};
 use crate::layer::{Layer, LayerId, LayerMask, LayerPath, LayerTree, RawBlock};
 use crate::selection::Selection;
 use crate::tile::{TileBuf, TileCoord, TileMap, TILE_PIXELS};
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use schist_color::{ColorMode, Depth};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -736,9 +736,14 @@ impl<'a> EditBuilder<'a> {
         let Some(raster) = layer.as_raster() else {
             return;
         };
-        let mut coords: Vec<TileCoord> = raster.tiles.coords().collect();
+        // A set, not a linear scan: this ran `Vec::contains` per tile, so
+        // every transform, filter and Image Size on a large document paid
+        // a quadratic sweep -- a 12000x12000 document has ~2200 tiles, so
+        // roughly five million comparisons per call.
+        let mut seen: FxHashSet<TileCoord> = raster.tiles.coords().collect();
+        let mut coords: Vec<TileCoord> = seen.iter().copied().collect();
         for coord in new_tiles.coords() {
-            if !coords.contains(&coord) {
+            if seen.insert(coord) {
                 coords.push(coord);
             }
         }

--- a/crates/core/src/document.rs
+++ b/crates/core/src/document.rs
@@ -212,6 +212,18 @@ impl Document {
         self.dirty = true;
     }
 
+    /// Snapshot the document-level geometry that moves with the canvas.
+    pub fn geometry(&self) -> crate::history::DocGeometry {
+        crate::history::DocGeometry {
+            guides: self.guides.clone(),
+            artboards: self.artboards.clone(),
+            slices: self.slices.clone(),
+            notes: self.notes.clone(),
+            counts: self.counts.clone(),
+            paths: self.paths.clone(),
+        }
+    }
+
     pub fn take_damage(&mut self) -> Vec<IntRect> {
         std::mem::take(&mut self.damage)
     }
@@ -492,6 +504,20 @@ impl Document {
                 };
                 self.selection = (**target).clone();
                 self.revision += 1;
+            }
+            EditOp::GeometrySet { before, after } => {
+                let g = if dir == Direction::Undo {
+                    before
+                } else {
+                    after
+                };
+                self.guides = g.guides.clone();
+                self.artboards = g.artboards.clone();
+                self.slices = g.slices.clone();
+                self.notes = g.notes.clone();
+                self.counts = g.counts.clone();
+                self.paths = g.paths.clone();
+                self.damage_all();
             }
             EditOp::IccProfileSet { before, after } => {
                 let target = if dir == Direction::Undo {
@@ -964,6 +990,63 @@ impl<'a> EditBuilder<'a> {
     }
 
     /// Replace the selection via closure; captures before/after.
+    /// Move every piece of document-level geometry with the canvas.
+    ///
+    /// Guides, artboards, slices, notes, counts and stored paths are not
+    /// layer content, so no layer op touches them: crop, canvas size,
+    /// image size and the rotate/flip commands moved the pixels and left
+    /// all of it at the old coordinates. `map` takes a document-space
+    /// point and returns where it lands.
+    pub fn map_geometry(&mut self, map: impl Fn(f32, f32) -> (f32, f32)) {
+        let before = self.doc.geometry();
+        for guide in &mut self.doc.guides {
+            let (x, y) = if guide.horizontal {
+                map(0.0, guide.position)
+            } else {
+                map(guide.position, 0.0)
+            };
+            guide.position = if guide.horizontal { y } else { x };
+        }
+        let map_rect = |r: IntRect| {
+            let (x0, y0) = map(r.left as f32, r.top as f32);
+            let (x1, y1) = map(r.right as f32, r.bottom as f32);
+            IntRect::new(
+                x0.min(x1).round() as i32,
+                y0.min(y1).round() as i32,
+                x0.max(x1).round() as i32,
+                y0.max(y1).round() as i32,
+            )
+        };
+        for a in &mut self.doc.artboards {
+            a.rect = map_rect(a.rect);
+        }
+        for sl in &mut self.doc.slices {
+            sl.rect = map_rect(sl.rect);
+        }
+        for n in &mut self.doc.notes {
+            n.at = map(n.at.0, n.at.1);
+        }
+        for c in &mut self.doc.counts {
+            for p in &mut c.points {
+                *p = map(p.0, p.1);
+            }
+        }
+        for path in &mut self.doc.paths {
+            for sub in &mut path.subpaths {
+                for anchor in &mut sub.anchors {
+                    anchor.point = map(anchor.point.0, anchor.point.1);
+                }
+            }
+        }
+        let after = self.doc.geometry();
+        if before != after {
+            self.ops.push(EditOp::GeometrySet {
+                before: Box::new(before),
+                after: Box::new(after),
+            });
+        }
+    }
+
     pub fn change_selection(&mut self, f: impl FnOnce(&mut Selection, IntRect)) {
         let canvas = self.doc.canvas_rect();
         let before = Box::new(self.doc.selection.clone());

--- a/crates/core/src/document.rs
+++ b/crates/core/src/document.rs
@@ -994,7 +994,6 @@ impl<'a> EditBuilder<'a> {
         });
     }
 
-    /// Replace the selection via closure; captures before/after.
     /// Move every piece of document-level geometry with the canvas.
     ///
     /// Guides, artboards, slices, notes, counts and stored paths are not
@@ -1052,6 +1051,7 @@ impl<'a> EditBuilder<'a> {
         }
     }
 
+    /// Replace the selection via closure; captures before/after.
     pub fn change_selection(&mut self, f: impl FnOnce(&mut Selection, IntRect)) {
         let canvas = self.doc.canvas_rect();
         let before = Box::new(self.doc.selection.clone());

--- a/crates/core/src/document.rs
+++ b/crates/core/src/document.rs
@@ -1001,7 +1001,7 @@ impl<'a> EditBuilder<'a> {
     /// image size and the rotate/flip commands moved the pixels and left
     /// all of it at the old coordinates. `map` takes a document-space
     /// point and returns where it lands.
-    pub fn map_geometry(&mut self, map: impl Fn(f32, f32) -> (f32, f32)) {
+    pub fn map_geometry(&mut self, map: impl Fn(f32, f32) -> (f32, f32), swap_guide_axes: bool) {
         let before = self.doc.geometry();
         for guide in &mut self.doc.guides {
             let (x, y) = if guide.horizontal {
@@ -1009,6 +1009,9 @@ impl<'a> EditBuilder<'a> {
             } else {
                 map(guide.position, 0.0)
             };
+            if swap_guide_axes {
+                guide.horizontal = !guide.horizontal;
+            }
             guide.position = if guide.horizontal { y } else { x };
         }
         let map_rect = |r: IntRect| {
@@ -1819,5 +1822,41 @@ mod tests {
                 .is_none(),
             "undo must remove a tile that did not exist before"
         );
+    }
+
+    #[test]
+    fn quarter_turns_swap_guide_orientation_and_undo() {
+        let mut doc = Document::new("t", 200, 100, Depth::Eight);
+        doc.guides = vec![
+            Guide {
+                horizontal: true,
+                position: 30.0,
+            },
+            Guide {
+                horizontal: false,
+                position: 40.0,
+            },
+        ];
+        let before = doc.guides.clone();
+
+        let mut edit = doc.begin_edit("Rotate 90");
+        edit.map_geometry(|x, y| (100.0 - y, x), true);
+        assert!(edit.commit());
+
+        assert_eq!(
+            doc.guides,
+            vec![
+                Guide {
+                    horizontal: false,
+                    position: 70.0,
+                },
+                Guide {
+                    horizontal: true,
+                    position: 40.0,
+                },
+            ]
+        );
+        doc.undo().unwrap();
+        assert_eq!(doc.guides, before);
     }
 }

--- a/crates/core/src/history.rs
+++ b/crates/core/src/history.rs
@@ -134,6 +134,18 @@ pub enum EditOp {
         before: Box<Selection>,
         after: Box<Selection>,
     },
+    /// Document-level geometry moved with the canvas (Crop, Canvas Size,
+    /// Image Size, rotate/flip).
+    ///
+    /// Guides, artboards, slices, notes, counts and stored paths are not
+    /// layer content, so no layer op touches them and they were left at
+    /// their old coordinates while the pixels moved. They ride in the same
+    /// edit, or undo would restore the canvas and leave them where the
+    /// redo had put them.
+    GeometrySet {
+        before: Box<DocGeometry>,
+        after: Box<DocGeometry>,
+    },
     /// The document's embedded ICC profile changed (Assign / Convert to
     /// Profile). Rides in the same edit as the pixel rewrite so undo puts
     /// the pixels and their tag back together; undoing only the pixels
@@ -163,6 +175,17 @@ pub enum EditOp {
         before: schist_color::ColorMode,
         after: schist_color::ColorMode,
     },
+}
+
+/// A snapshot of the document-level geometry that moves with the canvas.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct DocGeometry {
+    pub guides: Vec<crate::document::Guide>,
+    pub artboards: Vec<crate::annotate::Artboard>,
+    pub slices: Vec<crate::annotate::Slice>,
+    pub notes: Vec<crate::annotate::Note>,
+    pub counts: Vec<crate::annotate::CountGroup>,
+    pub paths: Vec<crate::path::VectorPath>,
 }
 
 impl EditOp {

--- a/crates/core/src/resample.rs
+++ b/crates/core/src/resample.rs
@@ -418,12 +418,17 @@ pub fn resize_tiles(
 /// `layer.mask` at its old size and place, so the mask clipped the
 /// artwork along the wrong edge afterwards. Bilinear throughout: a mask is
 /// coverage, and nearest-neighbour would alias its edge.
+///
+/// Sampling goes through `LayerMask::value`, not the tile map: a
+/// revealing mask is `default_value` everywhere outside its `bounds`, and
+/// reading the bare tiles there returned 0 instead, so every transform
+/// grew a hidden black border along the mask's edge.
 pub fn transform_mask(
-    src: &crate::tile::MaskTileMap,
-    default_value: u8,
+    mask: &crate::layer::LayerMask,
     m: &Affine,
     clip: IntRect,
 ) -> crate::tile::MaskTileMap {
+    let default_value = mask.default_value;
     let mut out = crate::tile::MaskTileMap::new();
     let Some(inv) = m.invert() else { return out };
     if clip.is_empty() {
@@ -445,7 +450,7 @@ pub fn transform_mask(
                 let (ix, iy) = (fx.floor(), fy.floor());
                 let (tx, ty) = (fx - ix, fy - iy);
                 let at =
-                    |ox: i32, oy: i32| -> f32 { src.value(ix as i32 + ox, iy as i32 + oy) as f32 };
+                    |ox: i32, oy: i32| -> f32 { mask.value(ix as i32 + ox, iy as i32 + oy) as f32 };
                 let top = at(0, 0) * (1.0 - tx) + at(1, 0) * tx;
                 let bottom = at(0, 1) * (1.0 - tx) + at(1, 1) * tx;
                 let v = (top * (1.0 - ty) + bottom * ty).round().clamp(0.0, 255.0) as u8;

--- a/crates/core/src/resample.rs
+++ b/crates/core/src/resample.rs
@@ -6,7 +6,7 @@
 //! transparent pixels into the result and fringe the edge.
 
 use crate::geom::IntRect;
-use crate::tile::{TileBuf, TileCoord, TileMap, TILE_SIZE};
+use crate::tile::{TileBuf, TileCoord, TileMap, TILE_PIXELS, TILE_SIZE};
 use rayon::prelude::*;
 use schist_color::{Depth, Rgba};
 
@@ -410,6 +410,55 @@ pub fn resize_tiles(
     }
     let m = Affine::scale(to.0 as f32 / from.0 as f32, to.1 as f32 / from.1 as f32);
     transform_tiles(src, &m, depth, filter, IntRect::from_size(to.0, to.1))
+}
+
+/// Transform a layer mask by the same matrix as its pixels.
+///
+/// Image Size and Free Transform resampled `raster.tiles` and left
+/// `layer.mask` at its old size and place, so the mask clipped the
+/// artwork along the wrong edge afterwards. Bilinear throughout: a mask is
+/// coverage, and nearest-neighbour would alias its edge.
+pub fn transform_mask(
+    src: &crate::tile::MaskTileMap,
+    default_value: u8,
+    m: &Affine,
+    clip: IntRect,
+) -> crate::tile::MaskTileMap {
+    let mut out = crate::tile::MaskTileMap::new();
+    let Some(inv) = m.invert() else { return out };
+    if clip.is_empty() {
+        return out;
+    }
+    for coord in TileCoord::covering(&clip) {
+        let trect = coord.rect();
+        let region = trect.intersect(&clip);
+        if region.is_empty() {
+            continue;
+        }
+        let mut wrote = false;
+        let mut buf = [default_value; TILE_PIXELS];
+        for y in region.top..region.bottom {
+            for x in region.left..region.right {
+                let (sx, sy) = inv.apply(x as f32 + 0.5, y as f32 + 0.5);
+                // Bilinear over the four neighbours, in mask space.
+                let (fx, fy) = (sx - 0.5, sy - 0.5);
+                let (ix, iy) = (fx.floor(), fy.floor());
+                let (tx, ty) = (fx - ix, fy - iy);
+                let at =
+                    |ox: i32, oy: i32| -> f32 { src.value(ix as i32 + ox, iy as i32 + oy) as f32 };
+                let top = at(0, 0) * (1.0 - tx) + at(1, 0) * tx;
+                let bottom = at(0, 1) * (1.0 - tx) + at(1, 1) * tx;
+                let v = (top * (1.0 - ty) + bottom * ty).round().clamp(0.0, 255.0) as u8;
+                let i = ((y - trect.top) * TILE_SIZE + (x - trect.left)) as usize;
+                buf[i] = v;
+                wrote |= v != default_value;
+            }
+        }
+        if wrote {
+            out.insert(coord, std::sync::Arc::new(buf));
+        }
+    }
+    out
 }
 
 #[cfg(test)]

--- a/crates/core/src/selection.rs
+++ b/crates/core/src/selection.rs
@@ -151,6 +151,32 @@ impl Selection {
     }
 
     /// Rectangular selection (hard edges).
+    /// Zero everything outside `bounds`, keeping the shape that was
+    /// generated from the full drag.
+    ///
+    /// Clipping the *generating* rect instead re-inscribes the shape in
+    /// the clipped box, so a partly off-canvas elliptical drag committed
+    /// a different ellipse than the preview had drawn.
+    pub fn clip_to(&mut self, bounds: IntRect) {
+        let coords: Vec<TileCoord> = self.mask.iter().map(|(c, _)| *c).collect();
+        for coord in coords {
+            let rect = coord.rect();
+            if bounds.intersect(&rect) == rect {
+                continue;
+            }
+            let buf = self.mask.get_mut_or_insert(coord);
+            for ly in 0..TILE_SIZE {
+                for lx in 0..TILE_SIZE {
+                    if !bounds.contains(rect.left + lx, rect.top + ly) {
+                        buf[(ly * TILE_SIZE + lx) as usize] = 0;
+                    }
+                }
+            }
+        }
+        self.mask.prune_blank();
+        self.recompute_bounds();
+    }
+
     pub fn select_rect(&mut self, rect: IntRect, op: SelectOp) {
         self.apply_shape(rect, op, |_, _| 255);
     }
@@ -567,43 +593,46 @@ impl Selection {
 /// 0-250 px range it could not deliver. The whole taps inside the radius
 /// count once; the pair just outside count `frac`, which makes the pass
 /// continuous in `r`.
+// Both passes carry a running sum of the integer window: one add and one
+// subtract per pixel, whatever the radius. Only the two fractional taps
+// are re-read, and those are O(1) too, so a 250px feather costs the same
+// per pixel as a 1px one.
 fn box_blur_h(src: &[f32], dst: &mut [f32], w: usize, h: usize, r: f32) {
-    let ir = r.floor().max(0.0) as usize;
+    let ir = r.floor().max(0.0) as isize;
     let frac = r - r.floor();
     let norm = 1.0 / ((2 * ir + 1) as f32 + 2.0 * frac);
     for y in 0..h {
         let row = &src[y * w..(y + 1) * w];
         let at = |i: isize| -> f32 { row[i.clamp(0, w as isize - 1) as usize] };
+        // f64 so a long row does not drift the running sum.
+        let mut acc: f64 = (-ir..=ir).map(|d| at(d) as f64).sum();
         for x in 0..w {
             let xi = x as isize;
-            let mut acc = 0.0;
-            for d in -(ir as isize)..=(ir as isize) {
-                acc += at(xi + d);
-            }
+            let mut v = acc as f32;
             if frac > 0.0 {
-                acc += frac * (at(xi - ir as isize - 1) + at(xi + ir as isize + 1));
+                v += frac * (at(xi - ir - 1) + at(xi + ir + 1));
             }
-            dst[y * w + x] = acc * norm;
+            dst[y * w + x] = v * norm;
+            acc += (at(xi + ir + 1) - at(xi - ir)) as f64;
         }
     }
 }
 
 fn box_blur_v(src: &[f32], dst: &mut [f32], w: usize, h: usize, r: f32) {
-    let ir = r.floor().max(0.0) as usize;
+    let ir = r.floor().max(0.0) as isize;
     let frac = r - r.floor();
     let norm = 1.0 / ((2 * ir + 1) as f32 + 2.0 * frac);
     for x in 0..w {
         let at = |i: isize| -> f32 { src[i.clamp(0, h as isize - 1) as usize * w + x] };
+        let mut acc: f64 = (-ir..=ir).map(|d| at(d) as f64).sum();
         for y in 0..h {
             let yi = y as isize;
-            let mut acc = 0.0;
-            for d in -(ir as isize)..=(ir as isize) {
-                acc += at(yi + d);
-            }
+            let mut v = acc as f32;
             if frac > 0.0 {
-                acc += frac * (at(yi - ir as isize - 1) + at(yi + ir as isize + 1));
+                v += frac * (at(yi - ir - 1) + at(yi + ir + 1));
             }
-            dst[y * w + x] = acc * norm;
+            dst[y * w + x] = v * norm;
+            acc += (at(yi + ir + 1) - at(yi - ir)) as f64;
         }
     }
 }
@@ -711,6 +740,42 @@ mod tests {
         assert!(center > 240, "center = {center}");
         assert!(edge > 30 && edge < 220, "edge = {edge}");
         assert!(outside < 30, "outside = {outside}");
+    }
+
+    #[test]
+    fn the_sliding_window_blur_matches_a_direct_sum() {
+        // The running sum is only worth having if it agrees with the
+        // straightforward per-pixel loop it replaced.
+        let (w, h) = (23usize, 5usize);
+        let src: Vec<f32> = (0..w * h).map(|i| ((i * 37) % 256) as f32).collect();
+        for r in [0.0f32, 0.5, 1.0, 2.75, 7.0, 40.0] {
+            let ir = r.floor().max(0.0) as isize;
+            let frac = r - r.floor();
+            let norm = 1.0 / ((2 * ir + 1) as f32 + 2.0 * frac);
+            let mut want = vec![0f32; w * h];
+            for y in 0..h {
+                let row = &src[y * w..(y + 1) * w];
+                let at = |i: isize| -> f32 { row[i.clamp(0, w as isize - 1) as usize] };
+                for x in 0..w {
+                    let xi = x as isize;
+                    let mut acc: f32 = (-ir..=ir).map(|d| at(xi + d)).sum();
+                    if frac > 0.0 {
+                        acc += frac * (at(xi - ir - 1) + at(xi + ir + 1));
+                    }
+                    want[y * w + x] = acc * norm;
+                }
+            }
+            let mut got = vec![0f32; w * h];
+            box_blur_h(&src, &mut got, w, h, r);
+            for i in 0..w * h {
+                assert!(
+                    (got[i] - want[i]).abs() < 0.01,
+                    "r={r} i={i}: {} vs {}",
+                    got[i],
+                    want[i]
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/core/src/selection.rs
+++ b/crates/core/src/selection.rs
@@ -275,7 +275,7 @@ impl Selection {
     /// Feather: approximate gaussian blur of the coverage mask using three
     /// box blurs. Radius in pixels.
     pub fn feather(&mut self, radius: f32) {
-        if self.is_empty() || radius < 0.5 {
+        if self.is_empty() || radius <= 0.0 {
             return;
         }
         let work = self.bounds.inflated(radius.ceil() as i32 * 3 + 1);
@@ -287,7 +287,8 @@ impl Selection {
                 a[y * w + x] = self.mask.value(work.left + x as i32, work.top + y as i32) as f32;
             }
         }
-        let r = (radius / (3f32).sqrt()).max(0.5);
+        // Three box passes approximate a gaussian of this sigma.
+        let r = radius / (3f32).sqrt();
         let mut b = vec![0f32; w * h];
         for _ in 0..3 {
             box_blur_h(&a, &mut b, w, h, r);
@@ -384,11 +385,17 @@ impl Selection {
         if width <= 0 || !self.active {
             return;
         }
-        let half = (width / 2).max(1);
+        // Straddle the edge: half the width outside, half inside. The old
+        // `max(1)` forced at least one pixel outward, so Border 1 sat
+        // entirely outside the selection and Border 3 was 1 out / 2 in.
+        let outward = width / 2;
+        let inward = width - outward;
         let mut outer = self.clone();
-        outer.expand(half, canvas);
+        if outward > 0 {
+            outer.expand(outward, canvas);
+        }
         let mut inner = self.clone();
-        inner.contract(width - half, canvas);
+        inner.contract(inward, canvas);
         let rect = outer.bounds();
         let mut out = Selection::new();
         out.active = true;
@@ -553,40 +560,49 @@ impl Selection {
     pub const _TILE_PIXELS_CHECK: usize = TILE_PIXELS;
 }
 
+/// One box-blur pass with a fractional radius.
+///
+/// `r as usize` truncated, so any radius under 1 was the identity and 2
+/// and 3 blurred identically: the Feather slider advertises a continuous
+/// 0-250 px range it could not deliver. The whole taps inside the radius
+/// count once; the pair just outside count `frac`, which makes the pass
+/// continuous in `r`.
 fn box_blur_h(src: &[f32], dst: &mut [f32], w: usize, h: usize, r: f32) {
-    let ir = r as usize;
-    let norm = 1.0 / (2 * ir + 1) as f32;
+    let ir = r.floor().max(0.0) as usize;
+    let frac = r - r.floor();
+    let norm = 1.0 / ((2 * ir + 1) as f32 + 2.0 * frac);
     for y in 0..h {
         let row = &src[y * w..(y + 1) * w];
-        let mut acc: f32 = row[0] * (ir + 1) as f32;
-        for &v in &row[..ir.min(w)] {
-            acc += v;
-        }
+        let at = |i: isize| -> f32 { row[i.clamp(0, w as isize - 1) as usize] };
         for x in 0..w {
-            let add = row[(x + ir).min(w - 1)];
-            let sub = if x > ir { row[x - ir - 1] } else { row[0] };
-            acc += add - sub;
+            let xi = x as isize;
+            let mut acc = 0.0;
+            for d in -(ir as isize)..=(ir as isize) {
+                acc += at(xi + d);
+            }
+            if frac > 0.0 {
+                acc += frac * (at(xi - ir as isize - 1) + at(xi + ir as isize + 1));
+            }
             dst[y * w + x] = acc * norm;
         }
     }
 }
 
 fn box_blur_v(src: &[f32], dst: &mut [f32], w: usize, h: usize, r: f32) {
-    let ir = r as usize;
-    let norm = 1.0 / (2 * ir + 1) as f32;
+    let ir = r.floor().max(0.0) as usize;
+    let frac = r - r.floor();
+    let norm = 1.0 / ((2 * ir + 1) as f32 + 2.0 * frac);
     for x in 0..w {
-        let mut acc: f32 = src[x] * (ir + 1) as f32;
-        for y in 0..ir.min(h) {
-            acc += src[y * w + x];
-        }
+        let at = |i: isize| -> f32 { src[i.clamp(0, h as isize - 1) as usize * w + x] };
         for y in 0..h {
-            let add = src[(y + ir).min(h - 1) * w + x];
-            let sub = if y > ir {
-                src[(y - ir - 1) * w + x]
-            } else {
-                src[x]
-            };
-            acc += add - sub;
+            let yi = y as isize;
+            let mut acc = 0.0;
+            for d in -(ir as isize)..=(ir as isize) {
+                acc += at(yi + d);
+            }
+            if frac > 0.0 {
+                acc += frac * (at(yi - ir as isize - 1) + at(yi + ir as isize + 1));
+            }
             dst[y * w + x] = acc * norm;
         }
     }
@@ -858,5 +874,51 @@ mod outline_tests {
         assert_ne!(start, after_select);
         sel.deselect();
         assert_ne!(after_select, sel.generation());
+    }
+    #[test]
+    fn feather_is_continuous_in_its_radius() {
+        // `r as usize` truncated, so every radius under 1.74 px was a
+        // silent no-op and 2 px blurred identically to 3 px, while the
+        // slider advertised a continuous 0-250 px range.
+        let edge = |radius: f32| {
+            let mut sel = Selection::new();
+            sel.select_rect(IntRect::from_xywh(0, 0, 64, 64), SelectOp::Replace);
+            sel.feather(radius);
+            sel.coverage(63, 32)
+        };
+        let hard = edge(0.0);
+        assert_eq!(hard, 255, "no feather leaves a hard edge");
+
+        let small = edge(1.0);
+        assert!(small < hard, "1 px must soften the edge, got {small}");
+
+        // Distinct radii must give distinct results.
+        let two = edge(2.0);
+        let three = edge(3.0);
+        assert_ne!(two, three, "2 px and 3 px must differ (both were {two})");
+
+        // And softening must be monotonic.
+        assert!(small >= two && two >= three, "{small} {two} {three}");
+    }
+
+    #[test]
+    fn border_straddles_the_selection_edge() {
+        let bordered = |width: i32| {
+            let canvas = IntRect::from_xywh(0, 0, 64, 64);
+            let mut sel = Selection::new();
+            sel.select_rect(IntRect::from_xywh(16, 16, 32, 32), SelectOp::Replace);
+            sel.border(width, canvas);
+            sel
+        };
+
+        // Border 1 used to land entirely outside the selection.
+        let one = bordered(1);
+        assert!(one.coverage(16, 32) > 0, "the edge pixel must be included");
+
+        // Border 2: one pixel either side of the boundary.
+        let two = bordered(2);
+        assert!(two.coverage(15, 32) > 0, "one pixel outside");
+        assert!(two.coverage(16, 32) > 0, "one pixel inside");
+        assert_eq!(two.coverage(13, 32), 0, "and no further out");
     }
 }

--- a/crates/core/src/tile.rs
+++ b/crates/core/src/tile.rs
@@ -381,6 +381,17 @@ impl MaskTileMap {
         Arc::make_mut(arc)
     }
 
+    /// Drop a tile entirely.
+    ///
+    /// Undoing a mask write has to be able to remove a tile the stroke
+    /// created, which `prune_blank` cannot do: it only drops tiles that
+    /// are entirely zero, so any tile the stroke left with coverage
+    /// survived the undo, and other legitimately blank tiles were deleted
+    /// as collateral.
+    pub fn remove(&mut self, coord: TileCoord) {
+        self.tiles.remove(&coord);
+    }
+
     pub fn insert(&mut self, coord: TileCoord, buf: Arc<[u8; TILE_PIXELS]>) {
         self.tiles.insert(coord, buf);
     }

--- a/plugins/commands-core/src/lib.rs
+++ b/plugins/commands-core/src/lib.rs
@@ -865,7 +865,11 @@ fn move_layer_by(ctx: &mut CommandCtx, delta: i32) {
     };
     let index = *path.0.last().unwrap() as i32;
     let target = index + delta;
-    if target < 0 {
+    // Both ends, not just the bottom: cmd-] on the topmost layer used to
+    // push a "Bring Forward" entry that changed nothing, which the user
+    // then had to undo away.
+    let siblings = sibling_count(ctx.doc, &path) as i32;
+    if target < 0 || target >= siblings {
         return;
     }
     let mut to = path.clone();
@@ -877,6 +881,21 @@ fn move_layer_by(ctx: &mut CommandCtx, delta: i32) {
     });
     edit.move_layer(path, to);
     edit.commit();
+}
+
+/// How many layers share `path`'s container.
+fn sibling_count(doc: &schist_core::Document, path: &LayerPath) -> usize {
+    let Some((_, groups)) = path.0.split_last() else {
+        return 0;
+    };
+    let mut layers: &[Layer] = &doc.tree.layers;
+    for step in groups {
+        match layers.get(*step).and_then(|l| l.children()) {
+            Some(children) => layers = children,
+            None => return 0,
+        }
+    }
+    layers.len()
 }
 
 /// Move the active layer to the top or bottom of its group.
@@ -1589,5 +1608,30 @@ mod m11_tests {
         binds.sort();
         binds.dedup();
         assert_eq!(binds.len(), count, "two commands share a keybinding");
+    }
+    #[test]
+    fn reordering_at_the_ends_of_the_stack_records_nothing() {
+        // `target` was only checked against `< 0`, so cmd-] on the
+        // topmost layer pushed a "Bring Forward" entry that changed
+        // nothing and then had to be undone away.
+        let reg = registry();
+        let mut state = EditorState::default();
+        let mut doc = Document::new("t", 8, 8, Depth::Eight);
+        let bottom = doc.push_layer(Layer::new_raster("bottom"));
+        let top = doc.push_layer(Layer::new_raster("top"));
+
+        doc.active_layer = Some(top);
+        run(&reg, "layer.raise", &mut doc, &mut state);
+        assert!(!doc.history.can_undo(), "no-op at the top of the stack");
+
+        doc.active_layer = Some(bottom);
+        run(&reg, "layer.lower", &mut doc, &mut state);
+        assert!(!doc.history.can_undo(), "no-op at the bottom of the stack");
+
+        // A move that does something still records.
+        doc.active_layer = Some(bottom);
+        run(&reg, "layer.raise", &mut doc, &mut state);
+        assert!(doc.history.can_undo());
+        assert_eq!(doc.tree.layers[1].id, bottom);
     }
 }

--- a/plugins/tools-basic/src/lib.rs
+++ b/plugins/tools-basic/src/lib.rs
@@ -38,6 +38,10 @@ struct Drag {
     /// the original stays put, as in Photoshop. Decided at press time so
     /// letting go of Alt mid-drag does not undo the duplicate.
     duplicated: bool,
+    /// The layer that was selected when the drag began. Cancelling an
+    /// Alt-drag deletes the copy, and the selection has to go back to
+    /// this rather than to a layer that no longer exists.
+    source: schist_core::LayerId,
 }
 
 impl MoveTool {
@@ -126,6 +130,38 @@ impl MoveTool {
         damage = damage.union(&layer.content_bounds());
         ctx.doc.add_damage(damage.inflated(1));
     }
+
+    fn finish(ctx: &mut ToolCtx, drag: Drag, dx: i32, dy: i32) {
+        // Put the layer back where its pixels actually are, then record the
+        // move as one edit so undo restores the original position.
+        Self::undo_preview(ctx, drag.layer);
+        if dx == 0 && dy == 0 && !drag.duplicated {
+            return;
+        }
+        let name = if drag.duplicated {
+            "Duplicate and Move"
+        } else {
+            "Move Layer"
+        };
+        // The copy was inserted straight into the tree so the drag could
+        // move it live. Take it back out and let the edit put it in, so
+        // one undo removes the copy and the move together.
+        let reinsert = drag
+            .duplicated
+            .then(|| ctx.doc.tree.remove(drag.layer))
+            .flatten();
+        let mut edit = ctx.doc.begin_edit(name);
+        if let Some((path, layer)) = reinsert {
+            edit.insert_layer(path, layer);
+        }
+        edit.translate_layer(drag.layer, dx, dy);
+        edit.commit();
+        if drag.duplicated {
+            // `remove_layer` clears the active layer, and the reinsert
+            // above does not know it was the one selected.
+            ctx.doc.active_layer = Some(drag.layer);
+        }
+    }
 }
 
 impl ToolPlugin for MoveTool {
@@ -193,6 +229,7 @@ impl ToolPlugin for MoveTool {
         }
         // Alt-drag duplicates: the copy is what moves and the original
         // is left where it was.
+        let source = id;
         let (id, duplicated) = if input.modifiers.alt {
             match Self::duplicate_for_drag(ctx, id) {
                 Some(copy) => (copy, true),
@@ -206,6 +243,7 @@ impl ToolPlugin for MoveTool {
             start: (input.x, input.y),
             offset: (0, 0),
             duplicated,
+            source,
         });
     }
 
@@ -242,45 +280,28 @@ impl ToolPlugin for MoveTool {
             input.y - drag.start.1,
             input.modifiers.shift,
         );
-        // Put the layer back where its pixels actually are, then record the
-        // move as one edit so undo restores the original position.
-        Self::undo_preview(ctx, drag.layer);
-        if dx == 0 && dy == 0 && !drag.duplicated {
-            return;
-        }
-        let name = if drag.duplicated {
-            "Duplicate and Move"
-        } else {
-            "Move Layer"
-        };
-        // The copy was inserted straight into the tree so the drag could
-        // move it live. Take it back out and let the edit put it in, so
-        // one undo removes the copy and the move together.
-        let reinsert = drag
-            .duplicated
-            .then(|| ctx.doc.tree.remove(drag.layer))
-            .flatten();
-        let mut edit = ctx.doc.begin_edit(name);
-        if let Some((path, layer)) = reinsert {
-            edit.insert_layer(path, layer);
-        }
-        edit.translate_layer(drag.layer, dx, dy);
-        edit.commit();
-        if drag.duplicated {
-            // `remove_layer` clears the active layer, and the reinsert
-            // above does not know it was the one selected.
-            ctx.doc.active_layer = Some(drag.layer);
-        }
+        Self::finish(ctx, drag, dx, dy);
     }
 
     fn on_cancel(&mut self, ctx: &mut ToolCtx) {
-        if let Some(drag) = self.drag.take() {
-            Self::undo_preview(ctx, drag.layer);
-            if drag.duplicated {
-                ctx.doc.tree.remove(drag.layer);
-                ctx.doc.damage_all();
-            }
+        let Some(drag) = self.drag.take() else { return };
+        Self::undo_preview(ctx, drag.layer);
+        if drag.duplicated {
+            ctx.doc.tree.remove(drag.layer);
+            // `remove` clears the active layer, and the copy it pointed
+            // at is gone: hand the selection back to the original.
+            ctx.doc.active_layer = Some(drag.source);
+            ctx.doc.damage_all();
         }
+    }
+
+    /// Switching tools mid-drag committed nothing and left the layer
+    /// sitting on its preview `render_offset`, which the next render
+    /// wrote nowhere.
+    fn on_deactivate(&mut self, ctx: &mut ToolCtx) {
+        let Some(drag) = self.drag.take() else { return };
+        let (dx, dy) = drag.offset;
+        Self::finish(ctx, drag, dx, dy);
     }
 
     // No overlay: the layer itself moves, so an outline would just be
@@ -966,6 +987,7 @@ mod tests {
     #[test]
     fn cancelling_an_alt_drag_removes_the_copy() {
         let mut doc = red_square_doc();
+        let original = doc.active_layer.unwrap();
         let before = doc.tree.len();
         let mut state = EditorState::default();
         let mut tool = MoveTool::new();
@@ -989,5 +1011,39 @@ mod tests {
         assert_eq!(ctx.doc.tree.len(), before + 1);
         tool.on_cancel(&mut ctx);
         assert_eq!(ctx.doc.tree.len(), before);
+        // And the selection goes back to the layer that is still there:
+        // it pointed at the deleted copy, so every later edit was dropped.
+        assert_eq!(ctx.doc.active_layer, Some(original));
+        assert!(ctx.doc.tree.find(original).is_some());
+    }
+
+    /// Switching tools mid-drag committed nothing and left the layer on
+    /// its preview offset.
+    #[test]
+    fn deactivating_mid_drag_commits_the_move() {
+        let mut doc = red_square_doc();
+        let id = doc.active_layer.unwrap();
+        let mut state = EditorState::default();
+        let mut tool = MoveTool::new();
+        let at = |x: f32, y: f32| PointerInput {
+            x,
+            y,
+            pressure: 1.0,
+            modifiers: Modifiers::default(),
+        };
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut doc,
+                state: &mut state,
+            };
+            tool.on_pointer_down(&mut ctx, at(60.0, 60.0));
+            tool.on_pointer_move(&mut ctx, at(120.0, 60.0));
+            tool.on_deactivate(&mut ctx);
+        }
+
+        assert_eq!(doc.tree.find(id).unwrap().render_offset, (0, 0));
+        assert_eq!(doc.history.undo_name(), Some("Move Layer"));
+        doc.undo();
+        assert_eq!(doc.history.undo_name(), None);
     }
 }

--- a/plugins/tools-basic/src/lib.rs
+++ b/plugins/tools-basic/src/lib.rs
@@ -34,6 +34,10 @@ struct Drag {
     start: (f32, f32),
     /// The offset currently applied to the layer.
     offset: (i32, i32),
+    /// Alt was held when the drag began: the layer is a fresh copy and
+    /// the original stays put, as in Photoshop. Decided at press time so
+    /// letting go of Alt mid-drag does not undo the duplicate.
+    duplicated: bool,
 }
 
 impl MoveTool {
@@ -87,6 +91,29 @@ impl MoveTool {
     /// and the canvas re-composites and colour-manages what it throws away
     /// -- for a click that moved nothing at all, which is what an ordinary
     /// click with the Move tool is.
+    /// Clone the layer in place for an Alt-drag, returning the copy's id.
+    ///
+    /// Inserted directly rather than through an edit so the drag can move
+    /// it live; `on_pointer_up` folds the insert and the move into one
+    /// undoable step, and `on_cancel` takes it back out.
+    fn duplicate_for_drag(
+        ctx: &mut ToolCtx,
+        layer_id: schist_core::LayerId,
+    ) -> Option<schist_core::LayerId> {
+        let mut copy = ctx.doc.tree.find(layer_id)?.clone();
+        copy.id = schist_core::LayerId::next();
+        copy.name = format!("{} copy", copy.name);
+        let new_id = copy.id;
+        let mut path = ctx.doc.tree.path_of(layer_id)?;
+        // Directly above the original, which is where Photoshop puts it.
+        *path.0.last_mut()? += 1;
+        ctx.doc.tree.insert_at(&path, copy).then(|| {
+            ctx.doc.active_layer = Some(new_id);
+            ctx.doc.damage_all();
+            new_id
+        })
+    }
+
     fn undo_preview(ctx: &mut ToolCtx, layer_id: schist_core::LayerId) {
         let Some(layer) = ctx.doc.tree.find_mut(layer_id) else {
             return;
@@ -164,18 +191,30 @@ impl ToolPlugin for MoveTool {
         if layer.locked {
             return;
         }
+        // Alt-drag duplicates: the copy is what moves and the original
+        // is left where it was.
+        let (id, duplicated) = if input.modifiers.alt {
+            match Self::duplicate_for_drag(ctx, id) {
+                Some(copy) => (copy, true),
+                None => (id, false),
+            }
+        } else {
+            (id, false)
+        };
         self.drag = Some(Drag {
             layer: id,
             start: (input.x, input.y),
             offset: (0, 0),
+            duplicated,
         });
     }
 
     fn on_pointer_move(&mut self, ctx: &mut ToolCtx, input: PointerInput) {
         let Some(drag) = &mut self.drag else { return };
-        let offset = (
-            (input.x - drag.start.0).round() as i32,
-            (input.y - drag.start.1).round() as i32,
+        let offset = constrain(
+            input.x - drag.start.0,
+            input.y - drag.start.1,
+            input.modifiers.shift,
         );
         if offset == drag.offset {
             return;
@@ -198,29 +237,78 @@ impl ToolPlugin for MoveTool {
         let Some(drag) = self.drag.take() else { return };
         // Take the offset from the release point: a fast drag can deliver
         // down and up with no move event in between.
-        let (dx, dy) = (
-            (input.x - drag.start.0).round() as i32,
-            (input.y - drag.start.1).round() as i32,
+        let (dx, dy) = constrain(
+            input.x - drag.start.0,
+            input.y - drag.start.1,
+            input.modifiers.shift,
         );
         // Put the layer back where its pixels actually are, then record the
         // move as one edit so undo restores the original position.
         Self::undo_preview(ctx, drag.layer);
-        if dx == 0 && dy == 0 {
+        if dx == 0 && dy == 0 && !drag.duplicated {
             return;
         }
-        let mut edit = ctx.doc.begin_edit("Move Layer");
+        let name = if drag.duplicated {
+            "Duplicate and Move"
+        } else {
+            "Move Layer"
+        };
+        // The copy was inserted straight into the tree so the drag could
+        // move it live. Take it back out and let the edit put it in, so
+        // one undo removes the copy and the move together.
+        let reinsert = drag
+            .duplicated
+            .then(|| ctx.doc.tree.remove(drag.layer))
+            .flatten();
+        let mut edit = ctx.doc.begin_edit(name);
+        if let Some((path, layer)) = reinsert {
+            edit.insert_layer(path, layer);
+        }
         edit.translate_layer(drag.layer, dx, dy);
         edit.commit();
+        if drag.duplicated {
+            // `remove_layer` clears the active layer, and the reinsert
+            // above does not know it was the one selected.
+            ctx.doc.active_layer = Some(drag.layer);
+        }
     }
 
     fn on_cancel(&mut self, ctx: &mut ToolCtx) {
         if let Some(drag) = self.drag.take() {
             Self::undo_preview(ctx, drag.layer);
+            if drag.duplicated {
+                ctx.doc.tree.remove(drag.layer);
+                ctx.doc.damage_all();
+            }
         }
     }
 
     // No overlay: the layer itself moves, so an outline would just be
     // noise on top of it.
+}
+
+/// A drag offset, snapped to the dominant axis while Shift is held.
+///
+/// Nothing in the move tool read `input.modifiers`, so shift-dragging did
+/// not constrain -- the one gesture every editor has for "move this
+/// straight across".
+fn constrain(dx: f32, dy: f32, shift: bool) -> (i32, i32) {
+    if !shift {
+        return (dx.round() as i32, dy.round() as i32);
+    }
+    // Horizontal, vertical, or the 45-degree diagonal between them,
+    // whichever the drag is closest to.
+    let (ax, ay) = (dx.abs(), dy.abs());
+    let diagonal = (ax - ay).abs() < ax.max(ay) * 0.5;
+    if diagonal {
+        let d = ax.max(ay).round();
+        return ((d * dx.signum()) as i32, (d * dy.signum()) as i32);
+    }
+    if ax >= ay {
+        (dx.round() as i32, 0)
+    } else {
+        (0, dy.round() as i32)
+    }
 }
 
 /// Eyedropper: picks the composited color under the cursor into the
@@ -814,5 +902,92 @@ mod tests {
             [255, 0, 0, 255],
             "a held button samples wherever it goes"
         );
+    }
+
+    /// Nothing in the move tool read `input.modifiers`, so shift-dragging
+    /// did not constrain -- the one gesture every editor has for "move
+    /// this straight across".
+    #[test]
+    fn shift_constrains_a_move_to_an_axis() {
+        // Mostly horizontal: the vertical component is dropped.
+        assert_eq!(constrain(100.0, 12.0, true), (100, 0));
+        // Mostly vertical.
+        assert_eq!(constrain(-9.0, -80.0, true), (0, -80));
+        // Close enough to 45 degrees to snap to the diagonal, keeping
+        // both signs.
+        assert_eq!(constrain(60.0, -58.0, true), (60, -60));
+        // Without shift, nothing is constrained.
+        assert_eq!(constrain(100.0, 12.0, false), (100, 12));
+    }
+
+    /// Alt-drag duplicates the layer and moves the copy, leaving the
+    /// original where it was — the standard gesture, and one the move
+    /// tool did not implement at all.
+    #[test]
+    fn alt_dragging_duplicates_the_layer() {
+        let mut doc = red_square_doc();
+        let original = doc.active_layer.unwrap();
+        let before = doc.tree.len();
+        let mut state = EditorState::default();
+        let mut tool = MoveTool::new();
+        let alt = Modifiers {
+            alt: true,
+            ..Default::default()
+        };
+        let at = |x: f32, y: f32| PointerInput {
+            x,
+            y,
+            pressure: 1.0,
+            modifiers: alt,
+        };
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut doc,
+                state: &mut state,
+            };
+            tool.on_pointer_down(&mut ctx, at(60.0, 60.0));
+            tool.on_pointer_move(&mut ctx, at(120.0, 60.0));
+            tool.on_pointer_up(&mut ctx, at(120.0, 60.0));
+        }
+
+        assert_eq!(doc.tree.len(), before + 1, "no copy was made");
+        let copy = doc.active_layer.unwrap();
+        assert_ne!(copy, original, "the original was moved instead of a copy");
+        assert!(doc.tree.find(copy).unwrap().name.ends_with("copy"));
+        assert_eq!(doc.history.undo_name(), Some("Duplicate and Move"));
+
+        // One undo takes back both the copy and the move.
+        doc.undo();
+        assert_eq!(doc.tree.len(), before);
+    }
+
+    /// And cancelling mid-drag takes the copy away rather than leaving a
+    /// stray layer behind.
+    #[test]
+    fn cancelling_an_alt_drag_removes_the_copy() {
+        let mut doc = red_square_doc();
+        let before = doc.tree.len();
+        let mut state = EditorState::default();
+        let mut tool = MoveTool::new();
+        let alt = Modifiers {
+            alt: true,
+            ..Default::default()
+        };
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        tool.on_pointer_down(
+            &mut ctx,
+            PointerInput {
+                x: 60.0,
+                y: 60.0,
+                pressure: 1.0,
+                modifiers: alt,
+            },
+        );
+        assert_eq!(ctx.doc.tree.len(), before + 1);
+        tool.on_cancel(&mut ctx);
+        assert_eq!(ctx.doc.tree.len(), before);
     }
 }

--- a/plugins/tools-paint/src/lib.rs
+++ b/plugins/tools-paint/src/lib.rs
@@ -879,6 +879,21 @@ impl ToolPlugin for PaintTool {
         }
     }
 
+    fn on_deactivate(&mut self, ctx: &mut ToolCtx) {
+        if let Some(stroke) = self.stroke.take() {
+            stroke.edit.cancel(ctx.doc);
+        }
+        // The clone source is a point in *this* document. The tool lives
+        // for the whole session, so keeping it meant alt-clicking a source
+        // in one document and then cloning in another sampled the new
+        // document at the old coordinates. The brush-cursor circle is
+        // dropped for the same reason: a stale one from a previous
+        // document reappeared the moment the tool was picked again.
+        self.clone_source = None;
+        self.clone_offset = None;
+        self.cursor = None;
+    }
+
     fn overlays(&self, _doc: &Document, state: &EditorState) -> Vec<Overlay> {
         match self.cursor {
             Some((cx, cy)) => {
@@ -1733,6 +1748,44 @@ mod tests {
         tool.on_cancel(&mut ctx);
         assert_eq!(pixel(&doc, 50, 50)[3], 0);
         assert!(!doc.history.can_undo());
+    }
+
+    #[test]
+    fn leaving_the_clone_tool_forgets_its_source() {
+        // The registry owns the tool for the whole session, so a source
+        // alt-clicked in one document was still set when another document
+        // came to the front: cloning there sampled the new document at the
+        // old coordinates.
+        let mut doc = doc_with_layer();
+        let mut state = EditorState::default();
+        let mut tool = PaintTool::new(PaintMode::Clone);
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut doc,
+                state: &mut state,
+            };
+            // Alt-click sets the source.
+            tool.on_pointer_down(
+                &mut ctx,
+                PointerInput {
+                    x: 20.0,
+                    y: 20.0,
+                    pressure: 1.0,
+                    modifiers: Modifiers {
+                        alt: true,
+                        ..Modifiers::default()
+                    },
+                },
+            );
+            assert!(tool.clone_source.is_some(), "alt-click sets a source");
+
+            tool.on_deactivate(&mut ctx);
+        }
+        assert!(
+            tool.clone_source.is_none() && tool.clone_offset.is_none(),
+            "the source belongs to the document it was picked in"
+        );
+        assert!(tool.cursor.is_none(), "and the cursor circle goes with it");
     }
 }
 

--- a/plugins/tools-paint/src/lib.rs
+++ b/plugins/tools-paint/src/lib.rs
@@ -84,14 +84,58 @@ enum Tone {
     Sponge,
 }
 
+/// Which part of the tonal range dodge and burn act on.
+///
+/// Photoshop's Range menu. The tools had none: they always used the
+/// midtone weighting below, so there was no way to lift only the
+/// shadows or hold back only the highlights.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToneRange {
+    Shadows,
+    Midtones,
+    Highlights,
+}
+
+pub const TONE_RANGES: &[&str] = &["Shadows", "Midtones", "Highlights"];
+
+impl ToneRange {
+    fn from_index(i: usize) -> ToneRange {
+        match i {
+            0 => ToneRange::Shadows,
+            2 => ToneRange::Highlights,
+            _ => ToneRange::Midtones,
+        }
+    }
+
+    fn index(self) -> usize {
+        match self {
+            ToneRange::Shadows => 0,
+            ToneRange::Midtones => 1,
+            ToneRange::Highlights => 2,
+        }
+    }
+
+    /// How strongly a pixel of this luminance is affected, 0..=1.
+    fn weight(self, lum: f32) -> f32 {
+        match self {
+            // The midtone bell this always used, unchanged, so the
+            // default behaviour is exactly what it was.
+            ToneRange::Midtones => 1.0 - (lum - 0.5).abs() * 0.8,
+            // Falling off away from black / white respectively.
+            ToneRange::Shadows => (1.0 - lum * 1.6).clamp(0.0, 1.0),
+            ToneRange::Highlights => ((lum - 0.375) * 1.6).clamp(0.0, 1.0),
+        }
+    }
+}
+
 /// Photoshop-style dodge/burn: scale toward white or black, weighted so
 /// midtones move more than the extremes; sponge pulls colour toward or away
 /// from its own luminance.
-fn apply_tone(tone: Tone, px: Rgba, amount: f32) -> Rgba {
+fn apply_tone(tone: Tone, range: ToneRange, px: Rgba, amount: f32) -> Rgba {
     let lum = 0.3 * px.r + 0.59 * px.g + 0.11 * px.b;
     match tone {
         Tone::Dodge => {
-            let w = amount * (1.0 - (lum - 0.5).abs() * 0.8);
+            let w = amount * range.weight(lum);
             Rgba {
                 r: px.r + (1.0 - px.r) * w,
                 g: px.g + (1.0 - px.g) * w,
@@ -100,7 +144,7 @@ fn apply_tone(tone: Tone, px: Rgba, amount: f32) -> Rgba {
             }
         }
         Tone::Burn => {
-            let w = amount * (1.0 - (lum - 0.5).abs() * 0.8);
+            let w = amount * range.weight(lum);
             Rgba {
                 r: px.r * (1.0 - w),
                 g: px.g * (1.0 - w),
@@ -313,6 +357,11 @@ impl Stroke {
             // Ensure before-capture happens (and get write access).
             let cov = self.coverage.get(&coord).unwrap();
             let (ink, opacity) = (self.ink.clone(), self.opacity);
+            let (range, exposure, strength) = (
+                self.dynamics.range,
+                self.dynamics.exposure,
+                self.dynamics.strength,
+            );
             let carried = self.carried;
             let (heal, heal_rect) = (&self.heal, self.heal_rect);
             let Some(tile) = self.edit.writable_tile(doc, self.layer, coord) else {
@@ -348,11 +397,12 @@ impl Stroke {
                             if orig.a <= 0.0 {
                                 orig
                             } else {
-                                apply_tone(*tone, orig, a)
+                                apply_tone(*tone, range, orig, a * exposure * 2.0)
                             }
                         }
                         Ink::Convolve { snapshot, sharpen } => {
                             let out = convolve_at(snapshot, x, y, *sharpen);
+                            let a = a * strength * 2.0;
                             Rgba {
                                 r: orig.r + (out.r - orig.r) * a,
                                 g: orig.g + (out.g - orig.g) * a,
@@ -574,6 +624,7 @@ impl Stroke {
         if n == 0.0 {
             return;
         }
+        let mix = self.dynamics.smudge_mix;
         let here = Rgba {
             r: acc[0] / n,
             g: acc[1] / n,
@@ -583,10 +634,10 @@ impl Stroke {
         self.carried = Some(match self.carried {
             None => here,
             Some(c) => Rgba {
-                r: c.r + (here.r - c.r) * 0.35,
-                g: c.g + (here.g - c.g) * 0.35,
-                b: c.b + (here.b - c.b) * 0.35,
-                a: c.a + (here.a - c.a) * 0.35,
+                r: c.r + (here.r - c.r) * mix,
+                g: c.g + (here.g - c.g) * mix,
+                b: c.b + (here.b - c.b) * mix,
+                a: c.a + (here.a - c.a) * mix,
             },
         });
     }
@@ -648,6 +699,17 @@ struct Dynamics {
     spacing: f32,
     /// Pen pressure scales coverage as well as radius.
     pressure_opacity: bool,
+    /// Dodge / burn: which part of the tonal range to act on.
+    range: ToneRange,
+    /// Dodge / burn / sponge strength, 0..=1. Photoshop calls it
+    /// Exposure; there was no control at all, so how hard the tool hit
+    /// was whatever the tool opacity happened to be.
+    exposure: f32,
+    /// Blur / sharpen strength, 0..=1.
+    strength: f32,
+    /// How much colour the smudge brush picks up per dab, 0..=1. Was
+    /// hard-coded to 0.35.
+    smudge_mix: f32,
 }
 
 impl Default for Dynamics {
@@ -657,6 +719,13 @@ impl Default for Dynamics {
             // The 15% this was hard-coded to.
             spacing: 0.15,
             pressure_opacity: false,
+            range: ToneRange::Midtones,
+            // Half strength, so the default doubles to the 1.0 the
+            // tools used to apply and nothing changes until it is moved.
+            exposure: 0.5,
+            strength: 0.5,
+            // The 0.35 this was hard-coded to.
+            smudge_mix: 0.35,
         }
     }
 }
@@ -893,6 +962,50 @@ impl ToolPlugin for PaintTool {
                 "%",
             ));
         }
+        // Dodge and burn act on a chosen part of the tonal range at a
+        // chosen strength; sponge takes the strength. None of these had
+        // any control at all.
+        if matches!(self.mode, PaintMode::Dodge | PaintMode::Burn) {
+            out.push(ToolOption::choice(
+                "tone-range",
+                "Range",
+                TONE_RANGES,
+                self.dynamics.range.index(),
+            ));
+        }
+        if matches!(
+            self.mode,
+            PaintMode::Dodge | PaintMode::Burn | PaintMode::Sponge
+        ) {
+            out.push(ToolOption::slider(
+                "tone-exposure",
+                "Exposure",
+                self.dynamics.exposure * 100.0,
+                1.0,
+                100.0,
+                "%",
+            ));
+        }
+        if matches!(self.mode, PaintMode::Blur | PaintMode::Sharpen) {
+            out.push(ToolOption::slider(
+                "convolve-strength",
+                "Strength",
+                self.dynamics.strength * 100.0,
+                1.0,
+                100.0,
+                "%",
+            ));
+        }
+        if self.mode == PaintMode::Smudge {
+            out.push(ToolOption::slider(
+                "smudge-mix",
+                "Strength",
+                self.dynamics.smudge_mix * 100.0,
+                1.0,
+                100.0,
+                "%",
+            ));
+        }
         // Dynamics belong to anything that stamps dabs, which is every
         // mode here.
         out.push(ToolOption::slider(
@@ -931,6 +1044,22 @@ impl ToolPlugin for PaintTool {
             }
             "brush-pressure-opacity" => {
                 self.dynamics.pressure_opacity = value.bool();
+                return;
+            }
+            "tone-range" => {
+                self.dynamics.range = ToneRange::from_index(value.index());
+                return;
+            }
+            "tone-exposure" => {
+                self.dynamics.exposure = (value.num() / 100.0).clamp(0.01, 1.0);
+                return;
+            }
+            "convolve-strength" => {
+                self.dynamics.strength = (value.num() / 100.0).clamp(0.01, 1.0);
+                return;
+            }
+            "smudge-mix" => {
+                self.dynamics.smudge_mix = (value.num() / 100.0).clamp(0.01, 1.0);
                 return;
             }
             _ => {}
@@ -1034,7 +1163,118 @@ pub enum GradientStyle {
 }
 
 const GRADIENT_STYLES: &[&str] = &["Linear", "Radial", "Angle", "Reflected", "Diamond"];
-const GRADIENT_FILLS: &[&str] = &["Foreground to Background", "Foreground to Transparent"];
+/// The ramps offered in the options bar.
+///
+/// The first two are built from the current foreground and background;
+/// the rest are fixed multi-stop presets. The ramp used to be exactly two
+/// colours interpolated end to end -- five *styles* but no way to put a
+/// third colour anywhere, and no per-stop opacity.
+const GRADIENT_FILLS: &[&str] = &[
+    "Foreground to Background",
+    "Foreground to Transparent",
+    "Black, White",
+    "Spectrum",
+    "Sunset",
+    "Transparent to Foreground to Transparent",
+];
+
+/// One colour stop on a gradient ramp.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GradientStop {
+    /// Where it sits, 0..=1 along the ramp.
+    pub at: f32,
+    pub color: Rgba,
+}
+
+/// The colour a ramp shows at `t`, interpolating between the two stops
+/// that bracket it. Stops must be sorted; a ramp with none is
+/// transparent, and one with a single stop is that colour throughout.
+pub fn ramp_at(stops: &[GradientStop], t: f32) -> Rgba {
+    let Some(first) = stops.first() else {
+        return Rgba::new(0.0, 0.0, 0.0, 0.0);
+    };
+    if t <= first.at {
+        return first.color;
+    }
+    let last = stops[stops.len() - 1];
+    if t >= last.at {
+        return last.color;
+    }
+    for pair in stops.windows(2) {
+        let (a, b) = (pair[0], pair[1]);
+        if t > b.at {
+            continue;
+        }
+        let span = b.at - a.at;
+        // Two stops in the same place are a hard edge; take the later.
+        let f = if span <= f32::EPSILON {
+            1.0
+        } else {
+            (t - a.at) / span
+        };
+        return Rgba {
+            r: a.color.r + (b.color.r - a.color.r) * f,
+            g: a.color.g + (b.color.g - a.color.g) * f,
+            b: a.color.b + (b.color.b - a.color.b) * f,
+            a: a.color.a + (b.color.a - a.color.a) * f,
+        };
+    }
+    last.color
+}
+
+/// The stops for the fill at `index`, given the current swatches.
+pub fn gradient_stops(index: usize, foreground: Rgba, background: Rgba) -> Vec<GradientStop> {
+    let stop = |at: f32, color: Rgba| GradientStop { at, color };
+    let rgb = |r: f32, g: f32, b: f32| Rgba::new(r, g, b, 1.0);
+    match index {
+        1 => vec![
+            stop(0.0, foreground),
+            stop(
+                1.0,
+                Rgba {
+                    a: 0.0,
+                    ..foreground
+                },
+            ),
+        ],
+        2 => vec![stop(0.0, rgb(0.0, 0.0, 0.0)), stop(1.0, rgb(1.0, 1.0, 1.0))],
+        3 => vec![
+            stop(0.0, rgb(1.0, 0.0, 0.0)),
+            stop(0.17, rgb(1.0, 1.0, 0.0)),
+            stop(0.33, rgb(0.0, 1.0, 0.0)),
+            stop(0.5, rgb(0.0, 1.0, 1.0)),
+            stop(0.67, rgb(0.0, 0.0, 1.0)),
+            stop(0.83, rgb(1.0, 0.0, 1.0)),
+            stop(1.0, rgb(1.0, 0.0, 0.0)),
+        ],
+        4 => vec![
+            stop(0.0, rgb(0.13, 0.10, 0.30)),
+            stop(0.45, rgb(0.85, 0.35, 0.30)),
+            stop(0.75, rgb(0.98, 0.70, 0.30)),
+            stop(1.0, rgb(1.0, 0.94, 0.72)),
+        ],
+        // Per-stop opacity, which the two-colour ramp could not express:
+        // opaque in the middle, transparent at both ends.
+        5 => vec![
+            stop(
+                0.0,
+                Rgba {
+                    a: 0.0,
+                    ..foreground
+                },
+            ),
+            stop(0.5, foreground),
+            stop(
+                1.0,
+                Rgba {
+                    a: 0.0,
+                    ..foreground
+                },
+            ),
+        ],
+        _ => vec![stop(0.0, foreground), stop(1.0, background)],
+    }
+}
 
 impl GradientStyle {
     fn from_index(i: usize) -> GradientStyle {
@@ -1061,7 +1301,8 @@ impl GradientStyle {
 pub struct GradientTool {
     pub kind: GradientKind,
     /// Fade the foreground out instead of ending on the background colour.
-    pub to_transparent: bool,
+    /// Index into [`GRADIENT_FILLS`].
+    pub fill: usize,
     /// The shape drawn. Starts at whichever one this tool was registered
     /// as, and follows the options bar after that.
     style: GradientStyle,
@@ -1077,7 +1318,7 @@ impl GradientTool {
     fn new(kind: GradientKind) -> GradientTool {
         GradientTool {
             kind,
-            to_transparent: false,
+            fill: 0,
             style: match kind {
                 GradientKind::Linear => GradientStyle::Linear,
                 GradientKind::Radial => GradientStyle::Radial,
@@ -1151,7 +1392,7 @@ impl ToolPlugin for GradientTool {
             ctx,
             GradientFill {
                 style: self.style,
-                to_transparent: self.to_transparent,
+                fill: self.fill,
                 reverse: self.reverse,
                 dither: self.dither,
             },
@@ -1167,12 +1408,7 @@ impl ToolPlugin for GradientTool {
 
     fn options(&self) -> Vec<ToolOption> {
         vec![
-            ToolOption::choice(
-                "gradient-fill",
-                "Gradient",
-                GRADIENT_FILLS,
-                usize::from(self.to_transparent),
-            ),
+            ToolOption::choice("gradient-fill", "Gradient", GRADIENT_FILLS, self.fill),
             ToolOption::choice(
                 "gradient-style",
                 "Style",
@@ -1186,7 +1422,7 @@ impl ToolPlugin for GradientTool {
 
     fn set_option(&mut self, key: &str, value: OptionValue) {
         match key {
-            "gradient-fill" => self.to_transparent = value.index() == 1,
+            "gradient-fill" => self.fill = value.index().min(GRADIENT_FILLS.len() - 1),
             "gradient-style" => self.style = GradientStyle::from_index(value.index()),
             "gradient-reverse" => self.reverse = value.bool(),
             "gradient-dither" => self.dither = value.bool(),
@@ -1210,7 +1446,7 @@ impl ToolPlugin for GradientTool {
 /// Everything the options bar contributes to one gradient.
 struct GradientFill {
     style: GradientStyle,
-    to_transparent: bool,
+    fill: usize,
     reverse: bool,
     dither: bool,
 }
@@ -1218,22 +1454,14 @@ struct GradientFill {
 fn fill_gradient(ctx: &mut ToolCtx, fill: GradientFill, from: (f32, f32), to: (f32, f32)) {
     let GradientFill {
         style,
-        to_transparent,
+        fill,
         reverse,
         dither,
     } = fill;
     let Some(layer) = paintable_layer(ctx.doc) else {
         return;
     };
-    let start = ctx.state.foreground;
-    let end = if to_transparent {
-        Rgba {
-            a: 0.0,
-            ..ctx.state.foreground
-        }
-    } else {
-        ctx.state.background
-    };
+    let stops = gradient_stops(fill, ctx.state.foreground, ctx.state.background);
     let opacity = ctx.state.tool_opacity;
     let canvas = ctx.doc.canvas_rect();
     let region = if ctx.doc.selection.is_empty() {
@@ -1293,11 +1521,10 @@ fn fill_gradient(ctx: &mut ToolCtx, fill: GradientFill, from: (f32, f32), to: (f
                     let n = (((x * 7 + y * 13) & 7) as f32 / 8.0 - 0.5) / 255.0;
                     t = (t + n).clamp(0.0, 1.0);
                 }
+                let ramp = ramp_at(&stops, t);
                 let src = Rgba {
-                    r: start.r + (end.r - start.r) * t,
-                    g: start.g + (end.g - start.g) * t,
-                    b: start.b + (end.b - start.b) * t,
-                    a: (start.a + (end.a - start.a) * t) * opacity * sel,
+                    a: ramp.a * opacity * sel,
+                    ..ramp
                 };
                 let ix = ((y - trect.top) * TILE_SIZE + (x - trect.left)) as usize;
                 tile.set(ix, src.over(tile.get(ix)));
@@ -2044,6 +2271,120 @@ mod tests {
         // leaves gaps between the dabs.
         assert_eq!(gaps(0.15), 0);
         assert!(gaps(2.0) > 0, "a 200% spacing should leave gaps");
+    }
+
+    /// The ramp was two colours interpolated end to end: five styles but
+    /// no way to put a third colour anywhere, and no per-stop opacity.
+    #[test]
+    fn a_ramp_interpolates_through_every_stop() {
+        let red = Rgba::new(1.0, 0.0, 0.0, 1.0);
+        let green = Rgba::new(0.0, 1.0, 0.0, 1.0);
+        let blue = Rgba::new(0.0, 0.0, 1.0, 1.0);
+        let stops = vec![
+            GradientStop {
+                at: 0.0,
+                color: red,
+            },
+            GradientStop {
+                at: 0.5,
+                color: green,
+            },
+            GradientStop {
+                at: 1.0,
+                color: blue,
+            },
+        ];
+
+        assert_eq!(ramp_at(&stops, 0.0), red);
+        assert_eq!(ramp_at(&stops, 0.5), green);
+        assert_eq!(ramp_at(&stops, 1.0), blue);
+        // A quarter of the way is halfway between the first two, which a
+        // two-colour ramp could never produce.
+        let quarter = ramp_at(&stops, 0.25);
+        assert!((quarter.r - 0.5).abs() < 1e-5, "{quarter:?}");
+        assert!((quarter.g - 0.5).abs() < 1e-5, "{quarter:?}");
+        assert!(quarter.b.abs() < 1e-5, "{quarter:?}");
+        // Past the ends it holds, rather than extrapolating.
+        assert_eq!(ramp_at(&stops, -1.0), red);
+        assert_eq!(ramp_at(&stops, 2.0), blue);
+    }
+
+    /// Per-stop opacity: transparent at both ends, opaque in the middle.
+    #[test]
+    fn a_preset_can_vary_opacity_along_the_ramp() {
+        let fg = Rgba::new(0.2, 0.4, 0.8, 1.0);
+        let stops = gradient_stops(5, fg, Rgba::new(0.0, 0.0, 0.0, 1.0));
+        assert!(ramp_at(&stops, 0.0).a < 0.01);
+        assert!((ramp_at(&stops, 0.5).a - 1.0).abs() < 1e-5);
+        assert!(ramp_at(&stops, 1.0).a < 0.01);
+        // And the colour is the foreground all the way along.
+        assert!((ramp_at(&stops, 0.25).r - fg.r).abs() < 1e-5);
+    }
+
+    /// The two swatch-driven fills still behave exactly as they did.
+    #[test]
+    fn the_swatch_fills_are_unchanged() {
+        let fg = Rgba::new(1.0, 0.0, 0.0, 1.0);
+        let bg = Rgba::new(0.0, 0.0, 1.0, 1.0);
+        let fg_to_bg = gradient_stops(0, fg, bg);
+        assert_eq!(ramp_at(&fg_to_bg, 0.0), fg);
+        assert_eq!(ramp_at(&fg_to_bg, 1.0), bg);
+
+        let fg_to_clear = gradient_stops(1, fg, bg);
+        assert_eq!(ramp_at(&fg_to_clear, 0.0), fg);
+        assert!(ramp_at(&fg_to_clear, 1.0).a < 1e-5);
+    }
+
+    /// Dodge and burn always used the midtone weighting, so there was no
+    /// way to lift only the shadows or hold back only the highlights.
+    #[test]
+    fn the_tone_range_decides_which_pixels_move() {
+        // The weighting is the thing that differs; the visible change
+        // also depends on how much headroom a pixel has, which is why
+        // this checks the weight rather than the result.
+        assert!(ToneRange::Shadows.weight(0.05) > ToneRange::Shadows.weight(0.5));
+        assert_eq!(
+            ToneRange::Shadows.weight(0.9),
+            0.0,
+            "shadows leave highlights alone"
+        );
+
+        assert!(ToneRange::Highlights.weight(0.95) > ToneRange::Highlights.weight(0.5));
+        assert_eq!(
+            ToneRange::Highlights.weight(0.1),
+            0.0,
+            "highlights leave shadows alone"
+        );
+
+        // Midtones is the bell the tools always used, unchanged.
+        let mid = ToneRange::Midtones;
+        assert!(mid.weight(0.5) > mid.weight(0.05));
+        assert!(mid.weight(0.5) > mid.weight(0.95));
+        assert!((mid.weight(0.5) - 1.0).abs() < 1e-6);
+    }
+
+    /// And a range that excludes a pixel leaves it completely alone.
+    #[test]
+    fn a_pixel_outside_the_range_is_untouched() {
+        let bright = Rgba::new(0.95, 0.95, 0.95, 1.0);
+        let out = apply_tone(Tone::Burn, ToneRange::Shadows, bright, 1.0);
+        assert_eq!(out, bright);
+
+        let dark = Rgba::new(0.05, 0.05, 0.05, 1.0);
+        let out = apply_tone(Tone::Dodge, ToneRange::Highlights, dark, 1.0);
+        assert_eq!(out, dark);
+    }
+
+    /// Exposure scales how hard dodge and burn hit; there was no control
+    /// at all, so the strength was whatever the tool opacity happened to
+    /// be. The default doubles to the 1.0 the tools used to apply.
+    #[test]
+    fn exposure_scales_the_tone_change() {
+        let px = Rgba::new(0.5, 0.5, 0.5, 1.0);
+        let light = apply_tone(Tone::Dodge, ToneRange::Midtones, px, 0.2);
+        let heavy = apply_tone(Tone::Dodge, ToneRange::Midtones, px, 1.0);
+        assert!(heavy.r > light.r);
+        assert!(light.r > px.r);
     }
 }
 

--- a/plugins/tools-paint/src/lib.rs
+++ b/plugins/tools-paint/src/lib.rs
@@ -597,7 +597,10 @@ fn paintable_layer(doc: &Document) -> Option<LayerId> {
 pub struct PaintTool {
     mode: PaintMode,
     stroke: Option<Stroke>,
+    /// Where the brush cursor sits, and the pressure it was last drawn
+    /// with, so the preview circle matches the dab it would leave.
     cursor: Option<(f32, f32)>,
+    cursor_pressure: f32,
     /// Clone stamp: the alt-clicked source point, and the offset locked in
     /// when the first stroke after it begins.
     clone_source: Option<(f32, f32)>,
@@ -612,6 +615,7 @@ impl PaintTool {
             mode,
             stroke: None,
             cursor: None,
+            cursor_pressure: 1.0,
             clone_source: None,
             clone_offset: None,
             tolerance: 0.12,
@@ -846,6 +850,7 @@ impl ToolPlugin for PaintTool {
 
     fn on_pointer_down(&mut self, ctx: &mut ToolCtx, input: PointerInput) {
         self.cursor = Some((input.x, input.y));
+        self.cursor_pressure = input.pressure;
         // Alt-click sets the clone stamp's source point.
         if matches!(self.mode, PaintMode::Clone | PaintMode::Heal) && input.modifiers.alt {
             self.clone_source = Some((input.x, input.y));
@@ -861,6 +866,7 @@ impl ToolPlugin for PaintTool {
 
     fn on_pointer_move(&mut self, ctx: &mut ToolCtx, input: PointerInput) {
         self.cursor = Some((input.x, input.y));
+        self.cursor_pressure = input.pressure;
         if let Some(stroke) = &mut self.stroke {
             stroke.extend(ctx.doc, input.x, input.y, input.pressure);
         }
@@ -879,8 +885,12 @@ impl ToolPlugin for PaintTool {
     }
 
     fn on_deactivate(&mut self, ctx: &mut ToolCtx) {
+        // A stroke in progress is real pixels the user already painted,
+        // so it is committed rather than rolled back: switching tools
+        // mid-drag should not throw the stroke away, and `finish` records
+        // it as one undoable edit.
         if let Some(stroke) = self.stroke.take() {
-            stroke.edit.cancel(ctx.doc);
+            stroke.finish(ctx.doc);
         }
         // The clone source is a point in *this* document. The tool lives
         // for the whole session, so keeping it meant alt-clicking a source
@@ -896,10 +906,13 @@ impl ToolPlugin for PaintTool {
     fn overlays(&self, _doc: &Document, state: &EditorState) -> Vec<Overlay> {
         match self.cursor {
             Some((cx, cy)) => {
+                // The dab's own radius: `size / 2 * pressure`, matching
+                // `Stroke::dab`. Drawing the unscaled half-size promised a
+                // stroke wider than the one a stylus would leave.
                 vec![Overlay::Circle {
                     cx,
                     cy,
-                    r: state.brush_size / 2.0,
+                    r: (state.brush_size / 2.0 * self.cursor_pressure.max(0.05)).max(0.5),
                 }]
             }
             None => Vec::new(),
@@ -1785,6 +1798,52 @@ mod tests {
             "the source belongs to the document it was picked in"
         );
         assert!(tool.cursor.is_none(), "and the cursor circle goes with it");
+    }
+
+    #[test]
+    fn the_brush_cursor_tracks_pressure_and_clears_on_deactivate() {
+        // The circle was always `brush_size / 2` even though a dab is
+        // `size / 2 * pressure`, so the preview promised a wider stroke
+        // than a stylus would leave -- and nothing ever cleared it, so
+        // the circle from the last document reappeared as soon as the
+        // brush was picked up again.
+        let mut doc = doc_with_layer();
+        let mut state = EditorState {
+            brush_size: 40.0,
+            ..Default::default()
+        };
+        let mut tool = PaintTool::new(PaintMode::Brush);
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+
+        let light = PointerInput {
+            x: 20.0,
+            y: 20.0,
+            pressure: 0.25,
+            modifiers: Modifiers::default(),
+        };
+        tool.on_pointer_down(&mut ctx, light);
+        let overlays = tool.overlays(ctx.doc, ctx.state);
+        let Some(&Overlay::Circle { r, .. }) = overlays.first() else {
+            panic!("no brush cursor: {overlays:?}");
+        };
+        assert!((r - 5.0).abs() < 1e-3, "radius {r} ignores pressure");
+
+        tool.on_pointer_up(&mut ctx, light);
+        tool.on_pointer_move(&mut ctx, input(30.0, 30.0));
+        let overlays = tool.overlays(ctx.doc, ctx.state);
+        let Some(&Overlay::Circle { r, .. }) = overlays.first() else {
+            panic!("no brush cursor: {overlays:?}");
+        };
+        assert!((r - 20.0).abs() < 1e-3, "full pressure should be half size");
+
+        tool.on_deactivate(&mut ctx);
+        assert!(
+            tool.overlays(ctx.doc, ctx.state).is_empty(),
+            "a stale cursor survived the tool switch"
+        );
     }
 }
 

--- a/plugins/tools-paint/src/lib.rs
+++ b/plugins/tools-paint/src/lib.rs
@@ -132,6 +132,12 @@ impl ToneRange {
 /// midtones move more than the extremes; sponge pulls colour toward or away
 /// from its own luminance.
 fn apply_tone(tone: Tone, range: ToneRange, px: Rgba, amount: f32) -> Rgba {
+    // Exposure runs to 100%, and the dab doubles it so that the slider's
+    // midpoint is a full-strength pass. Past that the blends run off the
+    // end of their range: Burn wrote negative channels and Dodge wrote
+    // over 1.0, both of which come back as garbage once the tile is
+    // stored.
+    let amount = amount.clamp(0.0, 1.0);
     let lum = 0.3 * px.r + 0.59 * px.g + 0.11 * px.b;
     match tone {
         Tone::Dodge => {
@@ -402,7 +408,10 @@ impl Stroke {
                         }
                         Ink::Convolve { snapshot, sharpen } => {
                             let out = convolve_at(snapshot, x, y, *sharpen);
-                            let a = a * strength * 2.0;
+                            // Same doubling, same clamp: a blend factor
+                            // above 1 extrapolates past the filtered
+                            // pixel instead of reaching it.
+                            let a = (a * strength * 2.0).clamp(0.0, 1.0);
                             Rgba {
                                 r: orig.r + (out.r - orig.r) * a,
                                 g: orig.g + (out.g - orig.g) * a,
@@ -660,8 +669,9 @@ impl Stroke {
 /// ignored `visible`, despite the doc comment claiming otherwise, so paint
 /// could go onto a hidden layer and appear to do nothing at all.
 ///
-/// Photoshop refuses and says why; refusing is the half we can do here,
-/// and the caller reports it.
+/// Photoshop refuses and says why. Refusing is the half that belongs
+/// here; there is no channel from a tool back to the status bar yet, so
+/// the stroke simply does nothing.
 fn paintable_layer(doc: &Document) -> Option<LayerId> {
     let id = doc.active_layer?;
     let layer = doc.tree.find(id)?;
@@ -1781,6 +1791,28 @@ mod tests {
         let mut doc = Document::new("t", 128, 128, Depth::Eight);
         doc.push_layer(Layer::new_raster("paint"));
         doc
+    }
+
+    #[test]
+    fn a_full_exposure_burn_stops_at_black() {
+        // Exposure is doubled inside the dab, so 100% asked for twice the
+        // blend the formula has room for: Burn went past black into
+        // negative channels and Dodge past white.
+        let px = Rgba {
+            r: 0.5,
+            g: 0.5,
+            b: 0.5,
+            a: 1.0,
+        };
+        let burn = apply_tone(Tone::Burn, ToneRange::Midtones, px, 2.0);
+        assert!(burn.r >= 0.0, "burn wrote {}", burn.r);
+        assert!(burn.r <= 0.5);
+        let dodge = apply_tone(Tone::Dodge, ToneRange::Midtones, px, 2.0);
+        assert!(dodge.r <= 1.0, "dodge wrote {}", dodge.r);
+        assert!(dodge.r >= 0.5);
+        // A sponge cannot overshoot the luminance it is pulling towards.
+        let sponge = apply_tone(Tone::Sponge, ToneRange::Midtones, px, 2.0);
+        assert!((0.0..=1.0).contains(&sponge.r));
     }
 
     fn input(x: f32, y: f32) -> PointerInput {

--- a/plugins/tools-paint/src/lib.rs
+++ b/plugins/tools-paint/src/lib.rs
@@ -130,6 +130,7 @@ struct Stroke {
     opacity: f32,
     size: f32,
     hardness: f32,
+    dynamics: Dynamics,
     mode: PaintMode,
     /// The layer as it was when the stroke began. Tile maps are
     /// copy-on-write, so this is a handful of Arc clones, not a copy.
@@ -151,6 +152,7 @@ impl Stroke {
         mode: PaintMode,
         ink: Ink,
         heal_offset: (i32, i32),
+        dynamics: Dynamics,
     ) -> Option<Stroke> {
         let layer = paintable_layer(ctx.doc)?;
         let mut stroke = Stroke {
@@ -175,6 +177,7 @@ impl Stroke {
             last: (input.x, input.y),
             spacing_debt: 0.0,
             ink,
+            dynamics,
             opacity: ctx.state.tool_opacity,
             size: ctx.state.brush_size,
             hardness: if mode == PaintMode::Pencil {
@@ -200,7 +203,7 @@ impl Stroke {
     }
 
     fn spacing(&self) -> f32 {
-        (self.size * 0.15).max(1.0)
+        (self.size * self.dynamics.spacing).max(1.0)
     }
 
     fn extend(&mut self, doc: &mut Document, x: f32, y: f32, pressure: f32) {
@@ -226,6 +229,15 @@ impl Stroke {
     /// from their pre-stroke values.
     fn dab(&mut self, doc: &mut Document, cx: f32, cy: f32, pressure: f32) {
         let radius = (self.size / 2.0 * pressure.max(0.05)).max(0.5);
+        let flow = self.dynamics.flow;
+        // Pen pressure changed the dab's size only; with this on it
+        // changes how much ink lands too, which is what a pressure-
+        // sensitive brush is for.
+        let ink_scale = if self.dynamics.pressure_opacity {
+            pressure.clamp(0.0, 1.0)
+        } else {
+            1.0
+        };
         let bounds = IntRect::new(
             (cx - radius).floor() as i32,
             (cy - radius).floor() as i32,
@@ -272,12 +284,23 @@ impl Stroke {
                         a = if a >= 0.5 { 1.0 } else { 0.0 };
                     }
                     a *= selection.coverage(x, y) as f32 / 255.0;
+                    a *= ink_scale;
                     if a <= 0.0 {
                         continue;
                     }
                     let ix = ((y - trect.top) * TILE_SIZE + (x - trect.left)) as usize;
-                    if a > cov[ix] {
-                        cov[ix] = a;
+                    // At full flow the dabs of one stroke take the
+                    // maximum, so scribbling over the same spot at 50%
+                    // opacity stays 50%. Below full flow they accumulate
+                    // toward the same ceiling, which is what makes a low
+                    // flow build up as you go over an area again.
+                    let next = if flow >= 1.0 {
+                        a.max(cov[ix])
+                    } else {
+                        (cov[ix] + a * flow).min(1.0)
+                    };
+                    if next > cov[ix] {
+                        cov[ix] = next;
                         touched = true;
                     }
                 }
@@ -607,6 +630,35 @@ pub struct PaintTool {
     clone_offset: Option<(i32, i32)>,
     /// Background eraser colour tolerance, 0..=1.
     tolerance: f32,
+    /// Brush dynamics. The brush had no Flow, no adjustable spacing and
+    /// pen pressure only changed the dab's *size*, never how much ink it
+    /// laid down.
+    dynamics: Dynamics,
+}
+
+/// Per-stroke brush dynamics.
+#[derive(Debug, Clone, Copy)]
+struct Dynamics {
+    /// How much coverage one dab lays down, 0..=1. At 1 the dabs of a
+    /// stroke take the maximum, which is Photoshop's opacity model and
+    /// what this always did; below 1 they build up toward the tool
+    /// opacity instead, which is what Flow means.
+    flow: f32,
+    /// Dab spacing as a fraction of the brush diameter.
+    spacing: f32,
+    /// Pen pressure scales coverage as well as radius.
+    pressure_opacity: bool,
+}
+
+impl Default for Dynamics {
+    fn default() -> Self {
+        Dynamics {
+            flow: 1.0,
+            // The 15% this was hard-coded to.
+            spacing: 0.15,
+            pressure_opacity: false,
+        }
+    }
 }
 
 impl PaintTool {
@@ -619,6 +671,7 @@ impl PaintTool {
             clone_source: None,
             clone_offset: None,
             tolerance: 0.12,
+            dynamics: Dynamics::default(),
         }
     }
 
@@ -829,20 +882,59 @@ impl ToolPlugin for PaintTool {
     }
 
     fn options(&self) -> Vec<ToolOption> {
-        match self.mode {
-            PaintMode::BackgroundEraser => vec![ToolOption::slider(
+        let mut out = Vec::new();
+        if self.mode == PaintMode::BackgroundEraser {
+            out.push(ToolOption::slider(
                 "bge-tolerance",
                 "Tolerance",
                 self.tolerance * 100.0,
                 1.0,
                 100.0,
                 "%",
-            )],
-            _ => Vec::new(),
+            ));
         }
+        // Dynamics belong to anything that stamps dabs, which is every
+        // mode here.
+        out.push(ToolOption::slider(
+            "brush-flow",
+            "Flow",
+            self.dynamics.flow * 100.0,
+            1.0,
+            100.0,
+            "%",
+        ));
+        out.push(ToolOption::slider(
+            "brush-spacing",
+            "Spacing",
+            self.dynamics.spacing * 100.0,
+            1.0,
+            200.0,
+            "%",
+        ));
+        out.push(ToolOption::toggle(
+            "brush-pressure-opacity",
+            "Pressure \u{2192} Opacity",
+            self.dynamics.pressure_opacity,
+        ));
+        out
     }
 
     fn set_option(&mut self, key: &str, value: OptionValue) {
+        match key {
+            "brush-flow" => {
+                self.dynamics.flow = (value.num() / 100.0).clamp(0.01, 1.0);
+                return;
+            }
+            "brush-spacing" => {
+                self.dynamics.spacing = (value.num() / 100.0).clamp(0.01, 2.0);
+                return;
+            }
+            "brush-pressure-opacity" => {
+                self.dynamics.pressure_opacity = value.bool();
+                return;
+            }
+            _ => {}
+        }
         if key == "bge-tolerance" {
             self.tolerance = (value.num() / 100.0).clamp(0.01, 1.0);
         }
@@ -861,7 +953,7 @@ impl ToolPlugin for PaintTool {
             return;
         };
         let heal_offset = self.clone_offset.unwrap_or((0, 0));
-        self.stroke = Stroke::begin(ctx, input, self.mode, ink, heal_offset);
+        self.stroke = Stroke::begin(ctx, input, self.mode, ink, heal_offset, self.dynamics);
     }
 
     fn on_pointer_move(&mut self, ctx: &mut ToolCtx, input: PointerInput) {
@@ -1844,6 +1936,114 @@ mod tests {
             tool.overlays(ctx.doc, ctx.state).is_empty(),
             "a stale cursor survived the tool switch"
         );
+    }
+
+    /// Flow is how much ink one dab lays down. The brush had none: every
+    /// dab laid down full coverage and the dabs of a stroke took the
+    /// maximum, so there was no way to build a tone up gradually.
+    #[test]
+    fn flow_scales_what_one_dab_lays_down() {
+        let one_dab = |flow: f32| {
+            let mut doc = doc_with_layer();
+            let mut state = EditorState {
+                foreground: Rgba::new(0.0, 0.0, 0.0, 1.0),
+                brush_size: 24.0,
+                ..Default::default()
+            };
+            let mut tool = PaintTool::new(PaintMode::Brush);
+            tool.set_option("brush-flow", OptionValue::Num(flow * 100.0));
+            let mut ctx = ToolCtx {
+                doc: &mut doc,
+                state: &mut state,
+            };
+            tool.on_pointer_down(&mut ctx, input(40.0, 40.0));
+            tool.on_pointer_up(&mut ctx, input(40.0, 40.0));
+            pixel(&doc, 40, 40)[3]
+        };
+
+        assert_eq!(one_dab(1.0), 255, "full flow should be opaque");
+        let quarter = one_dab(0.25);
+        assert!(
+            (quarter as i32 - 64).abs() <= 4,
+            "a quarter flow dab came out at {quarter}, expected about 64"
+        );
+        assert!(one_dab(0.5) > quarter);
+    }
+
+    /// And within one stroke, low-flow dabs accumulate toward the tool
+    /// opacity rather than each replacing the last.
+    #[test]
+    fn low_flow_dabs_accumulate_along_a_stroke() {
+        let along = |flow: f32| {
+            let mut doc = doc_with_layer();
+            let mut state = EditorState {
+                foreground: Rgba::new(0.0, 0.0, 0.0, 1.0),
+                brush_size: 24.0,
+                ..Default::default()
+            };
+            let mut tool = PaintTool::new(PaintMode::Brush);
+            tool.set_option("brush-flow", OptionValue::Num(flow * 100.0));
+            let mut ctx = ToolCtx {
+                doc: &mut doc,
+                state: &mut state,
+            };
+            tool.on_pointer_down(&mut ctx, input(40.0, 40.0));
+            tool.on_pointer_move(&mut ctx, input(48.0, 40.0));
+            tool.on_pointer_up(&mut ctx, input(48.0, 40.0));
+            pixel(&doc, 44, 40)[3]
+        };
+        // A short drag stamps several overlapping dabs over the midpoint,
+        // so even a low flow builds past what one dab alone leaves.
+        let single = {
+            let mut doc = doc_with_layer();
+            let mut state = EditorState {
+                foreground: Rgba::new(0.0, 0.0, 0.0, 1.0),
+                brush_size: 24.0,
+                ..Default::default()
+            };
+            let mut tool = PaintTool::new(PaintMode::Brush);
+            tool.set_option("brush-flow", OptionValue::Num(10.0));
+            let mut ctx = ToolCtx {
+                doc: &mut doc,
+                state: &mut state,
+            };
+            tool.on_pointer_down(&mut ctx, input(44.0, 40.0));
+            tool.on_pointer_up(&mut ctx, input(44.0, 40.0));
+            pixel(&doc, 44, 40)[3]
+        };
+        assert!(
+            along(0.1) > single,
+            "dabs did not accumulate: {} vs one dab's {single}",
+            along(0.1)
+        );
+    }
+
+    /// Spacing was hard-coded at 15% of the brush size.
+    #[test]
+    fn spacing_controls_how_far_apart_the_dabs_land() {
+        let gaps = |spacing: f32| {
+            let mut doc = doc_with_layer();
+            let mut state = EditorState {
+                foreground: Rgba::new(0.0, 0.0, 0.0, 1.0),
+                brush_size: 4.0,
+                ..Default::default()
+            };
+            let mut tool = PaintTool::new(PaintMode::Brush);
+            tool.set_option("brush-spacing", OptionValue::Num(spacing * 100.0));
+            let mut ctx = ToolCtx {
+                doc: &mut doc,
+                state: &mut state,
+            };
+            tool.on_pointer_down(&mut ctx, input(10.0, 40.0));
+            tool.on_pointer_move(&mut ctx, input(110.0, 40.0));
+            tool.on_pointer_up(&mut ctx, input(110.0, 40.0));
+            // How many pixels along the stroke are untouched.
+            (10..110).filter(|&x| pixel(&doc, x, 40)[3] == 0).count()
+        };
+        // A tight spacing leaves a continuous line; a very wide one
+        // leaves gaps between the dabs.
+        assert_eq!(gaps(0.15), 0);
+        assert!(gaps(2.0) > 0, "a 200% spacing should leave gaps");
     }
 }
 

--- a/plugins/tools-paint/src/lib.rs
+++ b/plugins/tools-paint/src/lib.rs
@@ -578,21 +578,20 @@ impl Stroke {
     }
 }
 
-/// Topmost paintable (raster, unlocked, visible) layer if the active layer
-/// isn't paintable.
+/// The active layer, if it can be painted on.
+///
+/// This used to fall back to the topmost other raster layer when the
+/// active one was a group, an adjustment layer or locked, so a brush
+/// stroke silently landed somewhere else entirely. The fallback also
+/// ignored `visible`, despite the doc comment claiming otherwise, so paint
+/// could go onto a hidden layer and appear to do nothing at all.
+///
+/// Photoshop refuses and says why; refusing is the half we can do here,
+/// and the caller reports it.
 fn paintable_layer(doc: &Document) -> Option<LayerId> {
-    if let Some(id) = doc.active_layer {
-        if let Some(l) = doc.tree.find(id) {
-            if matches!(l.kind, LayerKind::Raster(_)) && !l.locked {
-                return Some(id);
-            }
-        }
-    }
-    doc.tree
-        .iter()
-        .filter(|l| matches!(l.kind, LayerKind::Raster(_)) && !l.locked)
-        .map(|l| l.id)
-        .last()
+    let id = doc.active_layer?;
+    let layer = doc.tree.find(id)?;
+    (matches!(layer.kind, LayerKind::Raster(_)) && !layer.locked && layer.visible).then_some(id)
 }
 
 pub struct PaintTool {

--- a/plugins/tools-retouch/src/lib.rs
+++ b/plugins/tools-retouch/src/lib.rs
@@ -541,7 +541,14 @@ impl ToolPlugin for RedEyeTool {
             return;
         };
         let (threshold, darken) = (1.0 - self.amount, self.darken);
+        // Every sibling tool in this file confines itself to the selection;
+        // Red Eye recoloured matching pixels outside it too.
+        let sel = ctx.doc.selection.clone();
         write_rect(ctx.doc, layer, rect, "Red Eye", |x, y| {
+            let cov = sel.coverage(x, y) as f32 / 255.0;
+            if cov <= 0.0 {
+                return None;
+            }
             let c = tiles.pixel(x, y);
             if c.a <= 0.0 {
                 return None;
@@ -556,10 +563,18 @@ impl ToolPlugin for RedEyeTool {
             // what turns a glowing pupil back into a pupil.
             let grey = (c.g + c.b) / 2.0;
             let k = 1.0 - darken;
-            Some(Rgba {
+            let fixed = Rgba {
                 r: grey * k,
                 g: c.g * k,
                 b: c.b * k,
+                a: c.a,
+            };
+            // Feathered selection edges fade the correction rather than
+            // ending it abruptly.
+            Some(Rgba {
+                r: c.r + (fixed.r - c.r) * cov,
+                g: c.g + (fixed.g - c.g) * cov,
+                b: c.b + (fixed.b - c.b) * cov,
                 a: c.a,
             })
         });

--- a/plugins/tools-retouch/tests/retouch.rs
+++ b/plugins/tools-retouch/tests/retouch.rs
@@ -287,3 +287,42 @@ fn content_aware_fill_puts_texture_back_rather_than_an_average() {
         mean(2, 2)
     );
 }
+
+#[test]
+fn red_eye_stays_inside_the_selection() {
+    // Every sibling tool in this file gates on `sel.coverage`; red eye
+    // did not, so it recoloured matching pixels outside the selection.
+    let mut doc = doc_with(|doc, id| {
+        for y in 40..80 {
+            for x in 20..100 {
+                set(doc, id, x, y, Rgba::new(0.9, 0.1, 0.1, 1.0));
+            }
+        }
+    });
+    // Select only the left half of the red band.
+    doc.selection
+        .select_rect(IntRect::from_xywh(0, 0, 60, 120), SelectOp::Replace);
+
+    let mut state = EditorState::default();
+    let mut tool = RedEyeTool::default_tool();
+    {
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(20.0, 40.0));
+        tool.on_pointer_move(&mut ctx, input(100.0, 80.0));
+        tool.on_pointer_up(&mut ctx, input(100.0, 80.0));
+    }
+
+    let inside = get(&doc, 40, 60);
+    let outside = get(&doc, 80, 60);
+    assert!(
+        inside.r < 0.5,
+        "inside the selection must be corrected: {inside:?}"
+    );
+    assert!(
+        (outside.r - 0.9).abs() < 0.05,
+        "outside must be untouched: {outside:?}"
+    );
+}

--- a/plugins/tools-select/src/lib.rs
+++ b/plugins/tools-select/src/lib.rs
@@ -322,6 +322,12 @@ impl ToolPlugin for MarqueeTool {
                 MarqueeShape::Ellipse => target.select_ellipse(rect, op),
             });
             sel.clip_to(canvas);
+            // The clipped rect can touch the canvas while the ellipse
+            // itself does not. Do not leave an active all-zero mask that
+            // silently blocks every subsequent pixel tool.
+            if sel.bounds().is_empty() {
+                sel.deselect();
+            }
         });
         edit.commit();
     }
@@ -1634,6 +1640,34 @@ mod tests {
         assert!(
             b.left >= 0 && b.top >= 0 && b.right <= 64 && b.bottom <= 64,
             "selection escaped the canvas: {b:?}"
+        );
+    }
+
+    #[test]
+    fn an_ellipse_that_only_touches_a_canvas_corner_deselects() {
+        let mut doc = Document::new("t", 200, 200, Depth::Eight);
+        doc.selection
+            .select_rect(IntRect::from_xywh(10, 10, 30, 30), SelectOp::Replace);
+        let mut state = EditorState::default();
+        let mut tool = MarqueeTool::new(MarqueeShape::Ellipse);
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+
+        // The bounding box clips the canvas at its corner, but the ellipse
+        // inscribed in that box has no coverage there.
+        drag(
+            &mut tool,
+            &mut ctx,
+            (190.0, 190.0),
+            (400.0, 400.0),
+            Modifiers::default(),
+        );
+
+        assert!(
+            ctx.doc.selection.is_empty(),
+            "an all-zero mask must not remain active"
         );
     }
 

--- a/plugins/tools-select/src/lib.rs
+++ b/plugins/tools-select/src/lib.rs
@@ -62,7 +62,14 @@ fn commit_pixels(ctx: &mut ToolCtx, pixels: &[(i32, i32)], op: SelectOp, name: &
                 }
             }
         }
-        sel.activate();
+        // An empty Replace means "no selection", not "a selection of
+        // nothing": `is_empty()` is just `!active`, so activating an
+        // all-zero mask made every paint, fill, gradient and retouch tool
+        // silently do nothing document-wide until the user deselected by
+        // hand.
+        if !pixels.is_empty() {
+            sel.activate();
+        }
         sel.recompute_bounds();
     });
     edit.commit();
@@ -299,11 +306,13 @@ impl ToolPlugin for MarqueeTool {
         }
         let shape = self.shape;
         let feather = self.feather;
-        // A drag that starts or ends off-canvas would otherwise put the
-        // selection's bounds outside the document, which Transform
-        // Selection then frames and `coverage_ratio` over-reports.
-        let rect = rect.intersect(&ctx.doc.canvas_rect());
-        if rect.is_empty() {
+        // The *shape* comes from the full drag; only the resulting mask
+        // is clipped to the canvas. Clipping the generating rect first
+        // inscribed the ellipse in the clipped box, so a partly
+        // off-canvas drag committed a different ellipse than the preview
+        // had drawn.
+        let canvas = ctx.doc.canvas_rect();
+        if rect.intersect(&canvas).is_empty() {
             return;
         }
         let mut edit = ctx.doc.begin_edit("Select");
@@ -311,7 +320,8 @@ impl ToolPlugin for MarqueeTool {
             commit_shape(sel, feather, op, |target, op| match shape {
                 MarqueeShape::Rect => target.select_rect(rect, op),
                 MarqueeShape::Ellipse => target.select_ellipse(rect, op),
-            })
+            });
+            sel.clip_to(canvas);
         });
         edit.commit();
     }
@@ -1368,6 +1378,37 @@ mod tests {
         drag(&mut tool, &mut ctx, (150.0, 10.0), (190.0, 50.0), plain);
         assert_eq!(ctx.doc.selection.coverage(20, 20), 0, "the old one is gone");
         assert_eq!(ctx.doc.selection.coverage(170, 30), 255);
+    }
+
+    #[test]
+    fn a_half_offscreen_ellipse_keeps_the_shape_it_previewed() {
+        let mut doc = Document::new("t", 200, 200, Depth::Eight);
+        let mut state = EditorState::default();
+        let mut tool = MarqueeTool::new(MarqueeShape::Ellipse);
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+
+        // A circle centred on the canvas edge: the drag runs from x=100
+        // out to x=300, so only its left half lands on the document.
+        drag(
+            &mut tool,
+            &mut ctx,
+            (100.0, 0.0),
+            (300.0, 200.0),
+            Modifiers::default(),
+        );
+
+        // The widest row of that circle is y=100, and it runs off the
+        // right edge.
+        assert_eq!(ctx.doc.selection.coverage(199, 100), 255);
+        // Near the bottom the circle has narrowed to x=157..243. Clipping
+        // the drag rect first would have inscribed a half-width ellipse
+        // spanning x=128..172 there instead, which gets both of these
+        // backwards.
+        assert_eq!(ctx.doc.selection.coverage(180, 190), 255);
+        assert_eq!(ctx.doc.selection.coverage(135, 190), 0);
     }
 
     #[test]

--- a/plugins/tools-select/src/lib.rs
+++ b/plugins/tools-select/src/lib.rs
@@ -597,6 +597,25 @@ impl ToolPlugin for LassoTool {
         self.commit(ctx);
     }
 
+    fn on_key(
+        &mut self,
+        _ctx: &mut ToolCtx,
+        key: &str,
+        _text: Option<&str>,
+        _modifiers: Modifiers,
+    ) -> bool {
+        // Backspace drops the last anchor. Without it one misplaced click
+        // in a long polygonal selection meant starting over: escape
+        // discards the whole path and nothing else was handled.
+        if self.kind == LassoKind::Free {
+            return false;
+        }
+        match key {
+            "backspace" | "delete" => self.points.pop().is_some(),
+            _ => false,
+        }
+    }
+
     fn on_cancel(&mut self, _ctx: &mut ToolCtx) {
         self.points.clear();
         self.cursor = None;
@@ -1853,5 +1872,72 @@ mod new_tool_tests {
             tool.on_pointer_down(&mut ctx, input(20.0, 20.0, Modifiers::default()));
         }
         assert_eq!(doc.selection.coverage(80, 80), 255, "missed the far square");
+    }
+    #[test]
+    fn the_elliptical_marquee_previews_an_ellipse() {
+        // Both shapes emitted `AntsRect`, so an elliptical drag showed a
+        // rectangle right up until the mouse went up.
+        let mut doc = Document::new("t", 200, 200, Depth::Eight);
+        let mut state = EditorState::default();
+        let mut tool = MarqueeTool::new(MarqueeShape::Ellipse);
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(20.0, 40.0, Modifiers::default()));
+        tool.on_pointer_move(&mut ctx, input(120.0, 100.0, Modifiers::default()));
+
+        let overlays = tool.overlays(ctx.doc, ctx.state);
+        let Some(Overlay::AntsPolygon(points)) = overlays.first() else {
+            panic!("expected an ellipse outline, got {overlays:?}");
+        };
+        // Every point sits on the ellipse inscribed in the drag rect.
+        let (cx, cy, rx, ry) = (70.0f32, 70.0f32, 50.0f32, 30.0f32);
+        for &(x, y) in points {
+            let d = ((x - cx) / rx).powi(2) + ((y - cy) / ry).powi(2);
+            assert!((d - 1.0).abs() < 1e-3, "({x}, {y}) is not on the ellipse");
+        }
+        // ... and it is a curve, not four corners.
+        assert!(points.len() > 16);
+    }
+
+    #[test]
+    fn backspace_drops_the_last_polygonal_anchor() {
+        // Without this, one misplaced click in a long polygonal selection
+        // meant restarting: escape discards the whole path, and nothing
+        // else was handled.
+        let mut doc = Document::new("t", 200, 200, Depth::Eight);
+        let mut state = EditorState::default();
+        let mut tool = LassoTool::new(LassoKind::Polygonal);
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        for p in [(10.0, 10.0), (90.0, 10.0), (90.0, 90.0), (11.0, 91.0)] {
+            tool.on_pointer_down(&mut ctx, input(p.0, p.1, Modifiers::default()));
+            tool.on_pointer_up(&mut ctx, input(p.0, p.1, Modifiers::default()));
+        }
+        assert_eq!(tool.points.len(), 4);
+        assert!(tool.on_key(&mut ctx, "backspace", None, Modifiers::default()));
+        assert_eq!(tool.points.len(), 3);
+
+        // An empty path has nothing to drop, and the key is not claimed.
+        tool.points.clear();
+        assert!(!tool.on_key(&mut ctx, "backspace", None, Modifiers::default()));
+    }
+
+    /// The freehand lasso has no anchors to drop; it must leave backspace
+    /// to whatever else wants it.
+    #[test]
+    fn the_freehand_lasso_does_not_claim_backspace() {
+        let mut doc = Document::new("t", 200, 200, Depth::Eight);
+        let mut state = EditorState::default();
+        let mut tool = LassoTool::new(LassoKind::Free);
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(10.0, 10.0, Modifiers::default()));
+        assert!(!tool.on_key(&mut ctx, "backspace", None, Modifiers::default()));
     }
 }

--- a/plugins/tools-select/src/lib.rs
+++ b/plugins/tools-select/src/lib.rs
@@ -136,20 +136,28 @@ fn commit_shape(
     sel.apply_shape(bounds, op, |x, y| shape.coverage(x, y));
 }
 
-fn drag_rect(ax: f32, ay: f32, bx: f32, by: f32, square: bool) -> IntRect {
+/// The rectangle a drag from `(ax, ay)` to `(bx, by)` describes.
+///
+/// `square` constrains it; `from_centre` treats the press point as the
+/// centre rather than a corner, which is what Alt-drag means everywhere
+/// else and was not implemented anywhere here.
+fn drag_rect_from(ax: f32, ay: f32, bx: f32, by: f32, square: bool, from_centre: bool) -> IntRect {
     let (mut w, mut h) = (bx - ax, by - ay);
     if square {
         let m = w.abs().max(h.abs());
         w = m * w.signum();
         h = m * h.signum();
     }
-    let (x1, x2) = if w < 0.0 { (ax + w, ax) } else { (ax, ax + w) };
-    let (y1, y2) = if h < 0.0 { (ay + h, ay) } else { (ay, ay + h) };
+    let (x1, x2, y1, y2) = if from_centre {
+        (ax - w, ax + w, ay - h, ay + h)
+    } else {
+        (ax, ax + w, ay, ay + h)
+    };
     IntRect::new(
-        x1.round() as i32,
-        y1.round() as i32,
-        x2.round() as i32,
-        y2.round() as i32,
+        x1.min(x2).round() as i32,
+        y1.min(y2).round() as i32,
+        x1.max(x2).round() as i32,
+        y1.max(y2).round() as i32,
     )
 }
 
@@ -258,7 +266,10 @@ impl ToolPlugin for MarqueeTool {
             // constraint during drag) — use press-time modifiers for the op
             // and live shift for the constraint, like Photoshop.
             let square = input.modifiers.shift && !m.shift;
-            self.current = Some(drag_rect(ax, ay, input.x, input.y, square));
+            // Alt is overloaded exactly as Shift is: subtract-from-
+            // selection at press time, draw-from-centre during the drag.
+            let centre = input.modifiers.alt && !m.alt;
+            self.current = Some(drag_rect_from(ax, ay, input.x, input.y, square, centre));
         }
     }
 
@@ -266,10 +277,16 @@ impl ToolPlugin for MarqueeTool {
         let Some((ax, ay, m)) = self.anchor.take() else {
             return;
         };
-        let rect = self
-            .current
-            .take()
-            .unwrap_or_else(|| drag_rect(ax, ay, input.x, input.y, false));
+        let rect = self.current.take().unwrap_or_else(|| {
+            drag_rect_from(
+                ax,
+                ay,
+                input.x,
+                input.y,
+                input.modifiers.shift && !m.shift,
+                input.modifiers.alt && !m.alt,
+            )
+        });
         let op = op_from(m, self.mode);
         if rect.is_empty() {
             // Click without drag: deselect (Photoshop behavior).
@@ -1576,6 +1593,34 @@ mod tests {
         assert!(
             b.left >= 0 && b.top >= 0 && b.right <= 64 && b.bottom <= 64,
             "selection escaped the canvas: {b:?}"
+        );
+    }
+
+    /// Alt-drag draws from the centre, which nothing here implemented —
+    /// alt was consumed entirely by subtract-from-selection with no
+    /// fallback for the geometry.
+    #[test]
+    fn alt_draws_a_marquee_from_its_centre() {
+        // Corner drag: the press point is one corner.
+        assert_eq!(
+            drag_rect_from(100.0, 100.0, 140.0, 130.0, false, false),
+            IntRect::new(100, 100, 140, 130)
+        );
+        // From centre: the press point is the middle, and the rect grows
+        // both ways.
+        assert_eq!(
+            drag_rect_from(100.0, 100.0, 140.0, 130.0, false, true),
+            IntRect::new(60, 70, 140, 130)
+        );
+        // Dragging up and left from the centre gives the same rect.
+        assert_eq!(
+            drag_rect_from(100.0, 100.0, 60.0, 70.0, false, true),
+            IntRect::new(60, 70, 140, 130)
+        );
+        // Square plus from-centre compose.
+        assert_eq!(
+            drag_rect_from(100.0, 100.0, 140.0, 130.0, true, true),
+            IntRect::new(60, 60, 140, 140)
         );
     }
 }

--- a/plugins/tools-select/src/lib.rs
+++ b/plugins/tools-select/src/lib.rs
@@ -17,7 +17,10 @@ use schist_plugin_api::{
 /// Shared by every tool that produces a pixel set rather than a shape:
 /// the wand, quick selection and object selection.
 fn commit_pixels(ctx: &mut ToolCtx, pixels: &[(i32, i32)], op: SelectOp, name: &str) {
-    if pixels.is_empty() {
+    // An empty result in Replace mode still clears what was there, the way
+    // clicking with a marquee does. Returning early left the old selection
+    // in place, so wanding an empty area looked like nothing happened.
+    if pixels.is_empty() && (op != SelectOp::Replace || ctx.doc.selection.is_empty()) {
         return;
     }
     let mut edit = ctx.doc.begin_edit(name.to_string());
@@ -279,6 +282,13 @@ impl ToolPlugin for MarqueeTool {
         }
         let shape = self.shape;
         let feather = self.feather;
+        // A drag that starts or ends off-canvas would otherwise put the
+        // selection's bounds outside the document, which Transform
+        // Selection then frames and `coverage_ratio` over-reports.
+        let rect = rect.intersect(&ctx.doc.canvas_rect());
+        if rect.is_empty() {
+            return;
+        }
         let mut edit = ctx.doc.begin_edit("Select");
         edit.change_selection(|sel, _| {
             commit_shape(sel, feather, op, |target, op| match shape {
@@ -1519,6 +1529,34 @@ mod tests {
             ctx.doc.selection.coverage(40, 30),
             0,
             "blue side not selected"
+        );
+    }
+    #[test]
+    fn a_marquee_dragged_off_canvas_stays_inside_it() {
+        // `apply_shape` takes no canvas, so a drag starting outside put
+        // the selection's bounds off-document. Transform Selection then
+        // framed that, and `coverage_ratio` over-reported.
+        let mut doc = Document::new("t", 64, 64, Depth::Eight);
+        doc.push_layer(Layer::new_raster("bg"));
+        let mut state = EditorState::default();
+        let mut tool = MarqueeTool::new(MarqueeShape::Rect);
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut doc,
+                state: &mut state,
+            };
+            drag(
+                &mut tool,
+                &mut ctx,
+                (-40.0, -40.0),
+                (30.0, 30.0),
+                Modifiers::default(),
+            );
+        }
+        let b = doc.selection.bounds();
+        assert!(
+            b.left >= 0 && b.top >= 0 && b.right <= 64 && b.bottom <= 64,
+            "selection escaped the canvas: {b:?}"
         );
     }
 }

--- a/plugins/tools-transform/src/lib.rs
+++ b/plugins/tools-transform/src/lib.rs
@@ -105,6 +105,14 @@ struct Session {
     offset: (f32, f32),
     /// Live drag state.
     drag: Option<Drag>,
+    /// Where the transform is anchored, in 0..1 of `base`.
+    ///
+    /// Scaling pins the handle opposite the one being dragged, so the
+    /// dragged handle follows the cursor. Anchoring at the centre (which
+    /// is what this always used to be) moves each edge half the drag, so
+    /// the handle lagged the cursor and every scale behaved like an
+    /// Alt-drag with no way to ask for the ordinary one.
+    pivot_anchor: (f32, f32),
     dirty: bool,
 }
 
@@ -119,12 +127,12 @@ struct Drag {
 impl Session {
     fn pivot(&self) -> (f32, f32) {
         (
-            self.base.left as f32 + self.base.width() as f32 / 2.0,
-            self.base.top as f32 + self.base.height() as f32 / 2.0,
+            self.base.left as f32 + self.base.width() as f32 * self.pivot_anchor.0,
+            self.base.top as f32 + self.base.height() as f32 * self.pivot_anchor.1,
         )
     }
 
-    /// Current matrix: scale, then rotate, both about the box centre, then
+    /// Current matrix: scale, then rotate, both about the pivot, then
     /// translate.
     fn matrix(&self) -> Affine {
         let (px, py) = self.pivot();
@@ -146,7 +154,7 @@ impl Session {
         ]
     }
 
-    fn handle_pos(&self, handle: Handle) -> (f32, f32) {
+    fn handle_pos(&self, handle: Handle, zoom: f32) -> (f32, f32) {
         let (ux, uy) = handle.anchor();
         let m = self.matrix();
         let r = self.base;
@@ -160,7 +168,11 @@ impl Session {
             let top = m.apply(r.left as f32 + r.width() as f32 * 0.5, r.top as f32);
             let (dx, dy) = (top.0 - sx, top.1 - sy);
             let len = (dx * dx + dy * dy).sqrt().max(1e-3);
-            (top.0 + dx / len * 24.0, top.1 + dy / len * 24.0)
+            // 24 *screen* pixels, like the hit radius below. As a flat
+            // document offset the handle sat 3 px away at 800% zoom and
+            // 240 px away at 10%.
+            let reach = 24.0 / zoom.max(0.01);
+            (top.0 + dx / len * reach, top.1 + dy / len * reach)
         } else {
             (sx, sy)
         }
@@ -170,7 +182,7 @@ impl Session {
         // Handles are ~9 screen pixels; convert to document units.
         let r = (9.0 / zoom.max(0.01)).max(1.0);
         for handle in [Handle::Rotate].into_iter().chain(Handle::ALL) {
-            let (hx, hy) = self.handle_pos(handle);
+            let (hx, hy) = self.handle_pos(handle, zoom);
             if (x - hx).abs() <= r && (y - hy).abs() <= r {
                 return Some(handle);
             }
@@ -319,6 +331,7 @@ impl TransformTool {
             rotation: 0.0,
             offset: (0.0, 0.0),
             drag: None,
+            pivot_anchor: (0.5, 0.5),
             dirty: false,
         });
     }
@@ -405,6 +418,15 @@ impl ToolPlugin for TransformTool {
         let zoom = ctx.state.zoom;
         if let Some(session) = &mut self.session {
             if let Some(handle) = session.hit(input.x, input.y, zoom) {
+                // Pin the handle opposite the one being dragged, so the
+                // dragged one lands under the cursor. Alt asks for the
+                // centre, which is Photoshop's scale-from-centre.
+                let (ax, ay) = handle.anchor();
+                session.pivot_anchor = if input.modifiers.alt {
+                    (0.5, 0.5)
+                } else {
+                    (1.0 - ax, 1.0 - ay)
+                };
                 session.drag = Some(Drag {
                     handle,
                     start: (input.x, input.y),
@@ -466,7 +488,34 @@ impl ToolPlugin for TransformTool {
                     sx = drag.start_scale.0 * f;
                     sy = drag.start_scale.1 * f;
                 }
-                session.scale = (sx, sy);
+                // A handle dragged onto the pivot gives scale 0, whose
+                // matrix has no inverse: `transform_tiles` then returns an
+                // empty map and the layer vanishes. A later Shift-drag
+                // divides by that 0 and produces NaN, which `det.abs() <
+                // 1e-9` does not catch, so the NaN matrix saturates the
+                // bounds to empty and the commit records the empty result.
+                // Keep at least one pixel on each axis. Scale 0 has no
+                // invertible matrix, so `transform_tiles` returned an
+                // empty map and the layer vanished; a later Shift-drag
+                // then divided by that 0 and produced NaN, which
+                // `det.abs() < 1e-9` does not catch, so the NaN matrix
+                // saturated the bounds to empty and the commit recorded
+                // the empty result.
+                let clamp = |v: f32, start: f32, extent: i32| {
+                    if !v.is_finite() {
+                        return start;
+                    }
+                    let min = 1.0 / extent.max(1) as f32;
+                    if v.abs() < min {
+                        min.copysign(if v == 0.0 { 1.0 } else { v })
+                    } else {
+                        v
+                    }
+                };
+                session.scale = (
+                    clamp(sx, drag.start_scale.0, session.base.width()),
+                    clamp(sy, drag.start_scale.1, session.base.height()),
+                );
             }
         }
         session.dirty = true;
@@ -498,8 +547,9 @@ impl ToolPlugin for TransformTool {
             .inflated(session.base.width().max(session.base.height()));
         if session.mode == TransformMode::Selection {
             // Only the mask moves; the pixels are untouched, so this is one
-            // selection edit rather than a tile rewrite.
-            session.restore(ctx.doc);
+            // selection edit rather than a tile rewrite. (`restore` already
+            // ran above; calling it twice was harmless but obscured the
+            // control flow.)
             let canvas = ctx.doc.canvas_rect();
             let matrix = session.matrix();
             let base = session.original_selection.clone();
@@ -572,7 +622,7 @@ impl ToolPlugin for TransformTool {
         self.on_commit(ctx);
     }
 
-    fn overlays(&self, _doc: &Document, _state: &EditorState) -> Vec<Overlay> {
+    fn overlays(&self, _doc: &Document, state: &EditorState) -> Vec<Overlay> {
         let Some(session) = &self.session else {
             return Vec::new();
         };
@@ -585,7 +635,7 @@ impl ToolPlugin for TransformTool {
         }
         let r = 3.0;
         for handle in Handle::ALL {
-            let (x, y) = session.handle_pos(handle);
+            let (x, y) = session.handle_pos(handle, state.zoom);
             out.push(Overlay::Rect(IntRect::new(
                 (x - r) as i32,
                 (y - r) as i32,
@@ -593,7 +643,7 @@ impl ToolPlugin for TransformTool {
                 (y + r) as i32,
             )));
         }
-        let (rx, ry) = session.handle_pos(Handle::Rotate);
+        let (rx, ry) = session.handle_pos(Handle::Rotate, state.zoom);
         out.push(Overlay::Circle {
             cx: rx,
             cy: ry,
@@ -1367,7 +1417,7 @@ mod tests {
         };
         tool.on_activate(&mut ctx);
         let session = tool.session.as_ref().unwrap();
-        let (hx, hy) = session.handle_pos(Handle::Rotate);
+        let (hx, hy) = session.handle_pos(Handle::Rotate, 1.0);
         let (cx, cy) = session.pivot();
         tool.on_pointer_down(&mut ctx, input(hx, hy));
         // Drag the rotate handle a quarter turn around the centre.
@@ -1472,5 +1522,81 @@ mod tests {
             "mask bounds must be inside the new canvas: {:?}",
             mask.bounds
         );
+    }
+
+    #[test]
+    fn a_scale_handle_follows_the_cursor() {
+        // Scaling pivoted on the box centre, so each edge moved half the
+        // drag: the handle lagged the cursor by half, and every scale
+        // behaved like an Alt-drag with no way to ask for the ordinary
+        // one. Dragging the right handle should pin the left edge.
+        let mut doc = doc_with_square();
+        let mut state = EditorState {
+            zoom: 1.0,
+            ..EditorState::default()
+        };
+        let mut tool = TransformTool::default();
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut doc,
+                state: &mut state,
+            };
+            tool.on_activate(&mut ctx);
+            let base = tool.session.as_ref().unwrap().base;
+            // Grab the right-middle handle and pull it 40 px right.
+            let (hx, hy) = (
+                base.right as f32,
+                base.top as f32 + base.height() as f32 / 2.0,
+            );
+            tool.on_pointer_down(&mut ctx, input(hx, hy));
+            tool.on_pointer_move(&mut ctx, input(hx + 40.0, hy));
+
+            let session = tool.session.as_ref().unwrap();
+            let m = session.matrix();
+            let moved = m.transform_bounds(base);
+            assert_eq!(
+                moved.left, base.left,
+                "the opposite edge must stay pinned: {moved:?} vs {base:?}"
+            );
+            assert!(
+                (moved.right - (base.right + 40)).abs() <= 1,
+                "the dragged edge must land under the cursor: {moved:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_degenerate_scale_cannot_erase_the_layer() {
+        // Dragging a handle onto the pivot gave scale 0, whose matrix has
+        // no inverse, so the layer vanished and the commit recorded the
+        // empty result.
+        let mut doc = doc_with_square();
+        let mut state = EditorState {
+            zoom: 1.0,
+            ..EditorState::default()
+        };
+        let mut tool = TransformTool::default();
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut doc,
+                state: &mut state,
+            };
+            tool.on_activate(&mut ctx);
+            let base = tool.session.as_ref().unwrap().base;
+            let (hx, hy) = (
+                base.right as f32,
+                base.top as f32 + base.height() as f32 / 2.0,
+            );
+            tool.on_pointer_down(&mut ctx, input(hx, hy));
+            // Drag the right edge all the way onto the pinned left edge.
+            tool.on_pointer_move(&mut ctx, input(base.left as f32, hy));
+            tool.on_commit(&mut ctx);
+        }
+        let content = doc.tree.layers[0]
+            .as_raster()
+            .unwrap()
+            .tiles
+            .content_bounds();
+        assert!(!content.is_empty(), "the layer must not be erased");
     }
 }

--- a/plugins/tools-transform/src/lib.rs
+++ b/plugins/tools-transform/src/lib.rs
@@ -154,6 +154,13 @@ impl Session {
         ]
     }
 
+    /// Where a handle sits, in document space.
+    ///
+    /// `zoom` only matters to the rotate handle, whose standoff from the
+    /// box is a fixed number of *screen* pixels: it was a fixed 24
+    /// document units, so at 800% it sat three screen pixels off the box
+    /// and at 10% it floated 240 screen pixels away, while `hit` had
+    /// always divided its radius by the zoom.
     fn handle_pos(&self, handle: Handle, zoom: f32) -> (f32, f32) {
         let (ux, uy) = handle.anchor();
         let m = self.matrix();
@@ -550,6 +557,9 @@ impl ToolPlugin for TransformTool {
             // selection edit rather than a tile rewrite. (`restore` already
             // ran above; calling it twice was harmless but obscured the
             // control flow.)
+            // selection edit rather than a tile rewrite. (`restore` above
+            // has already run; calling it a second time here was
+            // idempotent but obscured the flow.)
             let canvas = ctx.doc.canvas_rect();
             let matrix = session.matrix();
             let base = session.original_selection.clone();
@@ -636,11 +646,15 @@ impl ToolPlugin for TransformTool {
         let r = 3.0;
         for handle in Handle::ALL {
             let (x, y) = session.handle_pos(handle, state.zoom);
+            // `as i32` truncates toward zero, so a handle shifts by a
+            // pixel once its coordinate goes negative -- on the
+            // off-canvas side, where the preview then disagrees with the
+            // floor/ceil used to commit the same gesture.
             out.push(Overlay::Rect(IntRect::new(
-                (x - r) as i32,
-                (y - r) as i32,
-                (x + r) as i32,
-                (y + r) as i32,
+                (x - r).floor() as i32,
+                (y - r).floor() as i32,
+                (x + r).ceil() as i32,
+                (y + r).ceil() as i32,
             )));
         }
         let (rx, ry) = session.handle_pos(Handle::Rotate, state.zoom);
@@ -1671,5 +1685,53 @@ mod tests {
         // The document was 200x200, so everything halves.
         assert_eq!(doc.guides[0].position, 50.0);
         assert_eq!(doc.notes[0].at, (50.0, 30.0));
+    }
+    /// The rotate handle's standoff is a fixed number of *screen* pixels.
+    /// It was a fixed 24 document units, so at 800% it sat three screen
+    /// pixels off the box and at 10% it floated 240 away -- while `hit`
+    /// had always divided its radius by the zoom.
+    #[test]
+    fn the_rotate_handle_keeps_its_screen_distance() {
+        let mut doc = doc_with_square();
+        let mut state = EditorState::default();
+        let mut tool = TransformTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        tool.on_activate(&mut ctx);
+        let session = tool.session.as_ref().unwrap();
+        let top = session.base.top as f32;
+
+        for zoom in [0.1f32, 1.0, 8.0] {
+            let (_, hy) = session.handle_pos(Handle::Rotate, zoom);
+            let screen = (top - hy) * zoom;
+            assert!(
+                (screen - 24.0).abs() < 0.5,
+                "at {zoom}x the handle stood {screen} screen pixels off the box"
+            );
+        }
+    }
+
+    /// And it stays grabbable at every zoom, which is the point.
+    #[test]
+    fn the_rotate_handle_is_hittable_at_any_zoom() {
+        let mut doc = doc_with_square();
+        let mut state = EditorState::default();
+        let mut tool = TransformTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        tool.on_activate(&mut ctx);
+        let session = tool.session.as_ref().unwrap();
+        for zoom in [0.1f32, 1.0, 8.0] {
+            let (hx, hy) = session.handle_pos(Handle::Rotate, zoom);
+            assert_eq!(
+                session.hit(hx, hy, zoom),
+                Some(Handle::Rotate),
+                "at {zoom}x"
+            );
+        }
     }
 }

--- a/plugins/tools-transform/src/lib.rs
+++ b/plugins/tools-transform/src/lib.rs
@@ -532,8 +532,29 @@ impl ToolPlugin for TransformTool {
                 clip,
             ),
         };
+        // The mask moves with the artwork it clips. Leaving it behind cut
+        // the transformed layer along the mask's old outline.
+        let moved_mask = ctx
+            .doc
+            .tree
+            .find(session.layer)
+            .and_then(|l| l.mask.as_ref())
+            .map(|mask| {
+                let mut next = mask.clone();
+                next.tiles = schist_core::resample::transform_mask(
+                    &mask.tiles,
+                    mask.default_value,
+                    &session.matrix(),
+                    clip,
+                );
+                next.bounds = session.matrix().transform_bounds(mask.bounds);
+                next
+            });
         let mut edit = ctx.doc.begin_edit("Free Transform");
         edit.replace_layer_tiles(session.layer, tiles);
+        if let Some(mask) = moved_mask {
+            edit.set_mask(session.layer, Some(mask));
+        }
         if let Some(so) = smart {
             edit.set_smart_object(session.layer, Some(Box::new(so)));
         }
@@ -773,6 +794,10 @@ pub fn resize_image(doc: &mut Document, width: u32, height: u32, filter: Filter)
         );
         edit.replace_layer_tiles(id, tiles);
     }
+    // Masks scale with the pixels they clip. Leaving them at the old size
+    // meant halving a document clipped every masked layer to a quarter of
+    // its intended area.
+    rescale_masks(&mut edit, from, (width, height));
     edit.set_canvas_size(width, height);
     edit.commit();
 }
@@ -1046,6 +1071,33 @@ fn double_plane(src: &[f32], w: usize, h: usize) -> Vec<f32> {
         }
     }
     out
+}
+
+/// Rescale every layer mask by the same factor as the canvas.
+fn rescale_masks(edit: &mut schist_core::EditBuilder, from: (u32, u32), to: (u32, u32)) {
+    if from.0 == 0 || from.1 == 0 {
+        return;
+    }
+    let m = schist_core::Affine::scale(to.0 as f32 / from.0 as f32, to.1 as f32 / from.1 as f32);
+    let clip = IntRect::from_size(to.0, to.1);
+    let masked: Vec<_> = edit
+        .doc()
+        .tree
+        .iter()
+        .filter(|l| l.mask.is_some())
+        .map(|l| l.id)
+        .collect();
+    for id in masked {
+        let Some(mask) = edit.doc().tree.find(id).and_then(|l| l.mask.as_ref()) else {
+            continue;
+        };
+        let tiles =
+            schist_core::resample::transform_mask(&mask.tiles, mask.default_value, &m, clip);
+        let mut next = mask.clone();
+        next.tiles = tiles;
+        next.bounds = m.transform_bounds(mask.bounds).intersect(&clip);
+        edit.set_mask(id, Some(next));
+    }
 }
 
 /// Change the canvas without rescaling pixels (Canvas Size). `anchor` is the
@@ -1374,5 +1426,51 @@ mod tests {
         assert_eq!(px(&doc, 130, 130), [0, 128, 255, 255]);
         doc.undo();
         assert_eq!(px(&doc, 30, 30), [0, 128, 255, 255]);
+    }
+
+    #[test]
+    fn image_size_rescales_layer_masks_with_the_pixels() {
+        // The mask stayed at its old size while the artwork halved, so a
+        // masked layer was clipped to a quarter of its intended area.
+        use schist_core::LayerMask;
+        let mut doc = doc_with_square();
+        let id = doc.tree.layers[0].id;
+        {
+            let layer = doc.tree.find_mut(id).unwrap();
+            let mut mask = LayerMask::new_revealing();
+            // Reveal the left half of the document.
+            for coord in schist_core::TileCoord::covering(&IntRect::from_xywh(0, 0, 100, 200)) {
+                let trect = coord.rect();
+                let buf = mask.tiles.get_mut_or_insert(coord);
+                for ly in 0..schist_core::TILE_SIZE {
+                    for lx in 0..schist_core::TILE_SIZE {
+                        if trect.left + lx < 100 {
+                            buf[(ly * schist_core::TILE_SIZE + lx) as usize] = 255;
+                        }
+                    }
+                }
+            }
+            mask.bounds = IntRect::from_xywh(0, 0, 100, 200);
+            layer.mask = Some(mask);
+        }
+
+        resize_image(&mut doc, 100, 100, Filter::Bilinear);
+
+        let mask = doc.tree.find(id).unwrap().mask.as_ref().expect("mask kept");
+        // The revealed half must have halved with the canvas: covered at
+        // x=40, clear at x=60.
+        assert!(
+            mask.tiles.value(40, 50) > 200,
+            "left half should stay revealed"
+        );
+        assert!(
+            mask.tiles.value(60, 50) < 55,
+            "right half should stay hidden"
+        );
+        assert!(
+            mask.bounds.right <= 100,
+            "mask bounds must be inside the new canvas: {:?}",
+            mask.bounds
+        );
     }
 }

--- a/plugins/tools-transform/src/lib.rs
+++ b/plugins/tools-transform/src/lib.rs
@@ -817,6 +817,11 @@ pub fn crop_to(doc: &mut Document, rect: IntRect) {
     for id in ids {
         edit.translate_layer(id, -rect.left, -rect.top);
     }
+    // Guides, artboards, slices, notes, counts and stored paths move with
+    // the pixels; cropping 100 px off the left used to leave every one of
+    // them 100 px out of place.
+    let (ox, oy) = (rect.left as f32, rect.top as f32);
+    edit.map_geometry(|x, y| (x - ox, y - oy));
     edit.set_canvas_size(rect.width() as u32, rect.height() as u32);
     edit.change_selection(|sel, _| sel.deselect());
     edit.commit();
@@ -848,6 +853,12 @@ pub fn resize_image(doc: &mut Document, width: u32, height: u32, filter: Filter)
     // meant halving a document clipped every masked layer to a quarter of
     // its intended area.
     rescale_masks(&mut edit, from, (width, height));
+    // Guides, artboards, slices, notes, counts and paths scale with the
+    // canvas; halving the image used to leave them at full-size
+    // coordinates.
+    let sx = width as f32 / from.0.max(1) as f32;
+    let sy = height as f32 / from.1.max(1) as f32;
+    edit.map_geometry(|x, y| (x * sx, y * sy));
     edit.set_canvas_size(width, height);
     edit.commit();
 }
@@ -1163,6 +1174,7 @@ pub fn resize_canvas(doc: &mut Document, width: u32, height: u32, anchor: (f32, 
     for id in ids {
         edit.translate_layer(id, dx, dy);
     }
+    edit.map_geometry(|x, y| (x + dx as f32, y + dy as f32));
     edit.set_canvas_size(width, height);
     edit.commit();
 }
@@ -1598,5 +1610,66 @@ mod tests {
             .tiles
             .content_bounds();
         assert!(!content.is_empty(), "the layer must not be erased");
+    }
+
+    /// A document carrying one of everything that should move with the
+    /// canvas.
+    fn doc_with_geometry() -> Document {
+        let mut doc = doc_with_square();
+        doc.guides.push(schist_core::Guide {
+            horizontal: false,
+            position: 100.0,
+        });
+        doc.guides.push(schist_core::Guide {
+            horizontal: true,
+            position: 60.0,
+        });
+        doc.artboards.push(schist_core::annotate::Artboard {
+            name: "a".into(),
+            rect: IntRect::from_xywh(100, 100, 40, 40),
+        });
+        doc.notes.push(schist_core::annotate::Note {
+            at: (100.0, 60.0),
+            author: "me".into(),
+            text: "here".into(),
+        });
+        doc
+    }
+
+    #[test]
+    fn cropping_moves_guides_notes_and_artboards_with_the_pixels() {
+        // Crop 40 px off the left and 20 off the top: everything
+        // document-level shifts by the same amount. It used to stay put,
+        // so every guide and note was that far out of place.
+        let mut doc = doc_with_geometry();
+        crop_to(&mut doc, IntRect::from_xywh(40, 20, 100, 100));
+
+        assert_eq!(doc.guides[0].position, 60.0, "vertical guide");
+        assert_eq!(doc.guides[1].position, 40.0, "horizontal guide");
+        assert_eq!(doc.artboards[0].rect.left, 60);
+        assert_eq!(doc.artboards[0].rect.top, 80);
+        assert_eq!(doc.notes[0].at, (60.0, 40.0));
+    }
+
+    #[test]
+    fn undo_puts_the_geometry_back_with_the_canvas() {
+        // The reason this has to ride inside the edit: undoing the canvas
+        // while leaving the geometry moved is worse than either state.
+        let mut doc = doc_with_geometry();
+        let before = doc.geometry();
+        crop_to(&mut doc, IntRect::from_xywh(40, 20, 100, 100));
+        assert_ne!(doc.geometry(), before, "crop moved it");
+
+        doc.undo();
+        assert_eq!(doc.geometry(), before, "undo must move it back");
+    }
+
+    #[test]
+    fn image_size_scales_the_geometry_too() {
+        let mut doc = doc_with_geometry();
+        resize_image(&mut doc, 100, 100, Filter::Bilinear);
+        // The document was 200x200, so everything halves.
+        assert_eq!(doc.guides[0].position, 50.0);
+        assert_eq!(doc.notes[0].at, (50.0, 30.0));
     }
 }

--- a/plugins/tools-transform/src/lib.rs
+++ b/plugins/tools-transform/src/lib.rs
@@ -90,6 +90,71 @@ pub enum TransformMode {
     Selection,
 }
 
+/// Split `tiles` into the selected pixels and everything else.
+///
+/// The floating half carries the selection's coverage in its alpha, and
+/// the residue has the same coverage taken out of it, so laying one back
+/// over the other reproduces the layer exactly while nothing has moved.
+fn lift(
+    tiles: &TileMap,
+    sel: &schist_core::Selection,
+    depth: schist_color::Depth,
+) -> (TileMap, TileMap) {
+    use schist_core::{TileCoord, TILE_PIXELS, TILE_SIZE};
+    let mut floating = TileMap::new();
+    let mut residue = tiles.clone();
+    let region = sel.bounds().intersect(&tiles.tile_bounds());
+    for coord in TileCoord::covering(&region) {
+        let Some(src) = tiles.get(coord).cloned() else {
+            continue;
+        };
+        let trect = coord.rect();
+        let mut cut = false;
+        let mut kept = (*src).clone();
+        let mut moved = schist_core::TileBuf::new(depth);
+        for i in 0..TILE_PIXELS {
+            let x = trect.left + (i as i32 % TILE_SIZE);
+            let y = trect.top + (i as i32 / TILE_SIZE);
+            let c = sel.coverage(x, y) as f32 / 255.0;
+            if c <= 0.0 {
+                continue;
+            }
+            cut = true;
+            let px = src.get(i);
+            moved.set(i, schist_color::Rgba { a: px.a * c, ..px });
+            kept.set(
+                i,
+                schist_color::Rgba {
+                    a: px.a * (1.0 - c),
+                    ..px
+                },
+            );
+        }
+        if cut {
+            floating.insert(coord, std::sync::Arc::new(moved));
+            residue.insert(coord, std::sync::Arc::new(kept));
+        }
+    }
+    (floating, residue)
+}
+
+/// `top` composited over `bottom`, tile by tile.
+fn over_tiles(bottom: &TileMap, top: &TileMap, depth: schist_color::Depth) -> TileMap {
+    use schist_core::TILE_PIXELS;
+    let mut out = bottom.clone();
+    for (coord, tile) in top.iter() {
+        let dst = out.get_mut_or_insert(*coord, depth);
+        for i in 0..TILE_PIXELS {
+            let src = tile.get(i);
+            if src.a <= 0.0 {
+                continue;
+            }
+            dst.set(i, src.over(dst.get(i)));
+        }
+    }
+    out
+}
+
 struct Session {
     mode: TransformMode,
     layer: LayerId,
@@ -97,6 +162,11 @@ struct Session {
     original: TileMap,
     /// Untransformed selection, for `TransformMode::Selection`.
     original_selection: schist_core::Selection,
+    /// With a selection up, Free Transform moves only what is selected:
+    /// the pixels are lifted off the layer and this holds the two halves,
+    /// the floating piece and what stays behind. `None` means the whole
+    /// layer moves.
+    lifted: Option<(TileMap, TileMap)>,
     /// Bounds of `original`, the box the handles frame.
     base: IntRect,
     /// Scale / rotation / skew accumulated so far.
@@ -130,6 +200,49 @@ impl Session {
             self.base.left as f32 + self.base.width() as f32 * self.pivot_anchor.0,
             self.base.top as f32 + self.base.height() as f32 * self.pivot_anchor.1,
         )
+    }
+
+    /// Move the pivot without moving the pixels.
+    ///
+    /// The matrix scales and rotates *about the pivot*, so changing the
+    /// pivot re-interprets everything accumulated so far. Compensating
+    /// the offset keeps the current matrix identical; without it, the
+    /// second press of a session jumped the layer by half its width.
+    ///
+    /// `offset` is composed ahead of the scale and rotation, so it lives
+    /// in pre-transform space: the correction has to go back through the
+    /// inverse linear map, or it lands scaled by however much the layer
+    /// has been scaled.
+    fn repivot(&mut self, anchor: (f32, f32)) {
+        if anchor == self.pivot_anchor {
+            return;
+        }
+        let before = self.matrix();
+        self.pivot_anchor = anchor;
+        let after = self.matrix();
+        // Both matrices share a linear part, so matching them at any one
+        // point matches them everywhere; the box centre will do.
+        let (cx, cy) = (
+            self.base.left as f32 + self.base.width() as f32 * 0.5,
+            self.base.top as f32 + self.base.height() as f32 * 0.5,
+        );
+        let (bx, by) = before.apply(cx, cy);
+        let (nx, ny) = after.apply(cx, cy);
+        let (dx, dy) = (bx - nx, by - ny);
+        // Undo the rotation, then the scale.
+        let (sin, cos) = (-self.rotation).sin_cos();
+        let (rx, ry) = (dx * cos - dy * sin, dx * sin + dy * cos);
+        let sx = if self.scale.0.abs() < 1e-6 {
+            1.0
+        } else {
+            self.scale.0
+        };
+        let sy = if self.scale.1.abs() < 1e-6 {
+            1.0
+        } else {
+            self.scale.1
+        };
+        self.offset = (self.offset.0 + rx / sx, self.offset.1 + ry / sy);
     }
 
     /// Current matrix: scale, then rotate, both about the pivot, then
@@ -214,13 +327,18 @@ impl Session {
                 * self.scale.0.abs().max(self.scale.1.abs())) as i32,
         );
         let depth = doc.depth;
-        let tiles = schist_core::resample::transform_tiles(
-            &self.original,
-            &self.matrix(),
-            depth,
-            filter,
-            clip,
-        );
+        let source = match &self.lifted {
+            Some((floating, _)) => floating,
+            None => &self.original,
+        };
+        let tiles =
+            schist_core::resample::transform_tiles(source, &self.matrix(), depth, filter, clip);
+        // What was not selected never moved: put the floating piece back
+        // down on top of it.
+        let tiles = match &self.lifted {
+            Some((_, residue)) => over_tiles(residue, &tiles, depth),
+            None => tiles,
+        };
         let before = doc
             .tree
             .find(self.layer)
@@ -320,10 +438,20 @@ impl TransformTool {
         let LayerKind::Raster(raster) = &layer.kind else {
             return;
         };
-        let base = match self.mode {
-            TransformMode::Layer => raster.tiles.content_bounds(),
+        // Free Transform used to move the whole layer whatever was
+        // selected. With a selection up it moves only the selected
+        // pixels, as every other editor does.
+        // A smart object re-renders from its own source, so there is no
+        // half of it to lift: it transforms whole, as before.
+        let selected = self.mode == TransformMode::Layer
+            && layer.smart.is_none()
+            && !ctx.doc.selection.is_empty();
+        let lifted = selected.then(|| lift(&raster.tiles, &ctx.doc.selection, ctx.doc.depth));
+        let base = match (&lifted, self.mode) {
+            (Some((floating, _)), _) => floating.content_bounds(),
+            (None, TransformMode::Layer) => raster.tiles.content_bounds(),
             // The handles frame the selection, not the artwork.
-            TransformMode::Selection => ctx.doc.selection.bounds(),
+            (None, TransformMode::Selection) => ctx.doc.selection.bounds(),
         };
         if base.is_empty() {
             return;
@@ -333,6 +461,7 @@ impl TransformTool {
             layer: id,
             original: raster.tiles.clone(),
             original_selection: ctx.doc.selection.clone(),
+            lifted,
             base,
             scale: (1.0, 1.0),
             rotation: 0.0,
@@ -428,12 +557,18 @@ impl ToolPlugin for TransformTool {
                 // Pin the handle opposite the one being dragged, so the
                 // dragged one lands under the cursor. Alt asks for the
                 // centre, which is Photoshop's scale-from-centre.
+                // Moving the pivot re-interprets the transform already
+                // accumulated about the old one, so the offset has to
+                // absorb the difference. Without this, scaling with one
+                // handle and then clicking to move jumped the layer by
+                // half its width on the second press.
                 let (ax, ay) = handle.anchor();
-                session.pivot_anchor = if input.modifiers.alt {
+                let next = if input.modifiers.alt {
                     (0.5, 0.5)
                 } else {
                     (1.0 - ax, 1.0 - ay)
                 };
+                session.repivot(next);
                 session.drag = Some(Drag {
                     handle,
                     start: (input.x, input.y),
@@ -470,20 +605,35 @@ impl ToolPlugin for TransformTool {
                 session.rotation = drag.start_rotation + delta;
             }
             _ => {
-                // Scale about the opposite edge/corner: distance from the
-                // pivot along each axis grows with the drag.
-                let half_w = (session.base.width() as f32 / 2.0).max(1.0);
-                let half_h = (session.base.height() as f32 / 2.0).max(1.0);
+                // How far the handle sits from the pivot is what the
+                // scale multiplies, so it also sets how fast the handle
+                // follows the cursor. Deriving it from the live pivot
+                // covers Alt too: scale-from-centre halves the arm, and
+                // the fixed divisor left that handle moving at half the
+                // cursor's speed.
                 let (ax, ay) = handle.anchor();
-                let dir_x = (ax - 0.5) * 2.0;
-                let dir_y = (ay - 0.5) * 2.0;
+                let (pax, pay) = session.pivot_anchor;
+                // At least a pixel of arm, or a degenerate layer divides
+                // by ~0 and the scale explodes.
+                let arm = |a: f32, p: f32, extent: i32| -> f32 {
+                    let v = (a - p) * extent as f32;
+                    if v.abs() < 1.0 {
+                        if v < 0.0 {
+                            -1.0
+                        } else {
+                            1.0
+                        }
+                    } else {
+                        v
+                    }
+                };
                 let mut sx = drag.start_scale.0;
                 let mut sy = drag.start_scale.1;
-                if handle.scales_x() && dir_x != 0.0 {
-                    sx = drag.start_scale.0 + dx * dir_x / half_w / 2.0;
+                if handle.scales_x() && ax != pax {
+                    sx = drag.start_scale.0 + dx / arm(ax, pax, session.base.width());
                 }
-                if handle.scales_y() && dir_y != 0.0 {
-                    sy = drag.start_scale.1 + dy * dir_y / half_h / 2.0;
+                if handle.scales_y() && ay != pay {
+                    sy = drag.start_scale.1 + dy / arm(ay, pay, session.base.height());
                 }
                 if input.modifiers.shift && handle.scales_x() && handle.scales_y() {
                     // Constrain proportions from the larger change.
@@ -500,14 +650,8 @@ impl ToolPlugin for TransformTool {
                 // empty map and the layer vanishes. A later Shift-drag
                 // divides by that 0 and produces NaN, which `det.abs() <
                 // 1e-9` does not catch, so the NaN matrix saturates the
-                // bounds to empty and the commit records the empty result.
-                // Keep at least one pixel on each axis. Scale 0 has no
-                // invertible matrix, so `transform_tiles` returned an
-                // empty map and the layer vanished; a later Shift-drag
-                // then divided by that 0 and produced NaN, which
-                // `det.abs() < 1e-9` does not catch, so the NaN matrix
-                // saturated the bounds to empty and the commit recorded
-                // the empty result.
+                // bounds to empty and the commit records the empty
+                // result. Keep at least one pixel on each axis.
                 let clamp = |v: f32, start: f32, extent: i32| {
                     if !v.is_finite() {
                         return start;
@@ -553,13 +697,10 @@ impl ToolPlugin for TransformTool {
             .canvas_rect()
             .inflated(session.base.width().max(session.base.height()));
         if session.mode == TransformMode::Selection {
-            // Only the mask moves; the pixels are untouched, so this is one
-            // selection edit rather than a tile rewrite. (`restore` already
-            // ran above; calling it twice was harmless but obscured the
-            // control flow.)
-            // selection edit rather than a tile rewrite. (`restore` above
-            // has already run; calling it a second time here was
-            // idempotent but obscured the flow.)
+            // Only the mask moves; the pixels are untouched, so this is
+            // one selection edit rather than a tile rewrite. (`restore`
+            // already ran above; calling it twice was harmless but
+            // obscured the control flow.)
             let canvas = ctx.doc.canvas_rect();
             let matrix = session.matrix();
             let base = session.original_selection.clone();
@@ -582,34 +723,48 @@ impl ToolPlugin for TransformTool {
                 next.apply(&session.matrix());
                 next
             });
+        let source = match &session.lifted {
+            Some((floating, _)) => floating,
+            None => &session.original,
+        };
         let tiles = match &smart {
             Some(so) => so.render(depth, clip),
             None => schist_core::resample::transform_tiles(
-                &session.original,
+                source,
                 &session.matrix(),
                 depth,
                 ctx.state.resample,
                 clip,
             ),
         };
+        // Only the selected pixels moved: they go back down over the ones
+        // that stayed.
+        let tiles = match &session.lifted {
+            Some((_, residue)) => over_tiles(residue, &tiles, depth),
+            None => tiles,
+        };
         // The mask moves with the artwork it clips. Leaving it behind cut
-        // the transformed layer along the mask's old outline.
+        // the transformed layer along the mask's old outline. When only
+        // the selected pixels moved the mask stays put: it still clips
+        // the same layer.
         let moved_mask = ctx
             .doc
             .tree
             .find(session.layer)
+            .filter(|_| session.lifted.is_none())
             .and_then(|l| l.mask.as_ref())
             .map(|mask| {
                 let mut next = mask.clone();
-                next.tiles = schist_core::resample::transform_mask(
-                    &mask.tiles,
-                    mask.default_value,
-                    &session.matrix(),
-                    clip,
-                );
+                next.tiles = schist_core::resample::transform_mask(mask, &session.matrix(), clip);
                 next.bounds = session.matrix().transform_bounds(mask.bounds);
                 next
             });
+        let canvas = ctx.doc.canvas_rect();
+        let moved_selection = session.lifted.is_some().then(|| {
+            session
+                .original_selection
+                .transformed(&session.matrix(), canvas)
+        });
         let mut edit = ctx.doc.begin_edit("Free Transform");
         edit.replace_layer_tiles(session.layer, tiles);
         if let Some(mask) = moved_mask {
@@ -617,6 +772,10 @@ impl ToolPlugin for TransformTool {
         }
         if let Some(so) = smart {
             edit.set_smart_object(session.layer, Some(Box::new(so)));
+        }
+        // The marching ants follow the pixels they were holding.
+        if let Some(sel) = moved_selection {
+            edit.change_selection(|s, _| *s = sel);
         }
         edit.commit();
     }
@@ -1166,8 +1325,7 @@ fn rescale_masks(edit: &mut schist_core::EditBuilder, from: (u32, u32), to: (u32
         let Some(mask) = edit.doc().tree.find(id).and_then(|l| l.mask.as_ref()) else {
             continue;
         };
-        let tiles =
-            schist_core::resample::transform_mask(&mask.tiles, mask.default_value, &m, clip);
+        let tiles = schist_core::resample::transform_mask(mask, &m, clip);
         let mut next = mask.clone();
         next.tiles = tiles;
         next.bounds = m.transform_bounds(mask.bounds).intersect(&clip);
@@ -1244,6 +1402,52 @@ mod tests {
             .tiles
             .pixel(x, y)
             .to_u8()
+    }
+
+    #[test]
+    fn free_transform_moves_only_the_selected_pixels() {
+        // It transformed the whole layer whatever was selected, so a
+        // selection was a suggestion rather than a boundary.
+        use schist_core::SelectOp;
+        let mut doc = doc_with_square();
+        doc.active_layer = Some(doc.tree.layers[0].id);
+        // The left half of the 20..60 square.
+        doc.selection
+            .select_rect(IntRect::from_xywh(20, 20, 20, 40), SelectOp::Replace);
+        let mut state = EditorState {
+            zoom: 1.0,
+            ..EditorState::default()
+        };
+        let mut tool = TransformTool::default();
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut doc,
+                state: &mut state,
+            };
+            tool.on_activate(&mut ctx);
+            // The handles frame the selected pixels, not the layer.
+            let base = tool.session.as_ref().unwrap().base;
+            assert!(base.right <= 41, "the box frames the selection: {base:?}");
+            // Drag the middle of the box 100 px right.
+            let (cx, cy) = (
+                base.left as f32 + base.width() as f32 / 2.0,
+                base.top as f32 + base.height() as f32 / 2.0,
+            );
+            tool.on_pointer_down(&mut ctx, input(cx, cy));
+            tool.on_pointer_move(&mut ctx, input(cx + 100.0, cy));
+            tool.on_pointer_up(&mut ctx, input(cx + 100.0, cy));
+            tool.on_commit(&mut ctx);
+        }
+
+        // The selected half moved...
+        assert_eq!(px(&doc, 30, 40)[3], 0, "the lifted pixels left a hole");
+        assert_eq!(px(&doc, 130, 40), [0, 128, 255, 255]);
+        // ...and the unselected half stayed exactly where it was.
+        assert_eq!(px(&doc, 50, 40), [0, 128, 255, 255]);
+        // One undo puts the layer back.
+        doc.undo();
+        assert_eq!(px(&doc, 30, 40), [0, 128, 255, 255]);
+        assert_eq!(px(&doc, 130, 40)[3], 0);
     }
 
     #[test]
@@ -1514,6 +1718,10 @@ mod tests {
         {
             let layer = doc.tree.find_mut(id).unwrap();
             let mut mask = LayerMask::new_revealing();
+            // Hidden outside `bounds`, so the mask really is "left half
+            // only" rather than "left half plus everything a revealing
+            // default lets through".
+            mask.default_value = 0;
             // Reveal the left half of the document.
             for coord in schist_core::TileCoord::covering(&IntRect::from_xywh(0, 0, 100, 200)) {
                 let trect = coord.rect();
@@ -1548,6 +1756,45 @@ mod tests {
             "mask bounds must be inside the new canvas: {:?}",
             mask.bounds
         );
+    }
+
+    #[test]
+    fn resampling_a_mask_keeps_what_lies_outside_its_bounds() {
+        // A revealing mask is 255 everywhere outside `bounds`. Resampling
+        // read the bare tile map instead, which is 0 out there, so every
+        // Image Size grew a hidden border along the mask's edge.
+        use schist_core::LayerMask;
+        let mut doc = doc_with_square();
+        let id = doc.tree.layers[0].id;
+        {
+            let layer = doc.tree.find_mut(id).unwrap();
+            let mut mask = LayerMask::new_revealing();
+            // A small hidden dot; everything else is revealed by default.
+            let coord = schist_core::TileCoord::containing(10, 10);
+            let trect = coord.rect();
+            let buf = mask.tiles.get_mut_or_insert(coord);
+            for ly in 0..schist_core::TILE_SIZE {
+                for lx in 0..schist_core::TILE_SIZE {
+                    let (x, y) = (trect.left + lx, trect.top + ly);
+                    if (0..20).contains(&x) && (0..20).contains(&y) {
+                        buf[(ly * schist_core::TILE_SIZE + lx) as usize] = 0;
+                    } else {
+                        buf[(ly * schist_core::TILE_SIZE + lx) as usize] = 255;
+                    }
+                }
+            }
+            mask.bounds = IntRect::from_xywh(0, 0, 20, 20);
+            layer.mask = Some(mask);
+        }
+
+        resize_image(&mut doc, 100, 100, Filter::Bilinear);
+
+        let mask = doc.tree.find(id).unwrap().mask.as_ref().expect("mask kept");
+        // The dot halved with the canvas...
+        assert!(mask.value(4, 4) < 55, "the hidden dot survives");
+        // ...and the rest of the layer is still revealed.
+        assert!(mask.value(50, 50) > 200, "outside the dot stays revealed");
+        assert!(mask.value(90, 12) > 200, "including past the old bounds");
     }
 
     #[test]
@@ -1587,6 +1834,61 @@ mod tests {
             assert!(
                 (moved.right - (base.right + 40)).abs() <= 1,
                 "the dragged edge must land under the cursor: {moved:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn an_alt_scale_handle_follows_the_cursor_too() {
+        // Alt scales from the centre, which halves the distance from the
+        // pivot to the handle. The divisor was fixed at the opposite-
+        // corner arm, so the Alt handle moved at half the cursor's speed
+        // -- the very lag this tool was meant to have lost.
+        let mut doc = doc_with_square();
+        let mut state = EditorState {
+            zoom: 1.0,
+            ..EditorState::default()
+        };
+        let mut tool = TransformTool::default();
+        {
+            let mut ctx = ToolCtx {
+                doc: &mut doc,
+                state: &mut state,
+            };
+            tool.on_activate(&mut ctx);
+            let base = tool.session.as_ref().unwrap().base;
+            let (hx, hy) = (
+                base.right as f32,
+                base.top as f32 + base.height() as f32 / 2.0,
+            );
+            let alt = PointerInput {
+                x: hx,
+                y: hy,
+                pressure: 1.0,
+                modifiers: Modifiers {
+                    alt: true,
+                    ..Default::default()
+                },
+            };
+            tool.on_pointer_down(&mut ctx, alt);
+            tool.on_pointer_move(
+                &mut ctx,
+                PointerInput {
+                    x: hx + 40.0,
+                    ..alt
+                },
+            );
+
+            let session = tool.session.as_ref().unwrap();
+            let moved = session.matrix().transform_bounds(base);
+            assert!(
+                (moved.right - (base.right + 40)).abs() <= 1,
+                "the dragged edge must land under the cursor: {moved:?}"
+            );
+            // And the far edge mirrors it, because the centre is pinned.
+            assert!(
+                (moved.left - (base.left - 40)).abs() <= 1,
+                "the opposite edge must mirror: {moved:?}"
             );
         }
     }
@@ -1731,6 +2033,45 @@ mod tests {
                 session.hit(hx, hy, zoom),
                 Some(Handle::Rotate),
                 "at {zoom}x"
+            );
+        }
+    }
+
+    /// The pivot moves per drag, and the matrix scales about it, so a
+    /// second press re-interpreted everything already accumulated: scale
+    /// with the right handle, release, then just click inside the box and
+    /// the layer jumped by half its width.
+    #[test]
+    fn a_second_press_does_not_move_the_layer() {
+        let mut doc = doc_with_square();
+        let mut state = EditorState::default();
+        let mut tool = TransformTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        tool.on_activate(&mut ctx);
+        let (rx, ry) = tool
+            .session
+            .as_ref()
+            .unwrap()
+            .handle_pos(Handle::Right, 1.0);
+
+        // Scale with the right handle.
+        tool.on_pointer_down(&mut ctx, input(rx, ry));
+        tool.on_pointer_move(&mut ctx, input(rx + 60.0, ry));
+        tool.on_pointer_up(&mut ctx, input(rx + 60.0, ry));
+        let after_scale = tool.session.as_ref().unwrap().corners();
+
+        // Press inside the box without moving: nothing should shift.
+        let (cx, cy) = tool.session.as_ref().unwrap().pivot();
+        tool.on_pointer_down(&mut ctx, input(cx, cy));
+        let after_press = tool.session.as_ref().unwrap().corners();
+
+        for (a, b) in after_scale.iter().zip(&after_press) {
+            assert!(
+                (a.0 - b.0).abs() < 0.01 && (a.1 - b.1).abs() < 0.01,
+                "the box jumped on the second press: {a:?} -> {b:?}"
             );
         }
     }

--- a/plugins/tools-transform/src/lib.rs
+++ b/plugins/tools-transform/src/lib.rs
@@ -93,8 +93,9 @@ pub enum TransformMode {
 /// Split `tiles` into the selected pixels and everything else.
 ///
 /// The floating half carries the selection's coverage in its alpha, and
-/// the residue has the same coverage taken out of it, so laying one back
-/// over the other reproduces the layer exactly while nothing has moved.
+/// the residue has the same coverage taken out of it. Hard selections
+/// recombine exactly; feathered edges follow ordinary float compositing
+/// and can retain a slight translucent seam.
 fn lift(
     tiles: &TileMap,
     sel: &schist_core::Selection,
@@ -229,9 +230,9 @@ impl Session {
         let (bx, by) = before.apply(cx, cy);
         let (nx, ny) = after.apply(cx, cy);
         let (dx, dy) = (bx - nx, by - ny);
-        // Undo the rotation, then the scale.
-        let (sin, cos) = (-self.rotation).sin_cos();
-        let (rx, ry) = (dx * cos - dy * sin, dx * sin + dy * cos);
+        // Invert the composed linear map in reverse order: scale, then
+        // rotation. Counter-rotating first is only correct for uniform
+        // scales and made a rotated, one-axis-scaled box jump on repivot.
         let sx = if self.scale.0.abs() < 1e-6 {
             1.0
         } else {
@@ -242,7 +243,10 @@ impl Session {
         } else {
             self.scale.1
         };
-        self.offset = (self.offset.0 + rx / sx, self.offset.1 + ry / sy);
+        let (ux, uy) = (dx / sx, dy / sy);
+        let (sin, cos) = (-self.rotation).sin_cos();
+        let (rx, ry) = (ux * cos - uy * sin, ux * sin + uy * cos);
+        self.offset = (self.offset.0 + rx, self.offset.1 + ry);
     }
 
     /// Current matrix: scale, then rotate, both about the pivot, then
@@ -994,7 +998,7 @@ pub fn crop_to(doc: &mut Document, rect: IntRect) {
     // the pixels; cropping 100 px off the left used to leave every one of
     // them 100 px out of place.
     let (ox, oy) = (rect.left as f32, rect.top as f32);
-    edit.map_geometry(|x, y| (x - ox, y - oy));
+    edit.map_geometry(|x, y| (x - ox, y - oy), false);
     edit.set_canvas_size(rect.width() as u32, rect.height() as u32);
     edit.change_selection(|sel, _| sel.deselect());
     edit.commit();
@@ -1031,7 +1035,7 @@ pub fn resize_image(doc: &mut Document, width: u32, height: u32, filter: Filter)
     // coordinates.
     let sx = width as f32 / from.0.max(1) as f32;
     let sy = height as f32 / from.1.max(1) as f32;
-    edit.map_geometry(|x, y| (x * sx, y * sy));
+    edit.map_geometry(|x, y| (x * sx, y * sy), false);
     edit.set_canvas_size(width, height);
     edit.commit();
 }
@@ -1216,6 +1220,7 @@ pub fn apply_upscaled(doc: &mut Document, up: Upscaled) {
         return;
     }
     let (width, height) = up.to;
+    let from = (doc.width, doc.height);
     let mut edit = doc.begin_edit("Image Size");
     for (id, rgba, (w, h)) in up.layers {
         if edit
@@ -1246,6 +1251,10 @@ pub fn apply_upscaled(doc: &mut Document, up: Upscaled) {
         }
         edit.replace_layer_tiles(id, tiles);
     }
+    rescale_masks(&mut edit, from, (width, height));
+    let sx = width as f32 / from.0.max(1) as f32;
+    let sy = height as f32 / from.1.max(1) as f32;
+    edit.map_geometry(|x, y| (x * sx, y * sy), false);
     edit.set_canvas_size(width, height);
     edit.commit();
 }
@@ -1346,7 +1355,7 @@ pub fn resize_canvas(doc: &mut Document, width: u32, height: u32, anchor: (f32, 
     for id in ids {
         edit.translate_layer(id, dx, dy);
     }
-    edit.map_geometry(|x, y| (x + dx as f32, y + dy as f32));
+    edit.map_geometry(|x, y| (x + dx as f32, y + dy as f32), false);
     edit.set_canvas_size(width, height);
     edit.commit();
 }
@@ -1948,6 +1957,7 @@ mod tests {
             at: (100.0, 60.0),
             author: "me".into(),
             text: "here".into(),
+            color: schist_core::annotate::DEFAULT_NOTE_COLOR,
         });
         doc
     }
@@ -2072,6 +2082,31 @@ mod tests {
             assert!(
                 (a.0 - b.0).abs() < 0.01 && (a.1 - b.1).abs() < 0.01,
                 "the box jumped on the second press: {a:?} -> {b:?}"
+            );
+        }
+    }
+    #[test]
+    fn repivot_preserves_a_rotated_nonuniform_scale() {
+        let mut doc = doc_with_square();
+        let mut state = EditorState::default();
+        let mut tool = TransformTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        tool.on_activate(&mut ctx);
+        let session = tool.session.as_mut().unwrap();
+        session.scale = (2.0, 0.75);
+        session.rotation = std::f32::consts::FRAC_PI_4;
+        session.offset = (13.0, -7.0);
+        let before = session.corners();
+
+        session.repivot((0.0, 1.0));
+
+        for (a, b) in before.iter().zip(session.corners()) {
+            assert!(
+                (a.0 - b.0).abs() < 0.01 && (a.1 - b.1).abs() < 0.01,
+                "repivot moved a rotated nonuniform scale: {a:?} -> {b:?}"
             );
         }
     }

--- a/plugins/tools-vector/src/lib.rs
+++ b/plugins/tools-vector/src/lib.rs
@@ -137,7 +137,10 @@ pub(crate) fn commit_layer(doc: &mut Document, layer: Layer, path: LayerPath, ed
 /// Insert a live shape layer.
 pub(crate) fn commit_shape_layer(doc: &mut Document, shape: schist_core::VectorShape, name: &str) {
     let layer = shape_layer(doc, shape, name);
-    let path = insert_path(doc, false);
+    // Keep a new shape beside the active layer, including inside its group.
+    // Sending live shapes to the root top made drawing inside a group jump
+    // the result out of that group and above the rest of the document.
+    let path = insert_path(doc, true);
     commit_layer(doc, layer, path, &format!("{name} Layer"));
 }
 

--- a/plugins/tools-vector/src/paths.rs
+++ b/plugins/tools-vector/src/paths.rs
@@ -116,6 +116,17 @@ pub fn store(doc: &mut Document, path: VectorPath) {
     doc.active_path = Some(doc.paths.len() - 1);
 }
 
+/// The opposite handle for a smooth point: `dragged`'s direction reversed,
+/// at `other`'s own length.
+fn mirror(dragged: (f32, f32), other: (f32, f32)) -> (f32, f32) {
+    let len = (dragged.0 * dragged.0 + dragged.1 * dragged.1).sqrt();
+    if len <= 1e-6 {
+        return other;
+    }
+    let keep = (other.0 * other.0 + other.1 * other.1).sqrt();
+    (-dragged.0 / len * keep, -dragged.1 / len * keep)
+}
+
 // ------------------------------------------------------ path selection
 
 /// Whether an arrow moves whole paths or individual anchors.
@@ -195,8 +206,12 @@ impl ToolPlugin for PathSelectTool {
                 .paths
                 .iter()
                 .position(|p| p.hit_anchor(input.x, input.y, r * 4.0).is_some());
-            if hit.is_some() {
-                ctx.doc.active_path = hit;
+            match hit {
+                Some(_) => ctx.doc.active_path = hit,
+                // A click that hit nothing must not drag whatever path
+                // happened to be active, possibly off-screen or belonging
+                // to a shape layer.
+                None => self.last = None,
             }
             return;
         }
@@ -252,16 +267,23 @@ impl ToolPlugin for PathSelectTool {
                             Grab::Point => *an = an.translated(dx, dy),
                             // Dragging one handle swings the other with it,
                             // which is what keeps a smooth point smooth.
+                            // A smooth point mirrors the opposite
+                            // handle's *direction* and keeps its own
+                            // length. Negating outright forced both to the
+                            // same magnitude, so dragging one handle
+                            // rescaled the curve on the other side and
+                            // asymmetric smooth points could not exist.
+                            // Alt breaks the pair into a corner point.
                             Grab::HandleOut => {
                                 an.handle_out = (an.handle_out.0 + dx, an.handle_out.1 + dy);
-                                if an.handle_in != (0.0, 0.0) {
-                                    an.handle_in = (-an.handle_out.0, -an.handle_out.1);
+                                if !input.modifiers.alt && an.handle_in != (0.0, 0.0) {
+                                    an.handle_in = mirror(an.handle_out, an.handle_in);
                                 }
                             }
                             Grab::HandleIn => {
                                 an.handle_in = (an.handle_in.0 + dx, an.handle_in.1 + dy);
-                                if an.handle_out != (0.0, 0.0) {
-                                    an.handle_out = (-an.handle_in.0, -an.handle_in.1);
+                                if !input.modifiers.alt && an.handle_out != (0.0, 0.0) {
+                                    an.handle_out = mirror(an.handle_in, an.handle_out);
                                 }
                             }
                         }

--- a/plugins/tools-vector/tests/paths.rs
+++ b/plugins/tools-vector/tests/paths.rs
@@ -170,6 +170,15 @@ fn direct_selection_ignores_a_click_on_nothing() {
     assert_eq!(doc.paths[0], before, "dragging empty space moved the path");
 }
 
+fn input_with(x: f32, y: f32, modifiers: Modifiers) -> PointerInput {
+    PointerInput {
+        x,
+        y,
+        pressure: 1.0,
+        modifiers,
+    }
+}
+
 #[test]
 fn dragging_a_handle_swings_its_partner() {
     let mut doc = doc();
@@ -194,12 +203,59 @@ fn dragging_a_handle_swings_its_partner() {
 
     let a = doc.paths[0].subpaths[0].anchors[1];
     assert_ne!(a.handle_out, grabbed.handle_out, "handle did not move");
-    assert_eq!(
-        a.handle_in,
-        (-a.handle_out.0, -a.handle_out.1),
-        "the opposite handle did not stay mirrored"
+
+    // A smooth point mirrors the opposite handle's *direction* and keeps
+    // its own length. This used to assert exact negation, which forced
+    // both handles to one magnitude: dragging either rescaled the curve on
+    // the far side of the anchor, and an asymmetric smooth point could not
+    // be built or preserved.
+    let len = |v: (f32, f32)| (v.0 * v.0 + v.1 * v.1).sqrt();
+    let dot = a.handle_in.0 * a.handle_out.0 + a.handle_in.1 * a.handle_out.1;
+    let cos = dot / (len(a.handle_in) * len(a.handle_out));
+    assert!(
+        (cos + 1.0).abs() < 1e-4,
+        "handles must stay anti-parallel, cos = {cos}"
+    );
+    assert!(
+        (len(a.handle_in) - len(grabbed.handle_in)).abs() < 1e-3,
+        "the opposite handle kept its own length: {} vs {}",
+        len(a.handle_in),
+        len(grabbed.handle_in)
     );
     assert_eq!(a.point, grabbed.point, "the anchor itself moved");
+}
+
+#[test]
+fn alt_breaks_a_smooth_point_into_a_corner() {
+    let mut doc = doc();
+    let mut path = square_path();
+    path.smooth_all();
+    let grabbed = path.subpaths[0].anchors[1];
+    doc.paths.push(path);
+    doc.active_path = Some(0);
+    let (hx, hy) = (
+        grabbed.point.0 + grabbed.handle_out.0,
+        grabbed.point.1 + grabbed.handle_out.1,
+    );
+    let mut state = EditorState::default();
+    let mut tool = PathSelectTool::new(ArrowKind::Direct);
+    let mut ctx = ToolCtx {
+        doc: &mut doc,
+        state: &mut state,
+    };
+    let alt = Modifiers {
+        alt: true,
+        ..Modifiers::default()
+    };
+    tool.on_pointer_down(&mut ctx, input_with(hx, hy, alt));
+    tool.on_pointer_move(&mut ctx, input_with(hx + 10.0, hy + 10.0, alt));
+    tool.on_pointer_up(&mut ctx, input_with(hx + 10.0, hy + 10.0, alt));
+
+    let a = doc.paths[0].subpaths[0].anchors[1];
+    assert_eq!(
+        a.handle_in, grabbed.handle_in,
+        "alt must leave the opposite handle alone"
+    );
 }
 
 #[test]

--- a/plugins/tools-warp/src/liquify.rs
+++ b/plugins/tools-warp/src/liquify.rs
@@ -75,12 +75,15 @@ pub struct LiquifyTool {
     pressure: f32,
     session: Option<Session>,
     cursor: Option<(f32, f32)>,
+    /// Size grew since the mesh was cut, so it needs re-cutting.
+    regrow: bool,
 }
 
 impl LiquifyTool {
     pub fn new() -> Self {
         LiquifyTool {
             mode: Mode::Forward,
+            regrow: false,
             size: 100.0,
             pressure: 50.0,
             session: None,
@@ -115,6 +118,7 @@ impl LiquifyTool {
         if rect.is_empty() {
             return;
         }
+        self.regrow = false;
         self.session = Some(Session {
             layer: id,
             original: raster.tiles.clone(),
@@ -131,6 +135,22 @@ impl LiquifyTool {
     /// the frozen snapshot through the mesh, and a dab only moves the
     /// vertices under the brush, so the rest of the layer was warped
     /// through offsets that still stand.
+    /// The region the live mesh covers, for tests and for anything that
+    /// needs to know how far a warp can reach.
+    pub fn mesh_rect(&self) -> Option<IntRect> {
+        self.session.as_ref().map(|s| s.mesh.rect)
+    }
+
+    /// True while the session's mesh still describes no deformation.
+    fn mesh_is_identity(&self) -> bool {
+        self.session.as_ref().is_none_or(|s| {
+            s.mesh
+                .offsets
+                .iter()
+                .all(|&(dx, dy)| dx == 0.0 && dy == 0.0)
+        })
+    }
+
     fn render(&self, doc: &mut Document, region: IntRect) {
         let Some(session) = &self.session else { return };
         let region = region.intersect(&doc.canvas_rect());
@@ -289,7 +309,18 @@ impl ToolPlugin for LiquifyTool {
     fn set_option(&mut self, key: &str, value: OptionValue) {
         match key {
             "liquify-mode" => self.mode = Mode::from_index(value.index()),
-            "liquify-size" => self.size = value.num(),
+            "liquify-size" => {
+                // The mesh is sized from the brush in `begin`, which only
+                // runs on activate/first press/after a commit -- so
+                // raising Size mid-session left the extra reach past the
+                // artwork's edge unavailable, because `Mesh::rect` was
+                // still cut for the old brush.
+                let grew = value.num() > self.size;
+                self.size = value.num();
+                if grew {
+                    self.regrow = true;
+                }
+            }
             "liquify-pressure" => self.pressure = value.num(),
             _ => {}
         }
@@ -301,6 +332,12 @@ impl ToolPlugin for LiquifyTool {
 
     fn on_pointer_down(&mut self, ctx: &mut ToolCtx, input: PointerInput) {
         if self.session.is_none() {
+            self.begin(ctx);
+        } else if self.regrow && self.mesh_is_identity() {
+            // Re-cut the mesh for the larger brush. Only while nothing has
+            // been warped yet: rebuilding the grid throws away the
+            // offsets already accumulated, and Enter re-cuts it anyway.
+            self.session = None;
             self.begin(ctx);
         }
         if let Some(session) = &mut self.session {

--- a/plugins/tools-warp/src/liquify.rs
+++ b/plugins/tools-warp/src/liquify.rs
@@ -127,14 +127,6 @@ impl LiquifyTool {
         });
     }
 
-    /// Re-render `region` of the layer from the snapshot through the
-    /// current mesh.
-    ///
-    /// Only the pixels a dab could have changed are redone. Everywhere else
-    /// the layer already holds the right answer: a render always goes from
-    /// the frozen snapshot through the mesh, and a dab only moves the
-    /// vertices under the brush, so the rest of the layer was warped
-    /// through offsets that still stand.
     /// The region the live mesh covers, for tests and for anything that
     /// needs to know how far a warp can reach.
     pub fn mesh_rect(&self) -> Option<IntRect> {
@@ -151,6 +143,14 @@ impl LiquifyTool {
         })
     }
 
+    /// Re-render `region` of the layer from the snapshot through the
+    /// current mesh.
+    ///
+    /// Only the pixels a dab could have changed are redone. Everywhere else
+    /// the layer already holds the right answer: a render always goes from
+    /// the frozen snapshot through the mesh, and a dab only moves the
+    /// vertices under the brush, so the rest of the layer was warped
+    /// through offsets that still stand.
     fn render(&self, doc: &mut Document, region: IntRect) {
         let Some(session) = &self.session else { return };
         let region = region.intersect(&doc.canvas_rect());

--- a/plugins/tools-warp/src/perspective.rs
+++ b/plugins/tools-warp/src/perspective.rs
@@ -133,6 +133,10 @@ fn sample(src: &TileMap, fx: f32, fy: f32) -> Rgba {
 /// That step in plane space is the whole trick -- an offset of half a unit
 /// along a receding wall is a shorter distance in pixels at the far end
 /// than at the near end, so the copy foreshortens with the wall.
+///
+/// `coverage` is the active selection sampled over `region`, row-major:
+/// the stamp was the one clone tool that painted straight through a
+/// selection.
 #[allow(clippy::too_many_arguments)]
 pub fn perspective_clone(
     src: &TileMap,
@@ -143,6 +147,7 @@ pub fn perspective_clone(
     radius: f32,
     centre: (f32, f32),
     depth: schist_color::Depth,
+    coverage: &[u8],
 ) {
     let Some(inv) = plane.invert() else { return };
     for coord in TileCoord::covering(&region) {
@@ -159,8 +164,16 @@ pub fn perspective_clone(
                 if d >= radius {
                     continue;
                 }
+                let sel = coverage
+                    .get(((y - region.top) * region.width() + (x - region.left)) as usize)
+                    .copied()
+                    .unwrap_or(255) as f32
+                    / 255.0;
+                if sel <= 0.0 {
+                    continue;
+                }
                 let t = 1.0 - d / radius;
-                let w = t * t * (3.0 - 2.0 * t);
+                let w = t * t * (3.0 - 2.0 * t) * sel;
                 // Image -> plane -> shifted -> image.
                 let (u, v) = inv.apply(fx, fy);
                 let (sx, sy) = plane.apply(u + offset.0, v + offset.1);
@@ -205,6 +218,32 @@ pub struct VanishingPointTool {
 }
 
 impl VanishingPointTool {
+    /// End an in-flight stroke, recording it as one history entry.
+    ///
+    /// Both a release and a tool switch need this; the tool has no
+    /// `on_commit` of its own, so calling that dispatched to the trait's
+    /// empty default and switching tools mid-stroke baked the preview
+    /// pixels in with no way to undo them.
+    fn finish_stroke(&mut self, ctx: &mut ToolCtx) {
+        let Some((id, snapshot)) = self.stroke.take() else {
+            return;
+        };
+        let after = ctx
+            .doc
+            .tree
+            .find(id)
+            .and_then(|l| l.as_raster())
+            .map(|r| r.tiles.clone());
+        if let Some(after) = after {
+            if let Some(raster) = ctx.doc.tree.find_mut(id).and_then(|l| l.as_raster_mut()) {
+                raster.tiles = snapshot;
+            }
+            let mut edit = ctx.doc.begin_edit("Vanishing Point");
+            edit.replace_layer_tiles(id, after);
+            edit.commit();
+        }
+    }
+
     pub fn new() -> Self {
         VanishingPointTool {
             corners: [(0.0, 0.0); 4],
@@ -326,7 +365,15 @@ impl ToolPlugin for VanishingPointTool {
         let Some(id) = ctx.doc.active_layer else {
             return;
         };
-        let Some(raster) = ctx.doc.tree.find(id).and_then(|l| l.as_raster()) else {
+        let Some(layer) = ctx.doc.tree.find(id) else {
+            return;
+        };
+        // A locked or hidden layer is not paintable, the same rule the
+        // brush follows. The stamp used to clone onto it regardless.
+        if layer.locked || !layer.visible {
+            return;
+        }
+        let Some(raster) = layer.as_raster() else {
             return;
         };
         self.stroke = Some((id, raster.tiles.clone()));
@@ -355,6 +402,14 @@ impl ToolPlugin for VanishingPointTool {
             (input.y + radius).ceil() as i32 + 1,
         )
         .intersect(&ctx.doc.canvas_rect());
+        // Sampled before the layer is borrowed mutably; the dab is brush
+        // sized, so this is a few hundred bytes.
+        let mut coverage = Vec::with_capacity((region.width() * region.height()) as usize);
+        for y in region.top..region.bottom {
+            for x in region.left..region.right {
+                coverage.push(ctx.doc.selection.coverage(x, y));
+            }
+        }
         let Some(raster) = ctx.doc.tree.find_mut(id).and_then(|l| l.as_raster_mut()) else {
             return;
         };
@@ -368,6 +423,7 @@ impl ToolPlugin for VanishingPointTool {
             radius,
             (input.x, input.y),
             depth,
+            &coverage,
         );
         raster.tiles = tiles;
         ctx.doc.add_damage(region);
@@ -375,23 +431,7 @@ impl ToolPlugin for VanishingPointTool {
 
     fn on_pointer_up(&mut self, ctx: &mut ToolCtx, _input: PointerInput) {
         self.grabbed = None;
-        // Record the whole stroke as one entry.
-        if let Some((id, snapshot)) = self.stroke.take() {
-            let after = ctx
-                .doc
-                .tree
-                .find(id)
-                .and_then(|l| l.as_raster())
-                .map(|r| r.tiles.clone());
-            if let Some(after) = after {
-                if let Some(raster) = ctx.doc.tree.find_mut(id).and_then(|l| l.as_raster_mut()) {
-                    raster.tiles = snapshot;
-                }
-                let mut edit = ctx.doc.begin_edit("Vanishing Point");
-                edit.replace_layer_tiles(id, after);
-                edit.commit();
-            }
-        }
+        self.finish_stroke(ctx);
     }
 
     fn on_cancel(&mut self, ctx: &mut ToolCtx) {
@@ -416,11 +456,15 @@ impl ToolPlugin for VanishingPointTool {
     }
 
     fn on_deactivate(&mut self, ctx: &mut ToolCtx) {
-        // Switching tools mid-stroke committed nothing and restored
-        // nothing, which is the same silent edit as cancelling was.
-        if self.stroke.is_some() {
-            self.on_commit(ctx);
-        }
+        // Strokes here commit in `on_pointer_up`, and this tool has no
+        // `on_commit` of its own -- calling it dispatched to the trait's
+        // empty default, so switching tools mid-stroke still baked the
+        // preview pixels in with no history entry. End the stroke the
+        // same way a release does.
+        self.finish_stroke(ctx);
+        self.grabbed = None;
+        self.source = None;
+        self.offset = None;
     }
 
     fn overlays(&self, _doc: &Document, _state: &EditorState) -> Vec<Overlay> {

--- a/plugins/tools-warp/src/perspective.rs
+++ b/plugins/tools-warp/src/perspective.rs
@@ -394,11 +394,33 @@ impl ToolPlugin for VanishingPointTool {
         }
     }
 
-    fn on_cancel(&mut self, _ctx: &mut ToolCtx) {
+    fn on_cancel(&mut self, ctx: &mut ToolCtx) {
+        // Put the pixels back, the way Liquify's cancel does. Dropping the
+        // snapshot without restoring left the cloned pixels on the layer
+        // with no history entry and `dirty` never set, so escape during a
+        // stroke baked an edit the user could neither see nor undo, and
+        // closing the document would not even prompt.
+        if let Some((id, original)) = self.stroke.take() {
+            if let Some(raster) = ctx.doc.tree.find_mut(id).and_then(|l| l.as_raster_mut()) {
+                let damage = raster
+                    .tiles
+                    .content_bounds()
+                    .union(&original.content_bounds());
+                raster.tiles = original;
+                ctx.doc.add_damage(damage);
+            }
+        }
         self.grabbed = None;
-        self.stroke = None;
         self.source = None;
         self.offset = None;
+    }
+
+    fn on_deactivate(&mut self, ctx: &mut ToolCtx) {
+        // Switching tools mid-stroke committed nothing and restored
+        // nothing, which is the same silent edit as cancelling was.
+        if self.stroke.is_some() {
+            self.on_commit(ctx);
+        }
     }
 
     fn overlays(&self, _doc: &Document, _state: &EditorState) -> Vec<Overlay> {

--- a/plugins/tools-warp/tests/incremental_warp.rs
+++ b/plugins/tools-warp/tests/incremental_warp.rs
@@ -135,7 +135,7 @@ fn a_cropped_source_plane_reaches_as_far_as_the_displacement_does() {
 // ===== the tool itself =====
 
 use schist_core::{Document, Layer};
-use schist_plugin_api::{EditorState, PointerInput, ToolCtx, ToolPlugin};
+use schist_plugin_api::{EditorState, OptionValue, PointerInput, ToolCtx, ToolPlugin};
 use schist_tools_warp::liquify::LiquifyTool;
 
 fn document() -> (Document, schist_core::LayerId) {
@@ -273,4 +273,75 @@ fn escape_puts_the_pixels_back() {
             );
         }
     }
+}
+
+/// Raising Size mid-session must widen the mesh.
+///
+/// The extent is cut in `begin`, which only runs on activate, on the
+/// first press, and after a commit — so the extra reach past the
+/// artwork's edge stayed unavailable and pixels could not be pushed as
+/// far as the new brush promised.
+#[test]
+fn raising_the_brush_size_recuts_the_mesh() {
+    let mut doc = Document::new("t", 2000, 2000, Depth::Eight);
+    let mut layer = Layer::new_raster("art");
+    let buf = [200u8, 30, 30, 255].repeat(64 * 64);
+    schist_core::blit_rgba8(
+        &mut layer.as_raster_mut().unwrap().tiles,
+        Depth::Eight,
+        schist_core::IntRect::from_xywh(900, 900, 64, 64),
+        &buf,
+    );
+    let id = layer.id;
+    doc.tree.layers.push(layer);
+    doc.active_layer = Some(id);
+
+    let mut state = EditorState::default();
+    let mut tool = LiquifyTool::new();
+    let mut ctx = ToolCtx {
+        doc: &mut doc,
+        state: &mut state,
+    };
+    tool.on_activate(&mut ctx);
+    let small = tool.mesh_rect().expect("a session");
+
+    tool.set_option("liquify-size", OptionValue::Num(800.0));
+    tool.on_pointer_down(&mut ctx, at(930.0, 930.0));
+    let large = tool.mesh_rect().expect("a session");
+
+    assert!(
+        large.width() > small.width() && large.height() > small.height(),
+        "mesh stayed {small:?} after the brush grew to 800 (now {large:?})"
+    );
+}
+
+/// But not once pixels have been pushed: re-cutting the grid would throw
+/// the accumulated offsets away, and Enter re-cuts it anyway.
+#[test]
+fn a_warp_in_progress_keeps_its_mesh() {
+    let (mut doc, _id) = document();
+    let mut state = EditorState::default();
+    let mut tool = LiquifyTool::new();
+    let mut ctx = ToolCtx {
+        doc: &mut doc,
+        state: &mut state,
+    };
+    tool.on_activate(&mut ctx);
+    stroke(&mut tool, &mut ctx);
+    let warped = tool.mesh_rect().expect("a session");
+
+    tool.set_option("liquify-size", OptionValue::Num(800.0));
+    tool.on_pointer_down(&mut ctx, at(100.0, 110.0));
+
+    assert_eq!(
+        tool.mesh_rect(),
+        Some(warped),
+        "the size slider re-cut a mesh that already held a warp"
+    );
+
+    // Committing re-cuts it for the new brush, which is where the extra
+    // reach becomes available.
+    tool.on_commit(&mut ctx);
+    let after = tool.mesh_rect().expect("a session");
+    assert!(after.width() >= warped.width());
 }

--- a/plugins/tools-warp/tests/vanishing_point.rs
+++ b/plugins/tools-warp/tests/vanishing_point.rs
@@ -1,0 +1,115 @@
+//! Vanishing Point clones onto the active layer, and has to obey the same
+//! two rules every other paint tool does: not onto a locked or hidden
+//! layer, and not outside the selection.
+
+use schist_color::{Depth, Rgba};
+use schist_core::{Document, IntRect, Layer, LayerId, SelectOp, TileCoord};
+use schist_plugin_api::{EditorState, Modifiers, OptionValue, PointerInput, ToolCtx, ToolPlugin};
+use schist_tools_warp::perspective::VanishingPointTool;
+
+fn doc() -> (Document, LayerId) {
+    let mut doc = Document::new("t", 200, 200, Depth::ThirtyTwo);
+    doc.push_layer(Layer::new_raster("art"));
+    let id = doc.tree.layers[0].id;
+    let raster = doc.tree.find_mut(id).unwrap().as_raster_mut().unwrap();
+    // A left half to clone from, so a stamp on the right is visible.
+    for coord in TileCoord::covering(&IntRect::from_xywh(0, 0, 200, 200)) {
+        let trect = coord.rect();
+        let buf = raster.tiles.get_mut_or_insert(coord, Depth::ThirtyTwo);
+        for ly in 0..schist_core::TILE_SIZE {
+            for lx in 0..schist_core::TILE_SIZE {
+                let x = trect.left + lx;
+                let c = if x < 100 {
+                    Rgba::new(1.0, 0.0, 0.0, 1.0)
+                } else {
+                    Rgba::new(0.0, 0.0, 1.0, 1.0)
+                };
+                buf.set((ly * schist_core::TILE_SIZE + lx) as usize, c);
+            }
+        }
+    }
+    doc.active_layer = Some(id);
+    (doc, id)
+}
+
+fn at(x: f32, y: f32, alt: bool) -> PointerInput {
+    PointerInput {
+        x,
+        y,
+        pressure: 1.0,
+        modifiers: Modifiers {
+            alt,
+            ..Default::default()
+        },
+    }
+}
+
+fn px(doc: &Document, id: LayerId, x: i32, y: i32) -> Rgba {
+    doc.tree
+        .find(id)
+        .unwrap()
+        .as_raster()
+        .unwrap()
+        .tiles
+        .pixel(x, y)
+}
+
+/// Alt-pick inside the red half, then stamp at `to`.
+fn stamp(tool: &mut VanishingPointTool, doc: &mut Document, to: (f32, f32)) {
+    let mut state = EditorState::default();
+    let mut ctx = ToolCtx {
+        doc,
+        state: &mut state,
+    };
+    tool.on_activate(&mut ctx);
+    tool.set_option("vp-phase", OptionValue::Choice(1));
+    tool.on_pointer_down(&mut ctx, at(50.0, 100.0, true));
+    tool.on_pointer_down(&mut ctx, at(to.0, to.1, false));
+    tool.on_pointer_up(&mut ctx, at(to.0, to.1, false));
+}
+
+#[test]
+fn the_stamp_lands_on_an_ordinary_layer() {
+    let (mut doc, id) = doc();
+    let mut tool = VanishingPointTool::new();
+    stamp(&mut tool, &mut doc, (150.0, 100.0));
+    assert!(
+        px(&doc, id, 150, 100).r > 0.5,
+        "the red source should have been cloned across"
+    );
+}
+
+#[test]
+fn a_locked_layer_refuses_the_stamp() {
+    let (mut doc, id) = doc();
+    doc.tree.find_mut(id).unwrap().locked = true;
+    let mut tool = VanishingPointTool::new();
+    stamp(&mut tool, &mut doc, (150.0, 100.0));
+    assert_eq!(px(&doc, id, 150, 100), Rgba::new(0.0, 0.0, 1.0, 1.0));
+    assert_eq!(doc.history.undo_name(), None, "and records no edit");
+}
+
+#[test]
+fn a_hidden_layer_refuses_the_stamp() {
+    let (mut doc, id) = doc();
+    doc.tree.find_mut(id).unwrap().visible = false;
+    let mut tool = VanishingPointTool::new();
+    stamp(&mut tool, &mut doc, (150.0, 100.0));
+    assert_eq!(px(&doc, id, 150, 100), Rgba::new(0.0, 0.0, 1.0, 1.0));
+}
+
+#[test]
+fn the_stamp_stays_inside_the_selection() {
+    let (mut doc, id) = doc();
+    // Only the top half is selected; the dab covers both.
+    doc.selection
+        .select_rect(IntRect::from_xywh(0, 0, 200, 100), SelectOp::Replace);
+    let mut tool = VanishingPointTool::new();
+    stamp(&mut tool, &mut doc, (150.0, 100.0));
+    assert!(px(&doc, id, 150, 95).r > 0.5, "inside the selection");
+    assert_eq!(
+        px(&doc, id, 150, 110),
+        Rgba::new(0.0, 0.0, 1.0, 1.0),
+        "outside it the layer is untouched"
+    );
+}


### PR DESCRIPTION

groups ten branches: the canvas tools.

**tools acting on the wrong thing**

- paint tools silently painted a *different* layer when the active one was locked or non-raster; red eye and vanishing point ignored the selection and the layer lock.
- free transform scaled about the box centre rather than the pinned corner, and the handle did not follow the cursor; it ignored the active selection and did not transform the layer's mask.
- image size did not rescale layer masks; crop and canvas size skipped group and adjustment layers, and left guides, artboards, paths and notes at the old coordinates.
- shape layers always landed at the top of the root stack; direct selection mirrored the opposite handle's *length* as well as its direction; path selection dragged the active path even when the click missed it.
- tool sessions were not scoped to a document, so switching tabs baked live-preview pixels in with no undo entry, and a clone source alt-clicked in one document sampled another at the old coordinates.

**selection maths**

feather was quantised to `floor(radius / √3)`, so small radii did nothing and 2 px equalled 3 px; `border` sat entirely outside the edge for odd widths; marquees were not clipped to the canvas.

**gestures that did not exist**

shift-constrain and alt-duplicate on the move tool, and alt-from-centre for the marquee. the brush had no Flow, no adjustable spacing, and pressure changed only the dab's size.

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr53-before.png) | ![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr53-after.png) |

alt-dragging with the move tool, and what the layers panel holds afterwards:

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr-altdup-before.png) | ![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr-altdup-after.png) |

**the gradient ramp was two colours**

five *styles* but no way to put a third colour anywhere, and no per-stop opacity. the ramp is a stop list now; the two swatch-driven fills behave exactly as they did.

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr54-before-list.png) | ![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr54-after-list.png) |

![spectrum](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr54-after.png)

dodge and burn also gain Range and Exposure, blur and sharpen a Strength, and the smudge brush's mix stops being hard-coded — all defaulting to what those paths already applied.

**previews that lied**

the elliptical marquee previewed a rectangle:

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr44-before.png) | ![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr44-after.png) |

the rotate handle's standoff was in document units, so at 800% it sat three screen pixels off the box and at 10% it floated 240 away; the brush cursor ignored pressure and was never cleared; the polygonal lasso had no way to drop an anchor; bring forward at the top of the stack recorded a no-op edit; `replace_layer_tiles` was quadratic in tile count.

**one merge decision worth flagging**

two branches independently added `on_deactivate` to the paint tool — one cancelling the in-progress stroke, one committing it. i kept **commit**: a stroke is pixels the user already painted, switching tools should not throw it away, and `finish` records it as one undoable edit.

---

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` — 667 passed, 0 failed.
---

**how this relates to my other open prs**

these seven are independent of each other — each branches off `main` and each is green on its own. they do share files with my five open prs (#36, #38, #42, #44, #46), mostly `workspace.rs`, so whichever lands first will leave the others needing a rebase. happy to rebase in whatever order suits you, or to split any of these further if one is too big to review in a sitting.

