### PR TITLE
fix: menu correctness, keyboard access and ui feedback

### DIFF
--- a/crates/app/src/color_picker.rs
+++ b/crates/app/src/color_picker.rs
@@ -634,10 +634,11 @@ fn hex_field(
     buffer: &str,
     cx: &mut Context<Workspace>,
 ) -> impl IntoElement {
+    let committed = format!("{:06X}", to_hex(chosen));
     let shown: SharedString = if focused {
         format!("#{buffer}").into()
     } else {
-        format!("#{:06X}", to_hex(chosen)).into()
+        format!("#{committed}").into()
     };
     ui::field_row(
         "#",
@@ -658,8 +659,8 @@ fn hex_field(
             .text_size(px(11.0))
             .on_mouse_down(
                 MouseButton::Left,
-                cx.listener(|ws, _e, _w, cx| {
-                    ws.focus_field("cp-hex");
+                cx.listener(move |ws, _e, _w, cx| {
+                    ws.focus_field("cp-hex", committed.clone());
                     cx.notify();
                 }),
             )

--- a/crates/app/src/curve_editor.rs
+++ b/crates/app/src/curve_editor.rs
@@ -136,8 +136,12 @@ fn histogram(ws: &Workspace) -> Vec<f32> {
     const GRID: i32 = 4;
     for gy in 0..GRID {
         for gx in 0..GRID {
-            let left = canvas.left + (canvas.width() - BLOCK).max(0) * gx / GRID.max(1);
-            let top = canvas.top + (canvas.height() - BLOCK).max(0) * gy / GRID.max(1);
+            // Divide by GRID - 1 so the last row and column reach the far
+            // edge; dividing by GRID never sampled the rightmost or
+            // bottom quarter of the canvas at all.
+            let span = (GRID - 1).max(1);
+            let left = canvas.left + (canvas.width() - BLOCK).max(0) * gx / span;
+            let top = canvas.top + (canvas.height() - BLOCK).max(0) * gy / span;
             let rect = IntRect::from_xywh(
                 left,
                 top,

--- a/crates/app/src/curve_editor.rs
+++ b/crates/app/src/curve_editor.rs
@@ -17,6 +17,7 @@ use gpui::{
     SharedString, Styled,
 };
 use schist_adjustments::{CurveChannel, Curves};
+use schist_core::{Document, IntRect, Layer};
 
 /// Side of the square graph, in pixels.
 const SIZE: f32 = 256.0;
@@ -77,39 +78,85 @@ fn commit(ws: &mut Workspace, curves: Curves, cx: &mut Context<Workspace>) {
     }
 }
 
-/// Histogram of the layer under the adjustment, 64 buckets, normalised.
+/// The pixels the open adjustment actually acts on.
+///
+/// An adjustment layer is not a raster, so looking it up through
+/// `as_raster` always missed and fell through to `tree.iter().last()` --
+/// the topmost layer of the document, which is normally *above* the
+/// adjustment and so not something it affects at all. The histogram was
+/// therefore drawn against the wrong pixels whenever a curves adjustment
+/// layer was being edited.
+///
+/// What such a layer sees is the composite of its lower siblings, so
+/// that is what this builds: the document with the adjustment itself and
+/// everything stacked over it inside its container removed.
+fn source_document(ws: &Workspace) -> Option<Document> {
+    let doc = ws.doc.as_ref()?;
+    // A scratch document that composites the same way the real one does:
+    // same canvas, depth and colour mode, but only the layers of interest.
+    let mut scratch = Document::new(&doc.title, doc.width, doc.height, doc.depth);
+    scratch.mode = doc.mode;
+    scratch.icc_profile = doc.icc_profile.clone();
+
+    let Some(Modal::Adjustment { layer, .. }) = ws.modal.as_ref() else {
+        // Image > Adjustments > Curves acts on the active layer's pixels.
+        let id = doc.active_layer?;
+        let mut only = doc.tree.find(id)?.clone();
+        only.visible = true;
+        only.opacity = 1.0;
+        scratch.tree.layers = vec![only];
+        return Some(scratch);
+    };
+    let path = doc.tree.path_of(*layer)?;
+    // Walk down to the adjustment's container, then keep only what is
+    // stacked below it there.
+    let (last, groups) = path.0.split_last()?;
+    let mut layers: &[Layer] = &doc.tree.layers;
+    for step in groups {
+        layers = layers.get(*step)?.children()?;
+    }
+    scratch.tree.layers = layers.get(..*last)?.to_vec();
+    Some(scratch)
+}
+
+/// Histogram of what the adjustment is acting on, 64 buckets, normalised.
 fn histogram(ws: &Workspace) -> Vec<f32> {
     let mut buckets = vec![0f32; 64];
-    let Some(doc) = ws.doc.as_ref() else {
+    let Some(doc) = source_document(ws) else {
         return buckets;
     };
-    let Some(raster) = doc
-        .active_layer
-        .and_then(|id| doc.tree.find(id))
-        .and_then(|l| l.as_raster())
-        .or_else(|| doc.tree.iter().last().and_then(|l| l.as_raster()))
-    else {
+    let canvas = doc.canvas_rect();
+    if canvas.is_empty() {
         return buckets;
-    };
-    let rect = doc.canvas_rect();
-    // Sample rather than scan: a histogram sketch does not need every
-    // pixel of a 100-megapixel document.
-    let step = ((rect.width() * rect.height()) as f32 / 20_000.0)
-        .sqrt()
-        .max(1.0) as i32;
-    let mut y = rect.top;
-    while y < rect.bottom {
-        let mut x = rect.left;
-        while x < rect.right {
-            let p = raster.tiles.pixel(x, y);
-            if p.a > 0.0 {
-                let l = 0.299 * p.r + 0.587 * p.g + 0.114 * p.b;
-                let b = ((l * 63.0).round() as usize).min(63);
+    }
+    // Sample blocks rather than the whole canvas: a histogram sketch does
+    // not need every pixel of a 100-megapixel document, and compositing
+    // one is far too slow to do on every frame of a curve drag.
+    const BLOCK: i32 = 48;
+    const GRID: i32 = 4;
+    for gy in 0..GRID {
+        for gx in 0..GRID {
+            let left = canvas.left + (canvas.width() - BLOCK).max(0) * gx / GRID.max(1);
+            let top = canvas.top + (canvas.height() - BLOCK).max(0) * gy / GRID.max(1);
+            let rect = IntRect::from_xywh(
+                left,
+                top,
+                BLOCK.min(canvas.width()) as u32,
+                BLOCK.min(canvas.height()) as u32,
+            );
+            if rect.is_empty() {
+                continue;
+            }
+            let rgba = schist_compositor::composite_region_rgba8(&doc, rect);
+            for px in rgba.as_chunks::<4>().0 {
+                if px[3] == 0 {
+                    continue;
+                }
+                let l = 0.299 * px[0] as f32 + 0.587 * px[1] as f32 + 0.114 * px[2] as f32;
+                let b = ((l * 63.0 / 255.0).round() as usize).min(63);
                 buckets[b] += 1.0;
             }
-            x += step;
         }
-        y += step;
     }
     let peak = buckets.iter().cloned().fold(0.0f32, f32::max);
     if peak > 0.0 {

--- a/crates/app/src/dialogs.rs
+++ b/crates/app/src/dialogs.rs
@@ -2099,15 +2099,28 @@ fn preferences(
                 .child(format!("Version {}", crate::crash::current_version())),
         );
 
-    let actions = div().flex().flex_row().gap_2().child(ui::button(
-        "Done",
-        true,
-        |ws, _w, cx| {
-            ws.save_view_options();
-            ws.close_modal(cx);
-        },
-        cx,
-    ));
+    let actions = div()
+        .flex()
+        .flex_row()
+        .gap_2()
+        .child(ui::button(
+            "Cancel",
+            false,
+            |ws, _w, cx| {
+                ws.revert_preferences(cx);
+                ws.close_modal(cx);
+            },
+            cx,
+        ))
+        .child(ui::button(
+            "Done",
+            true,
+            |ws, _w, cx| {
+                ws.keep_preferences();
+                ws.close_modal(cx);
+            },
+            cx,
+        ));
     ui::modal_frame("Preferences", 400.0, body, actions)
 }
 

--- a/crates/app/src/dialogs.rs
+++ b/crates/app/src/dialogs.rs
@@ -282,17 +282,21 @@ fn confirm_close_tab(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl In
                 true,
                 |ws, window, cx| {
                     ws.close_modal(cx);
+                    // The Save As prompt is async: it returns with the
+                    // document still dirty and finishes later, so the
+                    // close has to be pending rather than conditional.
+                    // Answering "Save…" used to save an Untitled document
+                    // and leave its tab open.
+                    ws.close_tab_after_save();
                     ws.save_current(window, cx);
-                    // The synchronous path (a known, writable path) leaves
-                    // the document clean; only then is closing safe.
-                    if ws.doc.as_ref().is_some_and(|d| !d.dirty) {
-                        let index = ws.active_tab();
-                        ws.close_tab(index, cx);
-                        ws.resume_quit(cx);
-                    } else {
-                        // Save As is asynchronous; do not hold a quit open
-                        // across a file prompt.
+                    if ws.has_pending_save() {
+                        // Still waiting on a file prompt. Do not hold a
+                        // quit open across it; the tab closes when the
+                        // save lands.
                         ws.cancel_quit();
+                    } else {
+                        // Saved synchronously, so the tab has gone.
+                        ws.resume_quit(cx);
                     }
                 },
                 cx,

--- a/crates/app/src/dialogs.rs
+++ b/crates/app/src/dialogs.rs
@@ -37,7 +37,10 @@ pub fn render(ws: &mut Workspace, cx: &mut Context<Workspace>) -> Option<gpui::A
         focused_field: ws.focused_field,
         field_buffer: ws.field_buffer.clone(),
     };
-    Some(match modal {
+    // Each dialog's primary button registers itself as the default
+    // action while it builds, so Enter can fire it.
+    ui::reset_default_action();
+    let body = match modal {
         Modal::ImageSize {
             width,
             height,
@@ -114,7 +117,9 @@ pub fn render(ws: &mut Workspace, cx: &mut Context<Workspace>) -> Option<gpui::A
             profile_dialog(&state, convert, selected, cx).into_any_element()
         }
         m @ Modal::NewDocument { .. } => new_document_dialog(&state, m, cx).into_any_element(),
-    })
+    };
+    ws.default_action = ui::take_default_action();
+    Some(body)
 }
 
 /// An image was dropped on the window while a document is open: its own
@@ -2114,6 +2119,7 @@ fn layer_properties(
     cx: &mut Context<Workspace>,
 ) -> impl IntoElement {
     let focused = state.focused_field == Some("layer-name");
+    let committed = name.clone();
     let shown = if focused && !state.field_buffer.is_empty() {
         state.field_buffer.clone()
     } else {
@@ -2138,8 +2144,8 @@ fn layer_properties(
             .text_size(px(12.0))
             .on_mouse_down(
                 gpui::MouseButton::Left,
-                cx.listener(|ws, _e, _w, cx| {
-                    ws.focus_field("layer-name");
+                cx.listener(move |ws, _e, _w, cx| {
+                    ws.focus_field("layer-name", committed.clone());
                     cx.notify();
                 }),
             )
@@ -2210,6 +2216,7 @@ fn new_document_dialog(
     };
 
     let name_focused = state.focused_field == Some("new-doc-name");
+    let committed = name.clone();
     let shown_name = if name_focused && !state.field_buffer.is_empty() {
         state.field_buffer.clone()
     } else {
@@ -2288,8 +2295,8 @@ fn new_document_dialog(
                 .text_size(px(12.0))
                 .on_mouse_down(
                     gpui::MouseButton::Left,
-                    cx.listener(|ws, _e, _w, cx| {
-                        ws.focus_field("new-doc-name");
+                    cx.listener(move |ws, _e, _w, cx| {
+                        ws.focus_field("new-doc-name", committed.clone());
                         cx.notify();
                     }),
                 )

--- a/crates/app/src/gallery.rs
+++ b/crates/app/src/gallery.rs
@@ -8,7 +8,7 @@
 
 use crate::dialogs::{param_slider, SliderSpec};
 use crate::ui;
-use crate::workspace::{GalleryEntry, Modal, Popup, Workspace};
+use crate::workspace::{GalleryEntry, Modal, Workspace};
 use gpui::{
     div, px, Context, InteractiveElement as _, IntoElement, MouseButton, MouseDownEvent,
     ParentElement as _, SharedString, StatefulInteractiveElement as _, Styled,
@@ -286,6 +286,5 @@ pub fn render(
             },
             cx,
         ));
-    let _ = Popup::BlendModes;
     ui::modal_frame("Filter Gallery", 620.0, body, actions)
 }

--- a/crates/app/src/keymap.rs
+++ b/crates/app/src/keymap.rs
@@ -7,7 +7,10 @@
 
 use crate::actions::*;
 use crate::workspace::Workspace;
-use gpui::{Context, KeyBinding, PathPromptOptions, Window};
+use gpui::{
+    Action, Context, DummyKeyboardMapper, KeyBinding, KeyBindingContextPredicate,
+    PathPromptOptions, Window,
+};
 use schist_plugin_api::PluginRegistry;
 use std::path::PathBuf;
 
@@ -155,24 +158,73 @@ pub fn build_bindings(registry: &PluginRegistry) -> Vec<KeyBinding> {
     // Format: { "<keystroke>": "command:<id>" | "tool:<id>" }
     if let Some(user) = load_user_keymap() {
         for (keystroke, target) in user {
-            if let Some(id) = target.strip_prefix("command:") {
-                bindings.push(KeyBinding::new(
-                    &keystroke,
-                    RunCommand { id: id.to_string() },
-                    CONTEXT,
-                ));
+            let action: Box<dyn Action> = if let Some(id) = target.strip_prefix("command:") {
+                Box::new(RunCommand { id: id.to_string() })
             } else if let Some(id) = target.strip_prefix("tool:") {
-                bindings.push(KeyBinding::new(
-                    &keystroke,
-                    ActivateTool { id: id.to_string() },
-                    CONTEXT,
-                ));
+                Box::new(ActivateTool { id: id.to_string() })
             } else {
                 log::warn!("keymap: unknown target {target:?} for {keystroke:?}");
+                continue;
+            };
+            // An unmodified key has to yield to whatever is capturing
+            // typing, exactly as the built-in tool shortcuts do. Binding
+            // an override in `CONTEXT` meant rebinding `e` to the eraser
+            // made the letter "e" unreachable inside a text layer, and
+            // since user bindings are appended last they win the tie-break
+            // against the built-in binding they were meant to replace.
+            let context = override_context(&keystroke);
+            match try_binding(&keystroke, action, context) {
+                Some(kb) => bindings.push(kb),
+                // `KeyBinding::new` panics on a keystroke gpui cannot
+                // parse, and "ctrl-page-up" or "cmd-arrow-left" are
+                // plausible things to write. One typo used to take the
+                // app down at launch, before any window existed to
+                // report it, leaving the user to find the file by hand.
+                None => log::error!(
+                    "keymap: cannot parse keystroke {keystroke:?} (bound to {target:?}); ignoring it"
+                ),
             }
         }
     }
     bindings
+}
+
+/// Which context a user override belongs in.
+///
+/// An unmodified key has to yield to whatever is capturing typing, as the
+/// built-in tool shortcuts do. Overrides were bound in `CONTEXT`
+/// unconditionally, so rebinding `e` to the eraser made the letter "e"
+/// unreachable inside a text layer -- and since user bindings are
+/// appended last they also win the tie-break against the built-in
+/// binding they were meant to replace, so the behaviour could not be
+/// restored without deleting the entry.
+fn override_context(keystroke: &str) -> Option<&'static str> {
+    if keystroke.contains('-') {
+        CONTEXT
+    } else {
+        TYPING_SAFE
+    }
+}
+
+/// `KeyBinding::new` without the panic on an unparseable keystroke.
+fn try_binding(
+    keystroke: &str,
+    action: Box<dyn Action>,
+    context: Option<&str>,
+) -> Option<KeyBinding> {
+    let predicate = match context {
+        Some(c) => Some(std::rc::Rc::new(KeyBindingContextPredicate::parse(c).ok()?)),
+        None => None,
+    };
+    KeyBinding::load(
+        keystroke,
+        action,
+        predicate,
+        false,
+        None,
+        &DummyKeyboardMapper,
+    )
+    .ok()
 }
 
 /// Where user keybinding overrides live.
@@ -282,7 +334,8 @@ pub fn save_file_dialog(ws: &mut Workspace, window: &mut Window, cx: &mut Contex
 
 #[cfg(test)]
 mod tests {
-    use super::{ALWAYS, CONTEXT, TYPING_SAFE};
+    use super::{override_context, try_binding, ALWAYS, CONTEXT, TYPING_SAFE};
+    use crate::actions::ActivateTool;
     use gpui::{KeyBindingContextPredicate, KeyContext};
 
     /// Does a binding registered with `predicate` fire in `state`?
@@ -350,5 +403,33 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn a_bad_user_keystroke_is_skipped_not_fatal() {
+        // `KeyBinding::new` panics on anything gpui cannot parse, and it
+        // runs before the window exists, so one typo in keymap.json took
+        // the app down at launch with a bare unwrap backtrace.
+        let tool = || {
+            Box::new(ActivateTool {
+                id: "eraser".into(),
+            })
+        };
+        assert!(try_binding("ctrl-s", tool(), CONTEXT).is_some());
+        // Two non-modifier components: gpui rejects these.
+        for bad in ["ctrl-s-a", "ctrl-page-up", "cmd-arrow-left", "alt-num-1"] {
+            assert!(
+                try_binding(bad, tool(), CONTEXT).is_none(),
+                "{bad} should be declined, not panic"
+            );
+        }
+    }
+
+    #[test]
+    fn unmodified_overrides_yield_to_typing() {
+        assert_eq!(override_context("e"), TYPING_SAFE);
+        assert_eq!(override_context("5"), TYPING_SAFE);
+        assert_eq!(override_context("ctrl-e"), CONTEXT);
+        assert_eq!(override_context("cmd-shift-s"), CONTEXT);
     }
 }

--- a/crates/app/src/keymap.rs
+++ b/crates/app/src/keymap.rs
@@ -324,9 +324,18 @@ pub fn save_file_dialog(ws: &mut Workspace, window: &mut Window, cx: &mut Contex
         .unwrap_or_else(|| "untitled.psd".into());
     let rx = cx.prompt_for_new_path(&dir, Some(&suggested));
     cx.spawn_in(window, async move |this, cx| {
-        if let Ok(Ok(Some(path))) = rx.await {
-            this.update_in(cx, |ws, _window, cx| ws.save_file_as(path, cx))
-                .ok();
+        match rx.await {
+            Ok(Ok(Some(path))) => {
+                this.update_in(cx, |ws, _window, cx| ws.save_file_as(path, cx))
+                    .ok();
+            }
+            // Cancelled, or the prompt failed. Anything waiting on the
+            // save -- closing the tab, say -- has to be called off, or it
+            // would fire on some later unrelated save instead.
+            _ => {
+                this.update_in(cx, |ws, _window, _cx| ws.cancel_pending_save())
+                    .ok();
+            }
         }
     })
     .detach();

--- a/crates/app/src/panels.rs
+++ b/crates/app/src/panels.rs
@@ -544,14 +544,17 @@ pub(crate) fn run_app_item(
         AppItem::AssignProfile => ws.open_modal(
             Modal::Profile {
                 convert: false,
-                selected: 0,
+                // The document's own profile, not always sRGB: opening on
+                // the wrong entry invited an accidental assign to sRGB on
+                // a document that was not in it.
+                selected: ws.current_profile_index(),
             },
             cx,
         ),
         AppItem::ConvertProfile => ws.open_modal(
             Modal::Profile {
                 convert: true,
-                selected: 0,
+                selected: ws.current_profile_index(),
             },
             cx,
         ),
@@ -566,7 +569,10 @@ pub(crate) fn run_app_item(
         AppItem::ToggleSnap => ws.toggle_snap(cx),
         AppItem::ClearGuides => ws.clear_guides(cx),
         AppItem::ScreenModeItem => ws.cycle_screen_mode(cx),
-        AppItem::Preferences => ws.open_modal(Modal::Preferences, cx),
+        AppItem::Preferences => {
+            ws.snapshot_preferences();
+            ws.open_modal(Modal::Preferences, cx)
+        }
         AppItem::ModeRgb => ws.set_color_mode(schist_color::ColorMode::Rgb, cx),
         AppItem::ModeGrayscale => ws.set_color_mode(schist_color::ColorMode::Grayscale, cx),
         AppItem::ModeCmyk => ws.set_color_mode(schist_color::ColorMode::Cmyk, cx),
@@ -787,6 +793,7 @@ fn menu_row(
         .justify_between()
         .px_2()
         .h(px(24.0))
+        .cursor_pointer()
         .hover(|s| {
             s.bg(gpui::rgb(palette().accent))
                 .text_color(gpui::rgb(palette().accent_text))
@@ -1433,6 +1440,7 @@ pub fn toolbar(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElem
                         .size(px(30.0))
                         .my(px(1.0))
                         .rounded_sm()
+                        .cursor_pointer()
                         .when_active(is_active)
                         .hover(move |s| {
                             if is_active {
@@ -1823,6 +1831,7 @@ fn icon_button(
         .justify_center()
         .size(px(22.0))
         .rounded_sm()
+        .cursor_pointer()
         .hover(|s| s.bg(gpui::rgb(palette().hover)))
         .on_mouse_down(
             MouseButton::Left,
@@ -2285,6 +2294,35 @@ fn history_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoEl
                 .overflow_y_scroll()
                 .flex_grow()
                 .min_h(px(0.0))
+                // The state the document opened in. The panel could walk
+                // back to "one edit applied" but never to "none": the
+                // topmost row still leaves the first edit in place, so
+                // getting all the way back needed one more cmd-Z.
+                // Photoshop's panel has this row too.
+                .child({
+                    let is_current = n_undo == 0;
+                    div()
+                        .px_1()
+                        .h(px(19.0))
+                        .flex_none()
+                        .text_size(px(11.0))
+                        .rounded_sm()
+                        .cursor_pointer()
+                        .when_active(is_current)
+                        .hover(move |s| {
+                            if is_current {
+                                s
+                            } else {
+                                s.bg(gpui::rgb(palette().hover))
+                            }
+                        })
+                        .text_color(gpui::rgb(palette().text_dim))
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |ws, _e, _w, cx| ws.history_jump(-n_undo, cx)),
+                        )
+                        .child("Opened")
+                })
                 .children(undo_entries.into_iter().enumerate().map(|(i, name)| {
                     // Jump so entry i becomes the last applied edit.
                     let steps = (i as i32 + 1) - n_undo;
@@ -2295,6 +2333,7 @@ fn history_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoEl
                         .flex_none()
                         .text_size(px(11.0))
                         .rounded_sm()
+                        .cursor_pointer()
                         .when_active(is_current)
                         .hover(move |s| {
                             if is_current {

--- a/crates/app/src/panels.rs
+++ b/crates/app/src/panels.rs
@@ -442,6 +442,18 @@ const FILTER_GROUPS: &[(&str, &[&str])] = &[
     ),
 ];
 
+/// One toolbar slot: its group, the icon of the tool currently showing,
+/// whether that tool is active, whether the group has more than one tool,
+/// and the name and shortcut for its hover label.
+type ToolSlot = (
+    &'static str,
+    &'static str,
+    bool,
+    bool,
+    String,
+    Option<SharedString>,
+);
+
 fn keybind_hint(kb: Option<&str>) -> String {
     let Some(kb) = kb else { return String::new() };
     let kb = if cfg!(target_os = "macos") {
@@ -1403,18 +1415,26 @@ pub fn toolbar(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElem
     let active = ws.editor.active_tool;
     // One slot per group, showing whichever tool that group last used —
     // Photoshop's nested tools, so twenty tools take eleven slots.
-    let slots: Vec<(&'static str, &'static str, bool, bool)> = ws
+    let slots: Vec<ToolSlot> = ws
         .tool_groups
         .clone()
         .into_iter()
         .map(|(group, tools)| {
             let shown = ws.group_tool(group);
-            let icon = ws
+            let (icon, name, key) = ws
                 .registry
                 .tool_mut(shown)
-                .map(|t| t.icon())
-                .unwrap_or("move");
-            (group, icon, tools.contains(&active), tools.len() > 1)
+                .map(|t| (t.icon(), t.name().to_string(), t.shortcut()))
+                .unwrap_or(("move", "Move".into(), None));
+            let hint = key.map(|k| SharedString::from(k.to_uppercase()));
+            (
+                group,
+                icon,
+                tools.contains(&active),
+                tools.len() > 1,
+                name,
+                hint,
+            )
         })
         .collect();
 
@@ -1428,71 +1448,71 @@ pub fn toolbar(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElem
         .border_r_1()
         .border_color(gpui::rgb(palette().panel_edge))
         .pt_1()
-        .children(
-            slots
-                .into_iter()
-                .map(|(group, icon_name, is_active, has_siblings)| {
-                    div()
-                        .relative()
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .size(px(30.0))
-                        .my(px(1.0))
-                        .rounded_sm()
-                        .cursor_pointer()
-                        .when_active(is_active)
-                        .hover(move |s| {
-                            if is_active {
-                                s
-                            } else {
-                                s.bg(gpui::rgb(palette().hover))
-                            }
-                        })
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(move |ws, ev: &MouseDownEvent, _w, cx| {
-                                ws.press_tool_group(group, ev.position, cx);
-                            }),
-                        )
-                        .on_mouse_up(
-                            MouseButton::Left,
-                            cx.listener(move |ws, _ev, _w, cx| {
-                                ws.release_tool_group(group, cx);
-                            }),
-                        )
-                        // Right-click opens the flyout immediately, for
-                        // people who don't want to wait out the hold.
-                        .on_mouse_down(
-                            MouseButton::Right,
-                            cx.listener(move |ws, ev: &MouseDownEvent, _w, cx| {
-                                ws.open_tool_flyout(group, ev.position, cx);
-                            }),
-                        )
-                        .child(icon(
-                            icon_name,
-                            16.0,
-                            if is_active {
+        .children(slots.into_iter().map(
+            |(group, icon_name, is_active, has_siblings, name, hint)| {
+                div()
+                    .id(SharedString::from(format!("tool-slot-{group}")))
+                    .relative()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .size(px(30.0))
+                    .my(px(1.0))
+                    .rounded_sm()
+                    .cursor_pointer()
+                    .tooltip(ui::tip(name, hint))
+                    .when_active(is_active)
+                    .hover(move |s| {
+                        if is_active {
+                            s
+                        } else {
+                            s.bg(gpui::rgb(palette().hover))
+                        }
+                    })
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |ws, ev: &MouseDownEvent, _w, cx| {
+                            ws.press_tool_group(group, ev.position, cx);
+                        }),
+                    )
+                    .on_mouse_up(
+                        MouseButton::Left,
+                        cx.listener(move |ws, _ev, _w, cx| {
+                            ws.release_tool_group(group, cx);
+                        }),
+                    )
+                    // Right-click opens the flyout immediately, for
+                    // people who don't want to wait out the hold.
+                    .on_mouse_down(
+                        MouseButton::Right,
+                        cx.listener(move |ws, ev: &MouseDownEvent, _w, cx| {
+                            ws.open_tool_flyout(group, ev.position, cx);
+                        }),
+                    )
+                    .child(icon(
+                        icon_name,
+                        16.0,
+                        if is_active {
+                            palette().accent_text
+                        } else {
+                            palette().text
+                        },
+                    ))
+                    .children(has_siblings.then(|| {
+                        // The corner mark that means "more tools here".
+                        div()
+                            .absolute()
+                            .right(px(2.0))
+                            .bottom(px(2.0))
+                            .size(px(4.0))
+                            .bg(gpui::rgb(if is_active {
                                 palette().accent_text
                             } else {
-                                palette().text
-                            },
-                        ))
-                        .children(has_siblings.then(|| {
-                            // The corner mark that means "more tools here".
-                            div()
-                                .absolute()
-                                .right(px(2.0))
-                                .bottom(px(2.0))
-                                .size(px(4.0))
-                                .bg(gpui::rgb(if is_active {
-                                    palette().accent_text
-                                } else {
-                                    palette().text_dim
-                                }))
-                        }))
-                }),
-        )
+                                palette().text_dim
+                            }))
+                    }))
+            },
+        ))
         .child(color_wells(ws, cx))
 }
 

--- a/crates/app/src/ui.rs
+++ b/crates/app/src/ui.rs
@@ -168,6 +168,7 @@ pub fn button(
         .px_3()
         .rounded_sm()
         .text_size(px(12.0))
+        .cursor_pointer()
         .bg(gpui::rgb(if primary {
             palette().accent
         } else {

--- a/crates/app/src/ui.rs
+++ b/crates/app/src/ui.rs
@@ -10,6 +10,8 @@ use gpui::{
     div, px, Context, InteractiveElement as _, IntoElement, MouseButton, ParentElement as _,
     SharedString, StatefulInteractiveElement as _, Styled as _,
 };
+use std::cell::RefCell;
+use std::rc::Rc;
 
 /// The chrome colours for one theme. Everything that isn't document
 /// content draws from here; the active set is swapped by [`set_light`].
@@ -120,12 +122,44 @@ pub fn palette() -> &'static Palette {
 }
 
 /// A labelled push button.
+/// What a dialog does when the user presses Enter.
+pub type DialogAction = Rc<dyn Fn(&mut Workspace, &mut gpui::Window, &mut Context<Workspace>)>;
+
+thread_local! {
+    /// The primary button built most recently.
+    ///
+    /// A dialog's default action is, by definition, whatever its primary
+    /// button does, and the buttons are built as plain closures deep
+    /// inside each dialog body with no path back to the workspace. Rather
+    /// than thread an out-parameter through every dialog function, the
+    /// primary button leaves its handler here and `dialogs::render` --
+    /// which brackets the whole build and does hold `&mut Workspace` --
+    /// picks it up. GPUI renders on one thread, synchronously, so the
+    /// slot is only ever live for the duration of one dialog build.
+    static DEFAULT_ACTION: RefCell<Option<DialogAction>> = const { RefCell::new(None) };
+}
+
+/// Start a dialog build: forget any previous dialog's default action.
+pub fn reset_default_action() {
+    DEFAULT_ACTION.with(|slot| *slot.borrow_mut() = None);
+}
+
+/// End a dialog build: take whatever its primary button registered.
+pub fn take_default_action() -> Option<DialogAction> {
+    DEFAULT_ACTION.with(|slot| slot.borrow_mut().take())
+}
+
 pub fn button(
     label: impl Into<SharedString>,
     primary: bool,
     on_click: impl Fn(&mut Workspace, &mut gpui::Window, &mut Context<Workspace>) + 'static,
     cx: &mut Context<Workspace>,
 ) -> impl IntoElement {
+    let on_click: DialogAction = Rc::new(on_click);
+    if primary {
+        let action = on_click.clone();
+        DEFAULT_ACTION.with(|slot| *slot.borrow_mut() = Some(action));
+    }
     div()
         .flex()
         .items_center()
@@ -186,12 +220,15 @@ pub fn num_field(
         focused,
         buffer,
     } = field;
-    let shown = if focused && !buffer.is_empty() {
-        buffer
-    } else if value.fract().abs() < 0.01 {
+    let committed = if value.fract().abs() < 0.01 {
         format!("{value:.0}")
     } else {
         format!("{value:.2}")
+    };
+    let shown = if focused && !buffer.is_empty() {
+        buffer
+    } else {
+        committed.clone()
     };
     let dec = on_change.clone();
     let inc = on_change.clone();
@@ -220,7 +257,7 @@ pub fn num_field(
                 .on_mouse_down(
                     MouseButton::Left,
                     cx.listener(move |ws, _e, _w, cx| {
-                        ws.focus_field(id);
+                        ws.focus_field(id, committed.clone());
                         cx.notify();
                     }),
                 )

--- a/crates/app/src/ui.rs
+++ b/crates/app/src/ui.rs
@@ -151,11 +151,12 @@ pub fn take_default_action() -> Option<DialogAction> {
 
 /// A hover label for an icon-only control.
 ///
-/// `grep -rn "tooltip" crates/app/` returned nothing: the sixteen toolbar
-/// slots, the layers-panel buttons, the history buttons, the visibility
-/// eyes, the swap-colours arrows and the tab close were all bare SVGs
-/// with no hover label and no shortcut hint. The only place a tool's name
-/// and key appeared was inside the flyout, which most slots do not have.
+/// `grep -rn "tooltip" crates/app/` returned nothing: every icon in the
+/// window was a bare SVG with no hover label and no shortcut hint, and
+/// the only place a tool's name and key appeared was inside the flyout,
+/// which most slots do not have. The toolbar slots use this; the panel
+/// buttons, visibility eyes and tab close are still unlabelled, and want
+/// an `id` each before they can be.
 pub struct Tooltip {
     label: SharedString,
     /// A keyboard shortcut, shown dimmed after the label.

--- a/crates/app/src/ui.rs
+++ b/crates/app/src/ui.rs
@@ -7,8 +7,8 @@
 
 use crate::workspace::{Popup, Workspace};
 use gpui::{
-    div, px, Context, InteractiveElement as _, IntoElement, MouseButton, ParentElement as _,
-    SharedString, StatefulInteractiveElement as _, Styled as _,
+    div, px, AppContext as _, Context, InteractiveElement as _, IntoElement, MouseButton,
+    ParentElement as _, SharedString, StatefulInteractiveElement as _, Styled as _,
 };
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -147,6 +147,55 @@ pub fn reset_default_action() {
 /// End a dialog build: take whatever its primary button registered.
 pub fn take_default_action() -> Option<DialogAction> {
     DEFAULT_ACTION.with(|slot| slot.borrow_mut().take())
+}
+
+/// A hover label for an icon-only control.
+///
+/// `grep -rn "tooltip" crates/app/` returned nothing: the sixteen toolbar
+/// slots, the layers-panel buttons, the history buttons, the visibility
+/// eyes, the swap-colours arrows and the tab close were all bare SVGs
+/// with no hover label and no shortcut hint. The only place a tool's name
+/// and key appeared was inside the flyout, which most slots do not have.
+pub struct Tooltip {
+    label: SharedString,
+    /// A keyboard shortcut, shown dimmed after the label.
+    hint: Option<SharedString>,
+}
+
+impl gpui::Render for Tooltip {
+    fn render(&mut self, _window: &mut gpui::Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let mut row = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap_2()
+            .px_2()
+            .py_1()
+            .rounded_sm()
+            .bg(gpui::rgb(palette().popup_bg))
+            .border_1()
+            .border_color(gpui::rgb(palette().panel_edge))
+            .text_size(px(11.0))
+            .text_color(gpui::rgb(palette().text))
+            .child(self.label.clone());
+        if let Some(hint) = self.hint.clone() {
+            row = row.child(div().text_color(gpui::rgb(palette().text_dim)).child(hint));
+        }
+        row
+    }
+}
+
+/// Build a tooltip callback for [`StatefulInteractiveElement::tooltip`].
+pub fn tip(
+    label: impl Into<SharedString>,
+    hint: Option<SharedString>,
+) -> impl Fn(&mut gpui::Window, &mut gpui::App) -> gpui::AnyView + 'static {
+    let label = label.into();
+    move |_window, cx| {
+        let label = label.clone();
+        let hint = hint.clone();
+        cx.new(|_| Tooltip { label, hint }).into()
+    }
 }
 
 pub fn button(

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -230,6 +230,13 @@ pub struct Workspace {
     /// checkbox to see what it did tore the backend down, rebuilt it and
     /// wrote the preference file, with no way to back out.
     preferences_snapshot: Option<Box<(ViewOptions, schist_colormgmt::Intent)>>,
+    /// Close the active tab once the in-flight save finishes.
+    ///
+    /// "Save…" on an Untitled document falls through to the *async* Save
+    /// As prompt and returns immediately with `dirty` still true, so the
+    /// close was skipped: the user asked to close the tab, the file was
+    /// written, and the tab stayed open.
+    close_after_save: bool,
     pub screen_mode: ScreenMode,
     /// A guide being dragged out of a ruler.
     dragging_guide: Option<schist_core::Guide>,
@@ -826,6 +833,7 @@ impl Workspace {
             pending_plugin_toggle: None,
             view: load_view_options(),
             preferences_snapshot: None,
+            close_after_save: false,
             screen_mode: ScreenMode::default(),
             dragging_guide: None,
             layer_drag: None,
@@ -1398,13 +1406,38 @@ impl Workspace {
                 }
                 self.clear_recovery();
                 self.status = format!("Saved {}", path.display()).into();
+                if std::mem::take(&mut self.close_after_save) {
+                    let index = self.active_tab();
+                    self.close_tab(index, cx);
+                }
             }
             Err(err) => {
+                // The tab stays open on a failed save, whatever was asked.
+                self.close_after_save = false;
                 log::error!("save failed: {err:#}");
                 self.status = format!("Save failed: {err}").into();
             }
         }
         cx.notify();
+    }
+
+    /// Ask for the active tab to close as soon as its save lands.
+    pub fn close_tab_after_save(&mut self) {
+        self.close_after_save = true;
+    }
+
+    /// Whether a save is still outstanding with a close waiting on it.
+    ///
+    /// Save As is asynchronous: `save_current` returns before the file
+    /// prompt resolves, so this is how a caller tells a synchronous save
+    /// (already done, tab already closed) from one still in flight.
+    pub fn has_pending_save(&self) -> bool {
+        self.close_after_save
+    }
+
+    /// The save never happened, so nothing is waiting on it.
+    pub fn cancel_pending_save(&mut self) {
+        self.close_after_save = false;
     }
 
     /// ⌘S: save over the document's existing path, or fall back to Save As

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -943,7 +943,7 @@ impl Workspace {
             );
         }
         doc.push_layer(layer);
-        doc.dirty = false;
+        doc.mark_saved();
         self.open_in_tab(doc, false);
     }
 
@@ -1377,7 +1377,7 @@ impl Workspace {
         match self.write_document_to(&path) {
             Ok(()) => {
                 if let Some(doc) = &mut self.doc {
-                    doc.dirty = false;
+                    doc.mark_saved();
                     doc.path = Some(path.clone());
                     if let Some(name) = path.file_name() {
                         doc.title = name.to_string_lossy().into_owned();
@@ -1997,6 +1997,36 @@ impl Workspace {
             lo = [l; 3];
             hi = [h; 3];
         }
+        // Auto Color additionally pulls each channel's midtone to neutral
+        // grey, which is the only thing distinguishing it from Auto Tone.
+        // This used to be `v.powf(1.0)`, the identity, so the two menu
+        // items produced byte-identical results.
+        let mut gamma = [1.0f32; 3];
+        if mode == AutoMode::Color {
+            let mut sum = [0.0f64; 3];
+            let mut n = 0u64;
+            for p in buf.as_chunks::<4>().0 {
+                if p[3] <= 0.0 {
+                    continue;
+                }
+                for ch in 0..3 {
+                    let span = (hi[ch] - lo[ch]).max(1e-4);
+                    sum[ch] += f64::from(((p[ch] - lo[ch]) / span).clamp(0.0, 1.0));
+                }
+                n += 1;
+            }
+            if n > 0 {
+                for ch in 0..3 {
+                    let mean = (sum[ch] / n as f64) as f32;
+                    // Solve mean^gamma = 0.5 for gamma, so the channel's
+                    // midtone lands on neutral grey. Clamped so a nearly
+                    // black or white channel cannot explode.
+                    if mean > 1e-3 && mean < 1.0 - 1e-3 {
+                        gamma[ch] = (0.5f32.ln() / mean.ln()).clamp(0.2, 5.0);
+                    }
+                }
+            }
+        }
         for p in buf.as_chunks_mut::<4>().0 {
             if p[3] <= 0.0 {
                 continue;
@@ -2004,9 +2034,8 @@ impl Workspace {
             for ch in 0..3 {
                 let span = (hi[ch] - lo[ch]).max(1e-4);
                 let mut v = ((p[ch] - lo[ch]) / span).clamp(0.0, 1.0);
-                if mode == AutoMode::Color {
-                    // Auto Color also pulls the midtones to neutral grey.
-                    v = v.powf(1.0);
+                if gamma[ch] != 1.0 {
+                    v = v.powf(gamma[ch]);
                 }
                 p[ch] = v;
             }
@@ -2117,7 +2146,16 @@ impl Workspace {
         if doc.mode == mode {
             return;
         }
-        if mode == schist_color::ColorMode::Grayscale || mode == schist_color::ColorMode::Indexed {
+        // Indexed Color needs palette quantisation, which does not exist.
+        // It used to fall into the greyscale branch below, desaturating
+        // the image and labelling the history entry "Grayscale", so the
+        // menu item claimed to do something it had never implemented.
+        if mode == schist_color::ColorMode::Indexed {
+            self.status = "Indexed Color is not supported yet".into();
+            cx.notify();
+            return;
+        }
+        if mode == schist_color::ColorMode::Grayscale {
             // Flatten colour out of every layer, which is what the mode
             // change actually means for the pixels.
             let ids: Vec<schist_core::LayerId> = doc.tree.iter().map(|l| l.id).collect();
@@ -2143,10 +2181,16 @@ impl Workspace {
                     }
                 }
             }
+            edit.set_color_mode(mode);
+            edit.commit();
+        } else {
+            // CMYK/Lab/RGB change nothing but the mode, which still has
+            // to be undoable: it used to produce no history entry at all.
+            let mut edit = doc.begin_edit(mode.display_name().to_string());
+            edit.set_color_mode(mode);
             edit.commit();
         }
         if let Some(doc) = self.doc.as_mut() {
-            doc.mode = mode;
             doc.damage_all();
         }
         self.status = mode.display_name().into();

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -4012,6 +4012,11 @@ impl Workspace {
             "backspace" => {
                 self.field_buffer.pop();
             }
+            // Escape is handled in `cancel_gesture`, which runs first:
+            // it is bound to `CancelGesture` in the always-matching
+            // "Workspace" context, so nothing escape-shaped ever reaches
+            // here. Kept as a fallback for a build with that binding
+            // removed rather than left as a dead arm that looks live.
             "escape" => {
                 self.focused_field = None;
                 self.field_buffer.clear();
@@ -4235,6 +4240,17 @@ impl Workspace {
         }
         if self.context_menu.is_some() {
             self.close_context_menu(cx);
+            return;
+        }
+        // A focused field takes the escape first: it drops focus and
+        // leaves the dialog up, which is what `field_key`'s "escape" arm
+        // meant to do before `CancelGesture` -- bound in the
+        // always-matching "Workspace" context -- got there ahead of it
+        // and closed the whole dialog on the first press.
+        if self.modal.is_some() && self.focused_field.is_some() {
+            self.focused_field = None;
+            self.field_buffer.clear();
+            cx.notify();
             return;
         }
         if self.modal.is_some() {

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -212,6 +212,9 @@ pub struct Workspace {
     /// Numeric field currently accepting digits, and its edit buffer.
     pub focused_field: Option<&'static str>,
     pub field_buffer: String,
+    /// True until the first keystroke after a field takes focus, so that
+    /// one can replace the seeded value rather than append to it.
+    field_fresh: bool,
     /// What Enter does in the open dialog: the primary button's action,
     /// captured while the dialog rendered.
     pub default_action: Option<crate::ui::DialogAction>,
@@ -828,6 +831,7 @@ impl Workspace {
             modal_stack: Vec::new(),
             focused_field: None,
             field_buffer: String::new(),
+            field_fresh: false,
             default_action: None,
             plugins,
             pending_plugin_toggle: None,
@@ -3978,6 +3982,7 @@ impl Workspace {
     pub fn focus_field(&mut self, id: &'static str, current: impl Into<String>) {
         self.focused_field = Some(id);
         self.field_buffer = current.into();
+        self.field_fresh = true;
     }
 
     /// Fire the open dialog's primary button, as Enter should.
@@ -4002,6 +4007,7 @@ impl Workspace {
         let Some(id) = self.focused_field else {
             return false;
         };
+        let fresh = std::mem::take(&mut self.field_fresh);
         // Text fields (layer and document names) take any printable
         // character; the picker's hex field takes hex digits up to a full
         // triplet; numeric fields only digits.
@@ -4026,15 +4032,15 @@ impl Workspace {
                 self.commit_field(id);
                 return true;
             }
+            _ if hex => match hex_field_after(&self.field_buffer, fresh, text.unwrap_or("")) {
+                Some(next) => self.field_buffer = next,
+                None => return false,
+            },
             _ => match text {
                 Some(t)
                     if !t.is_empty()
                         && !t.chars().any(char::is_control)
-                        && (textual
-                            || (hex
-                                && self.field_buffer.len() + t.len() <= 6
-                                && t.chars().all(|c| c.is_ascii_hexdigit()))
-                            || (!hex && numeric_accepts(&self.field_buffer, t))) =>
+                        && (textual || numeric_accepts(&self.field_buffer, t)) =>
                 {
                     self.field_buffer.push_str(t)
                 }
@@ -7006,6 +7012,24 @@ fn fetch_model(url: &str) -> Result<Vec<u8>, String> {
 /// were unreachable from the keyboard -- the only way to a non-integer
 /// was the +/- step buttons. A leading `-` and a single `.` go through
 /// now; `parse` still rejects whatever is malformed.
+/// The colour picker's hex field after a keystroke, or `None` when it
+/// refuses one.
+///
+/// The field is seeded with the committed value and capped at a full
+/// triplet, so typing into a freshly clicked one did nothing at all until
+/// the user backspaced six times. The first character replaces what is
+/// there, the way it would if the text were selected.
+fn hex_field_after(buffer: &str, fresh: bool, typed: &str) -> Option<String> {
+    let base = if fresh { "" } else { buffer };
+    if typed.is_empty()
+        || base.len() + typed.len() > 6
+        || !typed.chars().all(|c| c.is_ascii_hexdigit())
+    {
+        return None;
+    }
+    Some(format!("{base}{typed}"))
+}
+
 fn numeric_accepts(buffer: &str, t: &str) -> bool {
     let mut len = buffer.len();
     let mut dot = buffer.contains('.');
@@ -7033,7 +7057,7 @@ fn builtin_index(name: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::{builtin_index, numeric_accepts};
+    use super::{builtin_index, hex_field_after, numeric_accepts};
     use std::time::{Duration, SystemTime};
 
     #[test]
@@ -7051,6 +7075,25 @@ mod tests {
         assert!(!numeric_accepts("1.5", "."));
         assert!(!numeric_accepts("", "1.2.3"));
         assert!(!numeric_accepts("", "e"));
+    }
+
+    #[test]
+    fn the_first_keystroke_replaces_a_freshly_clicked_hex_field() {
+        // Seeded with the committed value and capped at six digits, so
+        // every keystroke was refused until the field was emptied by
+        // hand.
+        assert_eq!(hex_field_after("ff8800", true, "a").as_deref(), Some("a"));
+        // After that it appends, up to the cap.
+        assert_eq!(hex_field_after("a", false, "b").as_deref(), Some("ab"));
+        assert_eq!(hex_field_after("ffaa11", false, "b"), None);
+        // And it is still hex only.
+        assert_eq!(hex_field_after("ff", false, "z"), None);
+        assert_eq!(hex_field_after("ff", true, ""), None);
+        // A pasted triplet lands whole.
+        assert_eq!(
+            hex_field_after("112233", true, "aabbcc").as_deref(),
+            Some("aabbcc")
+        );
     }
 
     fn snap(secs: u64, name: &str) -> (SystemTime, std::path::PathBuf) {

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -230,13 +230,13 @@ pub struct Workspace {
     /// checkbox to see what it did tore the backend down, rebuilt it and
     /// wrote the preference file, with no way to back out.
     preferences_snapshot: Option<Box<(ViewOptions, schist_colormgmt::Intent)>>,
-    /// Close the active tab once the in-flight save finishes.
+    /// Close *this* document's tab once its in-flight save finishes.
     ///
     /// "Save…" on an Untitled document falls through to the *async* Save
     /// As prompt and returns immediately with `dirty` still true, so the
     /// close was skipped: the user asked to close the tab, the file was
     /// written, and the tab stayed open.
-    close_after_save: bool,
+    close_after_save: Option<schist_core::DocumentId>,
     pub screen_mode: ScreenMode,
     /// A guide being dragged out of a ruler.
     dragging_guide: Option<schist_core::Guide>,
@@ -833,7 +833,7 @@ impl Workspace {
             pending_plugin_toggle: None,
             view: load_view_options(),
             preferences_snapshot: None,
-            close_after_save: false,
+            close_after_save: None,
             screen_mode: ScreenMode::default(),
             dragging_guide: None,
             layer_drag: None,
@@ -1406,14 +1406,19 @@ impl Workspace {
                 }
                 self.clear_recovery();
                 self.status = format!("Saved {}", path.display()).into();
-                if std::mem::take(&mut self.close_after_save) {
+                // Only if this is the document the close was asked for.
+                // The Save As portal does not block the window on Linux,
+                // so the user can switch tabs and save another one while
+                // it is up, and a bare flag closed the wrong tab.
+                let saved = self.doc.as_ref().map(|d| d.id);
+                if self.close_after_save.take() == saved && saved.is_some() {
                     let index = self.active_tab();
                     self.close_tab(index, cx);
                 }
             }
             Err(err) => {
                 // The tab stays open on a failed save, whatever was asked.
-                self.close_after_save = false;
+                self.close_after_save = None;
                 log::error!("save failed: {err:#}");
                 self.status = format!("Save failed: {err}").into();
             }
@@ -1423,7 +1428,7 @@ impl Workspace {
 
     /// Ask for the active tab to close as soon as its save lands.
     pub fn close_tab_after_save(&mut self) {
-        self.close_after_save = true;
+        self.close_after_save = self.doc.as_ref().map(|d| d.id);
     }
 
     /// Whether a save is still outstanding with a close waiting on it.
@@ -1432,12 +1437,12 @@ impl Workspace {
     /// prompt resolves, so this is how a caller tells a synchronous save
     /// (already done, tab already closed) from one still in flight.
     pub fn has_pending_save(&self) -> bool {
-        self.close_after_save
+        self.close_after_save.is_some()
     }
 
     /// The save never happened, so nothing is waiting on it.
     pub fn cancel_pending_save(&mut self) {
-        self.close_after_save = false;
+        self.close_after_save = None;
     }
 
     /// ⌘S: save over the document's existing path, or fall back to Save As
@@ -4554,7 +4559,6 @@ impl Workspace {
 
     // ----- view options, guides and snapping -----
 
-    /// Persist view options so they survive a restart.
     /// Remember the current preferences so Cancel can restore them.
     pub fn snapshot_preferences(&mut self) {
         self.preferences_snapshot = Some(Box::new((self.view, self.color.intent)));
@@ -4578,6 +4582,9 @@ impl Workspace {
         self.color.intent = intent;
         if gpu_changed {
             init_compositor_backend(self.view.gpu_compositing);
+            // The caches hold tiles composited by the other backend; the
+            // dialog's own toggle drops them and reverting has to as well.
+            self.rebuild_after_backend_change(cx);
         }
         if theme_changed {
             self.set_theme_quiet(self.view.theme);
@@ -4587,6 +4594,7 @@ impl Workspace {
         cx.notify();
     }
 
+    /// Persist view options so they survive a restart.
     pub fn save_view_options(&self) {
         let Some(path) = prefs_path() else { return };
         if let Some(dir) = path.parent() {

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -222,6 +222,14 @@ pub struct Workspace {
     pub pending_plugin_toggle: Option<(String, bool)>,
     /// View toggles (rulers, grid, guides, snapping, theme).
     pub view: ViewOptions,
+    /// View options and rendering intent as they stood when Preferences
+    /// opened, so Cancel can put them back.
+    ///
+    /// Every control in that dialog applied and persisted on change and
+    /// the only action was "Done" -- flipping the GPU compositing
+    /// checkbox to see what it did tore the backend down, rebuilt it and
+    /// wrote the preference file, with no way to back out.
+    preferences_snapshot: Option<Box<(ViewOptions, schist_colormgmt::Intent)>>,
     pub screen_mode: ScreenMode,
     /// A guide being dragged out of a ruler.
     dragging_guide: Option<schist_core::Guide>,
@@ -817,6 +825,7 @@ impl Workspace {
             plugins,
             pending_plugin_toggle: None,
             view: load_view_options(),
+            preferences_snapshot: None,
             screen_mode: ScreenMode::default(),
             dragging_guide: None,
             layer_drag: None,
@@ -3901,6 +3910,10 @@ impl Workspace {
         // Same for a cancelled Layer Style session: OK clears the modal
         // itself before it gets here, so reaching this means Cancel.
         self.revert_layer_style();
+        // Escape out of Preferences is a cancel, like the button.
+        if matches!(self.modal, Some(Modal::Preferences)) {
+            self.revert_preferences(cx);
+        }
         // Closing the picker uncovers the dialog it was opened from.
         self.modal = self.modal_stack.pop();
         self.default_action = None;
@@ -4509,6 +4522,38 @@ impl Workspace {
     // ----- view options, guides and snapping -----
 
     /// Persist view options so they survive a restart.
+    /// Remember the current preferences so Cancel can restore them.
+    pub fn snapshot_preferences(&mut self) {
+        self.preferences_snapshot = Some(Box::new((self.view, self.color.intent)));
+    }
+
+    /// Accept whatever Preferences changed.
+    pub fn keep_preferences(&mut self) {
+        self.preferences_snapshot = None;
+        self.save_view_options();
+    }
+
+    /// Put back the preferences as they were when the dialog opened.
+    pub fn revert_preferences(&mut self, cx: &mut Context<Self>) {
+        let Some(snapshot) = self.preferences_snapshot.take() else {
+            return;
+        };
+        let (view, intent) = *snapshot;
+        let gpu_changed = view.gpu_compositing != self.view.gpu_compositing;
+        let theme_changed = view.theme != self.view.theme;
+        self.view = view;
+        self.color.intent = intent;
+        if gpu_changed {
+            init_compositor_backend(self.view.gpu_compositing);
+        }
+        if theme_changed {
+            self.set_theme_quiet(self.view.theme);
+        }
+        self.rebuild_color_transforms();
+        self.save_view_options();
+        cx.notify();
+    }
+
     pub fn save_view_options(&self) {
         let Some(path) = prefs_path() else { return };
         if let Some(dir) = path.parent() {
@@ -4753,6 +4798,28 @@ impl Workspace {
 
     fn color_managed(&self) -> bool {
         self.display_transform.is_some() || self.proof_transform.is_some()
+    }
+
+    /// Which built-in the document's profile matches, for the Assign /
+    /// Convert dialogs to open on.
+    ///
+    /// Both used to open on index 0 -- sRGB -- whatever the document was
+    /// actually in, so the dialog described a conversion the user had not
+    /// asked for and OK applied it.
+    pub fn current_profile_index(&self) -> usize {
+        let Some(name) = self
+            .doc
+            .as_ref()
+            .and_then(|d| d.icc_profile.as_ref())
+            .and_then(|bytes| schist_colormgmt::Profile::from_bytes(bytes).ok())
+            .map(|p| p.name().to_string())
+        else {
+            // No embedded profile means the working space, which is what
+            // the document is being shown in.
+            let working = self.color.working.name().to_string();
+            return builtin_index(&working);
+        };
+        builtin_index(&name)
     }
 
     /// Assign a profile: same numbers, new interpretation.
@@ -5044,7 +5111,13 @@ impl Workspace {
             return;
         };
         let mut buf = original.clone();
-        let filter = self.registry.filters().find(|f| f.id() == id).unwrap();
+        // Looked up a second time because the first borrow ended; an
+        // `unwrap` on registry state in a UI path is a panic waiting for
+        // someone to add an early return between the two lookups.
+        let Some(filter) = self.registry.filters().find(|f| f.id() == id) else {
+            self.status = "Filter went away".into();
+            return;
+        };
         filter.apply(
             &mut buf,
             region.width() as usize,
@@ -6135,6 +6208,33 @@ impl Workspace {
         job
     }
 
+    /// The pointer shape for the active tool, so the canvas says what a
+    /// click will do before it happens.
+    fn canvas_cursor(&self) -> gpui::CursorStyle {
+        use gpui::CursorStyle;
+        // Space-to-pan overrides whatever tool is active, and a pan in
+        // progress grabs.
+        if self.space_held || self.pan_last.is_some() {
+            return if self.pan_last.is_some() {
+                CursorStyle::ClosedHand
+            } else {
+                CursorStyle::OpenHand
+            };
+        }
+        match self.editor.active_tool {
+            "hand" => CursorStyle::OpenHand,
+            "zoom" => CursorStyle::Crosshair,
+            "type" => CursorStyle::IBeam,
+            // Everything that targets a point rather than a region: a
+            // crosshair is what Photoshop shows for these.
+            "eyedropper" | "crop" | "marquee.rect" | "marquee.ellipse" | "lasso.free"
+            | "lasso.polygonal" | "lasso.magnetic" | "wand" | "quick_select" | "object_select"
+            | "gradient" | "shape.rect" | "shape.ellipse" | "shape.line" | "shape.polygon"
+            | "pen" | "pen.freeform" | "pen.curvature" => CursorStyle::Crosshair,
+            _ => CursorStyle::Arrow,
+        }
+    }
+
     pub fn render_canvas(&mut self, cx: &mut Context<Self>) -> impl IntoElement {
         let entity = cx.entity();
         div()
@@ -6143,6 +6243,10 @@ impl Workspace {
             .size_full()
             .overflow_hidden()
             .bg(gpui::rgb(crate::ui::palette().canvas_bg))
+            // The pointer never changed shape anywhere in the app: the
+            // canvas showed an arrow whether the active tool was the
+            // hand, the zoom, the eyedropper, a brush or the crop.
+            .cursor(self.canvas_cursor())
             .track_focus(&self.focus)
             .on_mouse_down(
                 MouseButton::Left,
@@ -6549,6 +6653,7 @@ impl Render for Workspace {
                 }
             }))
             .on_action(cx.listener(|ws, _: &ShowPreferences, _w, cx| {
+                ws.snapshot_preferences();
                 ws.open_modal(Modal::Preferences, cx);
             }))
             .on_action(cx.listener(|ws, _: &ShowCanvasSize, _w, cx| {
@@ -6859,9 +6964,19 @@ fn numeric_accepts(buffer: &str, t: &str) -> bool {
     true
 }
 
+/// The built-in profile list position for a profile name, defaulting to
+/// the first entry when nothing matches (an embedded profile that is not
+/// one of ours).
+fn builtin_index(name: &str) -> usize {
+    schist_colormgmt::Profile::builtins()
+        .iter()
+        .position(|(n, _)| n.eq_ignore_ascii_case(name))
+        .unwrap_or(0)
+}
+
 #[cfg(test)]
 mod tests {
-    use super::numeric_accepts;
+    use super::{builtin_index, numeric_accepts};
     use std::time::{Duration, SystemTime};
 
     #[test]
@@ -6961,5 +7076,22 @@ mod tests {
                 zoom * texel * scale_factor
             );
         }
+    }
+
+    /// Assign / Convert Profile both opened on index 0 -- sRGB -- however
+    /// the document was actually tagged, so the dialog described a
+    /// conversion the user had not asked for and OK applied it.
+    #[test]
+    fn the_profile_dialog_opens_on_the_documents_own_profile() {
+        let builtins = schist_colormgmt::Profile::builtins();
+        for (i, (name, _)) in builtins.iter().enumerate() {
+            assert_eq!(builtin_index(name), i, "{name}");
+            // Names arrive from a parsed profile, whose casing we do not
+            // control.
+            assert_eq!(builtin_index(&name.to_lowercase()), i, "{name}");
+        }
+        // Anything we do not ship falls back to the first entry rather
+        // than to a wrong one.
+        assert_eq!(builtin_index("Some Scanner Profile"), 0);
     }
 }

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -212,6 +212,9 @@ pub struct Workspace {
     /// Numeric field currently accepting digits, and its edit buffer.
     pub focused_field: Option<&'static str>,
     pub field_buffer: String,
+    /// What Enter does in the open dialog: the primary button's action,
+    /// captured while the dialog rendered.
+    pub default_action: Option<crate::ui::DialogAction>,
     /// Third-party plugin registry state.
     pub plugins: schist_plugin_host_wasm::PluginManager,
     /// Plugin enable/disable requested from the manager UI, applied on the
@@ -810,6 +813,7 @@ impl Workspace {
             modal_stack: Vec::new(),
             focused_field: None,
             field_buffer: String::new(),
+            default_action: None,
             plugins,
             pending_plugin_toggle: None,
             view: load_view_options(),
@@ -3899,6 +3903,7 @@ impl Workspace {
         self.revert_layer_style();
         // Closing the picker uncovers the dialog it was opened from.
         self.modal = self.modal_stack.pop();
+        self.default_action = None;
         self.focused_field = None;
         self.field_buffer.clear();
         self.open_popup = None;
@@ -3912,9 +3917,32 @@ impl Workspace {
         }
     }
 
-    pub fn focus_field(&mut self, id: &'static str) {
+    /// Focus a field, seeded with the text it is currently showing.
+    ///
+    /// The buffer used to be cleared, and the field falls back to
+    /// rendering its committed value while the buffer is empty, so a
+    /// freshly clicked field looked full but behaved empty: backspace
+    /// popped nothing, and changing 1920 to 1820 meant retyping all four
+    /// digits.
+    pub fn focus_field(&mut self, id: &'static str, current: impl Into<String>) {
         self.focused_field = Some(id);
-        self.field_buffer.clear();
+        self.field_buffer = current.into();
+    }
+
+    /// Fire the open dialog's primary button, as Enter should.
+    pub fn confirm_modal(&mut self, window: &mut gpui::Window, cx: &mut Context<Self>) -> bool {
+        let Some(action) = self.default_action.clone() else {
+            return false;
+        };
+        action(self, window, cx);
+        true
+    }
+
+    /// Push whatever is in the focused field into the modal and unfocus.
+    pub fn commit_focused_field(&mut self) {
+        if let Some(id) = self.focused_field {
+            self.commit_field(id);
+        }
     }
 
     /// Feed a keystroke to the focused numeric field. Returns true when the
@@ -3950,7 +3978,7 @@ impl Workspace {
                             || (hex
                                 && self.field_buffer.len() + t.len() <= 6
                                 && t.chars().all(|c| c.is_ascii_hexdigit()))
-                            || (!hex && t.chars().all(|c| c.is_ascii_digit()))) =>
+                            || (!hex && numeric_accepts(&self.field_buffer, t))) =>
                 {
                     self.field_buffer.push_str(t)
                 }
@@ -6141,8 +6169,28 @@ impl Workspace {
             )
             .on_scroll_wheel(cx.listener(|ws, ev, w, cx| ws.on_scroll(ev, w, cx)))
             .on_pinch(cx.listener(|ws, ev, w, cx| ws.on_pinch(ev, w, cx)))
-            .on_key_down(cx.listener(|ws, ev: &gpui::KeyDownEvent, _w, cx| {
+            .on_key_down(cx.listener(|ws, ev: &gpui::KeyDownEvent, window, cx| {
                 if ws.layer_rename_key(ev, cx) {
+                    cx.stop_propagation();
+                    return;
+                }
+                // A modal owns the keyboard while it is up. Without this
+                // the key fell through to `tool_key` whenever no field
+                // was focused, so opening a dialog on top of a text
+                // session typed into the layer behind it.
+                if ws.modal.is_some() {
+                    match ev.keystroke.key.as_str() {
+                        // Enter is the dialog's primary button, which is
+                        // the only way to reach OK without the mouse.
+                        "enter" => {
+                            ws.commit_focused_field();
+                            ws.confirm_modal(window, cx);
+                        }
+                        key => {
+                            ws.field_key(key, ev.keystroke.key_char.as_deref());
+                        }
+                    }
+                    cx.notify();
                     cx.stop_propagation();
                     return;
                 }
@@ -6789,9 +6837,49 @@ fn fetch_model(url: &str) -> Result<Vec<u8>, String> {
     Ok(bytes)
 }
 
+/// Whether `t` can be appended to a numeric field holding `buffer`.
+///
+/// Digits alone used to be accepted, yet every one of these fields is
+/// read back with `parse::<f32>()`, so fractional and negative values
+/// were unreachable from the keyboard -- the only way to a non-integer
+/// was the +/- step buttons. A leading `-` and a single `.` go through
+/// now; `parse` still rejects whatever is malformed.
+fn numeric_accepts(buffer: &str, t: &str) -> bool {
+    let mut len = buffer.len();
+    let mut dot = buffer.contains('.');
+    for c in t.chars() {
+        match c {
+            '0'..='9' => {}
+            '-' if len == 0 => {}
+            '.' if !dot => dot = true,
+            _ => return false,
+        }
+        len += c.len_utf8();
+    }
+    true
+}
+
 #[cfg(test)]
 mod tests {
+    use super::numeric_accepts;
     use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn numeric_fields_take_fractions_and_negatives() {
+        // These fields are all read back with `parse::<f32>()`, but only
+        // ASCII digits were let through, so no fractional or negative
+        // value could be typed at all.
+        assert!(numeric_accepts("", "-"));
+        assert!(numeric_accepts("1", "."));
+        assert!(numeric_accepts("1.", "5"));
+        assert!(numeric_accepts("-1.", "5"));
+        assert!(numeric_accepts("", "12.5"));
+        // A minus only leads, and there is only one decimal point.
+        assert!(!numeric_accepts("1", "-"));
+        assert!(!numeric_accepts("1.5", "."));
+        assert!(!numeric_accepts("", "1.2.3"));
+        assert!(!numeric_accepts("", "e"));
+    }
 
     fn snap(secs: u64, name: &str) -> (SystemTime, std::path::PathBuf) {
         (

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -2903,9 +2903,15 @@ impl Workspace {
             let mut ctx = CommandCtx {
                 doc,
                 state: &mut self.editor,
+                refusal: None,
             };
             (command.run)(&mut ctx);
-            self.status = command.title.into();
+            // Reporting the command's own title regardless meant every
+            // silent no-op looked like it had worked.
+            self.status = match ctx.refusal {
+                Some(why) => why.into(),
+                None => command.title.into(),
+            };
             // ...and copying makes the pixels available everywhere else.
             if id.starts_with("edit.copy") || id == "edit.cut" {
                 self.sync_clipboard_out(cx);

--- a/crates/codec-affinity/examples/afwrite.rs
+++ b/crates/codec-affinity/examples/afwrite.rs
@@ -140,6 +140,6 @@ fn demo_document() -> Document {
     doc.push_layer(group);
 
     doc.damage_all();
-    doc.dirty = false;
+    doc.mark_saved();
     doc
 }

--- a/crates/codec-affinity/src/import.rs
+++ b/crates/codec-affinity/src/import.rs
@@ -239,7 +239,7 @@ fn build(archive: &Archive, graph: &Graph) -> Result<(Document, ImportReport), A
     }
 
     doc.damage_all();
-    doc.dirty = false;
+    doc.mark_saved();
     Ok((doc, report))
 }
 

--- a/crates/codec-psd/src/reader/mod.rs
+++ b/crates/codec-psd/src/reader/mod.rs
@@ -79,7 +79,7 @@ pub fn read_psd(bytes: &[u8]) -> Result<Document, PsdError> {
     // Topmost layer starts active (children are stored bottom-to-top).
     doc.active_layer = doc.tree.layers.last().map(|l| l.id);
     doc.damage_all();
-    doc.dirty = false;
+    doc.mark_saved();
     Ok(doc)
 }
 

--- a/crates/core/src/document.rs
+++ b/crates/core/src/document.rs
@@ -815,7 +815,6 @@ impl<'a> EditBuilder<'a> {
         }
     }
 
-    /// Replace the selection via closure; captures before/after.
     /// Change the document's colour mode as part of this edit.
     pub fn set_color_mode(&mut self, mode: schist_color::ColorMode) {
         if self.doc.mode == mode {
@@ -829,6 +828,7 @@ impl<'a> EditBuilder<'a> {
         });
     }
 
+    /// Replace the selection via closure; captures before/after.
     pub fn change_selection(&mut self, f: impl FnOnce(&mut Selection, IntRect)) {
         let canvas = self.doc.canvas_rect();
         let before = Box::new(self.doc.selection.clone());
@@ -1314,5 +1314,37 @@ mod tests {
         // Undoing *past* the save point is a change from what is on disk.
         doc.undo().unwrap();
         assert!(doc.dirty, "undoing past the save point must be dirty");
+    }
+    /// A save point that ends up in a discarded redo branch is
+    /// unreachable, so it must not go on matching the undo depth.
+    ///
+    /// Draw A, save, undo A, draw B (the redo branch holding the save
+    /// point is discarded), undo B, redo B: the depth matched again and
+    /// redo reported the document clean while it held B and the disk held
+    /// A. Behind the quit confirmation that loses B without asking.
+    #[test]
+    fn a_save_point_in_a_discarded_branch_does_not_come_back() {
+        let mut doc = Document::new("t", 8, 8, Depth::Eight);
+        let id = doc.push_layer(Layer::new_raster("l"));
+        let rename = |doc: &mut Document, to: &str| {
+            let mut e = doc.begin_edit("Rename");
+            e.change_props(id, |l| l.name = to.into());
+            assert!(e.commit());
+        };
+
+        rename(&mut doc, "a");
+        doc.mark_saved();
+        assert!(!doc.dirty);
+
+        doc.undo().unwrap();
+        rename(&mut doc, "b"); // discards the branch the save point was in
+        doc.undo().unwrap();
+        doc.redo().unwrap();
+
+        assert_eq!(doc.tree.find(id).unwrap().name, "b");
+        assert!(
+            doc.dirty,
+            "the document holds b and the disk holds a, so it is not saved"
+        );
     }
 }

--- a/crates/core/src/document.rs
+++ b/crates/core/src/document.rs
@@ -214,12 +214,22 @@ impl Document {
         }
     }
 
+    /// The document on disk now matches this state: clear the dirty flag
+    /// and remember where in history that is, so undoing back here later
+    /// clears it again rather than leaving a saved file marked modified.
+    pub fn mark_saved(&mut self) {
+        self.dirty = false;
+        self.history.mark_saved();
+    }
+
     pub fn undo(&mut self) -> Option<String> {
         let edit = self.history.pop_undo()?;
         for op in edit.ops.iter().rev() {
             self.apply_op(op, Direction::Undo);
         }
-        self.dirty = true;
+        // Undoing back to the last save leaves the document matching
+        // what is on disk, so it is no longer dirty.
+        self.dirty = !self.history.at_saved();
         Some(edit.name)
     }
 
@@ -228,7 +238,7 @@ impl Document {
         for op in edit.ops.iter() {
             self.apply_op(op, Direction::Redo);
         }
-        self.dirty = true;
+        self.dirty = !self.history.at_saved();
         Some(edit.name)
     }
 
@@ -438,6 +448,14 @@ impl Document {
                 };
                 self.selection = (**target).clone();
                 self.revision += 1;
+            }
+            EditOp::ColorModeSet { before, after } => {
+                self.mode = if dir == Direction::Undo {
+                    *before
+                } else {
+                    *after
+                };
+                self.damage_all();
             }
         }
     }
@@ -798,6 +816,19 @@ impl<'a> EditBuilder<'a> {
     }
 
     /// Replace the selection via closure; captures before/after.
+    /// Change the document's colour mode as part of this edit.
+    pub fn set_color_mode(&mut self, mode: schist_color::ColorMode) {
+        if self.doc.mode == mode {
+            return;
+        }
+        let before = self.doc.mode;
+        self.doc.mode = mode;
+        self.ops.push(EditOp::ColorModeSet {
+            before,
+            after: mode,
+        });
+    }
+
     pub fn change_selection(&mut self, f: impl FnOnce(&mut Selection, IntRect)) {
         let canvas = self.doc.canvas_rect();
         let before = Box::new(self.doc.selection.clone());
@@ -1220,5 +1251,68 @@ mod tests {
         doc.damage_all();
         assert!(doc.revision > 0, "repaint was requested");
         assert!(!doc.dirty, "but nothing was actually changed");
+    }
+
+    #[test]
+    fn the_colour_mode_undoes_with_the_pixels() {
+        // Image > Mode set `doc.mode` outside the edit, so undo restored
+        // the colour and left the document still reporting greyscale,
+        // which is also what it would then have been saved as.
+        let mut doc = Document::new("t", 16, 16, Depth::Eight);
+        assert_eq!(doc.mode, schist_color::ColorMode::Rgb);
+
+        let mut edit = doc.begin_edit("Grayscale");
+        edit.set_color_mode(schist_color::ColorMode::Grayscale);
+        edit.commit();
+        assert_eq!(doc.mode, schist_color::ColorMode::Grayscale);
+
+        doc.undo();
+        assert_eq!(
+            doc.mode,
+            schist_color::ColorMode::Rgb,
+            "undo must restore the mode too"
+        );
+        doc.redo();
+        assert_eq!(doc.mode, schist_color::ColorMode::Grayscale);
+    }
+    #[test]
+    fn undoing_back_to_the_save_point_is_no_longer_dirty() {
+        // Undo used to set `dirty = true` unconditionally, so a document
+        // that had been saved and then edited stayed marked modified even
+        // after the edit was undone, and closing it still nagged.
+        let mut doc = Document::new("t", 8, 8, Depth::Eight);
+        let id = doc.push_layer(Layer::new_raster("l"));
+        doc.mark_saved();
+        assert!(!doc.dirty);
+
+        let mut edit = doc.begin_edit("Rename");
+        edit.change_props(id, |l| l.name = "renamed".into());
+        assert!(edit.commit());
+        assert!(doc.dirty);
+
+        doc.undo().unwrap();
+        assert!(!doc.dirty, "undo back to the save point left it dirty");
+
+        doc.redo().unwrap();
+        assert!(doc.dirty, "redoing past the save point is a modification");
+    }
+
+    #[test]
+    fn saving_after_an_edit_moves_the_save_point() {
+        let mut doc = Document::new("t", 8, 8, Depth::Eight);
+        let id = doc.push_layer(Layer::new_raster("l"));
+        let mut edit = doc.begin_edit("Rename");
+        edit.change_props(id, |l| l.name = "a".into());
+        edit.commit();
+        doc.mark_saved();
+
+        let mut edit = doc.begin_edit("Rename");
+        edit.change_props(id, |l| l.name = "b".into());
+        edit.commit();
+        doc.undo().unwrap();
+        assert!(!doc.dirty);
+        // Undoing *past* the save point is a change from what is on disk.
+        doc.undo().unwrap();
+        assert!(doc.dirty, "undoing past the save point must be dirty");
     }
 }

--- a/crates/core/src/history.rs
+++ b/crates/core/src/history.rs
@@ -160,6 +160,15 @@ impl History {
     }
 
     pub fn push(&mut self, edit: Edit) {
+        // A new edit discards the redo branch. If the save point was in
+        // that branch it can never be reached again, so it has to go:
+        // otherwise draw A, save, undo A, draw B, undo B, redo B leaves
+        // `undo_stack.len() == saved_depth` and redo clears `dirty` while
+        // the document holds B and the disk holds A. With the quit
+        // confirmation in front of it, that loses B silently.
+        if self.saved_depth.is_some_and(|d| d > self.undo_stack.len()) {
+            self.saved_depth = None;
+        }
         self.redo_stack.clear();
         self.undo_stack.push(edit);
         if self.undo_stack.len() > self.limit {

--- a/crates/core/src/history.rs
+++ b/crates/core/src/history.rs
@@ -117,6 +117,16 @@ pub enum EditOp {
         before: Box<Selection>,
         after: Box<Selection>,
     },
+    /// The document's colour mode changed (Image > Mode).
+    ///
+    /// Set outside the edit, so undo restored the pixels and left the new
+    /// mode: a document converted to greyscale and undone still reported
+    /// (and saved as) greyscale. The CMYK/Lab/RGB cases changed nothing
+    /// else at all, so they produced no history entry whatsoever.
+    ColorModeSet {
+        before: schist_color::ColorMode,
+        after: schist_color::ColorMode,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -132,6 +142,11 @@ pub struct History {
     redo_stack: Vec<Edit>,
     /// Cap on retained edits; oldest are dropped past this.
     pub limit: usize,
+    /// How deep the undo stack was when the document was last saved, so
+    /// undoing back to that point can clear the dirty flag again. `None`
+    /// once that edit has aged out past `limit`, since we can no longer
+    /// tell whether we are standing on it.
+    saved_depth: Option<usize>,
 }
 
 impl History {
@@ -140,6 +155,7 @@ impl History {
             undo_stack: Vec::new(),
             redo_stack: Vec::new(),
             limit: 200,
+            saved_depth: Some(0),
         }
     }
 
@@ -149,7 +165,20 @@ impl History {
         if self.undo_stack.len() > self.limit {
             let excess = self.undo_stack.len() - self.limit;
             self.undo_stack.drain(0..excess);
+            // Dropping the oldest edits shifts every depth down; a save
+            // point that falls off the bottom is gone for good.
+            self.saved_depth = self.saved_depth.and_then(|d| d.checked_sub(excess));
         }
+    }
+
+    /// Record that the document as it stands right now is what is on disk.
+    pub fn mark_saved(&mut self) {
+        self.saved_depth = Some(self.undo_stack.len());
+    }
+
+    /// True when the current state is the one that was last saved.
+    pub fn at_saved(&self) -> bool {
+        self.saved_depth == Some(self.undo_stack.len())
     }
 
     pub fn pop_undo(&mut self) -> Option<Edit> {

--- a/crates/core/src/layer.rs
+++ b/crates/core/src/layer.rs
@@ -294,13 +294,6 @@ impl Layer {
         }
     }
 
-    pub fn children_mut(&mut self) -> Option<&mut Vec<Layer>> {
-        match &mut self.kind {
-            LayerKind::Group(g) => Some(&mut g.children),
-            _ => None,
-        }
-    }
-
     /// Content bounds in document space (tile-granular for raster),
     /// including any transient drag offset.
     pub fn content_bounds(&self) -> IntRect {

--- a/crates/core/src/layer.rs
+++ b/crates/core/src/layer.rs
@@ -294,6 +294,13 @@ impl Layer {
         }
     }
 
+    pub fn children_mut(&mut self) -> Option<&mut Vec<Layer>> {
+        match &mut self.kind {
+            LayerKind::Group(g) => Some(&mut g.children),
+            _ => None,
+        }
+    }
+
     /// Content bounds in document space (tile-granular for raster),
     /// including any transient drag offset.
     pub fn content_bounds(&self) -> IntRect {

--- a/crates/mcp/src/session.rs
+++ b/crates/mcp/src/session.rs
@@ -163,8 +163,14 @@ impl Session {
         let mut ctx = CommandCtx {
             doc: &mut self.doc,
             state: &mut self.state,
+            refusal: None,
         };
         (command.run)(&mut ctx);
+        // A command that declined has to say so: reporting its own title
+        // told the caller it had worked.
+        if let Some(why) = ctx.refusal {
+            bail!("{why}");
+        }
         let title = command.title.to_string();
         self.after_change();
         Ok(title)

--- a/crates/mcp/src/session.rs
+++ b/crates/mcp/src/session.rs
@@ -110,7 +110,7 @@ impl Session {
             &white,
         );
         doc.push_layer(bg);
-        doc.dirty = false;
+        doc.mark_saved();
         Ok(Session::install(doc))
     }
 
@@ -518,7 +518,7 @@ impl Session {
         })?;
         let bytes = codec.export(&self.doc)?;
         write_atomically(path, &bytes)?;
-        self.doc.dirty = false;
+        self.doc.mark_saved();
         self.doc.path = Some(path.to_path_buf());
         if let Some(name) = path.file_name() {
             self.doc.title = name.to_string_lossy().into_owned();

--- a/crates/plugin-api/src/lib.rs
+++ b/crates/plugin-api/src/lib.rs
@@ -342,6 +342,21 @@ pub trait CodecPlugin: Send + Sync {
 pub struct CommandCtx<'a> {
     pub doc: &'a mut Document,
     pub state: &'a mut EditorState,
+    /// Why the command did nothing, when it did nothing.
+    ///
+    /// The command layer had no way to say anything: it is full of bare
+    /// `return`s and the shell then set the status line to the command's
+    /// own title regardless, so Grow with no selection, Clipping Mask on
+    /// the bottom layer, Paste with an empty clipboard and a dozen others
+    /// all reported themselves as having worked.
+    pub refusal: Option<String>,
+}
+
+impl CommandCtx<'_> {
+    /// Decline to act, with a reason the user will see.
+    pub fn refuse(&mut self, why: impl Into<String>) {
+        self.refusal = Some(why.into());
+    }
 }
 
 /// A named, keybindable command. `id` is namespaced like "layer.duplicate".

--- a/crates/plugin-host-wasm/src/lib.rs
+++ b/crates/plugin-host-wasm/src/lib.rs
@@ -467,7 +467,7 @@ impl CodecPlugin for WasmCodec {
             &rgba,
         );
         doc.push_layer(layer);
-        doc.dirty = false;
+        doc.mark_saved();
         Ok(doc)
     }
 }

--- a/plugins/codecs-common/src/affinity.rs
+++ b/plugins/codecs-common/src/affinity.rs
@@ -80,7 +80,7 @@ impl CodecPlugin for AffinityCodec {
                     reference.visible = false;
                     doc.tree.layers.insert(0, reference);
                     doc.damage_all();
-                    doc.dirty = false;
+                    doc.mark_saved();
                 }
                 return Ok(doc);
             }
@@ -188,7 +188,7 @@ impl AffinityCodec {
             );
             doc.push_layer(layer);
             doc.damage_all();
-            doc.dirty = false;
+            doc.mark_saved();
             return Ok(doc);
         }
         anyhow::bail!(

--- a/plugins/codecs-common/src/lib.rs
+++ b/plugins/codecs-common/src/lib.rs
@@ -35,7 +35,7 @@ fn flat_document(
     );
     doc.push_layer(layer);
     doc.damage_all();
-    doc.dirty = false;
+    doc.mark_saved();
     Ok(doc)
 }
 

--- a/plugins/codecs-common/src/lib.rs
+++ b/plugins/codecs-common/src/lib.rs
@@ -103,19 +103,6 @@ fn import_with(format: ImageFormat, bytes: &[u8], title: &str) -> anyhow::Result
     };
 
     flat_document(title, w, h, rgba.as_raw(), icc)
-    let mut doc = Document::new(title, w, h, Depth::Eight);
-    doc.icc_profile = icc;
-    let mut layer = Layer::new_raster("Background");
-    blit_rgba8(
-        &mut layer.as_raster_mut().unwrap().tiles,
-        Depth::Eight,
-        IntRect::from_size(w, h),
-        rgba.as_raw(),
-    );
-    doc.push_layer(layer);
-    doc.damage_all();
-    doc.mark_saved();
-    Ok(doc)
 }
 
 fn export_flat(

--- a/plugins/codecs-common/src/lib.rs
+++ b/plugins/codecs-common/src/lib.rs
@@ -103,6 +103,19 @@ fn import_with(format: ImageFormat, bytes: &[u8], title: &str) -> anyhow::Result
     };
 
     flat_document(title, w, h, rgba.as_raw(), icc)
+    let mut doc = Document::new(title, w, h, Depth::Eight);
+    doc.icc_profile = icc;
+    let mut layer = Layer::new_raster("Background");
+    blit_rgba8(
+        &mut layer.as_raster_mut().unwrap().tiles,
+        Depth::Eight,
+        IntRect::from_size(w, h),
+        rgba.as_raw(),
+    );
+    doc.push_layer(layer);
+    doc.damage_all();
+    doc.mark_saved();
+    Ok(doc)
 }
 
 fn export_flat(

--- a/plugins/commands-core/src/lib.rs
+++ b/plugins/commands-core/src/lib.rs
@@ -33,6 +33,7 @@ fn cmd(
 /// tolerance, which is what `state.tolerance` carries.
 fn grow_selection(ctx: &mut CommandCtx, contiguous: bool) {
     if ctx.doc.selection.is_empty() {
+        ctx.refuse("Select something first");
         return;
     }
     let canvas = ctx.doc.canvas_rect();
@@ -248,7 +249,8 @@ fn merge_down(ctx: &mut CommandCtx) {
     };
     let ix = *path.0.last().unwrap();
     if ix == 0 {
-        return; // nothing below
+        ctx.refuse("No layer below to merge into");
+        return;
     }
     let mut below_path = path.clone();
     *below_path.0.last_mut().unwrap() = ix - 1;
@@ -337,6 +339,7 @@ fn merge_visible(ctx: &mut CommandCtx) {
 
 fn paste(ctx: &mut CommandCtx, in_place: bool) {
     let Some(clip) = ctx.state.clipboard.clone() else {
+        ctx.refuse("Nothing on the clipboard");
         return;
     };
     let rect = if in_place {
@@ -626,6 +629,7 @@ impl CommandPlugin for CoreCommandsPlugin {
             }),
             cmd("select.reselect", "Reselect", Some("cmd-shift-d"), |ctx| {
                 let Some(previous) = ctx.doc.last_selection.clone() else {
+                    ctx.refuse("Nothing to reselect");
                     return;
                 };
                 let mut edit = ctx.doc.begin_edit("Reselect");
@@ -645,6 +649,7 @@ impl CommandPlugin for CoreCommandsPlugin {
             }),
             cmd("select.save", "Save Selection", None, |ctx| {
                 if ctx.doc.selection.is_empty() {
+                    ctx.refuse("Select something first");
                     return;
                 }
                 let n = ctx.doc.saved_selections.len() + 1;
@@ -905,7 +910,11 @@ mod tests {
     }
 
     fn run(reg: &PluginRegistry, id: &str, doc: &mut Document, state: &mut EditorState) {
-        let mut ctx = CommandCtx { doc, state };
+        let mut ctx = CommandCtx {
+            doc,
+            state,
+            refusal: None,
+        };
         (reg.command(id).expect(id).run)(&mut ctx);
     }
 
@@ -1059,6 +1068,7 @@ mod tests {
         assert_eq!(group.children().unwrap().len(), 1);
         assert_eq!(group.children().unwrap()[0].name, "bg");
     }
+
     #[test]
     fn saving_a_selection_marks_the_document_unsaved() {
         // `select.save` mutates `saved_selections` directly rather than
@@ -1079,6 +1089,77 @@ mod tests {
         assert_eq!(doc.saved_selections.len(), 1, "selection was saved");
         assert!(doc.dirty, "and the document must count as unsaved");
     }
+
+    /// Run a command and return the refusal it recorded, if any.
+    fn run_for_refusal(
+        reg: &PluginRegistry,
+        id: &str,
+        doc: &mut Document,
+        state: &mut EditorState,
+    ) -> Option<String> {
+        let mut ctx = CommandCtx {
+            doc,
+            state,
+            refusal: None,
+        };
+        (reg.command(id).expect(id).run)(&mut ctx);
+        ctx.refusal
+    }
+
+    #[test]
+    fn a_command_that_does_nothing_says_why() {
+        // The command layer is full of bare `return`s and the shell then
+        // set the status line to the command's own title regardless, so
+        // every silent no-op reported itself as having worked.
+        let reg = registry();
+        let mut state = EditorState::default();
+
+        let mut doc = doc_with_pixels();
+        assert_eq!(
+            run_for_refusal(&reg, "select.grow", &mut doc, &mut state).as_deref(),
+            Some("Select something first"),
+            "Grow with no selection"
+        );
+
+        let mut doc = doc_with_pixels();
+        assert_eq!(
+            run_for_refusal(&reg, "select.reselect", &mut doc, &mut state).as_deref(),
+            Some("Nothing to reselect"),
+            "Reselect with no previous selection"
+        );
+
+        let mut doc = doc_with_pixels();
+        state.clipboard = None;
+        assert_eq!(
+            run_for_refusal(&reg, "edit.paste", &mut doc, &mut state).as_deref(),
+            Some("Nothing on the clipboard"),
+            "Paste with an empty clipboard"
+        );
+
+        let mut doc = doc_with_pixels();
+        doc.active_layer = Some(doc.tree.layers[0].id);
+        assert_eq!(
+            run_for_refusal(&reg, "layer.merge_down", &mut doc, &mut state).as_deref(),
+            Some("No layer below to merge into"),
+            "Merge Down on the bottom layer"
+        );
+    }
+
+    #[test]
+    fn a_command_that_works_refuses_nothing() {
+        let reg = registry();
+        let mut state = EditorState::default();
+        let mut doc = doc_with_pixels();
+        doc.selection.select_rect(
+            schist_core::IntRect::from_xywh(0, 0, 10, 10),
+            SelectOp::Replace,
+        );
+        assert_eq!(
+            run_for_refusal(&reg, "select.save", &mut doc, &mut state),
+            None,
+            "saving a real selection must not refuse"
+        );
+    }
 }
 
 #[cfg(test)]
@@ -1094,7 +1175,11 @@ mod m11_tests {
     }
 
     fn run(reg: &PluginRegistry, id: &str, doc: &mut Document, state: &mut EditorState) {
-        let mut ctx = CommandCtx { doc, state };
+        let mut ctx = CommandCtx {
+            doc,
+            state,
+            refusal: None,
+        };
         (reg.command(id)
             .unwrap_or_else(|| panic!("missing {id}"))
             .run)(&mut ctx);

--- a/plugins/commands-core/src/lib.rs
+++ b/plugins/commands-core/src/lib.rs
@@ -308,9 +308,37 @@ fn merge_down(ctx: &mut CommandCtx) {
 }
 
 fn merge_visible(ctx: &mut CommandCtx) {
+    merge_all(ctx, false)
+}
+
+/// Flatten: like Merge Visible, but hidden layers are discarded and the
+/// result is opaque, named Background.
+///
+/// `layer.flatten` used to call `merge_visible` verbatim, so Flatten Image
+/// left every hidden layer in place, kept transparency, and named the
+/// result "Merged". Someone flattening before export still shipped a
+/// multi-layer file with holes in it.
+fn flatten_image(ctx: &mut CommandCtx) {
+    merge_all(ctx, true)
+}
+
+fn merge_all(ctx: &mut CommandCtx, flatten: bool) {
     let canvas = ctx.doc.canvas_rect();
-    let rgba = schist_compositor::composite_region_rgba8(ctx.doc, canvas);
-    let mut merged = Layer::new_raster("Merged");
+    let mut rgba = schist_compositor::composite_region_rgba8(ctx.doc, canvas);
+    if flatten {
+        // Flattening composites onto an opaque white background, the way
+        // Photoshop does, so the result has no transparency left.
+        for px in rgba.as_chunks_mut::<4>().0 {
+            let a = px[3] as u32;
+            let inv = 255 - a;
+            for c in px[..3].iter_mut() {
+                *c = ((*c as u32 * a + 255 * inv) / 255) as u8;
+            }
+            px[3] = 255;
+        }
+    }
+    let name = if flatten { "Background" } else { "Merged" };
+    let mut merged = Layer::new_raster(name);
     blit_rgba8(
         &mut merged.as_raster_mut().unwrap().tiles,
         ctx.doc.depth,
@@ -319,17 +347,23 @@ fn merge_visible(ctx: &mut CommandCtx) {
     );
     let merged_id = merged.id;
 
-    let visible_ids: Vec<LayerId> = ctx
+    // Flatten removes every layer; Merge Visible leaves the hidden ones.
+    let doomed: Vec<LayerId> = ctx
         .doc
         .tree
         .layers
         .iter()
-        .filter(|l| l.visible)
+        .filter(|l| flatten || l.visible)
         .map(|l| l.id)
         .collect();
-    let mut edit = ctx.doc.begin_edit("Merge Visible");
-    for vid in visible_ids {
-        edit.remove_layer(vid);
+    let title = if flatten {
+        "Flatten Image"
+    } else {
+        "Merge Visible"
+    };
+    let mut edit = ctx.doc.begin_edit(title);
+    for id in doomed {
+        edit.remove_layer(id);
     }
     let top = LayerPath(vec![edit.doc().tree.layers.len()]);
     edit.insert_layer(top, merged);
@@ -763,9 +797,7 @@ impl CommandPlugin for CoreCommandsPlugin {
                 edit.set_mask(id, Some(mask));
                 edit.commit();
             }),
-            cmd("layer.flatten", "Flatten Image", None, |ctx| {
-                merge_visible(ctx);
-            }),
+            cmd("layer.flatten", "Flatten Image", None, flatten_image),
             cmd("layer.merge_down", "Merge Down", Some("cmd-e"), merge_down),
             cmd(
                 "layer.merge_visible",
@@ -1159,6 +1191,56 @@ mod tests {
             None,
             "saving a real selection must not refuse"
         );
+    }
+
+    #[test]
+    fn flatten_is_not_merge_visible() {
+        // `layer.flatten` called `merge_visible` verbatim, so Flatten
+        // Image left hidden layers in place, kept transparency and named
+        // the result "Merged".
+        let reg = registry();
+        let mut state = EditorState::default();
+
+        let build = || {
+            let mut doc = doc_with_pixels();
+            let mut hidden = Layer::new_raster("hidden");
+            hidden.visible = false;
+            doc.push_layer(hidden);
+            doc
+        };
+
+        let mut doc = build();
+        run(&reg, "layer.merge_visible", &mut doc, &mut state);
+        assert_eq!(doc.tree.len(), 2, "merge visible keeps the hidden layer");
+        assert!(doc.tree.iter().any(|l| l.name == "Merged"));
+
+        let mut doc = build();
+        run(&reg, "layer.flatten", &mut doc, &mut state);
+        assert_eq!(doc.tree.len(), 1, "flatten discards hidden layers");
+        assert_eq!(doc.tree.layers[0].name, "Background");
+    }
+
+    #[test]
+    fn flatten_leaves_no_transparency() {
+        let reg = registry();
+        let mut state = EditorState::default();
+        // A document whose only layer covers part of the canvas, so the
+        // rest is transparent.
+        let mut doc = Document::new("t", 32, 32, Depth::Eight);
+        let mut layer = Layer::new_raster("part");
+        let buf = [10u8, 20, 30, 255].repeat(8 * 8);
+        schist_core::blit_rgba8(
+            &mut layer.as_raster_mut().unwrap().tiles,
+            Depth::Eight,
+            schist_core::IntRect::from_xywh(0, 0, 8, 8),
+            &buf,
+        );
+        doc.push_layer(layer);
+
+        run(&reg, "layer.flatten", &mut doc, &mut state);
+        let px = doc.tree.layers[0].as_raster().unwrap().tiles.pixel(20, 20);
+        assert!(px.a >= 0.99, "flattened pixels must be opaque: {px:?}");
+        assert!(px.r > 0.9, "and matted onto white: {px:?}");
     }
 }
 


### PR DESCRIPTION

groups five branches: the app shell.

**flatten image was merge visible**

`layer.flatten` dispatched the identical function, so flattening left every hidden layer, kept transparency and named the result "Merged".

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr41-flatten-before.png) | ![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr41-flatten-after.png) |

image ▸ mode ▸ indexed color greyscaled the document and labelled the history entry "Grayscale"; mode changes were not undoable at all; and Auto Color was `v.powf(1.0)`, which is the identity.

**dialogs could only be driven with the mouse**

nothing anywhere invoked a dialog's OK action from the keyboard. escape closed the whole dialog even with a field focused, where it should drop focus and leave the dialog up; and the hex field was seeded with its committed value and capped at six digits, so typing into a freshly clicked one did nothing until you backspaced six times.

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr42-enter-before.png) | ![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr42-enter-after.png) |

clicking a field cleared the buffer *and* the modal's stored value, so the field went blank and OK from there would have renamed the layer to nothing:

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr42-before.png) | ![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr42-after.png) |

keystrokes also fell past an open modal into the active tool, one keymap typo panicked the app at launch before a window existed to report it, unmodified user overrides fired while typing, and numeric fields rejected `.` and `-` even though every one is read back with `parse::<f32>()`.

**the interface never told you anything**

no tooltips anywhere — sixteen toolbar slots and every panel button were bare svgs:

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr56-before.png) | ![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr56-after.png) |

the pointer never changed shape either; it now follows the active tool. preferences had no Cancel while every control applied and persisted on change; the history panel could not reach the opened state; assign/convert profile always opened on srgb.

| before | after |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr50-prefs-before.png) | ![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr50-prefs-after.png) |
| ![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr50-history-before.png) | ![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr50-history-after.png) |

Merge Down with nothing below the layer — the status bar afterwards:

before
![before](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr-feedback-before.png)

after
![after](https://raw.githubusercontent.com/ProdigyRahul/schist/pr-images/pr-feedback-after.png)

**and the rest**

commands that did nothing said nothing; undo left a saved document marked dirty; "Save…" on an untitled document saved it and left the tab open; the curves histogram read the topmost layer rather than what the adjustment acts on.

---

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` — 633 passed, 0 failed.
---

**how this relates to my other open prs**

these seven are independent of each other — each branches off `main` and each is green on its own. they do share files with my five open prs (#36, #38, #42, #44, #46), mostly `workspace.rs`, so whichever lands first will leave the others needing a rebase. happy to rebase in whatever order suits you, or to split any of these further if one is too big to review in a sitting.

