### PR TITLE
Ship Linux aarch64: release artifacts, managed libheif, AUR PKGBUILD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact: schist-linux-x86_64
+          - os: ubuntu-24.04-arm
+            artifact: schist-linux-aarch64
           - os: macos-latest
             artifact: schist-macos
           - os: windows-latest
@@ -63,17 +65,19 @@ jobs:
           strip --strip-debug target/release/schist target/release/schist-mcp
           sudo apt-get install -y libfuse2 || true
           curl -sSL -o /tmp/appimagetool \
-            https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+            "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-$(uname -m).AppImage"
           chmod +x /tmp/appimagetool
           # appimage.sh writes straight into dist/, so dist/ has to exist
           # before it runs -- mksquashfs otherwise dies with "Could not create
           # destination file" and no AppImage is produced.
           mkdir -p dist
           APPIMAGETOOL=/tmp/appimagetool ./packaging/linux/appimage.sh
-          cp target/release/schist dist/
+          # Arch-suffixed: the x86_64 and aarch64 jobs publish into the same
+          # release, and same-named assets would collide there.
+          cp target/release/schist "dist/schist-linux-$(uname -m)"
           # The MCP server is headless and needs none of the AppImage's
           # runtime, so it ships as a plain binary rather than inside it.
-          cp target/release/schist-mcp dist/
+          cp target/release/schist-mcp "dist/schist-mcp-linux-$(uname -m)"
 
       - name: Set up the signing keychain (macOS)
         if: runner.os == 'macOS'

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -16,7 +16,7 @@ commit:
 
 | platform | where it lands |
 |---|---|
-| Linux | `schist-mcp` on the release page, next to the AppImage |
+| Linux | `schist-mcp-linux-x86_64` / `schist-mcp-linux-aarch64` on the release page, next to the AppImages |
 | macOS | `schist-mcp-macos.zip` on the release page — unzip it anywhere |
 | Windows | `schist-mcp.exe`, installed beside `schist.exe` and also on the release page |
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -32,12 +32,14 @@ they will not break the plugin ABI or saved files.
 1. Update the version in the root `Cargo.toml` and `packaging/macos/Info.plist`.
 2. `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings`.
 3. Tag: `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`.
-4. The release workflow builds a Linux AppImage, a macOS `Schist.zip`
-   (signed and notarized when the secrets below exist), and a Windows
-   installer, then drafts the release. Each platform also ships the
-   `schist-mcp` server from the same build: a loose binary on Linux and
-   Windows, and on macOS `schist-mcp-macos.zip`, signed and notarized on
-   its own. See [mcp.md](mcp.md).
+4. The release workflow builds Linux AppImages for x86_64 and aarch64, a
+   macOS `Schist.zip` (signed and notarized when the secrets below
+   exist), and a Windows installer, then drafts the release. Each
+   platform also ships the `schist-mcp` server from the same build: a
+   loose arch-suffixed binary on Linux (`schist-mcp-linux-x86_64`,
+   `schist-mcp-linux-aarch64`), a loose binary on Windows, and on macOS
+   `schist-mcp-macos.zip`, signed and notarized on its own. See
+   [mcp.md](mcp.md).
 
 Unsigned builds are still produced when signing credentials are absent, so
 forks and local builds work without secrets.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -40,6 +40,17 @@ they will not break the plugin ABI or saved files.
    `schist-mcp-linux-aarch64`), a loose binary on Windows, and on macOS
    `schist-mcp-macos.zip`, signed and notarized on its own. See
    [mcp.md](mcp.md).
+5. Update the AUR package from `packaging/linux/aur/PKGBUILD`: bump
+   `pkgver` to the new version, reset `pkgrel=1`, then in an Arch
+   environment run `updpkgsums` (re-pins the tag tarball's sha256), test
+   with `makepkg -s` + `namcap`, and regenerate `.SRCINFO` with
+   `makepkg --printsrcinfo > .SRCINFO` — the AUR rejects pushes without
+   a current one. Commit `PKGBUILD` + `.SRCINFO` to the AUR remote
+   (`ssh://aur@aur.archlinux.org/schist.git`) and mirror the `PKGBUILD`
+   change back here. The PKGBUILD keeps `options=(!lto)` (makepkg's
+   `-flto=auto` breaks `ring`'s C objects under the clang link) and
+   `clang`/`mold` in `makedepends` for the linker settings in
+   `.cargo/config.toml` — don't drop either when touching it.
 
 Unsigned builds are still produced when signing credentials are absent, so
 forks and local builds work without secrets.

--- a/packaging/linux/appimage.sh
+++ b/packaging/linux/appimage.sh
@@ -34,9 +34,10 @@ exec "$HERE/usr/bin/schist" "$@"
 RUN
 chmod +x "$appdir/AppRun"
 
+out="$root/dist/Schist-$(uname -m).AppImage"
 if command -v "$tool" >/dev/null 2>&1; then
-    "$tool" "$appdir" "$root/dist/Schist-x86_64.AppImage"
-    echo "built $root/dist/Schist-x86_64.AppImage"
+    "$tool" "$appdir" "$out"
+    echo "built $out"
 else
     echo "appimagetool not found; the AppDir is ready at $appdir" >&2
 fi

--- a/packaging/linux/aur/PKGBUILD
+++ b/packaging/linux/aur/PKGBUILD
@@ -1,0 +1,45 @@
+# Maintainer: Astrid <astrid@infrawrench.com>
+pkgname=schist
+pkgver=0.6.0
+pkgrel=1
+pkgdesc="Layered image editor with PSD and Affinity support"
+arch=(x86_64 aarch64)
+url="https://github.com/IAmJSD/schist"
+license=(MIT)
+# fontconfig/wayland/vulkan-icd-loader are dlopen'd, so namcap flags them
+# "may not be needed" — they are.
+depends=(fontconfig freetype2 hicolor-icon-theme libxcb libxkbcommon
+         libxkbcommon-x11 vulkan-icd-loader wayland)
+# clang + mold: the repo's .cargo/config.toml selects them as the linker.
+makedepends=(cargo clang mold)
+# !lto: makepkg's -flto=auto produces GCC-bitcode objects in ring's C archive
+# that the clang-driven link cannot read.
+options=(!lto)
+source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+sha256sums=('75f1eccce0d51f26778943212b1d3fee10c018ca98bd0ea8247f66ac62b137b8')
+
+prepare() {
+  cd "$pkgname-$pkgver"
+  export RUSTUP_TOOLCHAIN=stable
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd "$pkgname-$pkgver"
+  export RUSTUP_TOOLCHAIN=stable
+  export CARGO_TARGET_DIR=target
+  cargo build --frozen --release -p schist-app
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+  install -Dm755 target/release/schist "$pkgdir/usr/bin/schist"
+  install -Dm644 packaging/linux/schist.desktop \
+    "$pkgdir/usr/share/applications/schist.desktop"
+  # The desktop entry looks the icon up as its Icon= key, place.astrid.schist.
+  install -Dm644 packaging/linux/schist.png \
+    "$pkgdir/usr/share/icons/hicolor/256x256/apps/place.astrid.schist.png"
+  install -Dm644 packaging/linux/place.astrid.schist.mime.xml \
+    "$pkgdir/usr/share/mime/packages/place.astrid.schist.xml"
+  install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/plugins/codecs-common/src/heif.rs
+++ b/plugins/codecs-common/src/heif.rs
@@ -226,27 +226,33 @@ macro_rules! managed {
 /// system package instead).
 pub fn managed_library() -> Option<&'static ManagedLibrary> {
     static LINUX_X86_64: ManagedLibrary = managed!(
-        "v1.23.2-2", "1.23.2",
+        "v1.23.2-3", "1.23.2",
         "libheif-1.23.2-linux-x86_64.so" as "libheif.so.1",
         "317fdcc0372234421a415112a6ce0ef84ab88be782efb57c44ee322a10837089"
     );
+    static LINUX_AARCH64: ManagedLibrary = managed!(
+        "v1.23.2-3", "1.23.2",
+        "libheif-1.23.2-linux-aarch64.so" as "libheif.so.1",
+        "cbdba60d3eb17d699af12a53d8399680f56ae7b5b61307e63c07172523808368"
+    );
     static MACOS_AARCH64: ManagedLibrary = managed!(
-        "v1.23.2-2", "1.23.2",
+        "v1.23.2-3", "1.23.2",
         "libheif-1.23.2-macos-aarch64.dylib" as "libheif.dylib",
         "fd44ea1e8a6ba69d7e6756ee055d7bb8351684ba8e7da83aad77bd21f0d1b4fd"
     );
     static MACOS_X86_64: ManagedLibrary = managed!(
-        "v1.23.2-2", "1.23.2",
+        "v1.23.2-3", "1.23.2",
         "libheif-1.23.2-macos-x86_64.dylib" as "libheif.dylib",
         "8f67631af968e8765150f9d45f286a1182f90c3aacecd4a997dbfd2bb61eb030"
     );
     static WINDOWS_X86_64: ManagedLibrary = managed!(
-        "v1.23.2-2", "1.23.2",
+        "v1.23.2-3", "1.23.2",
         "libheif-1.23.2-windows-x86_64.dll" as "heif.dll",
-        "134e5d5a58fcf61c3555e5689fad2e58193162d67f813a68288aec5248aa8efc"
+        "a3e200cb857fdd78d01cb05329a7650c035eceb359e9d3f0783dab5cf950b594"
     );
     match (std::env::consts::OS, std::env::consts::ARCH) {
         ("linux", "x86_64") => Some(&LINUX_X86_64),
+        ("linux", "aarch64") => Some(&LINUX_AARCH64),
         ("macos", "aarch64") => Some(&MACOS_AARCH64),
         ("macos", "x86_64") => Some(&MACOS_X86_64),
         ("windows", "x86_64") => Some(&WINDOWS_X86_64),


### PR DESCRIPTION
Linux releases now cover both x86_64 and aarch64.

- **Release workflow**: new \`ubuntu-24.04-arm\` job producing \`Schist-aarch64.AppImage\`. The loose \`schist\`/\`schist-mcp\` binaries become arch-suffixed (\`schist-linux-x86_64\`, \`schist-mcp-linux-aarch64\`, …) since both Linux jobs publish into the same release and same-named assets would collide. \`appimage.sh\` and the appimagetool download now key off \`uname -m\`.
- **Managed libheif**: pins move to [libheif-prebuilt v1.23.2-3](https://github.com/IAmJSD/libheif-prebuilt/releases/tag/v1.23.2-3), which adds a \`linux-aarch64\` artifact built on the (now-available) \`ubuntu-22.04-arm\` runner. The linux-x86_64 and both macOS artifacts rebuilt byte-identical to v1.23.2-2, so only the Windows hash changes. The new \`.so\` was verified to depend only on libc/libm, and the public download URLs serve exactly the pinned bytes.
- **AUR**: adds \`packaging/linux/aur/PKGBUILD\` (\`arch=(x86_64 aarch64)\`), built/installed/namcap-verified against v0.6.0 in a clean Arch container. Gotchas encoded: \`options=(!lto)\` (makepkg's \`-flto=auto\` breaks ring's C archive under the clang link), clang/mold in makedepends, dlopen'd runtime deps that namcap wrongly flags.

Verified: \`cargo fmt --check\`, \`clippy --workspace --all-targets -D warnings\`, codecs-common tests (16 passed, incl. the HEIF fixtures).

The aarch64 release path itself gets its first real exercise on the next tag; \`ubuntu-24.04-arm\` is free for public repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)