### PR TITLE
feat: show these files in Finder, with macOS Quick Look

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5799,7 +5799,6 @@ dependencies = [
  "env_logger",
  "image",
  "log",
- "rustc-hash 2.1.3",
  "schist-adjustments",
  "schist-codec-psd",
  "schist-codecs-common",
@@ -5880,8 +5879,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "schist-preview"
+version = "0.6.0"
+dependencies = [
+ "anyhow",
+ "image",
+ "log",
+ "schist-codec-affinity",
+ "schist-codec-psd",
+ "schist-codecs-common",
+ "schist-compositor",
+ "schist-core",
+ "schist-plugin-api",
+]
+
+[[package]]
 name = "schist-psd-descriptor"
 version = "0.6.0"
+
+[[package]]
+name = "schist-quicklook"
+version = "0.6.0"
+dependencies = [
+ "anyhow",
+ "block2",
+ "env_logger",
+ "log",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "schist-preview",
+]
 
 [[package]]
 name = "schist-text-engine"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ members = [
     "crates/adjustments",
     "crates/plugin-host-wasm",
     "crates/plugin-sdk",
+    "crates/preview",
+    "crates/quicklook",
     "crates/colormgmt",
     "crates/mcp",
     "plugins/codecs-common",
@@ -58,6 +60,7 @@ schist-vector = { path = "crates/vector" }
 schist-layer-fx = { path = "crates/layer-fx" }
 schist-neural = { path = "crates/neural" }
 schist-psd-descriptor = { path = "crates/psd-descriptor" }
+schist-preview = { path = "crates/preview" }
 
 # zlib for PSD's zip-compressed channels; pure Rust, no C toolchain.
 miniz_oxide = "0.8"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ register `.psd`, `.psb`, `.afphoto`, `.afdesign`, `.afpub` and `.af` as
 openable, never as the default handler: an installed Schist joins the
 "Open with" menu rather than taking files off Photoshop or Affinity.
 
+On macOS the bundle also carries two Quick Look app extensions, so
+Finder draws real thumbnails for those files and the space bar opens a
+real preview of them — layers, masks, blend modes and effects composited
+by Schist itself, or the writing app's own embedded preview when that is
+already big enough for the size asked for. Nothing needs enabling: the
+extensions register when the app is first opened, and
+`schist-quicklook --render file.afphoto out.png` shows what Quick Look
+would show. See [docs/quicklook.md](docs/quicklook.md).
+
 The logo is generated, not drawn: [`tools/logo.py`](tools/logo.py) holds the
 geometry and `python3 tools/logo.py` re-emits the SVGs and every `.icns`,
 `.ico` and `.png` the packaging needs. Edit the constants at the top of that
@@ -276,4 +285,5 @@ schist-mcp` builds it from source. See [docs/mcp.md](docs/mcp.md).
 * [docs/architecture.md](docs/architecture.md) — how the pieces fit
 * [docs/plugin-guide.md](docs/plugin-guide.md) — writing plugins
 * [docs/mcp.md](docs/mcp.md) — the MCP server
+* [docs/quicklook.md](docs/quicklook.md) — the macOS Quick Look extensions
 * [docs/versioning.md](docs/versioning.md) — compatibility and releases

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -2964,7 +2964,7 @@ impl Workspace {
         let depth = doc.depth;
         let canvas = doc.canvas_rect();
         reshape_layers(&mut doc.tree.layers, depth, canvas, &mut grew);
-        restyle_layers(&mut doc.tree.layers, &mut grew);
+        schist_compositor::restyle_layers(&mut doc.tree.layers, &mut grew);
         // A shadow can appear outside the layer's old bounds, so the
         // newly covered area has to be repainted too.
         for rect in grew {
@@ -6796,83 +6796,6 @@ fn blend_region_tile(
                     mix(original[src + 3], filtered[src + 3]),
                 ),
             );
-        }
-    }
-}
-
-/// Walk the layer tree rebuilding stale styled rasters, collecting the
-/// areas that changed so they can be repainted.
-fn restyle_layers(layers: &mut [Layer], damage: &mut Vec<IntRect>) {
-    for layer in layers.iter_mut() {
-        if let schist_core::LayerKind::Group(g) = &mut layer.kind {
-            restyle_layers(&mut g.children, damage);
-        }
-        let wanted = !layer.style.is_empty();
-        if !wanted {
-            if let Some(old) = layer.styled.take() {
-                damage.push(old.bounds);
-            }
-            continue;
-        }
-        // `fx_key` changes whenever anything the raster depends on does.
-        let key = fx_key(layer);
-        if layer.styled.as_ref().map(|s| s.key) == Some(key) {
-            continue;
-        }
-        let before = layer.styled.as_ref().map(|s| s.bounds);
-        layer.styled = schist_compositor::render_styled(layer).map(|mut r| {
-            r.key = key;
-            Arc::new(r)
-        });
-        if let Some(b) = before {
-            damage.push(b);
-        }
-        if let Some(s) = layer.styled.as_ref() {
-            damage.push(s.bounds);
-        }
-    }
-}
-
-/// A cheap fingerprint of everything the styled raster is derived from.
-fn fx_key(layer: &Layer) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut h = rustc_hash::FxHasher::default();
-    // The style itself, via its debug form: these are small plain structs
-    // with float fields, so there is nothing cheaper that is also correct.
-    format!("{:?}", layer.style).hash(&mut h);
-    layer.fill_opacity.to_bits().hash(&mut h);
-    if let Some(r) = layer.as_raster() {
-        r.tiles.fingerprint().hash(&mut h);
-    }
-    // A group's styled raster is rendered from its flattened children,
-    // so anything that moves their pixels must change the key. Children
-    // restyle before their parent, so child styled keys are fresh here.
-    if let schist_core::LayerKind::Group(g) = &layer.kind {
-        fx_key_children(&g.children, &mut h);
-    }
-    h.finish()
-}
-
-fn fx_key_children(layers: &[Layer], h: &mut rustc_hash::FxHasher) {
-    use std::hash::Hash;
-    for l in layers {
-        l.visible.hash(h);
-        l.opacity.to_bits().hash(h);
-        l.fill_opacity.to_bits().hash(h);
-        format!("{:?}", l.blend).hash(h);
-        l.render_offset.hash(h);
-        l.clipping.hash(h);
-        if let Some(r) = l.as_raster() {
-            r.tiles.fingerprint().hash(h);
-        }
-        if let Some(s) = l.styled.as_ref() {
-            s.key.hash(h);
-        }
-        if let Some(m) = &l.mask {
-            m.enabled.hash(h);
-        }
-        if let schist_core::LayerKind::Group(g) = &l.kind {
-            fx_key_children(&g.children, h);
         }
     }
 }

--- a/crates/codec-psd/src/lib.rs
+++ b/crates/codec-psd/src/lib.rs
@@ -32,7 +32,7 @@ pub(crate) const PSB_U64_KEYS: [[u8; 4]; 13] = [
 ];
 
 pub use error::PsdError;
-pub use reader::read_psd;
+pub use reader::{read_dimensions, read_psd, read_thumbnail, Thumbnail};
 pub use writer::{write_psd, write_psd_with, PSB_MAX_DIM, PSD_MAX_DIM};
 
 /// Quick signature probe: does this buffer look like a PSD/PSB file?

--- a/crates/codec-psd/src/reader/mod.rs
+++ b/crates/codec-psd/src/reader/mod.rs
@@ -5,11 +5,13 @@ mod header;
 mod image_data;
 mod layers;
 mod pixels;
+mod preview;
 mod resources;
 pub(crate) mod rle;
 
 use crate::error::PsdError;
 use cursor::Cursor;
+pub use preview::{read_dimensions, read_thumbnail, Thumbnail};
 use schist_color::ColorMode;
 use schist_core::{Document, IntRect, Layer, PreservedResource, RasterLayer};
 

--- a/crates/codec-psd/src/reader/preview.rs
+++ b/crates/codec-psd/src/reader/preview.rs
@@ -1,0 +1,119 @@
+//! The cheap ways to look at a PSD without decoding one: the canvas size
+//! from the 26-byte header, and the thumbnail Photoshop embeds in an
+//! image resource.
+//!
+//! Both exist for callers that need a picture of a file *now* — macOS
+//! Quick Look gets seconds, and a layered 2 GB PSB does not open in
+//! seconds. `read_psd` remains the accurate path; this one skips the
+//! layer and merged-image sections entirely, touching only the header
+//! and the resource block's own lengths.
+
+use super::cursor::Cursor;
+use super::header;
+use crate::error::PsdError;
+
+/// Photoshop 5.0 and later: a JPEG thumbnail in RGB order.
+const RES_THUMBNAIL: u16 = 0x040C;
+/// Photoshop 4.0: the same block, but the JPEG's channels are BGR.
+const RES_THUMBNAIL_PS4: u16 = 0x0409;
+
+/// The `kJpegRGB` value of the resource's format field. The alternative,
+/// `kRawRGB` (0), is not known to have shipped in a real file.
+const FORMAT_JPEG: u32 = 1;
+
+/// A file's embedded thumbnail, still JPEG-encoded: decoding it is the
+/// caller's business, and this crate deliberately owns no image decoder.
+#[derive(Debug, Clone, Copy)]
+pub struct Thumbnail<'a> {
+    /// Width the resource declares. Photoshop fits the thumbnail in a
+    /// 256-pixel box, so this is small, and it is what the JPEG holds.
+    pub width: u32,
+    pub height: u32,
+    /// The JPEG's channels are in BGR order rather than RGB — true only
+    /// for the Photoshop 4.0 resource (0x0409).
+    pub bgr: bool,
+    pub jpeg: &'a [u8],
+}
+
+/// The canvas size, from the header alone.
+pub fn read_dimensions(bytes: &[u8]) -> Result<(u32, u32), PsdError> {
+    let mut cur = Cursor::new(bytes);
+    let h = header::parse_header(&mut cur)?;
+    Ok((h.width, h.height))
+}
+
+/// The embedded thumbnail, if the file carries one.
+///
+/// Prefers the modern RGB resource over the Photoshop 4.0 one when a
+/// file (unusually) carries both. Returns `None` rather than an error
+/// for anything malformed: a missing thumbnail and an unreadable one
+/// call for the same fallback.
+pub fn read_thumbnail(bytes: &[u8]) -> Option<Thumbnail<'_>> {
+    let mut cur = Cursor::new(bytes);
+    header::parse_header(&mut cur).ok()?;
+
+    // Color Mode Data, skipped: its length is u32 even in PSB.
+    let cm_len = cur.u32().ok()? as usize;
+    cur.skip(cm_len).ok()?;
+
+    let res_len = cur.u32().ok()? as usize;
+    let mut sec = cur.sub(res_len).ok()?;
+
+    let mut ps4 = None;
+    while sec.remaining() >= 4 {
+        if &sec.sig4().ok()? != b"8BIM" {
+            break;
+        }
+        let id = sec.u16().ok()?;
+        // Pascal name: length byte plus content, the pair padded to even.
+        let name_len = sec.u8().ok()? as usize;
+        sec.skip(name_len + (1 + name_len) % 2).ok()?;
+        let data_len = sec.u32().ok()? as usize;
+        let data = sec.take(data_len).ok()?;
+        if data_len % 2 == 1 && !sec.is_empty() {
+            sec.skip(1).ok()?;
+        }
+
+        match id {
+            RES_THUMBNAIL => return parse_thumbnail(data, false),
+            RES_THUMBNAIL_PS4 => ps4 = parse_thumbnail(data, true),
+            _ => {}
+        }
+    }
+    ps4
+}
+
+/// The resource body: a 28-byte header, then the JPEG.
+///
+/// ```text
+/// u32 format   u32 width       u32 height
+/// u32 widthbytes (padded row stride)       u32 total size
+/// u32 compressed size   u16 bits per pixel   u16 planes
+/// ```
+fn parse_thumbnail(data: &[u8], bgr: bool) -> Option<Thumbnail<'_>> {
+    let head = data.get(..28)?;
+    let u32_at = |i: usize| u32::from_be_bytes(head[i..i + 4].try_into().unwrap());
+    if u32_at(0) != FORMAT_JPEG {
+        return None;
+    }
+    let width = u32_at(4);
+    let height = u32_at(8);
+    let jpeg = &data[28..];
+    // The declared compressed size is advisory: trust it only when it
+    // fits, since a truncated resource is likelier than a padded one.
+    let declared = u32_at(20) as usize;
+    let jpeg = if declared > 0 && declared <= jpeg.len() {
+        &jpeg[..declared]
+    } else {
+        jpeg
+    };
+    if width == 0 || height == 0 || jpeg.is_empty() {
+        return None;
+    }
+    Some(Thumbnail {
+        width,
+        height,
+        bgr,
+        jpeg,
+    })
+}

--- a/crates/codec-psd/tests/reader.rs
+++ b/crates/codec-psd/tests/reader.rs
@@ -3,7 +3,7 @@
 mod common;
 
 use common::{resolution_res, Mask, Psd, Res, L};
-use schist_codec_psd::{is_psd, read_psd, PsdError};
+use schist_codec_psd::{is_psd, read_dimensions, read_psd, read_thumbnail, PsdError};
 use schist_color::{ColorMode, Depth};
 use schist_core::{BlendMode, Layer, LayerKind};
 
@@ -533,4 +533,84 @@ fn truncated_buffers_error_never_panic() {
     for n in 4..26 {
         assert!(read_psd(&bytes[..n]).is_err(), "prefix {n} should fail");
     }
+}
+
+/// A 0x040C (or 0x0409) thumbnail resource wrapping `jpeg`.
+fn thumbnail_res(id: u16, w: u32, h: u32, jpeg: &[u8]) -> Res {
+    let mut d = Vec::new();
+    d.extend(1u32.to_be_bytes()); // format: kJpegRGB
+    d.extend(w.to_be_bytes());
+    d.extend(h.to_be_bytes());
+    d.extend((w * 3).to_be_bytes()); // row stride
+    d.extend((w * h * 3).to_be_bytes()); // decompressed size
+    d.extend((jpeg.len() as u32).to_be_bytes());
+    d.extend(24u16.to_be_bytes()); // bits per pixel
+    d.extend(1u16.to_be_bytes()); // planes
+    d.extend_from_slice(jpeg);
+    Res {
+        id,
+        name: Vec::new(),
+        data: d,
+    }
+}
+
+#[test]
+fn dimensions_come_from_the_header_alone() {
+    let mut psd = Psd::rgb8(320, 200);
+    psd.layers
+        .push(L::solid("Red", (0, 0, 200, 320), [255, 0, 0, 255]));
+    let bytes = psd.build();
+    assert_eq!(read_dimensions(&bytes).unwrap(), (320, 200));
+    // Truncated to the header: still enough, where read_psd would fail.
+    assert_eq!(read_dimensions(&bytes[..26]).unwrap(), (320, 200));
+    assert!(read_psd(&bytes[..26]).is_err());
+}
+
+#[test]
+fn embedded_thumbnail_is_found_past_other_resources() {
+    let mut psd = Psd::rgb8(64, 48);
+    psd.resources.push(resolution_res(300.0));
+    // An odd-length resource before it: its pad byte has to be consumed
+    // or every later block is misread.
+    psd.resources.push(Res {
+        id: 0x03F0,
+        name: Vec::new(),
+        data: b"odd".to_vec(),
+    });
+    psd.resources
+        .push(thumbnail_res(0x040C, 16, 12, b"\xff\xd8not-really-a-jpeg"));
+    psd.layers
+        .push(L::solid("Red", (0, 0, 48, 64), [255, 0, 0, 255]));
+    let bytes = psd.build();
+
+    let thumb = read_thumbnail(&bytes).expect("thumbnail resource");
+    assert_eq!((thumb.width, thumb.height), (16, 12));
+    assert!(!thumb.bgr);
+    assert_eq!(thumb.jpeg, b"\xff\xd8not-really-a-jpeg");
+}
+
+#[test]
+fn photoshop_4_thumbnail_is_flagged_bgr_and_yields_to_the_modern_one() {
+    let mut psd = Psd::rgb8(64, 48);
+    psd.resources.push(thumbnail_res(0x0409, 8, 6, b"old"));
+    let bytes = psd.build();
+    let thumb = read_thumbnail(&bytes).expect("0x0409 thumbnail");
+    assert!(thumb.bgr);
+    assert_eq!(thumb.jpeg, b"old");
+
+    let mut psd = Psd::rgb8(64, 48);
+    psd.resources.push(thumbnail_res(0x0409, 8, 6, b"old"));
+    psd.resources.push(thumbnail_res(0x040C, 8, 6, b"new"));
+    let bytes = psd.build();
+    let thumb = read_thumbnail(&bytes).expect("0x040C thumbnail");
+    assert!(!thumb.bgr);
+    assert_eq!(thumb.jpeg, b"new");
+}
+
+#[test]
+fn no_thumbnail_resource_is_none_not_an_error() {
+    let psd = Psd::rgb8(8, 8);
+    assert!(read_thumbnail(&psd.build()).is_none());
+    assert!(read_thumbnail(b"not a psd").is_none());
+    assert!(read_thumbnail(&[]).is_none());
 }

--- a/crates/compositor/src/lib.rs
+++ b/crates/compositor/src/lib.rs
@@ -308,6 +308,87 @@ pub fn render_styled(layer: &Layer) -> Option<schist_core::StyledRaster> {
     )
 }
 
+/// Walk the layer tree rebuilding stale styled rasters, collecting the
+/// areas that changed.
+///
+/// Layer effects are a cache: the compositor blends `layer.styled` and
+/// ignores `layer.style` on its own, so nothing with effects renders
+/// until this has run. Editors call it after every change; a freshly
+/// imported document needs it once, before the first composite.
+pub fn restyle_layers(layers: &mut [Layer], damage: &mut Vec<IntRect>) {
+    for layer in layers.iter_mut() {
+        if let LayerKind::Group(g) = &mut layer.kind {
+            restyle_layers(&mut g.children, damage);
+        }
+        if layer.style.is_empty() {
+            if let Some(old) = layer.styled.take() {
+                damage.push(old.bounds);
+            }
+            continue;
+        }
+        // `fx_key` changes whenever anything the raster depends on does.
+        let key = fx_key(layer);
+        if layer.styled.as_ref().map(|s| s.key) == Some(key) {
+            continue;
+        }
+        let before = layer.styled.as_ref().map(|s| s.bounds);
+        layer.styled = render_styled(layer).map(|mut r| {
+            r.key = key;
+            Arc::new(r)
+        });
+        if let Some(b) = before {
+            damage.push(b);
+        }
+        if let Some(s) = layer.styled.as_ref() {
+            damage.push(s.bounds);
+        }
+    }
+}
+
+/// A cheap fingerprint of everything the styled raster is derived from.
+fn fx_key(layer: &Layer) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut h = rustc_hash::FxHasher::default();
+    // The style itself, via its debug form: these are small plain structs
+    // with float fields, so there is nothing cheaper that is also correct.
+    format!("{:?}", layer.style).hash(&mut h);
+    layer.fill_opacity.to_bits().hash(&mut h);
+    if let Some(r) = layer.as_raster() {
+        r.tiles.fingerprint().hash(&mut h);
+    }
+    // A group's styled raster is rendered from its flattened children,
+    // so anything that moves their pixels must change the key. Children
+    // restyle before their parent, so child styled keys are fresh here.
+    if let LayerKind::Group(g) = &layer.kind {
+        fx_key_children(&g.children, &mut h);
+    }
+    h.finish()
+}
+
+fn fx_key_children(layers: &[Layer], h: &mut rustc_hash::FxHasher) {
+    use std::hash::Hash;
+    for l in layers {
+        l.visible.hash(h);
+        l.opacity.to_bits().hash(h);
+        l.fill_opacity.to_bits().hash(h);
+        format!("{:?}", l.blend).hash(h);
+        l.render_offset.hash(h);
+        l.clipping.hash(h);
+        if let Some(r) = l.as_raster() {
+            r.tiles.fingerprint().hash(h);
+        }
+        if let Some(s) = l.styled.as_ref() {
+            s.key.hash(h);
+        }
+        if let Some(m) = &l.mask {
+            m.enabled.hash(h);
+        }
+        if let LayerKind::Group(g) = &l.kind {
+            fx_key_children(&g.children, h);
+        }
+    }
+}
+
 /// Composite a run of sibling layers (bottom-to-top) onto `dst` for `coord`.
 fn composite_layers(
     doc: &Document,

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -33,7 +33,6 @@ schist-commands-core.workspace = true
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-rustc-hash.workspace = true
 image.workspace = true
 log.workspace = true
 env_logger.workspace = true

--- a/crates/mcp/src/session.rs
+++ b/crates/mcp/src/session.rs
@@ -559,7 +559,7 @@ impl Session {
         let canvas = self.doc.canvas_rect();
         let mut grew = Vec::new();
         reshape_layers(&mut self.doc.tree.layers, depth, canvas, &mut grew);
-        restyle_layers(&mut self.doc.tree.layers, &mut grew);
+        schist_compositor::restyle_layers(&mut self.doc.tree.layers, &mut grew);
         for rect in grew {
             self.doc.add_damage(rect);
         }
@@ -601,77 +601,6 @@ fn reshape_layers(layers: &mut [Layer], depth: Depth, canvas: IntRect, damage: &
         layer.styled = None;
         damage.push(before);
         damage.push(layer.content_bounds());
-    }
-}
-
-/// Rebuild stale styled rasters (layer effects), collecting changed areas.
-fn restyle_layers(layers: &mut [Layer], damage: &mut Vec<IntRect>) {
-    for layer in layers.iter_mut() {
-        if let LayerKind::Group(g) = &mut layer.kind {
-            restyle_layers(&mut g.children, damage);
-        }
-        if layer.style.is_empty() {
-            if let Some(old) = layer.styled.take() {
-                damage.push(old.bounds);
-            }
-            continue;
-        }
-        let key = fx_key(layer);
-        if layer.styled.as_ref().map(|s| s.key) == Some(key) {
-            continue;
-        }
-        let before = layer.styled.as_ref().map(|s| s.bounds);
-        layer.styled = schist_compositor::render_styled(layer).map(|mut r| {
-            r.key = key;
-            std::sync::Arc::new(r)
-        });
-        if let Some(b) = before {
-            damage.push(b);
-        }
-        if let Some(s) = &layer.styled {
-            damage.push(s.bounds);
-        }
-    }
-}
-
-/// Fingerprint of everything a styled raster depends on.
-fn fx_key(layer: &Layer) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut h = rustc_hash::FxHasher::default();
-    format!("{:?}", layer.style).hash(&mut h);
-    layer.fill_opacity.to_bits().hash(&mut h);
-    if let Some(r) = layer.as_raster() {
-        r.tiles.fingerprint().hash(&mut h);
-    }
-    // A group's styled raster renders from its flattened children;
-    // children restyle first, so their styled keys are fresh here.
-    if let LayerKind::Group(g) = &layer.kind {
-        fx_key_children(&g.children, &mut h);
-    }
-    h.finish()
-}
-
-fn fx_key_children(layers: &[Layer], h: &mut rustc_hash::FxHasher) {
-    use std::hash::Hash;
-    for l in layers {
-        l.visible.hash(h);
-        l.opacity.to_bits().hash(h);
-        l.fill_opacity.to_bits().hash(h);
-        format!("{:?}", l.blend).hash(h);
-        l.render_offset.hash(h);
-        l.clipping.hash(h);
-        if let Some(r) = l.as_raster() {
-            r.tiles.fingerprint().hash(h);
-        }
-        if let Some(s) = l.styled.as_ref() {
-            s.key.hash(h);
-        }
-        if let Some(m) = &l.mask {
-            m.enabled.hash(h);
-        }
-        if let LayerKind::Group(g) = &l.kind {
-            fx_key_children(&g.children, h);
-        }
     }
 }
 

--- a/crates/preview/Cargo.toml
+++ b/crates/preview/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "schist-preview"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Windowless document previews: one image of a file, as fast as the file allows"
+
+[dependencies]
+schist-core.workspace = true
+schist-compositor.workspace = true
+schist-codec-psd.workspace = true
+schist-codec-affinity.workspace = true
+schist-codecs-common.workspace = true
+schist-plugin-api.workspace = true
+anyhow.workspace = true
+image.workspace = true
+log.workspace = true

--- a/crates/preview/src/lib.rs
+++ b/crates/preview/src/lib.rs
@@ -1,0 +1,382 @@
+//! One picture of a document, rendered without a window.
+//!
+//! This is what a file browser wants: not the editable document, just
+//! the image, at some size, soon. macOS Quick Look is the caller that
+//! shaped it — it gives an extension seconds, and a layered 2 GB PSB
+//! does not open in seconds — but nothing here is macOS-specific.
+//!
+//! Two ways to the same picture, cheapest first:
+//!
+//! 1. **The embedded preview.** Photoshop writes a JPEG thumbnail into
+//!    an image resource; Affinity writes a PNG of the page into the
+//!    container. Both are the writing app's own render, so when one is
+//!    large enough for the size asked for, it is both the fastest and
+//!    the most faithful answer available.
+//! 2. **A real composite.** Otherwise the file opens through the same
+//!    codecs and compositor the editor uses — layers, masks, blend
+//!    modes, adjustment layers and layer effects included — and the
+//!    result is scaled down in bands, so peak memory follows the
+//!    requested size rather than the document's.
+//!
+//! Everything else (PNG, JPEG, WebP, TIFF) decodes and scales directly.
+
+use anyhow::{bail, Context as _, Result};
+use image::RgbaImage;
+use schist_core::{Document, IntRect, TILE_SIZE};
+use schist_plugin_api::CodecPlugin as _;
+use std::path::Path;
+
+/// Ceiling on the longest edge of a rendered preview.
+///
+/// The downscale accumulator is four floats per output pixel, so this is
+/// what bounds it: 2048 costs 67 MB, and no preview surface asks for
+/// more (a Quick Look panel on a Retina display tops out around 1600).
+pub const MAX_EDGE: u32 = 2048;
+
+/// Composite no more than this many pixels at a time. A band of tiles
+/// costs 16 bytes a pixel while it is being composited, so this is the
+/// knob that keeps a 100-megapixel document inside 64 MB.
+const BAND_PIXELS: u32 = 4 << 20;
+
+/// Above this canvas size, an embedded preview wins even when it is
+/// smaller than the size asked for: compositing a document this large
+/// takes longer than any thumbnail is worth.
+const COMPOSITE_PIXEL_BUDGET: u64 = 64 << 20;
+
+/// Where a preview's pixels came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    /// The preview the writing app embedded in the file.
+    Embedded,
+    /// A full composite of the document, through Schist's own codecs.
+    Composited,
+    /// A plain image format, decoded as-is.
+    Decoded,
+}
+
+/// A rendered preview: straight-alpha RGBA8, `width * height * 4` bytes.
+pub struct Preview {
+    pub width: u32,
+    pub height: u32,
+    pub rgba: Vec<u8>,
+    pub source: Source,
+}
+
+impl Preview {
+    fn from_image(img: RgbaImage, source: Source) -> Preview {
+        Preview {
+            width: img.width(),
+            height: img.height(),
+            rgba: img.into_raw(),
+            source,
+        }
+    }
+
+    /// The preview as a PNG.
+    pub fn to_png(&self) -> Result<Vec<u8>> {
+        let img = RgbaImage::from_raw(self.width, self.height, self.rgba.clone())
+            .context("preview buffer had the wrong size")?;
+        let mut out = std::io::Cursor::new(Vec::new());
+        img.write_to(&mut out, image::ImageFormat::Png)
+            .context("encoding the preview as PNG")?;
+        Ok(out.into_inner())
+    }
+}
+
+/// Render a preview of the file at `path`, no larger than `max_edge` on
+/// its longest side.
+pub fn render_file(path: &Path, max_edge: u32) -> Result<Preview> {
+    let bytes = std::fs::read(path).with_context(|| format!("reading {}", path.display()))?;
+    render(&bytes, max_edge)
+}
+
+/// Render a preview of a file already in memory.
+///
+/// The format is detected from the bytes, never from a file name, and
+/// `max_edge` is clamped to `16..=`[`MAX_EDGE`] — a thumbnail smaller
+/// than that is an icon, and drawing one is the caller's business.
+pub fn render(bytes: &[u8], max_edge: u32) -> Result<Preview> {
+    let max_edge = max_edge.clamp(16, MAX_EDGE);
+    if schist_codec_psd::is_psd(bytes) {
+        psd_preview(bytes, max_edge)
+    } else if schist_codecs_common::AffinityCodec.probe(bytes) {
+        affinity_preview(bytes, max_edge)
+    } else {
+        let img = image::load_from_memory(bytes)
+            .context("no Schist codec and no image decoder recognized this file")?
+            .into_rgba8();
+        Ok(Preview::from_image(fit(img, max_edge), Source::Decoded))
+    }
+}
+
+/// PSD/PSB: the image resource thumbnail, else the composited document.
+fn psd_preview(bytes: &[u8], max_edge: u32) -> Result<Preview> {
+    let embedded = schist_codec_psd::read_thumbnail(bytes).and_then(decode_psd_thumbnail);
+    let canvas_pixels = schist_codec_psd::read_dimensions(bytes)
+        .map(|(w, h)| w as u64 * h as u64)
+        .unwrap_or(0);
+    if let Some(img) = &embedded {
+        if img.width().max(img.height()) >= max_edge || canvas_pixels > COMPOSITE_PIXEL_BUDGET {
+            return Ok(Preview::from_image(
+                fit(img.clone(), max_edge),
+                Source::Embedded,
+            ));
+        }
+    }
+    match schist_codec_psd::read_psd(bytes) {
+        Ok(doc) => composite_preview(doc, max_edge),
+        Err(e) => match embedded {
+            // A file Schist cannot open still has a picture in it, and
+            // showing that beats showing the generic document icon.
+            Some(img) => {
+                log::info!("psd: opening failed ({e}); falling back to the embedded thumbnail");
+                Ok(Preview::from_image(fit(img, max_edge), Source::Embedded))
+            }
+            None => Err(e.into()),
+        },
+    }
+}
+
+/// The thumbnail resource holds a JPEG, in BGR order on files old enough.
+fn decode_psd_thumbnail(thumb: schist_codec_psd::Thumbnail<'_>) -> Option<RgbaImage> {
+    let mut img = image::load_from_memory_with_format(thumb.jpeg, image::ImageFormat::Jpeg)
+        .map_err(|e| log::info!("psd: embedded thumbnail did not decode: {e}"))
+        .ok()?
+        .into_rgba8();
+    if thumb.bgr {
+        for px in img.pixels_mut() {
+            px.0.swap(0, 2);
+        }
+    }
+    Some(img)
+}
+
+/// Affinity: the container's own PNG preview, else the imported document.
+fn affinity_preview(bytes: &[u8], max_edge: u32) -> Result<Preview> {
+    let embedded = schist_codec_affinity::Archive::parse(bytes)
+        .ok()
+        .and_then(|archive| archive.thumbnail())
+        .and_then(|png| {
+            image::load_from_memory(png)
+                .map_err(|e| log::info!("affinity: embedded thumbnail did not decode: {e}"))
+                .ok()
+        })
+        .map(|img| img.into_rgba8());
+    if let Some(img) = &embedded {
+        if img.width().max(img.height()) >= max_edge {
+            return Ok(Preview::from_image(
+                fit(img.clone(), max_edge),
+                Source::Embedded,
+            ));
+        }
+    }
+    // The Affinity codec already falls back to the flattened preview for
+    // files whose layers it cannot recover, so a failure here is real.
+    match schist_codecs_common::AffinityCodec.import(bytes) {
+        Ok(doc) => composite_preview(doc, max_edge),
+        Err(e) => match embedded {
+            Some(img) => {
+                log::info!("affinity: import failed ({e}); falling back to the embedded thumbnail");
+                Ok(Preview::from_image(fit(img, max_edge), Source::Embedded))
+            }
+            None => Err(e),
+        },
+    }
+}
+
+/// Composite a document to at most `max_edge` on its longest side.
+fn composite_preview(mut doc: Document, max_edge: u32) -> Result<Preview> {
+    // Layer effects live in a cache the compositor blends and does not
+    // build; a freshly imported document has none yet.
+    let mut damage = Vec::new();
+    schist_compositor::restyle_layers(&mut doc.tree.layers, &mut damage);
+
+    let canvas = doc.canvas_rect();
+    if canvas.is_empty() {
+        bail!("the document has no canvas to render");
+    }
+    let (w, h) = (canvas.width() as u32, canvas.height() as u32);
+    let (tw, th) = fit_size(w, h, max_edge);
+
+    let mut acc = Accumulator::new(w, h, tw, th);
+    let rows = band_rows(w);
+    let mut top = canvas.top;
+    while top < canvas.bottom {
+        let bottom = (top + rows as i32).min(canvas.bottom);
+        let band = IntRect {
+            left: canvas.left,
+            top,
+            right: canvas.right,
+            bottom,
+        };
+        let pixels = schist_compositor::composite_region_rgba8(&doc, band);
+        acc.add_band(&pixels, (top - canvas.top) as u32, (bottom - top) as u32);
+        top = bottom;
+    }
+
+    let img = RgbaImage::from_raw(tw, th, acc.finish())
+        .context("downscaled preview had the wrong size")?;
+    Ok(Preview::from_image(img, Source::Composited))
+}
+
+/// How many document rows to composite at once.
+fn band_rows(width: u32) -> u32 {
+    let tile = TILE_SIZE as u32;
+    let rows = (BAND_PIXELS / width.max(1)).max(tile);
+    // Whole tile rows: the compositor works in tiles either way, so a
+    // band that ends mid-tile only composites the same tile twice.
+    (rows / tile) * tile
+}
+
+/// The size `w * h` scales to inside a `max_edge` box, never upscaling.
+fn fit_size(w: u32, h: u32, max_edge: u32) -> (u32, u32) {
+    let longest = w.max(h);
+    if longest <= max_edge || longest == 0 {
+        return (w.max(1), h.max(1));
+    }
+    let scale = max_edge as f64 / longest as f64;
+    (
+        ((w as f64 * scale).round() as u32).max(1),
+        ((h as f64 * scale).round() as u32).max(1),
+    )
+}
+
+/// Scale a decoded image into the `max_edge` box, if it is over it.
+fn fit(img: RgbaImage, max_edge: u32) -> RgbaImage {
+    let (w, h) = (img.width(), img.height());
+    let (tw, th) = fit_size(w, h, max_edge);
+    if (tw, th) == (w, h) {
+        return img;
+    }
+    image::imageops::resize(&img, tw, th, image::imageops::FilterType::Triangle)
+}
+
+/// A box-filter downscale that never holds the whole source.
+///
+/// Source pixel `(x, y)` falls in output cell `(x * tw / w, y * th / h)`,
+/// a mapping that is separable, so the number of source pixels behind a
+/// cell is the product of two small tables rather than a third image.
+/// Colour is summed weighted by alpha (a transparent pixel must not drag
+/// a cell's colour towards black) and unweighted at the end.
+struct Accumulator {
+    w: u32,
+    h: u32,
+    tw: u32,
+    th: u32,
+    /// Per output cell: alpha-weighted r, g, b, then plain alpha.
+    sums: Vec<f32>,
+    cols: Vec<u32>,
+    rows: Vec<u32>,
+}
+
+impl Accumulator {
+    fn new(w: u32, h: u32, tw: u32, th: u32) -> Accumulator {
+        let mut cols = vec![0u32; tw as usize];
+        for x in 0..w {
+            cols[(x as u64 * tw as u64 / w as u64) as usize] += 1;
+        }
+        let mut rows = vec![0u32; th as usize];
+        for y in 0..h {
+            rows[(y as u64 * th as u64 / h as u64) as usize] += 1;
+        }
+        Accumulator {
+            w,
+            h,
+            tw,
+            th,
+            sums: vec![0.0; tw as usize * th as usize * 4],
+            cols,
+            rows,
+        }
+    }
+
+    /// Fold in `rows` rows of RGBA8 starting at document row `first_row`.
+    fn add_band(&mut self, pixels: &[u8], first_row: u32, rows: u32) {
+        // Precompute the column mapping once for the whole band.
+        let col: Vec<u32> = (0..self.w)
+            .map(|x| (x as u64 * self.tw as u64 / self.w as u64) as u32)
+            .collect();
+        for row in 0..rows {
+            let ty = ((first_row + row) as u64 * self.th as u64 / self.h as u64) as usize;
+            let src = row as usize * self.w as usize * 4;
+            let src = &pixels[src..src + self.w as usize * 4];
+            for (x, px) in src.as_chunks::<4>().0.iter().enumerate() {
+                let a = px[3] as f32 / 255.0;
+                let d = (ty * self.tw as usize + col[x] as usize) * 4;
+                self.sums[d] += px[0] as f32 * a;
+                self.sums[d + 1] += px[1] as f32 * a;
+                self.sums[d + 2] += px[2] as f32 * a;
+                self.sums[d + 3] += a;
+            }
+        }
+    }
+
+    fn finish(self) -> Vec<u8> {
+        let mut out = vec![0u8; self.tw as usize * self.th as usize * 4];
+        for ty in 0..self.th as usize {
+            for tx in 0..self.tw as usize {
+                let i = (ty * self.tw as usize + tx) * 4;
+                let count = (self.cols[tx] * self.rows[ty]) as f32;
+                if count == 0.0 {
+                    continue;
+                }
+                let alpha_sum = self.sums[i + 3];
+                if alpha_sum > 0.0 {
+                    for c in 0..3 {
+                        out[i + c] = (self.sums[i + c] / alpha_sum).round().clamp(0.0, 255.0) as u8;
+                    }
+                }
+                out[i + 3] = (self.sums[i + 3] / count * 255.0).round().clamp(0.0, 255.0) as u8;
+            }
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fit_size_keeps_the_aspect_and_never_upscales() {
+        assert_eq!(fit_size(800, 600, 200), (200, 150));
+        assert_eq!(fit_size(600, 800, 200), (150, 200));
+        // Already inside the box: left exactly as it is.
+        assert_eq!(fit_size(120, 90, 200), (120, 90));
+        // A sliver still has a pixel of height.
+        assert_eq!(fit_size(4000, 3, 100), (100, 1));
+    }
+
+    #[test]
+    fn transparent_pixels_dilute_coverage_without_tinting_colour() {
+        let mut acc = Accumulator::new(2, 1, 1, 1);
+        // Opaque red beside fully transparent green.
+        acc.add_band(&[255, 0, 0, 255, 0, 255, 0, 0], 0, 1);
+        let out = acc.finish();
+        // The green never happened, as far as colour goes...
+        assert_eq!(&out[..3], &[255, 0, 0]);
+        // ... but the cell is only half covered.
+        assert_eq!(out[3], 128);
+    }
+
+    #[test]
+    fn a_banded_downscale_matches_the_rows_it_came_from() {
+        let white = [255u8, 255, 255, 255];
+        let black = [0u8, 0, 0, 255];
+        let row = |c: [u8; 4]| c.repeat(4);
+        let mut acc = Accumulator::new(4, 4, 2, 2);
+        // Two bands of two rows: white on top, black underneath.
+        acc.add_band(&[row(white), row(white)].concat(), 0, 2);
+        acc.add_band(&[row(black), row(black)].concat(), 2, 2);
+        let out = acc.finish();
+        assert_eq!(&out[0..8], &[255, 255, 255, 255, 255, 255, 255, 255]);
+        assert_eq!(&out[8..16], &[0, 0, 0, 255, 0, 0, 0, 255]);
+    }
+
+    #[test]
+    fn bands_cover_whole_tile_rows() {
+        assert_eq!(band_rows(1024) % TILE_SIZE as u32, 0);
+        assert_eq!(band_rows(100_000), TILE_SIZE as u32);
+        assert!(band_rows(512) * 512 <= BAND_PIXELS);
+    }
+}

--- a/crates/preview/tests/preview.rs
+++ b/crates/preview/tests/preview.rs
@@ -1,0 +1,104 @@
+//! Previews of real files, over the vendored fixtures.
+//!
+//! Following the codec convention, these skip (pass) when a corpus is
+//! missing so a partial checkout still builds green.
+
+use schist_preview::{render, render_file, Source, MAX_EDGE};
+use std::path::PathBuf;
+
+fn fixture(rel: &str) -> Option<PathBuf> {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../fixtures")
+        .join(rel);
+    if path.exists() {
+        Some(path)
+    } else {
+        eprintln!("skipping: no fixture at {}", path.display());
+        None
+    }
+}
+
+/// Not all zero, not all one colour: a real picture came out.
+fn has_content(rgba: &[u8]) -> bool {
+    let pixels = rgba.as_chunks::<4>().0;
+    pixels.iter().any(|px| *px != pixels[0])
+}
+
+#[test]
+fn an_affinity_file_previews_from_its_embedded_thumbnail() {
+    let Some(path) = fixture("affinity-probe/shp_pie.af") else {
+        return;
+    };
+    // The probe fixtures are 512x512 and Affinity embeds a thumbnail of
+    // the same size, so anything smaller is served from it directly.
+    let preview = render_file(&path, 128).unwrap();
+    assert_eq!(preview.source, Source::Embedded);
+    assert_eq!((preview.width, preview.height), (128, 128));
+    assert_eq!(preview.rgba.len(), 128 * 128 * 4);
+    assert!(has_content(&preview.rgba));
+}
+
+#[test]
+fn a_bigger_request_than_the_thumbnail_composites_the_document() {
+    let Some(path) = fixture("affinity-probe/shp_pie.af") else {
+        return;
+    };
+    let preview = render_file(&path, MAX_EDGE).unwrap();
+    assert_eq!(preview.source, Source::Composited);
+    // Never upscaled past the document's own size.
+    assert_eq!((preview.width, preview.height), (512, 512));
+    assert!(has_content(&preview.rgba));
+}
+
+#[test]
+fn a_psd_without_a_thumbnail_resource_composites() {
+    let Some(path) = fixture("psd/im_two_layers.psd") else {
+        return;
+    };
+    let preview = render_file(&path, 64).unwrap();
+    assert_eq!(preview.source, Source::Composited);
+    assert!(preview.width.max(preview.height) <= 64);
+    assert!(has_content(&preview.rgba));
+    // PNG round trip: what the Quick Look extensions actually hand over.
+    let png = preview.to_png().unwrap();
+    let decoded = image::load_from_memory(&png).unwrap().into_rgba8();
+    assert_eq!(
+        (decoded.width(), decoded.height()),
+        (preview.width, preview.height)
+    );
+}
+
+#[test]
+fn a_plain_image_decodes_and_scales() {
+    // A 64x32 checkerboard, encoded as PNG.
+    let mut img = image::RgbaImage::new(64, 32);
+    for (x, y, px) in img.enumerate_pixels_mut() {
+        *px = if (x + y) % 2 == 0 {
+            image::Rgba([255, 255, 255, 255])
+        } else {
+            image::Rgba([0, 0, 0, 255])
+        };
+    }
+    let mut png = std::io::Cursor::new(Vec::new());
+    img.write_to(&mut png, image::ImageFormat::Png).unwrap();
+
+    let preview = render(png.get_ref(), 512).unwrap();
+    assert_eq!(preview.source, Source::Decoded);
+    // Under the requested size, so it is left alone rather than blown up.
+    assert_eq!((preview.width, preview.height), (64, 32));
+
+    let preview = render(png.get_ref(), 16).unwrap();
+    assert_eq!((preview.width, preview.height), (16, 8));
+
+    // Sizes below the floor are raised to it, not honoured.
+    let preview = render(png.get_ref(), 2).unwrap();
+    assert_eq!((preview.width, preview.height), (16, 8));
+}
+
+#[test]
+fn an_unreadable_file_is_an_error_not_a_panic() {
+    assert!(render(b"", 256).is_err());
+    assert!(render(b"nothing recognizable here", 256).is_err());
+    // A PSD signature with nothing behind it.
+    assert!(render(b"8BPS\x00\x01rubbish", 256).is_err());
+}

--- a/crates/quicklook/Cargo.toml
+++ b/crates/quicklook/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "schist-quicklook"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "macOS Quick Look thumbnail and preview extensions for Schist's document formats"
+
+[[bin]]
+name = "schist-quicklook"
+path = "src/main.rs"
+
+# macOS-only by nature: on every other platform this builds to a binary
+# that says so and exits. The dependencies follow the same rule, so a
+# Linux or Windows `cargo build --workspace` never fetches them.
+[target.'cfg(target_os = "macos")'.dependencies]
+schist-preview.workspace = true
+anyhow.workspace = true
+log.workspace = true
+env_logger.workspace = true
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSString", "NSURL"] }
+# "objc2" is what teaches CGSize how to cross a message send.
+objc2-core-foundation = { version = "0.3", default-features = false, features = ["std", "objc2", "CFCGTypes"] }
+block2 = "0.6"

--- a/crates/quicklook/build.rs
+++ b/crates/quicklook/build.rs
@@ -1,0 +1,21 @@
+//! Link the two Quick Look frameworks even though nothing calls into
+//! them.
+//!
+//! Both provider superclasses are reached by name through the
+//! Objective-C runtime, so this binary references no symbol from either
+//! framework and a plain `-framework` flag gets dropped from the load
+//! commands as unused — leaving the classes unfindable at runtime.
+//! `-needed_framework` is the same flag that keeps its dylib regardless.
+//!
+//! QuickLookUI resolves to Quartz, the umbrella it belongs to; loading
+//! that is what puts `QLPreviewProvider` in the runtime.
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
+        return;
+    }
+    for framework in ["QuickLookThumbnailing", "QuickLookUI"] {
+        println!("cargo:rustc-link-arg=-Wl,-needed_framework,{framework}");
+    }
+}

--- a/crates/quicklook/src/macos.rs
+++ b/crates/quicklook/src/macos.rs
@@ -1,0 +1,244 @@
+//! The Objective-C half: two provider classes, built at runtime.
+//!
+//! There is no Objective-C source and no Xcode project here. Both
+//! classes are assembled with the runtime's own class builder before
+//! `NSExtensionMain` runs, which is the only thing an app extension's
+//! executable has to arrange: by the time the host looks its principal
+//! class up by name, the class exists.
+
+use block2::Block;
+use objc2::rc::{Allocated, Retained};
+use objc2::runtime::{AnyClass, AnyObject, AnyProtocol, ClassBuilder, Sel};
+use objc2::{msg_send, sel};
+use objc2_core_foundation::{CGFloat, CGSize};
+use objc2_foundation::{NSString, NSURL};
+use std::ffi::c_int;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime};
+
+/// The completion block both providers are handed: `(reply, error)`.
+/// Passing two nulls is how a provider says "no preview from me", which
+/// leaves Quick Look showing the document icon.
+type Completion = Block<dyn Fn(*mut AnyObject, *mut AnyObject)>;
+
+/// Thumbnails Quick Look asks for without saying a size.
+const DEFAULT_EDGE: u32 = 512;
+
+/// Rendered PNGs older than this are another request's leftovers.
+const KEEP_TEMP_FOR: Duration = Duration::from_secs(600);
+
+extern "C" {
+    /// Every app extension's real entry point. Reads the bundle's
+    /// `NSExtension` dictionary, instantiates the principal class and
+    /// serves the host over XPC; never returns.
+    fn NSExtensionMain() -> c_int;
+}
+
+pub fn main() {
+    // Only an explicit `--render` takes the command-line path: an
+    // extension host is free to launch this binary with arguments of its
+    // own, and mistaking those for a request to render a file would take
+    // the extension out of service.
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.first().map(String::as_str) == Some("--render") {
+        env_logger::init();
+        std::process::exit(cli(&args));
+    }
+    register_providers();
+    unsafe { NSExtensionMain() };
+}
+
+/// Build `SchistThumbnailProvider` and `SchistPreviewProvider`, the two
+/// principal classes the `.appex` Info.plists name.
+fn register_providers() {
+    if let Some(superclass) = AnyClass::get(c"QLThumbnailProvider") {
+        if let Some(mut builder) = ClassBuilder::new(c"SchistThumbnailProvider", superclass) {
+            unsafe {
+                builder.add_method(
+                    sel!(provideThumbnailForFileRequest:completionHandler:),
+                    provide_thumbnail as extern "C" fn(_, _, _, _),
+                );
+            }
+            builder.register();
+        }
+    }
+    // Data-based previews are macOS 12 and later. On anything older the
+    // class is missing, this half quietly does not exist, and Finder's
+    // thumbnails — the older extension point — still work.
+    if let (Some(superclass), Some(protocol)) = (
+        AnyClass::get(c"QLPreviewProvider"),
+        AnyProtocol::get(c"QLPreviewingController"),
+    ) {
+        if let Some(mut builder) = ClassBuilder::new(c"SchistPreviewProvider", superclass) {
+            let _ = builder.add_protocol(protocol);
+            unsafe {
+                builder.add_method(
+                    sel!(providePreviewForFileRequest:completionHandler:),
+                    provide_preview as extern "C" fn(_, _, _, _),
+                );
+            }
+            builder.register();
+        }
+    }
+}
+
+/// `-[QLThumbnailProvider provideThumbnailForFileRequest:completionHandler:]`
+extern "C" fn provide_thumbnail(
+    _this: &AnyObject,
+    _cmd: Sel,
+    request: &AnyObject,
+    handler: &Completion,
+) {
+    // `maximumSize` is in points and `scale` turns them into pixels.
+    let size: CGSize = unsafe { msg_send![request, maximumSize] };
+    let scale: CGFloat = unsafe { msg_send![request, scale] };
+    let edge = size.width.max(size.height) * scale.max(1.0);
+    let max_edge = if edge.is_finite() && edge >= 1.0 {
+        edge.ceil() as u32
+    } else {
+        DEFAULT_EDGE
+    };
+
+    let reply = render(request, max_edge).and_then(|png| {
+        let url = file_url(&png);
+        let class = AnyClass::get(c"QLThumbnailReply")?;
+        // Autoreleased (+0), so `msg_send!` retains it for us.
+        let reply: Retained<AnyObject> = unsafe { msg_send![class, replyWithImageFileURL: &*url] };
+        Some(reply)
+    });
+    answer(handler, reply);
+}
+
+/// `-[QLPreviewingController providePreviewForFileRequest:completionHandler:]`
+extern "C" fn provide_preview(
+    _this: &AnyObject,
+    _cmd: Sel,
+    request: &AnyObject,
+    handler: &Completion,
+) {
+    let reply = render(request, schist_preview::MAX_EDGE).and_then(|png| {
+        let url = file_url(&png);
+        let class = AnyClass::get(c"QLPreviewReply")?;
+        // `-init...` hands over +1, which `Retained` then owns.
+        let allocated: Allocated<AnyObject> = unsafe { msg_send![class, alloc] };
+        let reply: Retained<AnyObject> = unsafe { msg_send![allocated, initWithFileURL: &*url] };
+        Some(reply)
+    });
+    answer(handler, reply);
+}
+
+/// Render the request's file to a PNG in this process's temporary
+/// directory, returning its path. Errors are logged, not raised: a
+/// preview that cannot be made is a document icon, never a failure the
+/// user has to deal with.
+fn render(request: &AnyObject, max_edge: u32) -> Option<PathBuf> {
+    let url: Retained<NSURL> = unsafe { msg_send![request, fileURL] };
+    let path = PathBuf::from(url.path()?.to_string());
+    match render_to_temp(&path, max_edge) {
+        Ok(png) => Some(png),
+        Err(e) => {
+            log::warn!("quicklook: {} could not be rendered: {e:#}", path.display());
+            None
+        }
+    }
+}
+
+/// Hand Quick Look the reply, or nothing at all.
+fn answer(handler: &Completion, reply: Option<Retained<AnyObject>>) {
+    let ptr = reply
+        .as_deref()
+        .map_or(std::ptr::null_mut(), |r| (r as *const AnyObject).cast_mut());
+    // The host retains what it keeps, so `reply` may be released after.
+    handler.call((ptr, std::ptr::null_mut()));
+}
+
+fn file_url(path: &Path) -> Retained<NSURL> {
+    NSURL::fileURLWithPath(&NSString::from_str(&path.to_string_lossy()))
+}
+
+/// Where rendered PNGs live: inside the extension's own container, the
+/// one directory a sandboxed app extension can always write to.
+fn temp_dir() -> PathBuf {
+    std::env::temp_dir().join("schist-quicklook")
+}
+
+fn render_to_temp(path: &Path, max_edge: u32) -> anyhow::Result<PathBuf> {
+    let preview = schist_preview::render_file(path, max_edge)?;
+    let png = preview.to_png()?;
+    let dir = temp_dir();
+    std::fs::create_dir_all(&dir)?;
+    prune(&dir);
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let out = dir.join(format!(
+        "{}-{}.png",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::write(&out, png)?;
+    Ok(out)
+}
+
+/// Drop PNGs left by earlier requests.
+///
+/// The reply hands Quick Look a URL and the host reads it moments
+/// later, so a file this old has certainly been read — and the
+/// alternative, deleting each file as soon as the handler returns,
+/// races the read.
+fn prune(dir: &Path) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let stale = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .map(|t| SystemTime::now().duration_since(t).unwrap_or_default() > KEEP_TEMP_FOR)
+            .unwrap_or(false);
+        if stale {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
+/// `schist-quicklook --render <file> <out.png> [max-edge]`: what the
+/// providers do, without an extension host, for looking at the result.
+fn cli(args: &[String]) -> i32 {
+    let usage = "usage: schist-quicklook --render <file> <out.png> [max-edge]";
+    if args.len() < 3 || args.len() > 4 {
+        eprintln!("{usage}");
+        return 2;
+    }
+    let max_edge = match args.get(3).map(|s| s.parse::<u32>()) {
+        Some(Ok(n)) => n,
+        Some(Err(_)) => {
+            eprintln!("{usage}");
+            return 2;
+        }
+        None => schist_preview::MAX_EDGE,
+    };
+    let preview = match schist_preview::render_file(Path::new(&args[1]), max_edge) {
+        Ok(preview) => preview,
+        Err(e) => {
+            eprintln!("{e:#}");
+            return 1;
+        }
+    };
+    let png = match preview.to_png() {
+        Ok(png) => png,
+        Err(e) => {
+            eprintln!("{e:#}");
+            return 1;
+        }
+    };
+    if let Err(e) = std::fs::write(&args[2], png) {
+        eprintln!("writing {}: {e}", args[2]);
+        return 1;
+    }
+    println!(
+        "{}x{} ({:?}) -> {}",
+        preview.width, preview.height, preview.source, args[2]
+    );
+    0
+}

--- a/crates/quicklook/src/main.rs
+++ b/crates/quicklook/src/main.rs
@@ -1,0 +1,33 @@
+//! Schist's macOS Quick Look extensions.
+//!
+//! One binary, two app extensions: Finder's thumbnails
+//! (`QLThumbnailProvider`) and the space-bar preview panel
+//! (`QLPreviewProvider`). macOS allows one extension point per bundle,
+//! so `packaging/macos/quicklook` wraps this same executable in two
+//! `.appex` bundles whose Info.plists name different principal classes;
+//! both classes are registered at startup, and `NSExtensionMain` picks
+//! whichever the host asked for.
+//!
+//! Both providers answer the same way: render the file through
+//! [`schist_preview`], write a PNG to this process's temporary
+//! directory, and hand Quick Look its URL.
+//!
+//! Run it directly to see what Quick Look would see:
+//!
+//! ```sh
+//! schist-quicklook --render file.afphoto out.png [max-edge]
+//! ```
+
+#[cfg(target_os = "macos")]
+mod macos;
+
+#[cfg(target_os = "macos")]
+fn main() {
+    macos::main();
+}
+
+#[cfg(not(target_os = "macos"))]
+fn main() {
+    eprintln!("schist-quicklook is a macOS app extension; there is nothing to run here");
+    std::process::exit(1);
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,10 @@ crates/app              GPUI shell: window, canvas, panels, dialogs, keymap
 ├── crates/plugin-host-wasm  sandboxed third-party plugins
 └── crates/plugin-sdk   what plugin authors compile against
 
+crates/quicklook        macOS Quick Look thumbnail and preview extensions
+└── crates/preview      one windowless image of a file, as fast as the file allows
+crates/mcp              headless editing sessions over the Model Context Protocol
+
 plugins/                first-party features, each optional at compile time
 ├── tools-basic         move, eyedropper, hand, zoom
 ├── tools-paint         brush, pencil, eraser, clone, gradient, bucket, dodge…

--- a/docs/quicklook.md
+++ b/docs/quicklook.md
@@ -48,7 +48,8 @@ macOS allows one extension point per bundle and thumbnails and previews
 are two, so `packaging/macos/bundle.sh` wraps that one executable in two
 `.appex` bundles under `Schist.app/Contents/PlugIns`, each with its own
 Info.plist. Both are sandboxed (`packaging/macos/quicklook/entitlements.plist`)
-and are signed before the app, whose signature seals them.
+and are signed before the app, whose signature seals them. `make release`
+is what runs that script on macOS.
 
 Data-based previews need macOS 12. On macOS 11 the preview extension's
 class does not exist, the binary notices and skips it, and thumbnails —
@@ -66,10 +67,13 @@ cargo run -p schist-quicklook -- --render file.afphoto out.png [max-edge]
 It prints the size and which of the two paths above produced it.
 
 To exercise the real thing, build the bundle and let Launch Services see
-it:
+it. `make release` cross-builds the `.8bf` plug-in helpers on the way,
+which the extensions never touch, so the script it wraps builds the same
+bundle without them — `./packaging/macos/bundle.sh debug` — if the rustup
+targets those helpers need are not installed:
 
 ```sh
-./packaging/macos/bundle.sh debug
+make release PROFILE=debug
 cp -R dist/Schist.app ~/Applications/
 # Sign them the way bundle.sh does -- inside out, the extensions with
 # their own sandboxed entitlements first -- so what is tested matches

--- a/docs/quicklook.md
+++ b/docs/quicklook.md
@@ -1,0 +1,127 @@
+# Quick Look on macOS
+
+Finder asks an app for two different pictures of a document: the
+thumbnail it draws as the file's icon, and the preview the space bar
+opens. Schist supplies both for the formats nothing else on the system
+can read — `.psd`, `.psb`, `.afphoto`, `.afdesign`, `.afpub` and `.af` —
+so those files stop looking like blank pages in a folder.
+
+Nothing has to be enabled. The extensions live inside `Schist.app`, and
+macOS registers them the first time the app is launched from a location
+Launch Services scans (`/Applications` or `~/Applications`). Moving the
+app re-registers them; deleting it takes them with it.
+
+## What it renders
+
+Cheapest path first:
+
+1. **The embedded preview.** Photoshop writes a JPEG thumbnail into
+   image resource `0x040C`; Affinity writes a PNG of the page into its
+   container. Both are the writing app's own render, so whenever one is
+   at least as large as the size Quick Look asked for, it is used
+   as-is — and for a document over 64 megapixels it is used even when it
+   is smaller, because nothing else can answer in the time an extension
+   is given.
+2. **A composite.** Otherwise the file opens through Schist's own
+   codecs and is composited exactly as the editor would: layers, groups,
+   masks, blend modes, adjustment layers and layer effects. The result
+   is scaled down in bands of tiles, so a 400-megapixel PSB is rendered
+   in about 64 MB rather than in gigabytes.
+
+If the document cannot be opened at all, an embedded preview is still
+shown when the file has one. A file with neither produces no
+preview — Quick Look falls back to the document icon, which is what it
+would have shown anyway.
+
+## How it is built
+
+`crates/preview` does the rendering and knows nothing about macOS.
+`crates/quicklook` is the extension binary: it registers two
+Objective-C classes with the runtime — `SchistThumbnailProvider`, a
+`QLThumbnailProvider`, and `SchistPreviewProvider`, a
+`QLPreviewProvider` conforming to `QLPreviewingController` — and then
+calls `NSExtensionMain`. There is no Objective-C source and no Xcode
+project; the classes are assembled at startup, before the host looks up
+the principal class its Info.plist names.
+
+macOS allows one extension point per bundle and thumbnails and previews
+are two, so `packaging/macos/bundle.sh` wraps that one executable in two
+`.appex` bundles under `Schist.app/Contents/PlugIns`, each with its own
+Info.plist. Both are sandboxed (`packaging/macos/quicklook/entitlements.plist`)
+and are signed before the app, whose signature seals them.
+
+Data-based previews need macOS 12. On macOS 11 the preview extension's
+class does not exist, the binary notices and skips it, and thumbnails —
+the older extension point — still work.
+
+## Looking at what it produces
+
+The extension binary renders from the command line too, which needs no
+signing, no installation and no Finder:
+
+```sh
+cargo run -p schist-quicklook -- --render file.afphoto out.png [max-edge]
+```
+
+It prints the size and which of the two paths above produced it.
+
+To exercise the real thing, build the bundle and let Launch Services see
+it:
+
+```sh
+./packaging/macos/bundle.sh debug
+cp -R dist/Schist.app ~/Applications/
+# Sign them the way bundle.sh does -- inside out, the extensions with
+# their own sandboxed entitlements first -- so what is tested matches
+# what ships. An ad-hoc signature is enough for a local run.
+for ext in ~/Applications/Schist.app/Contents/PlugIns/*.appex; do
+    codesign --force --sign - \
+        --entitlements packaging/macos/quicklook/entitlements.plist "$ext"
+done
+codesign --force --sign - \
+    --entitlements packaging/macos/entitlements.plist ~/Applications/Schist.app
+
+# Registration happens when the app is launched, not when it is copied.
+open -g -j ~/Applications/Schist.app
+pluginkit -m | grep schist
+```
+
+Two identifiers listed means both extensions are live; Finder and the
+space bar will use them from then on. Nothing listed means the app was
+not registered — that is Launch Services, not Quick Look, and a bundle
+sitting in a build directory is not somewhere it looks.
+
+`qlmanage -p file.afphoto` opens the preview panel the extension fills.
+For thumbnails, ask the framework directly rather than through Finder's
+icon cache, which will happily keep showing an older answer:
+
+```swift
+// swift probe.swift file.afphoto
+import QuickLookThumbnailing
+let request = QLThumbnailGenerator.Request(
+    fileAt: URL(fileURLWithPath: CommandLine.arguments[1]),
+    size: CGSize(width: 512, height: 512), scale: 1,
+    representationTypes: .thumbnail)
+let done = DispatchSemaphore(value: 0)
+QLThumbnailGenerator.shared.generateBestRepresentation(for: request) { rep, err in
+    print(rep.map { "\($0.cgImage.width)x\($0.cgImage.height)" }
+        ?? "none: \(String(describing: err))")
+    done.signal()
+}
+_ = done.wait(timeout: .now() + 30)
+```
+
+Each extension renders into its own sandbox container, so
+`~/Library/Containers/place.astrid.schist.quicklook-*/Data/tmp/schist-quicklook`
+holds exactly the PNGs it handed Quick Look — the quickest way to see
+what a provider actually produced.
+
+## Which files it claims
+
+The `QLSupportedContentTypes` in both Info.plists are exactly the type
+identifiers `Schist.app` imports. Where Affinity itself is installed it
+declares its own (`com.canva.affinity*`) and previews them with its own
+extension; Schist does not shadow those. Photoshop's identifiers are
+system-declared, so `.psd` previews resolve to whichever extension the
+system prefers — and `.psb`, which nothing else declares, is Schist's
+either way.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -29,7 +29,10 @@ they will not break the plugin ABI or saved files.
 
 ## Releasing
 
-1. Update the version in the root `Cargo.toml` and `packaging/macos/Info.plist`.
+1. Update the version in the root `Cargo.toml`, `packaging/macos/Info.plist`
+   and both `packaging/macos/quicklook/*-Info.plist` (an app extension
+   carries its own version, and macOS re-registers one whose version
+   moved).
 2. `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings`.
 3. Tag: `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`.
 4. The release workflow builds Linux AppImages for x86_64 and aarch64, a

--- a/packaging/macos/bundle.sh
+++ b/packaging/macos/bundle.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Build Schist.app and the standalone schist-mcp server, signing and
-# notarizing both when credentials are present. Always leaves two
+# Build Schist.app -- with its two Quick Look app extensions inside --
+# and the standalone schist-mcp server, signing and notarizing both when
+# credentials are present. Always leaves two
 # distributables:
 #   dist/Schist.zip            the app bundle
 #   dist/schist-mcp-macos.zip  the MCP server, a plain CLI binary
@@ -27,13 +28,33 @@ mcp_stage="$root/target/macos-mcp"
 mcp="$mcp_stage/schist-mcp"
 mcp_zip="$root/dist/schist-mcp-macos.zip"
 
-cargo build --"$target" -p schist-app -p schist-mcp
+# `debug` names a directory under target/, not a cargo flag: it is what
+# `cargo build` does with no profile flag at all.
+packages=(-p schist-app -p schist-mcp -p schist-quicklook)
+if [ "$target" = "debug" ]; then
+    cargo build "${packages[@]}"
+else
+    cargo build --"$target" "${packages[@]}"
+fi
 
 rm -rf "$app"
 mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
 cp "$root/packaging/macos/Info.plist" "$app/Contents/Info.plist"
 cp "$root/target/$target/schist" "$app/Contents/MacOS/schist"
 cp "$root/packaging/macos/schist.icns" "$app/Contents/Resources/"
+
+# Quick Look ships as two app extensions around one executable: macOS
+# allows a bundle only one extension point, and thumbnails (Finder icons)
+# and previews (the space-bar panel) are two. Each Info.plist names the
+# principal class the binary registers for that role.
+install_appex() {
+    ext="$app/Contents/PlugIns/$1.appex"
+    mkdir -p "$ext/Contents/MacOS"
+    cp "$root/packaging/macos/quicklook/$2" "$ext/Contents/Info.plist"
+    cp "$root/target/$target/schist-quicklook" "$ext/Contents/MacOS/schist-quicklook"
+}
+install_appex SchistQuickLookThumbnail thumbnail-Info.plist
+install_appex SchistQuickLookPreview preview-Info.plist
 
 # The MCP server ships on its own rather than inside the bundle: it is a stdio
 # CLI that a client spawns by path, so it wants a short path and has to be
@@ -45,23 +66,34 @@ cp "$root/target/$target/schist-mcp" "$mcp"
 signed=false
 if [ -n "${MACOS_CERT_NAME:-}" ]; then
     echo "signing with $MACOS_CERT_NAME"
+    # Expanded as `${keychain[@]+...}` below: bash 3.2, which is what
+    # /usr/bin/env finds on a stock macOS, calls an empty array unbound
+    # under `set -u`.
     keychain=()
     if [ -n "${MACOS_KEYCHAIN:-}" ]; then
         keychain=(--keychain "$MACOS_KEYCHAIN")
     fi
 
-    # No --deep: it is deprecated, and there is nothing nested to reach --
-    # plugins ship as wasm, not as dylibs.
+    # Inside out, and without --deep, which is deprecated: the app's
+    # signature seals the extensions inside it, so they have to be signed
+    # -- with their own, sandboxed entitlements -- before the app is.
+    for ext in "$app/Contents/PlugIns/"*.appex; do
+        codesign --force --options runtime --timestamp \
+            --entitlements "$root/packaging/macos/quicklook/entitlements.plist" \
+            ${keychain[@]+"${keychain[@]}"} --sign "$MACOS_CERT_NAME" "$ext"
+        codesign --verify --strict --verbose=2 "$ext"
+    done
+
     codesign --force --options runtime --timestamp \
         --entitlements "$root/packaging/macos/entitlements.plist" \
-        "${keychain[@]}" --sign "$MACOS_CERT_NAME" "$app"
+        ${keychain[@]+"${keychain[@]}"} --sign "$MACOS_CERT_NAME" "$app"
     codesign --verify --strict --verbose=2 "$app"
 
     # The server gets the same entitlements as the app: it hosts the same
     # wasmtime plugins, so under the hardened runtime it needs MAP_JIT too.
     codesign --force --options runtime --timestamp \
         --entitlements "$root/packaging/macos/entitlements.plist" \
-        "${keychain[@]}" --sign "$MACOS_CERT_NAME" "$mcp"
+        ${keychain[@]+"${keychain[@]}"} --sign "$MACOS_CERT_NAME" "$mcp"
     codesign --verify --strict --verbose=2 "$mcp"
     signed=true
 else

--- a/packaging/macos/quicklook/entitlements.plist
+++ b/packaging/macos/quicklook/entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- App extensions are sandboxed even when their container app is
+         not. Quick Look hands the extension a sandbox extension for the
+         one file being previewed, which is all the access it needs: the
+         readers here never open anything else, and unlike the app this
+         binary hosts no wasm plugins, so it wants no JIT either. -->
+    <key>com.apple.security.app-sandbox</key><true/>
+</dict>
+</plist>

--- a/packaging/macos/quicklook/preview-Info.plist
+++ b/packaging/macos/quicklook/preview-Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key><string>SchistQuickLookPreview</string>
+    <key>CFBundleDisplayName</key><string>Schist Previews</string>
+    <key>CFBundleIdentifier</key><string>place.astrid.schist.quicklook-preview</string>
+    <key>CFBundleVersion</key><string>0.6.0</string>
+    <key>CFBundleShortVersionString</key><string>0.6.0</string>
+    <key>CFBundleExecutable</key><string>schist-quicklook</string>
+    <!-- An app extension is an XPC service, not an application. -->
+    <key>CFBundlePackageType</key><string>XPC!</string>
+    <!-- QLPreviewProvider, the data-based preview class, is macOS 12.
+         Older systems load the thumbnail extension only. -->
+    <key>LSMinimumSystemVersion</key><string>12.0</string>
+
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.quicklook.preview</string>
+        <!-- Registered from Rust at startup; see crates/quicklook. -->
+        <key>NSExtensionPrincipalClass</key>
+        <string>SchistPreviewProvider</string>
+        <key>NSExtensionAttributes</key>
+        <dict>
+            <!-- The types the app's Info.plist imports, and only those:
+                 where Affinity itself is installed it declares its own
+                 (com.canva.affinity*) and previews them with its own
+                 extension, which needs no help from us. -->
+            <key>QLSupportedContentTypes</key>
+            <array>
+                <string>com.adobe.photoshop-image</string>
+                <string>com.adobe.photoshop-large-image</string>
+                <string>com.seriflabs.afphoto</string>
+                <string>com.seriflabs.afdesign</string>
+                <string>com.seriflabs.afpub</string>
+                <string>com.seriflabs.af</string>
+            </array>
+            <!-- The preview is an image this extension produces, not a
+                 view controller it presents. -->
+            <key>QLIsDataBasedPreview</key><true/>
+            <!-- Files only: Schist indexes nothing for Spotlight. -->
+            <key>QLSupportsSearchableItems</key><false/>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/packaging/macos/quicklook/thumbnail-Info.plist
+++ b/packaging/macos/quicklook/thumbnail-Info.plist
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key><string>SchistQuickLookThumbnail</string>
+    <key>CFBundleDisplayName</key><string>Schist Thumbnails</string>
+    <key>CFBundleIdentifier</key><string>place.astrid.schist.quicklook-thumbnail</string>
+    <key>CFBundleVersion</key><string>0.6.0</string>
+    <key>CFBundleShortVersionString</key><string>0.6.0</string>
+    <key>CFBundleExecutable</key><string>schist-quicklook</string>
+    <!-- An app extension is an XPC service, not an application. -->
+    <key>CFBundlePackageType</key><string>XPC!</string>
+    <key>LSMinimumSystemVersion</key><string>11.0</string>
+
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.quicklook.thumbnail</string>
+        <!-- Registered from Rust at startup; see crates/quicklook. -->
+        <key>NSExtensionPrincipalClass</key>
+        <string>SchistThumbnailProvider</string>
+        <key>NSExtensionAttributes</key>
+        <dict>
+            <!-- The types the app's Info.plist imports, and only those:
+                 where Affinity itself is installed it declares its own
+                 (com.canva.affinity*) and previews them with its own
+                 extension, which needs no help from us. -->
+            <key>QLSupportedContentTypes</key>
+            <array>
+                <string>com.adobe.photoshop-image</string>
+                <string>com.adobe.photoshop-large-image</string>
+                <string>com.seriflabs.afphoto</string>
+                <string>com.seriflabs.afdesign</string>
+                <string>com.seriflabs.afpub</string>
+                <string>com.seriflabs.af</string>
+            </array>
+            <!-- No size is too small to be worth drawing: every one of
+                 these formats can carry a picture at any dimension. -->
+            <key>QLThumbnailMinimumDimension</key><integer>0</integer>
+        </dict>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
A folder of .afphoto, .afdesign or .psb files looked like a folder of blank pages: nothing on the system can read them, so Finder drew the generic document icon and the space bar showed the same. Schist can read them, so it now answers both questions macOS asks about a document.

Two app extensions ship inside Schist.app -- thumbnails and previews are separate extension points and a bundle may only declare one, so one binary is wrapped twice, each Info.plist naming the principal class it wants. There is no Objective-C source and no Xcode project: both provider classes are assembled with the runtime's class builder before NSExtensionMain runs, which is all an extension's executable has to arrange.

The rendering behind them is `schist-preview`, which knows nothing about macOS. Cheapest path first: the preview the writing app embedded -- a JPEG in PSD image resource 0x040C, a PNG in Affinity's container -- when it is at least as large as the size asked for, and for a canvas over 64 megapixels even when it is smaller, because nothing else answers in the seconds an extension is given. Otherwise the file opens through Schist's own codecs and composites exactly as the editor would, scaled down in bands of tiles so a 400-megapixel PSB renders in about 64 MB rather than in gigabytes. A file that cannot be opened at all still shows its embedded preview if it has one.

Two things this needed elsewhere. `restyle_layers` moves into the compositor: layer effects are a cache the compositor blends but does not build, the app and the MCP server each had an identical private copy, and a preview that skipped it would silently drop every drop shadow. And codec-psd learns to read a file's dimensions and embedded thumbnail without decoding the document, which is the whole point of the fast path.

Verified against the real thing rather than only in tests: installed, registered, and answering QLThumbnailGenerator -- an .afdesign from its embedded preview, a .psd composited -- with the preview extension spawned by quicklookd for the space-bar panel.

Also fixes two things in bundle.sh that this ran into: `debug` was passed to cargo as `--debug`, which is not a flag, and its empty arrays tripped `set -u` under the bash 3.2 that /usr/bin/env finds on macOS.