### PR TITLE
feat: ship .deb, .rpm and .pkg.tar.zst beside the AppImage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,9 @@ jobs:
           # executable itself -- strip it here so neither the AppImage payload
           # nor the loose binaries ship it. Symbols stay; only DWARF goes.
           strip --strip-debug target/release/schist target/release/schist-mcp
-          sudo apt-get install -y libfuse2 || true
+          # libfuse2: appimagetool. rpm: rpmbuild, for the .rpm.
+          # libarchive-tools: bsdtar, which writes the .pkg.tar.zst's .MTREE.
+          sudo apt-get install -y libfuse2 rpm libarchive-tools || true
           curl -sSL -o /tmp/appimagetool \
             "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-$(uname -m).AppImage"
           chmod +x /tmp/appimagetool
@@ -105,6 +107,8 @@ jobs:
           # destination file" and no AppImage is produced.
           mkdir -p dist
           APPIMAGETOOL=/tmp/appimagetool ./packaging/linux/appimage.sh
+          # The .deb, .rpm and .pkg.tar.zst, from the same build.
+          ./packaging/linux/packages.sh
           # Arch-suffixed: the x86_64 and aarch64 jobs publish into the same
           # release, and same-named assets would collide there.
           cp target/release/schist "dist/schist-linux-$(uname -m)"

--- a/Makefile
+++ b/Makefile
@@ -187,6 +187,7 @@ release: stage-helpers
 	@mkdir -p dist
 ifeq ($(HOST),linux)
 	SCHIST_BUNDLED_HELPERS='$(HELPER_STAGE)' ./packaging/linux/appimage.sh
+	SCHIST_BUNDLED_HELPERS='$(HELPER_STAGE)' ./packaging/linux/packages.sh
 else ifeq ($(HOST),macos)
 	SCHIST_BUNDLED_HELPERS='$(HELPER_STAGE)' ./packaging/macos/bundle.sh $(PROFILE)
 else ifeq ($(HOST),windows)

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -35,7 +35,10 @@ they will not break the plugin ABI or saved files.
    moved).
 2. `cargo test --workspace` and `cargo clippy --workspace --all-targets -- -D warnings`.
 3. Tag: `git tag -a vX.Y.Z -m "vX.Y.Z" && git push origin vX.Y.Z`.
-4. The release workflow builds Linux AppImages for x86_64 and aarch64, a
+4. The release workflow builds, for x86_64 and aarch64, a Linux AppImage
+   plus the native packages `packaging/linux/packages.sh` emits (`.deb`,
+   `.rpm` and a binary `.pkg.tar.zst` — the last one is a convenience
+   build, not the AUR package from step 5), a
    macOS `Schist.zip` (signed and notarized when the secrets below
    exist), and a Windows installer, then drafts the release. Each
    platform also ships the `schist-mcp` server from the same build: a

--- a/packaging/linux/appimage.sh
+++ b/packaging/linux/appimage.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 # Build an AppImage. Requires `appimagetool` on PATH (or set APPIMAGETOOL).
+# The native packages -- .deb, .rpm, .pkg.tar.zst -- are packages.sh's job;
+# both ship the same tree, staged by payload.sh.
 set -euo pipefail
 
-root="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=packaging/linux/payload.sh
+source "$(dirname "$0")/payload.sh"
+root="$payload_root"
 # Scratch, not a deliverable: dist/ is uploaded wholesale by CI, and an
 # AppDir in there collides with the real artifacts on the release.
 appdir="$root/target/Schist.AppDir"
@@ -11,21 +15,13 @@ tool="${APPIMAGETOOL:-appimagetool}"
 cargo build --release -p schist-app
 
 rm -rf "$appdir"
-mkdir -p "$appdir/usr/bin" "$appdir/usr/share/applications" \
-         "$appdir/usr/share/mime/packages" \
-         "$appdir/usr/share/icons/hicolor/256x256/apps"
-cp "$root/target/release/schist" "$appdir/usr/bin/"
-cp "$root/packaging/linux/schist.desktop" "$appdir/usr/share/applications/"
-# The Affinity MIME types the desktop entry names; a desktop integrator that
-# installs the entry finds them here rather than binding it to nothing.
-cp "$root/packaging/linux/place.astrid.schist.mime.xml" \
-   "$appdir/usr/share/mime/packages/"
-cp "$root/packaging/linux/schist.desktop" "$appdir/schist.desktop"
-# appimagetool looks the icon up by the desktop entry's Icon= key, so both
-# copies have to carry the app ID as their name.
-icon="$appdir/usr/share/icons/hicolor/256x256/apps/place.astrid.schist.png"
-cp "$root/packaging/linux/schist.png" "$icon"
-cp "$icon" "$appdir/place.astrid.schist.png"
+stage_payload "$appdir"
+
+# appimagetool reads the desktop entry from the AppDir root and looks the
+# icon up there by its Icon= key, so both are duplicated out of usr/.
+cp "$appdir/usr/share/applications/schist.desktop" "$appdir/schist.desktop"
+cp "$appdir/usr/share/icons/hicolor/256x256/apps/place.astrid.schist.png" \
+   "$appdir/place.astrid.schist.png"
 
 cat > "$appdir/AppRun" <<'RUN'
 #!/bin/sh

--- a/packaging/linux/packages.sh
+++ b/packaging/linux/packages.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# Build the native Linux packages from one already-built binary:
+#
+#   dist/schist_VERSION-1_ARCH.deb            dpkg-deb, or ar+tar without it
+#   dist/schist-VERSION-1.ARCH.rpm            needs rpmbuild
+#   dist/schist-VERSION-1-ARCH.pkg.tar.zst    tar+zstd, .MTREE needs bsdtar
+#
+# Each format is skipped, loudly, when the tool it needs is absent, so a
+# machine with none of them still gets the ones it can build.
+#
+# Packages are built for the host architecture only: they carry a compiled
+# binary, and cargo builds one target per invocation. The Arch package here
+# is a *binary* package assembled from this checkout -- it is not what AUR
+# users get, which is built from source by packaging/linux/aur/PKGBUILD and
+# has to stay in step with the dependency lists below.
+set -euo pipefail
+
+# shellcheck source=packaging/linux/payload.sh
+source "$(dirname "$0")/payload.sh"
+
+version="$payload_version"
+# The package revision, bumped only when the packaging changes under a
+# version that has already shipped. The AUR PKGBUILD's pkgrel is its own.
+release=1
+summary="Layered image editor with PSD and Affinity support"
+url="https://github.com/IAmJSD/schist"
+# Both a .deb's Maintainer and a pacman package's packager want
+# "Name <email>", so there is no useful "unknown" to fall back to.
+packager="${PACKAGER:-Astrid <astrid@infrawrench.com>}"
+builddate="${SOURCE_DATE_EPOCH:-$(date +%s)}"
+
+machine="$(uname -m)"
+case "$machine" in
+    x86_64)  deb_arch=amd64; rpm_arch=x86_64;  pkg_arch=x86_64 ;;
+    aarch64) deb_arch=arm64; rpm_arch=aarch64; pkg_arch=aarch64 ;;
+    *) echo "error: no package architecture known for $machine" >&2; exit 1 ;;
+esac
+
+dist="$payload_root/dist"
+# Scratch, not a deliverable: dist/ is uploaded wholesale by CI, and a
+# staging tree in there would collide with the real artifacts.
+build="$payload_root/target/linux-packages"
+
+cargo build --release -p schist-app
+mkdir -p "$dist"
+rm -rf "$build"
+
+built=()
+
+# libheif is dlopen'd at run time for HEIC import -- present or not, the
+# app starts -- so it is a weak dependency in all three formats.
+
+build_deb() {
+    local work="$build/deb" out size
+    mkdir -p "$work/DEBIAN"
+    stage_payload "$work"
+    # Debian keeps the licence in the documentation directory and nowhere
+    # else; /usr/share/licenses is an rpm and pacman convention.
+    install -Dm644 "$work/usr/share/licenses/schist/LICENSE" \
+        "$work/usr/share/doc/schist/copyright"
+    rm -rf "$work/usr/share/licenses"
+
+    # The data archive carries an entry for ./ itself, which dpkg applies
+    # to / on install -- so it has to be 755 and not whatever the umask
+    # left on the staging directory.
+    chmod 755 "$work"
+
+    size="$(du -sk --exclude=DEBIAN "$work" | cut -f1)"
+    # Written out by hand rather than by shlibdeps: this runs on whatever
+    # machine cut the release, which is not necessarily a Debian one.
+    cat > "$work/DEBIAN/control" <<EOF
+Package: schist
+Version: $version-$release
+Section: graphics
+Priority: optional
+Architecture: $deb_arch
+Maintainer: $packager
+Installed-Size: $size
+Depends: libc6, libfontconfig1, libfreetype6, libxcb1, libxkbcommon0,
+ libxkbcommon-x11-0, libwayland-client0, libvulkan1, hicolor-icon-theme
+Recommends: libheif1
+Homepage: $url
+Description: $summary
+ Schist is a layered image editor that opens and writes Photoshop (PSD and
+ PSB) and Affinity documents, and hosts Photoshop .8bf filter plug-ins.
+EOF
+
+    # dpkg-deb does not generate md5sums itself; the Debian helper that
+    # normally would is not in play here.
+    ( cd "$work" && find usr -type f -exec md5sum {} + > DEBIAN/md5sums )
+
+    # Debian and Ubuntu fire these off dpkg triggers, so this only does
+    # anything on a system without the trigger-providing packages -- and
+    # then only for whichever of them is installed at all.
+    cat > "$work/DEBIAN/postinst" <<'EOF'
+#!/bin/sh
+set -e
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database -q /usr/share/applications || true
+fi
+if command -v update-mime-database >/dev/null 2>&1; then
+    update-mime-database /usr/share/mime || true
+fi
+if command -v gtk-update-icon-cache >/dev/null 2>&1; then
+    gtk-update-icon-cache -qtf /usr/share/icons/hicolor || true
+fi
+EOF
+    cp "$work/DEBIAN/postinst" "$work/DEBIAN/postrm"
+    chmod 755 "$work/DEBIAN/postinst" "$work/DEBIAN/postrm"
+
+    out="$dist/schist_${version}-${release}_${deb_arch}.deb"
+    rm -f "$out"
+    if command -v dpkg-deb >/dev/null 2>&1; then
+        dpkg-deb --root-owner-group --build "$work" "$out" >/dev/null
+    else
+        # No dpkg here: a .deb is an ar archive of exactly three members in
+        # exactly this order, which binutils' ar and tar can write.
+        local ar="$build/deb-ar"
+        mkdir -p "$ar"
+        echo 2.0 > "$ar/debian-binary"
+        tar --owner=0 --group=0 --numeric-owner \
+            -czf "$ar/control.tar.gz" -C "$work/DEBIAN" .
+        tar --owner=0 --group=0 --numeric-owner --exclude=./DEBIAN \
+            -czf "$ar/data.tar.gz" -C "$work" .
+        ( cd "$ar" && ar rcD "$out" debian-binary control.tar.gz data.tar.gz )
+    fi
+    built+=("$out")
+}
+
+build_rpm() {
+    if ! command -v rpmbuild >/dev/null 2>&1; then
+        echo "rpmbuild not found; skipping the .rpm" >&2
+        return
+    fi
+    local work="$build/rpm"
+    mkdir -p "$work/payload"
+    stage_payload "$work/payload"
+
+    # The payload is built and staged already, so the spec only wraps it:
+    # no %prep, no %build, and an %install that copies the tree in.
+    #
+    # Requires are Fedora's names for the libraries -- rpmbuild adds the
+    # sonames it can see in the ELF on top, but fontconfig, wayland and the
+    # Vulkan loader are dlopen'd and invisible to it.
+    cat > "$work/schist.spec" <<EOF
+%global debug_package %{nil}
+%global _build_id_links none
+
+Name:           schist
+Version:        $version
+Release:        $release
+Summary:        $summary
+License:        MIT
+URL:            $url
+Requires:       fontconfig
+Requires:       freetype
+Requires:       libxcb
+Requires:       libxkbcommon
+Requires:       libxkbcommon-x11
+Requires:       libwayland-client
+Requires:       vulkan-loader
+Requires:       hicolor-icon-theme
+Recommends:     libheif
+
+%description
+Schist is a layered image editor that opens and writes Photoshop (PSD and
+PSB) and Affinity documents, and hosts Photoshop .8bf filter plug-ins.
+
+%install
+cp -a %{payload}/. %{buildroot}/
+
+%files
+%license %{_datadir}/licenses/schist/LICENSE
+%{_bindir}/schist
+%{_datadir}/applications/schist.desktop
+%{_datadir}/icons/hicolor/256x256/apps/place.astrid.schist.png
+%{_datadir}/mime/packages/place.astrid.schist.xml
+
+%post
+update-desktop-database -q %{_datadir}/applications &>/dev/null || :
+update-mime-database %{_datadir}/mime &>/dev/null || :
+gtk-update-icon-cache -qtf %{_datadir}/icons/hicolor &>/dev/null || :
+
+%postun
+update-desktop-database -q %{_datadir}/applications &>/dev/null || :
+update-mime-database %{_datadir}/mime &>/dev/null || :
+gtk-update-icon-cache -qtf %{_datadir}/icons/hicolor &>/dev/null || :
+EOF
+
+    # _build_name_fmt keeps the result in dist/ rather than dist/<arch>/;
+    # the %% survive one round of macro expansion at --define time.
+    rpmbuild -bb --quiet --target "$rpm_arch" \
+        --define "_topdir $work" \
+        --define "payload $work/payload" \
+        --define "_rpmdir $dist" \
+        --define "_build_name_fmt %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
+        "$work/schist.spec"
+    built+=("$dist/schist-${version}-${release}.${rpm_arch}.rpm")
+}
+
+build_pkg() {
+    local work="$build/pkg" out size dep
+    mkdir -p "$work"
+    stage_payload "$work"
+
+    # size is the installed size in bytes, which is what pacman reports and
+    # what it checks the disk against.
+    size="$(du -sb "$work" | cut -f1)"
+    cat > "$work/.PKGINFO" <<EOF
+pkgname = schist
+pkgbase = schist
+pkgver = $version-$release
+pkgdesc = $summary
+url = $url
+builddate = $builddate
+packager = $packager
+size = $size
+arch = $pkg_arch
+license = MIT
+EOF
+    # The same list the AUR PKGBUILD carries: fontconfig, wayland and the
+    # Vulkan loader are dlopen'd rather than linked, and belong here even
+    # though nothing in the ELF points at them.
+    for dep in fontconfig freetype2 hicolor-icon-theme libxcb libxkbcommon \
+               libxkbcommon-x11 vulkan-icd-loader wayland; do
+        echo "depend = $dep" >> "$work/.PKGINFO"
+    done
+    echo "optdepend = libheif: HEIC import" >> "$work/.PKGINFO"
+    # Recorded in the .MTREE below, so it is set before that is written.
+    chmod 644 "$work/.PKGINFO"
+
+    # pacman reads the metadata from the front of the stream, so .PKGINFO
+    # goes in first and the payload last.
+    local entries=(.PKGINFO)
+    if command -v bsdtar >/dev/null 2>&1; then
+        # --uid/--gid record the ownership the tar below writes, not this
+        # user's, so the two agree and `pacman -Qkk` stays quiet.
+        ( cd "$work" && LC_ALL=C bsdtar -czf .MTREE --format=mtree \
+            --uid 0 --gid 0 --uname root --gname root \
+            --options='!all,use-set,type,uid,gid,mode,time,size,md5,sha256,link' \
+            .PKGINFO usr )
+        chmod 644 "$work/.MTREE"
+        entries+=(.MTREE)
+    else
+        echo "bsdtar not found; the .pkg.tar.zst ships without a .MTREE" \
+             "(it installs, but \`pacman -Qkk\` cannot verify it)" >&2
+    fi
+    entries+=(usr)
+
+    out="$dist/schist-${version}-${release}-${pkg_arch}.pkg.tar.zst"
+    tar --owner=0 --group=0 --numeric-owner -C "$work" -cf - "${entries[@]}" \
+        | zstd -q -T0 -19 -c > "$out"
+    built+=("$out")
+}
+
+build_deb
+build_rpm
+build_pkg
+
+for f in "${built[@]}"; do
+    echo "built $f" "$(du -h "$f" | cut -f1)"
+done

--- a/packaging/linux/payload.sh
+++ b/packaging/linux/payload.sh
@@ -1,0 +1,34 @@
+# Sourced, not run: the file layout every Linux package installs.
+#
+# The AppImage and the three native packages (packages.sh) ship the same
+# files under the same prefix; only the metadata wrapped around them
+# differs. Keeping the layout here means a new file lands in all four at
+# once rather than in whichever script was edited.
+
+payload_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+payload_root="$(cd "$payload_dir/../.." && pwd)"
+
+# The one version the whole workspace shares -- the same line the Makefile
+# reads to name the Windows installer.
+payload_version="$(sed -n '0,/^version = /s/^version = "\(.*\)"/\1/p' \
+    "$payload_root/Cargo.toml")"
+
+# stage_payload DIR -- fill DIR with the /usr tree a package installs.
+stage_payload() {
+    local dest="$1"
+
+    install -Dm755 "$payload_root/target/release/schist" "$dest/usr/bin/schist"
+    install -Dm644 "$payload_dir/schist.desktop" \
+        "$dest/usr/share/applications/schist.desktop"
+    # The desktop entry looks its icon up by the Icon= key, so the file has
+    # to carry the app ID as its name rather than the source's.
+    install -Dm644 "$payload_dir/schist.png" \
+        "$dest/usr/share/icons/hicolor/256x256/apps/place.astrid.schist.png"
+    # The Affinity MIME types the desktop entry names; without them the
+    # entry associates with nothing. update-mime-database compiles them at
+    # install time.
+    install -Dm644 "$payload_dir/place.astrid.schist.mime.xml" \
+        "$dest/usr/share/mime/packages/place.astrid.schist.xml"
+    install -Dm644 "$payload_root/LICENSE" \
+        "$dest/usr/share/licenses/schist/LICENSE"
+}


### PR DESCRIPTION
The Linux release was one AppImage. That works everywhere and belongs nowhere: nothing updates it, the desktop entry and the MIME types only take effect if the user runs an integrator by hand, and a distribution's own package manager has no idea Schist is installed. Every dependency Schist actually has is already packaged on every distribution it runs on, so there was nothing stopping a native package but the writing of it.

`packaging/linux/packages.sh` builds all three from one host build:

| file | needs |
| --- | --- |
| `dist/schist_VERSION-1_ARCH.deb` | `dpkg-deb`, or `ar`+`tar` without it |
| `dist/schist-VERSION-1.ARCH.rpm` | `rpmbuild` |
| `dist/schist-VERSION-1-ARCH.pkg.tar.zst` | `tar`+`zstd`; the `.MTREE` needs `bsdtar` |

A format whose tool is missing is skipped loudly rather than failing the run, so a machine with none of them still gets the ones it can build — and the `.deb` falls back to assembling the `ar` archive itself, which is what makes a release cut from a non-Debian machine produce one at all.

The tree the packages install is now `payload.sh`, shared with `appimage.sh` rather than restated: a file added to one is added to all four. The AppImage picks up the LICENSE it had been leaving out. `make release` and the Linux release job run the new script (CI installs `rpm` and `libarchive-tools` for it); `dist/*` is already uploaded wholesale, so the packages land on the release.

The dependency lists are written by hand in each format's own names, because the interesting ones are invisible to every tool that would generate them: fontconfig, wayland and the Vulkan loader are dlopen'd and appear nowhere in the ELF. `libheif` is weak in all three — HEIC import loads it at run time, and the app starts without it. The pacman package's list is the AUR PKGBUILD's, and the two have to stay in step; that package is a convenience binary for the release page and **not** what AUR users get, which is still built from source.

## Verification

In rootless podman against a real release build, each format on its own distribution:

- `debian:stable-slim` — `apt-get install /pkg/schist_*.deb` resolved every `Depends` from the archive, `dpkg -L` correct, `dpkg -r` clean.
- `fedora:latest` — `dnf install` resolved every `Requires` and pulled `libheif` through `Recommends`, `rpm -V schist` clean, `dnf remove` clean.
- `archlinux:base` — `pacman -U` resolved every `depend`, `pacman -Qkk schist` reported 0 altered files, `pacman -R` clean.
- The no-dpkg path was exercised separately by running the script inside an Arch container with a stub `cargo`; the `.deb` it assembled installs and removes on Debian too.

Two things that only showed up there, both now handled in the script:

- A `.deb`'s data archive carries an entry for `./` itself and dpkg applies its mode to `/`, so the staging root is `chmod 755` rather than shipping whatever the umask left.
- `pacman -Qkk` only stays quiet if the `.MTREE` records uid/gid 0, which bsdtar writes only when told to — the tar step's `--owner=0` does not reach it.

## Not in this change

The AUR `PKGBUILD` still has no `optdepends=('libheif: HEIC import')`, which is now inconsistent with the binary Arch package here. Left alone deliberately: touching it pulls in the `.SRCINFO` regeneration and the AUR push in the release checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)