### PR TITLE
feat: ship a .dmg alongside the macOS zip

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -38,9 +38,11 @@ they will not break the plugin ABI or saved files.
 4. The release workflow builds, for x86_64 and aarch64, a Linux AppImage
    plus the native packages `packaging/linux/packages.sh` emits (`.deb`,
    `.rpm` and a binary `.pkg.tar.zst` — the last one is a convenience
-   build, not the AUR package from step 5), a
-   macOS `Schist.zip` (signed and notarized when the secrets below
-   exist), and a Windows installer, then drafts the release. Each
+   build, not the AUR package from step 5), a macOS `Schist.dmg` and
+   `Schist.zip` (both signed and notarized when the secrets below exist
+   — the disk image is the one to point people at, the zip is for
+   anything that unpacks a download itself), and a Windows installer,
+   then drafts the release. Each
    platform also ships the `schist-mcp` server from the same build: a
    loose arch-suffixed binary on Linux (`schist-mcp-linux-x86_64`,
    `schist-mcp-linux-aarch64`), a loose binary on Windows, and on macOS

--- a/packaging/macos/bundle.sh
+++ b/packaging/macos/bundle.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 # Build Schist.app -- with its two Quick Look app extensions inside --
 # and the standalone schist-mcp server, signing and notarizing both when
-# credentials are present. Always leaves two
+# credentials are present. Always leaves three
 # distributables:
+#   dist/Schist.dmg            the app, in a window to drag into /Applications
 #   dist/Schist.zip            the app bundle
 #   dist/schist-mcp-macos.zip  the MCP server, a plain CLI binary
-# Only the zips are safe to hand to CI artifact upload, which would otherwise
-# strip permissions and symlinks and void the signatures.
+# Only the disk image and the zips are safe to hand to CI artifact upload,
+# which would otherwise strip permissions and symlinks and void the
+# signatures.
 #
 # Signing is optional -- without it both still build, unsigned:
 #   MACOS_CERT_NAME   "Developer ID Application: … (TEAMID)"
@@ -22,6 +24,10 @@ root="$(cd "$(dirname "$0")/../.." && pwd)"
 target="${1:-release}"
 app="$root/dist/Schist.app"
 zip="$root/dist/Schist.zip"
+dmg="$root/dist/Schist.dmg"
+# What the disk image is assembled in: the app plus the /Applications link,
+# and nothing else -- hdiutil images the directory exactly as it finds it.
+dmg_stage="$root/target/macos-dmg"
 # The server is staged outside dist/ and only its zip is published there: a
 # loose binary in dist/ would be uploaded alongside, minus its exec bit.
 mcp_stage="$root/target/macos-mcp"
@@ -155,6 +161,40 @@ fi
 rm -f "$zip"
 ditto -c -k --keepParent "$app" "$zip"
 
+# The disk image, built last and from the finished bundle: whatever signing
+# and stapling happened above is already inside it. ditto rather than cp,
+# which is the only copy that carries a bundle's symlinks and extended
+# attributes across intact -- a signature does not survive losing them.
+rm -rf "$dmg_stage"
+mkdir -p "$dmg_stage"
+ditto "$app" "$dmg_stage/Schist.app"
+# The drag-to-install target. A symlink to the real /Applications, so the
+# window Finder opens has somewhere to drop the app.
+ln -s /Applications "$dmg_stage/Applications"
+rm -f "$dmg"
+hdiutil create -volname Schist -srcfolder "$dmg_stage" -ov -format UDZO "$dmg"
+rm -rf "$dmg_stage"
+
+# The image is signed and notarized in its own right, not just for what it
+# carries: Gatekeeper assesses the .dmg the moment it is opened, which is
+# before anything inside it has been looked at.
+if [ "$signed" = true ]; then
+    codesign --force --timestamp \
+        ${keychain[@]+"${keychain[@]}"} --sign "$MACOS_CERT_NAME" "$dmg"
+    codesign --verify --strict --verbose=2 "$dmg"
+fi
+
+if [ "$signed" = true ] && [ ${#notary[@]} -gt 0 ]; then
+    echo "notarizing the disk image"
+    xcrun notarytool submit "$dmg" "${notary[@]}" --wait
+    # Unlike the flat MCP binary a disk image does take a stapled ticket, so
+    # this is also the check on the submission: stapling a rejected image
+    # fails rather than passing quietly.
+    xcrun stapler staple "$dmg"
+    xcrun stapler validate "$dmg"
+fi
+
 echo "built $app"
 echo "built $zip"
+echo "built $dmg"
 echo "built $mcp_zip"


### PR DESCRIPTION
The zip is what CI could upload safely, so it became what people downloaded -- and a zip of an .app leaves them dragging it into /Applications themselves, if they think to. Build a disk image from the finished bundle instead: the app and a symlink to /Applications, which is the install everyone already knows.

Built after stapling, from the bundle rather than a rebuild, so whatever signing happened is already inside it -- and copied with ditto, the only copy that carries a bundle's symlinks and extended attributes across without voiding the signature.

The image is signed and notarized in its own right, not just for what it carries: Gatekeeper assesses the .dmg when it is opened, before anything inside it has been looked at. Unlike the flat MCP binary a .dmg takes a stapled ticket, so `stapler staple` is also the check on the submission -- it fails on a rejected image rather than passing quietly, and needs no grep through the notarytool log.

The zip stays: it is still what anything that unpacks a download itself wants. The release workflow needed no change -- it uploads dist/* and its `rm -rf dist/Schist.app` still leaves the image alone.


Claude-Session: https://claude.ai/code/session_0197wHPNr9Kf1DwXTDkuMJaB