### PR TITLE
Say what Colour Transfer is actually short of

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,15 @@ Remap anything in `~/.config/schist/keymap.json`:
   than as wrong. Skin Smoothing's *smoothing* is frequency separation,
   which is what a retoucher does by hand; the network's job there is to
   say where the faces are, and it has opinions about dogs. Colour
-  Transfer has no model and is not missing one — moving one image's
-  colour distribution onto another's is arithmetic. Each filter says in
-  its own dialog which path it took, and the model-backed ones fall back
-  to a classical implementation rather than failing.
+  Transfer is the one that is genuinely short: Photoshop's takes the
+  palette from a *reference photograph* and matches it up scene to
+  scene, and this one aims at a hue you pick, because a filter here is
+  handed one buffer and a list of numbers and there is no way to hand it
+  a second image. The arithmetic that moves one colour distribution onto
+  another is all there; the picture to take the distribution from is
+  not. Each filter says in its own dialog which path it took, and the
+  model-backed ones fall back to a classical implementation rather than
+  failing.
 - **Object Selection and Content-Aware Fill are heuristics**, not the
   models Photoshop uses — background sampling and diffusion inpainting
   respectively. They degrade predictably (blurry over texture) rather

--- a/plugins/filters-core/src/neural.rs
+++ b/plugins/filters-core/src/neural.rs
@@ -8,13 +8,14 @@
 //! demand. Everything runs through `schist-neural`, which is `tract` --
 //! pure Rust, so there is no runtime to install.
 //!
-//! The two that are not networks are not networks for a reason. Colour
-//! Transfer is a statistic -- moving one image's colour distribution onto
-//! another's is arithmetic, and a network would be a slower way to get
-//! the same numbers. Skin Smoothing's *smoothing* is frequency
-//! separation, which is what a retoucher does by hand; the network's job
-//! there is to say where the faces are, which is the part that needs to
-//! know what a face is.
+//! The two that are not networks are not networks for different reasons.
+//! Skin Smoothing's *smoothing* is frequency separation, which is what a
+//! retoucher does by hand; the network's job there is to say where the
+//! faces are, which is the part that needs to know what a face is.
+//! Colour Transfer is short of the real thing: Photoshop's takes the
+//! palette from a reference photograph, and this one aims at a hue,
+//! because the filter interface hands a filter one buffer and a list of
+//! numbers with no way to pass it a second image.
 //!
 //! Every model-backed filter also works without its model, falling back
 //! to the classical path and saying so in its dialog. Nothing here is a
@@ -676,13 +677,15 @@ simple_filter!(
         param("contrast", "Match Contrast", 0.0, 100.0, 50.0, "")
     ],
     |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
-        // Reinhard-style colour transfer, aimed at a hue rather than a
-        // reference image: shift the image's mean chroma towards the
-        // target and optionally normalise its spread. There is no model
-        // here and there is no missing one -- moving one distribution
-        // onto another is arithmetic, and Photoshop's own network is
-        // doing the *segmentation* around it, which Object Selection is
-        // the filter for.
+        // Reinhard-style colour transfer, aimed at a hue rather than at
+        // a reference image: shift the image's mean chroma towards the
+        // target and optionally normalise its spread. Moving one
+        // distribution onto another is arithmetic and this is that
+        // arithmetic; what Photoshop has and this does not is the
+        // reference photograph to read a distribution *from*, and a
+        // network matching the two scene by scene so that its sky lands
+        // on this sky. A filter is handed one buffer and a list of
+        // numbers, so the second picture has nowhere to arrive.
         let _ = (w, h);
         let strength = v.get("strength") / 100.0;
         let match_contrast = v.get("contrast") / 100.0;


### PR DESCRIPTION
Checked the premise first: both Neural Filters that do not run a network here are real Photoshop Neural Filters. Skin Smoothing is one of Adobe's five *featured* ones, and Colour Transfer is in their beta list ("apply the color palette from any reference image onto the photo of your choosing"). So nothing needed removing from the menu or the docs on that count.

But the line about Colour Transfer was too comfortable:

> Colour Transfer has no model and is not missing one — moving one image's colour distribution onto another's is arithmetic.

The arithmetic part is true and is what this implements. The part it skipped is that Photoshop's filter reads its palette from a **reference photograph** and matches it scene to scene, and this one aims at a hue you pick from a slider. That is a real gap, and the reason for it is worth writing down: a filter here is handed one buffer and a list of numbers, so there is nowhere for a second image to arrive.

Docs only — README, the module header and the comment on the filter itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)