### PR TITLE
The Filter Gallery's effects, six missing classics, and five more Neural Filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,15 @@ Remap anything in `~/.config/schist/keymap.json`:
   than as wrong. Skin Smoothing's *smoothing* is frequency separation,
   which is what a retoucher does by hand; the network's job there is to
   say where the faces are, and it has opinions about dogs. Colour
-  Transfer has no model and is not missing one — moving one image's
-  colour distribution onto another's is arithmetic. Each filter says in
-  its own dialog which path it took, and the model-backed ones fall back
-  to a classical implementation rather than failing.
+  Transfer is the one that is genuinely short: Photoshop's takes the
+  palette from a *reference photograph* and matches it up scene to
+  scene, and this one aims at a hue you pick, because a filter here is
+  handed one buffer and a list of numbers and there is no way to hand it
+  a second image. The arithmetic that moves one colour distribution onto
+  another is all there; the picture to take the distribution from is
+  not. Each filter says in its own dialog which path it took, and the
+  model-backed ones fall back to a classical implementation rather than
+  failing.
 - **Object Selection and Content-Aware Fill are heuristics**, not the
   models Photoshop uses — background sampling and diffusion inpainting
   respectively. They degrade predictably (blurry over texture) rather

--- a/README.md
+++ b/README.md
@@ -117,11 +117,15 @@ glow, satin, colour overlay, gradient overlay, outer glow and drop shadow,
 with Photoshop's Fill-vs-Opacity semantics so "Fill 0% plus a drop shadow"
 does what you expect.
 
-**Filters.** Fifty-seven across ten categories — Blur, Distort, Noise,
-Pixelate, Render, Sharpen, Stylize, Other, Camera Raw and Neural Filters
-— all previewing live on the canvas inside the selection, with Cancel
-restoring exactly. The **Filter Gallery** stacks several and previews the
-result of the lot.
+**Filters.** A hundred and fifteen across fourteen categories —
+Artistic, Blur, Brush Strokes, Distort, Noise, Pixelate, Render, Sharpen,
+Sketch, Stylize, Texture, Other, Camera Raw and Neural Filters — all
+previewing live on the canvas inside the selection, with Cancel restoring
+exactly. That includes the forty-six effects Photoshop keeps *inside* the
+Filter Gallery — Watercolor, Sumi-e, Chrome, Stained Glass and the rest —
+which are ordinary filters here as well, so they can be run from the menu
+or stacked in the **Filter Gallery**, which previews the result of the
+lot.
 
 **Warping.** Liquify with all seven brushes, Puppet Warp (Moving Least
 Squares, so pins hold and nothing shears), Content-Aware Scale (seam
@@ -225,36 +229,43 @@ Remap anything in `~/.config/schist/keymap.json`:
   is a protocol of its own rather than an axis on the pointer, so binding
   it means synthesising the whole mouse event stream from the tool, tip
   and barrel buttons included. Reports from real hardware welcome.
-- **Five of the seven Neural Filters run a network, and they are not
-  Photoshop's networks.** Super Zoom, JPEG Artifact Removal and Colorize
-  use models trained for this application — `tools/train/`, between 39k
-  and 466k parameters, shipped inside the binary because they are small
-  enough to be; the first two were fitted to the Kodak suite and the
-  colouriser to twenty thousand CC BY photographs from Open Images,
-  which `tools/train/photos.py` will fetch again. Style Transfer uses the fast neural-style networks from
-  the ONNX Model Zoo, Depth Blur uses MiDaS and Skin Smoothing uses
-  UltraFace; those are somebody else's work and run from one megabyte to
-  sixty-six, so they are fetched on demand from Filter ▸ Neural
-  Filters ▸ Manage Models and checked against the hash this build
-  expects.
-  Inference is [`tract`](https://github.com/sonos/tract) — pure Rust,
-  nothing to install.
+- **Nine of the twelve Neural Filters run a network, and they are not
+  Photoshop's networks.** Super Zoom, JPEG Artifact Removal, Colorize and
+  Photo Restoration use models trained for this application —
+  `tools/train/`, between 39k and 466k parameters, shipped inside the
+  binary because they are small enough to be; the first two were fitted
+  to the Kodak suite and the colouriser to twenty thousand CC BY
+  photographs from Open Images, which `tools/train/photos.py` will fetch
+  again. Style Transfer uses the fast neural-style networks from the ONNX
+  Model Zoo, Depth Blur and Landscape Mixer use MiDaS, and Skin Smoothing
+  and Face to Caricature use UltraFace; those are somebody else's work
+  and run from one megabyte to sixty-six, so they are fetched on demand
+  from Filter ▸ Neural Filters ▸ Manage Models and checked against the
+  hash this build expects. Inference is
+  [`tract`](https://github.com/sonos/tract) — pure Rust, nothing to
+  install.
 
   What each one is honest about differs. Colorize knows what sky, foliage,
   wood and skin usually look like and is deliberately cautious about
   anything whose colour is a choice, which reads as desaturated rather
   than as wrong. Skin Smoothing's *smoothing* is frequency separation,
   which is what a retoucher does by hand; the network's job there is to
-  say where the faces are, and it has opinions about dogs. Colour
-  Transfer is the one that is genuinely short: Photoshop's takes the
-  palette from a *reference photograph* and matches it up scene to
-  scene, and this one aims at a hue you pick, because a filter here is
-  handed one buffer and a list of numbers and there is no way to hand it
-  a second image. The arithmetic that moves one colour distribution onto
-  another is all there; the picture to take the distribution from is
-  not. Each filter says in its own dialog which path it took, and the
-  model-backed ones fall back to a classical implementation rather than
-  failing.
+  say where the faces are, and it has opinions about dogs. Face to
+  Caricature does not find your features either — it assumes they are
+  where a face looking at the camera keeps them, which is why it works on
+  a portrait and falls apart on a profile.
+
+  Colour Transfer, Harmonization and Landscape Mixer need a second
+  picture, and the one a filter can be handed without a file picker is
+  the layer underneath: they take their reference from whatever the
+  document composites to below the layer being filtered, which is what
+  Photoshop's Harmonization asks you to pick by hand. Moving one colour
+  distribution onto another is arithmetic and that arithmetic is all
+  here; what Adobe's networks add is matching the two *by subject*, so
+  that a reference's sky lands on your sky. Landscape Mixer gets closest
+  to that by matching band by band through the depth model. Each filter
+  says in its own dialog which path it took, and the model-backed ones
+  fall back to a classical implementation rather than failing.
 - **Object Selection and Content-Aware Fill are heuristics**, not the
   models Photoshop uses — background sampling and diffusion inpainting
   respectively. They degrade predictably (blurry over texture) rather

--- a/crates/app/src/dialogs.rs
+++ b/crates/app/src/dialogs.rs
@@ -678,7 +678,16 @@ fn filter_dialog(
         .map(|f| (f.name().to_string(), f.params()))
         .unwrap_or_else(|| (id.to_string(), Vec::new()));
 
-    let mut body = div().flex().flex_col().gap_1();
+    // Scrolls, because Custom is a five-by-five kernel and Lighting
+    // Effects has a dozen sliders: a filter dialog is a list of whatever
+    // the filter declares, and some filters declare a lot.
+    let mut body = div()
+        .id("filter-params")
+        .flex()
+        .flex_col()
+        .gap_1()
+        .max_h(px(420.0))
+        .overflow_y_scroll();
     for spec in specs {
         let key = spec.key;
         body = body.child(param_slider(

--- a/crates/app/src/panels.rs
+++ b/crates/app/src/panels.rs
@@ -368,9 +368,31 @@ fn destructive_adjustment_entries() -> Vec<MenuEntry> {
 /// Menu grouping for the built-in filters.
 const FILTER_GROUPS: &[(&str, &[&str])] = &[
     (
+        "Artistic",
+        &[
+            "filter.colored_pencil",
+            "filter.cutout",
+            "filter.dry_brush",
+            "filter.film_grain",
+            "filter.fresco",
+            "filter.neon_glow",
+            "filter.paint_daubs",
+            "filter.palette_knife",
+            "filter.plastic_wrap",
+            "filter.poster_edges",
+            "filter.rough_pastels",
+            "filter.smudge_stick",
+            "filter.sponge",
+            "filter.underpainting",
+            "filter.watercolor",
+        ],
+    ),
+    (
         "Blur",
         &[
             "filter.average",
+            "filter.blur",
+            "filter.blur_more",
             "filter.box_blur",
             "filter.gaussian_blur",
             "filter.lens_blur",
@@ -380,9 +402,25 @@ const FILTER_GROUPS: &[(&str, &[&str])] = &[
         ],
     ),
     (
+        "Brush Strokes",
+        &[
+            "filter.accented_edges",
+            "filter.angled_strokes",
+            "filter.crosshatch",
+            "filter.dark_strokes",
+            "filter.ink_outlines",
+            "filter.spatter",
+            "filter.sprayed_strokes",
+            "filter.sumi_e",
+        ],
+    ),
+    (
         "Distort",
         &[
+            "filter.diffuse_glow",
             "filter.displace",
+            "filter.glass",
+            "filter.ocean_ripple",
             "filter.pinch",
             "filter.polar",
             "filter.ripple",
@@ -422,6 +460,7 @@ const FILTER_GROUPS: &[(&str, &[&str])] = &[
             "filter.difference_clouds",
             "filter.fibers",
             "filter.lens_flare",
+            "filter.lighting_effects",
         ],
     ),
     (
@@ -429,8 +468,28 @@ const FILTER_GROUPS: &[(&str, &[&str])] = &[
         &[
             "filter.sharpen",
             "filter.sharpen_edges",
+            "filter.sharpen_more",
             "filter.smart_sharpen",
             "filter.unsharp_mask",
+        ],
+    ),
+    (
+        "Sketch",
+        &[
+            "filter.bas_relief",
+            "filter.chalk_charcoal",
+            "filter.charcoal",
+            "filter.chrome",
+            "filter.conte_crayon",
+            "filter.graphic_pen",
+            "filter.halftone_pattern",
+            "filter.note_paper",
+            "filter.photocopy",
+            "filter.plaster",
+            "filter.reticulation",
+            "filter.stamp",
+            "filter.torn_edges",
+            "filter.water_paper",
         ],
     ),
     (
@@ -449,9 +508,22 @@ const FILTER_GROUPS: &[(&str, &[&str])] = &[
         ],
     ),
     (
+        "Texture",
+        &[
+            "filter.craquelure",
+            "filter.grain",
+            "filter.mosaic_tiles",
+            "filter.patchwork",
+            "filter.stained_glass",
+            "filter.texturizer",
+        ],
+    ),
+    (
         "Other",
         &[
+            "filter.custom",
             "filter.high_pass",
+            "filter.hsb_hsl",
             "filter.maximum",
             "filter.minimum",
             "filter.offset",
@@ -467,6 +539,11 @@ const FILTER_GROUPS: &[(&str, &[&str])] = &[
             "filter.neural.super_zoom",
             "filter.neural.color_transfer",
             "filter.neural.depth_blur",
+            "filter.neural.harmonization",
+            "filter.neural.landscape_mixer",
+            "filter.neural.photo_restoration",
+            "filter.neural.photo_to_sketch",
+            "filter.neural.face_to_caricature",
         ],
     ),
 ];

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -5060,6 +5060,51 @@ impl Workspace {
         Some(buf)
     }
 
+    /// What the document composites to *under* a layer, over a region.
+    ///
+    /// Produced by hiding the layer and everything above it, compositing,
+    /// and putting the visibility back -- which is cheaper than it
+    /// sounds and much cheaper than the alternative, since the
+    /// compositor already knows how to skip an invisible layer. Only
+    /// filters that ask for it pay for it.
+    fn read_backdrop(
+        &mut self,
+        layer_id: schist_core::LayerId,
+        region: IntRect,
+    ) -> Option<Vec<f32>> {
+        let doc = self.doc.as_mut()?;
+        let path = doc.tree.path_of(layer_id)?;
+        // Hide the layer itself and every sibling above it, at every
+        // level of the path: "above" in a nested group means later in
+        // that group *and* later in each of its ancestors.
+        let mut hidden: Vec<(schist_core::LayerId, bool)> = Vec::new();
+        {
+            let mut layers: &mut Vec<schist_core::Layer> = &mut doc.tree.layers;
+            for (depth, &ix) in path.0.iter().enumerate() {
+                let last = depth + 1 == path.0.len();
+                let from = if last { ix } else { ix + 1 };
+                for layer in layers.iter_mut().skip(from) {
+                    hidden.push((layer.id, layer.visible));
+                    layer.visible = false;
+                }
+                if last {
+                    break;
+                }
+                match &mut layers.get_mut(ix)?.kind {
+                    schist_core::LayerKind::Group(g) => layers = &mut g.children,
+                    _ => break,
+                }
+            }
+        }
+        let under = schist_compositor::composite_region_f32(doc, region);
+        for (id, was) in hidden {
+            if let Some(layer) = doc.tree.find_mut(id) {
+                layer.visible = was;
+            }
+        }
+        Some(under)
+    }
+
     /// Blend `filtered` back over `original` through the selection, so
     /// partial coverage feathers the result.
     ///
@@ -5164,7 +5209,15 @@ impl Workspace {
             let Some(filter) = self.registry.filters().find(|f| f.id() == id) else {
                 return;
             };
-            filter.apply(&mut buf, w, h, values);
+            let backdrop = if filter.wants_backdrop() {
+                self.read_backdrop(preview.layer, preview.region)
+            } else {
+                None
+            };
+            let Some(filter) = self.registry.filters().find(|f| f.id() == id) else {
+                return;
+            };
+            filter.apply_over(&mut buf, backdrop.as_deref(), w, h, values);
         }
         self.write_region(
             preview.layer,
@@ -5266,8 +5319,17 @@ impl Workspace {
             .detach();
             return;
         }
-        filter.apply(
+        let backdrop = if filter.wants_backdrop() {
+            self.read_backdrop(layer_id, region)
+        } else {
+            None
+        };
+        let Some(filter) = self.registry.filters().find(|f| f.id() == id) else {
+            return;
+        };
+        filter.apply_over(
             &mut buf,
+            backdrop.as_deref(),
             region.width() as usize,
             region.height() as usize,
             values,

--- a/crates/plugin-api/src/lib.rs
+++ b/crates/plugin-api/src/lib.rs
@@ -433,6 +433,37 @@ pub trait FilterPlugin: Send + Sync {
     /// `width * height` pixels.
     fn apply(&self, pixels: &mut [f32], width: usize, height: usize, values: &FilterValues);
 
+    /// Whether this filter wants to see what is underneath the layer.
+    ///
+    /// Most do not: a filter is a function of its own pixels. The ones
+    /// that match one image to another -- Harmonization, Colour
+    /// Transfer -- need something to match *to*, and the only second
+    /// image a filter dialog can offer without a file picker is the one
+    /// already in the document. Photoshop's Harmonization asks for a
+    /// layer the same way.
+    fn wants_backdrop(&self) -> bool {
+        false
+    }
+
+    /// Apply with the pixels underneath the layer, when the host has
+    /// them.
+    ///
+    /// `backdrop` is the same size as `pixels` and is what the document
+    /// composites to under this layer, or `None` when there is nothing
+    /// below or the host cannot produce one. The default ignores it,
+    /// which is right for every filter that did not ask.
+    fn apply_over(
+        &self,
+        pixels: &mut [f32],
+        backdrop: Option<&[f32]>,
+        width: usize,
+        height: usize,
+        values: &FilterValues,
+    ) {
+        let _ = backdrop;
+        self.apply(pixels, width, height, values);
+    }
+
     /// A line shown in the filter's dialog, for anything the user should
     /// know before running it -- which is mostly whether a neural filter
     /// found its model or is about to use its fallback.

--- a/plugins/filters-core/src/artistic.rs
+++ b/plugins/filters-core/src/artistic.rs
@@ -1,0 +1,619 @@
+//! Filter Gallery ▸ Artistic.
+//!
+//! Fifteen ways to make a photograph look like it was made by hand. They
+//! are the oldest effects in Photoshop -- they came in with Gallery
+//! Effects in 1992 and have not changed since -- and they all work the
+//! same way underneath: throw away the detail that a brush could not have
+//! painted, keep the tone, and put something back where the detail was.
+//! What differs is *what* goes back: dabs, hatching, flat paper, grain,
+//! a wet edge.
+//!
+//! None of these are the original implementations, which nobody outside
+//! Adobe has seen. They are each written from what the effect does to an
+//! image, which for this family is unusually legible: run one at full
+//! strength on a gradient and a photograph and the recipe falls out.
+
+use crate::util::{
+    at, blur_plane, edges, flatten_colour, from_luma, gaussian_rgba, luma, luma_map, put, sample,
+    streak, surface, value_noise,
+};
+use crate::{choice, param, simple_filter};
+use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
+
+/// Flatten an image into regions a brush could have painted.
+///
+/// A blur that stops at edges: the shared first step of Cutout, Dry
+/// Brush, Fresco, Palette Knife and Watercolor, which differ mostly in
+/// what they do afterwards. Edge-aware rather than plain, because the
+/// point is to lose the texture inside a shape while keeping the shape.
+fn flatten(px: &mut [f32], w: usize, h: usize, radius: f32, tolerance: f32) {
+    if radius < 0.5 {
+        return;
+    }
+    let src = px.to_vec();
+    let r = radius.round().max(1.0) as i32;
+    let tol = tolerance.max(0.01);
+    for y in 0..h as i32 {
+        for x in 0..w as i32 {
+            let here = at(&src, w, h, x, y);
+            let mut acc = [0.0f32; 3];
+            let mut total = 0.0f32;
+            for dy in -r..=r {
+                for dx in -r..=r {
+                    if dx * dx + dy * dy > r * r {
+                        continue;
+                    }
+                    let p = at(&src, w, h, x + dx, y + dy);
+                    // Only pixels close enough in colour to be the same
+                    // surface get a vote.
+                    let d = (0..3).map(|c| (p[c] - here[c]).abs()).fold(0.0, f32::max);
+                    if d > tol {
+                        continue;
+                    }
+                    let weight = 1.0 - d / tol;
+                    for c in 0..3 {
+                        acc[c] += p[c] * weight;
+                    }
+                    total += weight;
+                }
+            }
+            let total = total.max(1e-6);
+            put(
+                px,
+                w,
+                x as usize,
+                y as usize,
+                [acc[0] / total, acc[1] / total, acc[2] / total, here[3]],
+            );
+        }
+    }
+}
+
+simple_filter!(
+    ColoredPencil,
+    "filter.colored_pencil",
+    "Colored Pencil",
+    "Artistic",
+    [
+        param("width", "Pencil Width", 1.0, 24.0, 4.0, ""),
+        param("pressure", "Stroke Pressure", 0.0, 15.0, 8.0, ""),
+        param("paper", "Paper Brightness", 0.0, 50.0, 25.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Crosshatched pencil: the edges become strokes, the paper shows
+        // through everywhere else, and the hatching runs at a fixed
+        // diagonal the way a right-handed hand draws it.
+        let width = v.get("width").max(1.0);
+        let pressure = v.get("pressure") / 15.0;
+        let paper = v.get("paper") / 50.0;
+        let plane = luma_map(px, w, h);
+        let edge = edges(&plane, w, h);
+        let mut out = vec![0.0f32; w * h];
+        for y in 0..h {
+            for x in 0..w {
+                let i = y * w + x;
+                // The hatch: a diagonal comb whose density follows how
+                // dark the pixel is.
+                let phase = (x as f32 + y as f32) / width;
+                let hatch = (phase * std::f32::consts::PI).sin().abs();
+                let tone = plane[i];
+                let ink = ((1.0 - tone) * 1.4 + edge[i] * 2.0) * pressure;
+                let drawn = if hatch < ink { 1.0 - ink.min(1.0) } else { 1.0 };
+                // Paper Brightness lifts everything the pencil missed.
+                out[i] = (drawn * (0.75 + paper * 0.25)).clamp(0.0, 1.0);
+            }
+        }
+        // A pencil keeps a little of the subject's colour, not all of it.
+        from_luma(px, &out, 0.35);
+    }
+);
+
+simple_filter!(
+    Cutout,
+    "filter.cutout",
+    "Cutout",
+    "Artistic",
+    [
+        param("levels", "Number of Levels", 2.0, 8.0, 4.0, ""),
+        param("simplicity", "Edge Simplicity", 0.0, 10.0, 4.0, ""),
+        param("fidelity", "Edge Fidelity", 1.0, 3.0, 2.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Coloured paper cut out and layered: a few flat tones, and the
+        // boundaries between them simplified until they could have been
+        // cut with scissors.
+        let levels = v.get("levels").max(2.0);
+        let simplicity = v.get("simplicity");
+        let fidelity = v.get("fidelity").clamp(1.0, 3.0);
+        flatten(px, w, h, 1.0 + simplicity, 0.08 * fidelity);
+        for p in px.as_chunks_mut::<4>().0.iter_mut() {
+            flatten_colour(p, levels, 0.09);
+        }
+    }
+);
+
+simple_filter!(
+    DryBrush,
+    "filter.dry_brush",
+    "Dry Brush",
+    "Artistic",
+    [
+        param("size", "Brush Size", 0.0, 10.0, 2.0, ""),
+        param("detail", "Brush Detail", 0.0, 10.0, 8.0, ""),
+        param("texture", "Texture", 1.0, 3.0, 1.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Somewhere between oil and watercolour: flattened into painted
+        // regions, banded into a few tones per region, and dragged just
+        // enough to show the bristles.
+        let size = v.get("size");
+        let detail = v.get("detail");
+        let texture = v.get("texture");
+        flatten(px, w, h, 1.0 + size, 0.05 + detail * 0.02);
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let (x, y) = (i % w, i / w);
+            let bristle = value_noise(x as f32 * 0.6, y as f32 * 0.6, 91) - 0.5;
+            flatten_colour(p, 12.0 - detail * 0.6, 0.05);
+            for v in p.iter_mut().take(3) {
+                *v = (*v + bristle * 0.06 * texture).clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    FilmGrain,
+    "filter.film_grain",
+    "Film Grain",
+    "Artistic",
+    [
+        param("grain", "Grain", 0.0, 20.0, 4.0, ""),
+        param("highlight", "Highlight Area", 0.0, 20.0, 0.0, ""),
+        param("intensity", "Intensity", 0.0, 10.0, 10.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        let _ = h;
+        // Even grain through the shadows and midtones, with the
+        // highlights held back and, above the Highlight Area threshold,
+        // pushed towards white -- which is what film does and why the
+        // effect reads as film rather than as noise.
+        let grain = v.get("grain") / 20.0;
+        let threshold = 1.0 - v.get("highlight") / 20.0;
+        let intensity = v.get("intensity") / 10.0;
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let (x, y) = (i % w, i / w);
+            let n = value_noise(x as f32, y as f32, 4127) - 0.5;
+            let l = luma(p);
+            // Grain is strongest where the emulsion is working hardest.
+            let weight = (1.0 - (l - 0.35).abs()).clamp(0.0, 1.0);
+            for v in p.iter_mut().take(3) {
+                let mut val = *v + n * grain * weight * 0.9;
+                if l > threshold {
+                    val += (1.0 - val) * (l - threshold) * intensity;
+                }
+                *v = val.clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    Fresco,
+    "filter.fresco",
+    "Fresco",
+    "Artistic",
+    [
+        param("size", "Brush Size", 0.0, 10.0, 2.0, ""),
+        param("detail", "Brush Detail", 0.0, 10.0, 8.0, ""),
+        param("texture", "Texture", 1.0, 3.0, 1.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Painted onto wet plaster in short, dark, hurried dabs: coarse
+        // and much higher in contrast than Dry Brush, with the edges
+        // stained rather than outlined.
+        let size = v.get("size");
+        let detail = v.get("detail");
+        let texture = v.get("texture");
+        let plane = luma_map(px, w, h);
+        let edge = edges(&plane, w, h);
+        flatten(px, w, h, 1.5 + size, 0.06 + detail * 0.015);
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let (x, y) = (i % w, i / w);
+            let dab = value_noise(x as f32 * 0.35, y as f32 * 0.35, 613) - 0.5;
+            let stain = (edge[i] * 2.0).min(1.0);
+            for v in p.iter_mut().take(3) {
+                // Contrast around the midpoint, then the stain, then the
+                // plaster's own mottling.
+                let contrasted = ((*v - 0.5) * 1.35 + 0.5) * (1.0 - stain * 0.7);
+                *v = (contrasted + dab * 0.08 * texture).clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    NeonGlow,
+    "filter.neon_glow",
+    "Neon Glow",
+    "Artistic",
+    [
+        param("size", "Glow Size", 1.0, 24.0, 5.0, ""),
+        param("brightness", "Glow Brightness", 0.0, 50.0, 15.0, ""),
+        param("hue", "Glow Colour", 0.0, 360.0, 200.0, "\u{b0}")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // The image collapses to a dark ghost of itself and its edges
+        // light up in one colour. Photoshop takes the colour from the
+        // colour picker; there is no picker in a filter dialog, so it is
+        // a hue here.
+        let size = v.get("size");
+        let brightness = v.get("brightness") / 50.0;
+        let hue = v.get("hue").to_radians();
+        let glow_rgb = [
+            (hue.cos() * 0.5 + 0.5).clamp(0.0, 1.0),
+            ((hue - 2.094).cos() * 0.5 + 0.5).clamp(0.0, 1.0),
+            ((hue + 2.094).cos() * 0.5 + 0.5).clamp(0.0, 1.0),
+        ];
+        let plane = luma_map(px, w, h);
+        let mut glow = edges(&plane, w, h);
+        blur_plane(&mut glow, w, h, size);
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let base = plane[i] * 0.25;
+            let g = (glow[i] * (1.0 + brightness * 6.0)).min(1.0);
+            for c in 0..3 {
+                p[c] = (base + glow_rgb[c] * g).clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    PaintDaubs,
+    "filter.paint_daubs",
+    "Paint Daubs",
+    "Artistic",
+    [
+        param("size", "Brush Size", 1.0, 50.0, 8.0, ""),
+        param("sharpness", "Sharpness", 0.0, 40.0, 7.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Dabs laid *along* what they are painting: the smear follows the
+        // edge direction, so a cheek gets dabs that curve with it rather
+        // than a grid of blobs.
+        let size = v.get("size").max(1.0);
+        let sharpness = v.get("sharpness") / 40.0;
+        let plane = luma_map(px, w, h);
+        let grad = crate::util::gradient(&plane, w, h);
+        let src = px.to_vec();
+        let steps = size.round().max(1.0) as i32;
+        for y in 0..h {
+            for x in 0..w {
+                let (gx, gy) = grad[y * w + x];
+                // Along the edge is across the gradient.
+                let (dx, dy) = (-gy, gx);
+                let n = dx.hypot(dy);
+                let (dx, dy) = if n < 1e-4 {
+                    (1.0, 0.0)
+                } else {
+                    (dx / n, dy / n)
+                };
+                let mut acc = [0.0f32; 4];
+                let mut count = 0.0;
+                for t in -steps..=steps {
+                    let p = sample(
+                        &src,
+                        w,
+                        h,
+                        x as f32 + dx * t as f32,
+                        y as f32 + dy * t as f32,
+                    );
+                    for c in 0..4 {
+                        acc[c] += p[c];
+                    }
+                    count += 1.0;
+                }
+                let here = at(&src, w, h, x as i32, y as i32);
+                let mut out = [0.0f32; 4];
+                for c in 0..3 {
+                    let dabbed = acc[c] / count;
+                    // Sharpness puts some of the original edge back.
+                    out[c] = (dabbed + (here[c] - dabbed) * sharpness).clamp(0.0, 1.0);
+                }
+                out[3] = here[3];
+                put(px, w, x, y, out);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    PaletteKnife,
+    "filter.palette_knife",
+    "Palette Knife",
+    "Artistic",
+    [
+        param("size", "Stroke Size", 1.0, 50.0, 25.0, ""),
+        param("detail", "Stroke Detail", 1.0, 3.0, 3.0, ""),
+        param("softness", "Softness", 0.0, 10.0, 0.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Thin paint spread flat with a blade: large facets, hard edges
+        // between them, and no texture inside one.
+        let size = v.get("size");
+        let detail = v.get("detail");
+        let softness = v.get("softness");
+        flatten(px, w, h, 1.0 + size / 6.0, 0.1 / detail.max(1.0));
+        for p in px.as_chunks_mut::<4>().0.iter_mut() {
+            flatten_colour(p, 6.0, 0.08);
+        }
+        if softness > 0.0 {
+            gaussian_rgba(px, w, h, softness * 0.25);
+        }
+    }
+);
+
+simple_filter!(
+    PlasticWrap,
+    "filter.plastic_wrap",
+    "Plastic Wrap",
+    "Artistic",
+    [
+        param("strength", "Highlight Strength", 0.0, 20.0, 15.0, ""),
+        param("detail", "Detail", 1.0, 15.0, 9.0, ""),
+        param("smoothness", "Smoothness", 1.0, 15.0, 7.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Cling film over the subject. The film's shape is the image's
+        // own luminance as a height field, and what you see is the
+        // specular highlight sliding off it -- which is why the effect
+        // hugs the contours instead of sitting on top of them.
+        let strength = v.get("strength") / 20.0;
+        let detail = v.get("detail") / 15.0;
+        let smoothness = v.get("smoothness");
+        let mut height = luma_map(px, w, h);
+        blur_plane(&mut height, w, h, smoothness * 0.4);
+        let grad = crate::util::gradient(&height, w, h);
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let (gx, gy) = grad[i];
+            // A light from the upper left, glancing off the wrap.
+            let slope = (-gx - gy) * (6.0 + detail * 24.0);
+            let shine = slope.clamp(0.0, 1.0).powf(2.0) * strength;
+            let shadow = (-slope).clamp(0.0, 1.0) * strength * 0.4;
+            for v in p.iter_mut().take(3) {
+                *v = (*v * (1.0 - shadow) + shine).clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    PosterEdges,
+    "filter.poster_edges",
+    "Poster Edges",
+    "Artistic",
+    [
+        param("thickness", "Edge Thickness", 0.0, 10.0, 2.0, ""),
+        param("intensity", "Edge Intensity", 0.0, 10.0, 1.0, ""),
+        param("levels", "Posterization", 0.0, 6.0, 2.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Posterised colour with the boundaries inked in, which is the
+        // look of a screen-printed poster and the reason this one is
+        // still used for actual posters.
+        let thickness = v.get("thickness");
+        let intensity = v.get("intensity") / 10.0;
+        let levels = 2.0 + v.get("levels");
+        let plane = luma_map(px, w, h);
+        let mut edge = edges(&plane, w, h);
+        if thickness > 0.0 {
+            blur_plane(&mut edge, w, h, thickness * 0.4);
+        }
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let ink = (edge[i] * (1.0 + intensity * 8.0)).min(1.0);
+            flatten_colour(p, levels, 0.1);
+            for v in p.iter_mut().take(3) {
+                *v = (*v * (1.0 - ink)).clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+/// The textures the Artistic and Texture groups draw onto.
+pub const SURFACES: &[&str] = &["Canvas", "Sandstone", "Burlap", "Brick"];
+
+simple_filter!(
+    RoughPastels,
+    "filter.rough_pastels",
+    "Rough Pastels",
+    "Artistic",
+    [
+        param("length", "Stroke Length", 0.0, 40.0, 6.0, ""),
+        param("detail", "Stroke Detail", 1.0, 20.0, 4.0, ""),
+        choice("texture", "Texture", SURFACES, 0),
+        param("scaling", "Scaling", 50.0, 200.0, 100.0, "%"),
+        param("relief", "Relief", 0.0, 50.0, 20.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Chalk dragged across a rough surface: the stroke smears the
+        // colour, and the surface decides where the chalk actually lands.
+        let length = v.get("length");
+        let detail = v.get("detail");
+        let kind = v.get("texture").round().max(0.0) as u32;
+        let scaling = v.get("scaling") / 100.0 * 6.0;
+        let relief = v.get("relief") / 50.0;
+        let mut plane = luma_map(px, w, h);
+        if length > 0.5 {
+            // Strokes run at a constant angle, as a hand's do.
+            plane = streak(&plane, w, h, length * 0.4, |_, _| (0.94, 0.34));
+        }
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let (x, y) = ((i % w) as f32, (i / w) as f32);
+            let tex = surface(kind, x, y, scaling.max(1.0), 17);
+            // Where the surface is high the chalk sticks; where it is low
+            // the paper shows.
+            let grip = 1.0 + (tex - 0.5) * relief;
+            let tone = (plane[i] * grip).clamp(0.0, 1.0);
+            let l = luma(p).max(1e-4);
+            for v in p.iter_mut().take(3) {
+                let detailed = *v / l * tone;
+                *v = (tone + (detailed - tone) * (0.4 + detail / 40.0)).clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    SmudgeStick,
+    "filter.smudge_stick",
+    "Smudge Stick",
+    "Artistic",
+    [
+        param("length", "Stroke Length", 0.0, 10.0, 2.0, ""),
+        param("highlight", "Highlight Area", 0.0, 20.0, 0.0, ""),
+        param("intensity", "Intensity", 0.0, 10.0, 10.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Softens by smearing the dark areas along a diagonal while
+        // leaving the highlights alone, which is what a smudge stick does
+        // to charcoal: the shadows run, the paper stays.
+        let length = v.get("length");
+        let threshold = 1.0 - v.get("highlight") / 20.0;
+        let intensity = v.get("intensity") / 10.0;
+        let plane = luma_map(px, w, h);
+        let smeared = streak(&plane, w, h, 1.0 + length * 1.5, |_, _| (0.87, 0.5));
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let l = plane[i];
+            // Dark pixels smudge, bright ones do not.
+            let mix = ((1.0 - l) * intensity).clamp(0.0, 1.0);
+            let tone = l + (smeared[i] - l) * mix;
+            let tone = if l > threshold {
+                (tone + (l - threshold)).min(1.0)
+            } else {
+                tone
+            };
+            let scale = tone / l.max(1e-4);
+            for v in p.iter_mut().take(3) {
+                *v = (*v * scale).clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    Sponge,
+    "filter.sponge",
+    "Sponge",
+    "Artistic",
+    [
+        param("size", "Brush Size", 0.0, 10.0, 5.0, ""),
+        param("definition", "Definition", 0.0, 25.0, 12.0, ""),
+        param("smoothness", "Smoothness", 1.0, 15.0, 5.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Dabbed on with a sponge: blotches of colour with holes in them,
+        // the holes coming from a noise field rather than from the image.
+        let size = 1.0 + v.get("size");
+        let definition = v.get("definition") / 25.0;
+        let smoothness = v.get("smoothness");
+        flatten(px, w, h, smoothness * 0.4, 0.12);
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let (x, y) = ((i % w) as f32, (i / w) as f32);
+            let blotch = crate::util::fbm(x / size / 3.0, y / size / 3.0, 733, 3);
+            // Sharpen the blotch field into holes and pigment.
+            let hole = ((blotch - 0.5) * (2.0 + definition * 6.0) + 0.5).clamp(0.0, 1.0);
+            for v in p.iter_mut().take(3) {
+                let dark = *v * (0.45 + 0.55 * hole);
+                *v = (*v + (dark - *v) * (0.4 + definition * 0.6)).clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    Underpainting,
+    "filter.underpainting",
+    "Underpainting",
+    "Artistic",
+    [
+        param("size", "Brush Size", 0.0, 40.0, 6.0, ""),
+        param("coverage", "Texture Coverage", 0.0, 40.0, 16.0, ""),
+        choice("texture", "Texture", SURFACES, 0),
+        param("scaling", "Scaling", 50.0, 200.0, 100.0, "%"),
+        param("relief", "Relief", 0.0, 50.0, 20.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // The blocked-in first layer of a painting: the subject reduced
+        // to masses of colour on a textured ground, with the detail
+        // painted back on top only where it survives the coverage.
+        let size = v.get("size");
+        let coverage = v.get("coverage") / 40.0;
+        let kind = v.get("texture").round().max(0.0) as u32;
+        let scaling = v.get("scaling") / 100.0 * 6.0;
+        let relief = v.get("relief") / 50.0;
+        let detail = px.to_vec();
+        flatten(px, w, h, 2.0 + size / 3.0, 0.15);
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let (x, y) = ((i % w) as f32, (i / w) as f32);
+            let tex = surface(kind, x, y, scaling.max(1.0), 29);
+            let ground = 1.0 + (tex - 0.5) * relief;
+            for c in 0..3 {
+                let base = (p[c] * ground).clamp(0.0, 1.0);
+                let over = detail[i * 4 + c];
+                p[c] = (base + (over - base) * (1.0 - coverage) * 0.6).clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    Watercolor,
+    "filter.watercolor",
+    "Watercolor",
+    "Artistic",
+    [
+        param("detail", "Brush Detail", 1.0, 14.0, 9.0, ""),
+        param("shadow", "Shadow Intensity", 0.0, 10.0, 1.0, ""),
+        param("texture", "Texture", 1.0, 3.0, 1.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Flat washes that pool darker where they meet an edge, which is
+        // what watercolour does when the pigment dries at the boundary of
+        // a stroke. Photoshop's is famously heavy-handed in the shadows
+        // and this keeps that.
+        let detail = v.get("detail");
+        let shadow = v.get("shadow") / 10.0;
+        let texture = v.get("texture");
+        let plane = luma_map(px, w, h);
+        let edge = edges(&plane, w, h);
+        flatten(px, w, h, 2.0 + (14.0 - detail) * 0.4, 0.12);
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let (x, y) = ((i % w) as f32, (i / w) as f32);
+            let paper = value_noise(x * 0.9, y * 0.9, 271) - 0.5;
+            // The pooled edge, and the shadows dragged down with it.
+            let pool = (edge[i] * 3.0).min(1.0) * (0.35 + shadow);
+            for v in p.iter_mut().take(3) {
+                let washed = *v * (1.0 - pool);
+                let deepened = washed * (1.0 - (1.0 - washed) * shadow * 0.5);
+                *v = (deepened + paper * 0.05 * texture).clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
+    registry.register_filter(Box::new(ColoredPencil));
+    registry.register_filter(Box::new(Cutout));
+    registry.register_filter(Box::new(DryBrush));
+    registry.register_filter(Box::new(FilmGrain));
+    registry.register_filter(Box::new(Fresco));
+    registry.register_filter(Box::new(NeonGlow));
+    registry.register_filter(Box::new(PaintDaubs));
+    registry.register_filter(Box::new(PaletteKnife));
+    registry.register_filter(Box::new(PlasticWrap));
+    registry.register_filter(Box::new(PosterEdges));
+    registry.register_filter(Box::new(RoughPastels));
+    registry.register_filter(Box::new(SmudgeStick));
+    registry.register_filter(Box::new(Sponge));
+    registry.register_filter(Box::new(Underpainting));
+    registry.register_filter(Box::new(Watercolor));
+}

--- a/plugins/filters-core/src/brush.rs
+++ b/plugins/filters-core/src/brush.rs
@@ -1,0 +1,311 @@
+//! Filter Gallery ▸ Brush Strokes.
+//!
+//! Eight ways of putting a mark on the paper. Where the Artistic group is
+//! about *paint* -- flat areas, thick pigment, texture -- this one is
+//! about *strokes*, and a stroke is one operation: smear the image along
+//! a line rather than in a circle. The whole group is
+//! [`crate::util::streak`] with a different line each time, plus what
+//! each effect does with the ink afterwards.
+
+use crate::util::{blur_plane, edges, from_luma, luma_map, put, sample, streak, value_noise};
+use crate::{choice, param, simple_filter};
+use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
+
+/// The four stroke directions Photoshop offers, as unit vectors.
+pub const DIRECTIONS: &[&str] = &["Right Diagonal", "Horizontal", "Left Diagonal", "Vertical"];
+
+pub fn direction_of(pick: f32) -> (f32, f32) {
+    match (pick.round().max(0.0) as usize).min(3) {
+        0 => (0.707, -0.707),
+        1 => (1.0, 0.0),
+        2 => (0.707, 0.707),
+        _ => (0.0, 1.0),
+    }
+}
+
+simple_filter!(
+    AccentedEdges,
+    "filter.accented_edges",
+    "Accented Edges",
+    "Brush Strokes",
+    [
+        param("width", "Edge Width", 1.0, 14.0, 2.0, ""),
+        param("brightness", "Edge Brightness", 0.0, 50.0, 38.0, ""),
+        param("smoothness", "Smoothness", 1.0, 15.0, 5.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // The edges are picked out in ink: bright ink above the halfway
+        // mark on the brightness slider, black below it, which is the
+        // control Photoshop gives and the reason the filter can look
+        // either chalky or charred.
+        let width = v.get("width");
+        let brightness = v.get("brightness") / 50.0;
+        let smoothness = v.get("smoothness");
+        // Smoothness settles the picture *before* the edges are found,
+        // which is what keeps the accents on the subject's outline
+        // rather than on every leaf and ripple.
+        let mut plane = luma_map(px, w, h);
+        if smoothness > 1.0 {
+            blur_plane(&mut plane, w, h, smoothness * 0.2);
+        }
+        let mut edge = edges(&plane, w, h);
+        blur_plane(&mut edge, w, h, width * 0.25);
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let ink = (edge[i] * (2.0 + width) * 2.5).min(1.0);
+            let target = if brightness >= 0.5 { 1.0 } else { 0.0 };
+            let amount = ((brightness - 0.5).abs() * 2.0).max(0.15);
+            for v in p.iter_mut().take(3) {
+                *v = (*v + (target - *v) * ink * amount).clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    AngledStrokes,
+    "filter.angled_strokes",
+    "Angled Strokes",
+    "Brush Strokes",
+    [
+        param("balance", "Direction Balance", 0.0, 100.0, 50.0, ""),
+        param("length", "Stroke Length", 3.0, 50.0, 15.0, ""),
+        param("sharpness", "Sharpness", 0.0, 10.0, 3.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Light areas are painted one way and dark areas the other, so
+        // the two sets of strokes meet along the tonal boundaries. The
+        // balance decides where the handover happens.
+        let balance = v.get("balance") / 100.0;
+        let length = v.get("length");
+        let sharpness = v.get("sharpness") / 10.0;
+        let plane = luma_map(px, w, h);
+        let up = streak(&plane, w, h, length * 0.3, |_, _| (0.707, -0.707));
+        let down = streak(&plane, w, h, length * 0.3, |_, _| (0.707, 0.707));
+        let mut out = vec![0.0f32; w * h];
+        for i in 0..w * h {
+            let pick = if plane[i] > balance { &up } else { &down };
+            // Sharpness returns some of the original tone, which is what
+            // keeps the strokes from dissolving the subject.
+            out[i] = pick[i] + (plane[i] - pick[i]) * sharpness;
+        }
+        from_luma(px, &out, 1.0);
+    }
+);
+
+simple_filter!(
+    Crosshatch,
+    "filter.crosshatch",
+    "Crosshatch",
+    "Brush Strokes",
+    [
+        param("length", "Stroke Length", 3.0, 50.0, 9.0, ""),
+        param("sharpness", "Sharpness", 0.0, 20.0, 6.0, ""),
+        param("strength", "Strength", 1.0, 3.0, 1.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Pencil hatching in both diagonals at once. Taking the darker of
+        // the two passes is what makes them read as crossing rather than
+        // as an average of two blurs.
+        let length = v.get("length");
+        let sharpness = v.get("sharpness") / 20.0;
+        let strength = v.get("strength");
+        let plane = luma_map(px, w, h);
+        let mut out = plane.clone();
+        for pass in 0..strength.round().max(1.0) as usize {
+            let a = streak(&out, w, h, length * 0.3, |_, _| (0.707, -0.707));
+            let b = streak(&out, w, h, length * 0.3, |_, _| (0.707, 0.707));
+            for i in 0..w * h {
+                let hatched = a[i].min(b[i]);
+                // Every pass bites a little deeper, as a second layer of
+                // hatching would.
+                let bite = 0.6 + 0.2 * pass as f32;
+                out[i] = out[i] + (hatched - out[i]) * bite;
+            }
+        }
+        for i in 0..w * h {
+            out[i] += (plane[i] - out[i]) * sharpness;
+        }
+        from_luma(px, &out, 1.0);
+    }
+);
+
+simple_filter!(
+    DarkStrokes,
+    "filter.dark_strokes",
+    "Dark Strokes",
+    "Brush Strokes",
+    [
+        param("balance", "Balance", 0.0, 10.0, 5.0, ""),
+        param("black", "Black Intensity", 0.0, 10.0, 6.0, ""),
+        param("white", "White Intensity", 0.0, 10.0, 2.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Short strokes, black in the shadows and white in the
+        // highlights, with the balance deciding which tone counts as
+        // which. Photoshop's darkens hard; so does this.
+        let balance = v.get("balance") / 10.0;
+        let black = v.get("black") / 10.0;
+        let white = v.get("white") / 10.0;
+        let plane = luma_map(px, w, h);
+        let strokes = streak(&plane, w, h, 4.0, |_, _| (0.707, 0.707));
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let l = strokes[i];
+            let (target, amount) = if l < balance {
+                (0.0, (balance - l) / balance.max(1e-3) * black)
+            } else {
+                (1.0, (l - balance) / (1.0 - balance).max(1e-3) * white)
+            };
+            for v in p.iter_mut().take(3) {
+                let smeared = *v + (l - plane[i]);
+                *v = (smeared + (target - smeared) * amount.clamp(0.0, 1.0)).clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    InkOutlines,
+    "filter.ink_outlines",
+    "Ink Outlines",
+    "Brush Strokes",
+    [
+        param("length", "Stroke Length", 1.0, 50.0, 4.0, ""),
+        param("dark", "Dark Intensity", 0.0, 50.0, 20.0, ""),
+        param("light", "Light Intensity", 0.0, 50.0, 10.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // A pen drawing over the photograph: fine ink lines where the
+        // edges are, dragged along the stroke so they have a nib's
+        // thick-and-thin rather than a uniform outline.
+        let length = v.get("length");
+        let dark = v.get("dark") / 50.0;
+        let light = v.get("light") / 50.0;
+        let plane = luma_map(px, w, h);
+        let edge = edges(&plane, w, h);
+        let inked = streak(&edge, w, h, length * 0.25, |_, _| (0.707, 0.707));
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let ink = (inked[i] * 3.0).min(1.0);
+            for v in p.iter_mut().take(3) {
+                // Dark ink on the lines, and the highlights bleached to
+                // make room for it.
+                let darkened = *v * (1.0 - ink * dark * 1.6);
+                *v = (darkened + (1.0 - darkened) * (1.0 - ink) * light * plane[i] * 0.4)
+                    .clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    Spatter,
+    "filter.spatter",
+    "Spatter",
+    "Brush Strokes",
+    [
+        param("radius", "Spray Radius", 0.0, 25.0, 10.0, ""),
+        param("smoothness", "Smoothness", 1.0, 15.0, 5.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // An airbrush spitting: every pixel is fetched from somewhere
+        // nearby at random, so edges break up into flecks. The randomness
+        // is hashed from the coordinate, so the same image always
+        // spatters the same way.
+        let radius = v.get("radius");
+        let smoothness = v.get("smoothness");
+        let src = px.to_vec();
+        for y in 0..h {
+            for x in 0..w {
+                let jx = value_noise(x as f32 * 1.7, y as f32 * 1.3, 6151) - 0.5;
+                let jy = value_noise(x as f32 * 1.1, y as f32 * 1.9, 7919) - 0.5;
+                // Smoothness pulls the flecks back towards where they
+                // came from.
+                let reach = radius * (16.0 - smoothness) / 15.0;
+                let p = sample(
+                    &src,
+                    w,
+                    h,
+                    x as f32 + jx * reach * 2.0,
+                    y as f32 + jy * reach * 2.0,
+                );
+                put(px, w, x, y, p);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    SprayedStrokes,
+    "filter.sprayed_strokes",
+    "Sprayed Strokes",
+    "Brush Strokes",
+    [
+        param("length", "Stroke Length", 0.0, 20.0, 12.0, ""),
+        param("radius", "Spray Radius", 0.0, 25.0, 7.0, ""),
+        choice("direction", "Stroke Direction", DIRECTIONS, 0)
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Spatter with a grain to it: the jitter runs along the chosen
+        // stroke direction rather than in every direction, so the flecks
+        // line up into strokes.
+        let length = v.get("length");
+        let radius = v.get("radius");
+        let (dx, dy) = direction_of(v.get("direction"));
+        let src = px.to_vec();
+        for y in 0..h {
+            for x in 0..w {
+                let along = (value_noise(x as f32 * 0.9, y as f32 * 0.9, 3571) - 0.5) * length;
+                let across = (value_noise(x as f32 * 1.6, y as f32 * 1.2, 2963) - 0.5) * radius;
+                let (px_, py_) = (
+                    x as f32 + dx * along - dy * across * 0.4,
+                    y as f32 + dy * along + dx * across * 0.4,
+                );
+                put(px, w, x, y, sample(&src, w, h, px_, py_));
+            }
+        }
+    }
+);
+
+simple_filter!(
+    SumiE,
+    "filter.sumi_e",
+    "Sumi-e",
+    "Brush Strokes",
+    [
+        param("width", "Stroke Width", 3.0, 15.0, 10.0, ""),
+        param("pressure", "Stroke Pressure", 0.0, 15.0, 2.0, ""),
+        param("contrast", "Contrast", 0.0, 40.0, 16.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Ink on wet rice paper: a loaded brush, very few tones, and the
+        // dark drowning everything it touches. The width is a smear
+        // across the stroke, which is what gives the soft edge; the
+        // pressure decides how much ink is in the brush.
+        let width = v.get("width");
+        let pressure = v.get("pressure") / 15.0;
+        let contrast = v.get("contrast") / 40.0;
+        let mut plane = luma_map(px, w, h);
+        blur_plane(&mut plane, w, h, width * 0.15);
+        let ink = streak(&plane, w, h, width * 0.5, |_, _| (0.707, 0.707));
+        let mut out = vec![0.0f32; w * h];
+        for i in 0..w * h {
+            // Contrast around the midpoint, then the ink pooled into the
+            // darks by the brush pressure.
+            let hard = ((ink[i] - 0.5) * (1.0 + contrast * 1.5) + 0.5).clamp(0.0, 1.0);
+            out[i] = hard * (1.0 - (1.0 - hard) * pressure);
+        }
+        // Enough colour left to tell what the subject was, which is how
+        // sumi-e over a photograph reads rather than a threshold.
+        from_luma(px, &out, 0.5);
+    }
+);
+
+pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
+    registry.register_filter(Box::new(AccentedEdges));
+    registry.register_filter(Box::new(AngledStrokes));
+    registry.register_filter(Box::new(Crosshatch));
+    registry.register_filter(Box::new(DarkStrokes));
+    registry.register_filter(Box::new(InkOutlines));
+    registry.register_filter(Box::new(Spatter));
+    registry.register_filter(Box::new(SprayedStrokes));
+    registry.register_filter(Box::new(SumiE));
+}

--- a/plugins/filters-core/src/distort.rs
+++ b/plugins/filters-core/src/distort.rs
@@ -1,8 +1,8 @@
 //! Filter ▸ Distort. Every one of these is a coordinate remap through
 //! [`warp`], so they differ only in the mapping.
 
-use crate::util::{fbm, warp};
-use crate::{param, simple_filter};
+use crate::util::{blur_plane, fbm, luma, surface, value_noise, warp};
+use crate::{choice, param, simple_filter};
 use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
 
 simple_filter!(
@@ -214,6 +214,131 @@ simple_filter!(
     }
 );
 
+// The three Distort effects that live in the Filter Gallery rather than
+// in the Filter menu. They are distortions in the same sense as the rest
+// of this module -- Glass and Ocean Ripple are coordinate remaps -- with
+// the exception of Diffuse Glow, which Adobe filed here because it is
+// what happens when you distort *light* instead of position.
+
+simple_filter!(
+    DiffuseGlow,
+    "filter.diffuse_glow",
+    "Diffuse Glow",
+    "Distort",
+    [
+        param("graininess", "Graininess", 0.0, 10.0, 6.0, ""),
+        param("glow", "Glow Amount", 0.0, 20.0, 10.0, ""),
+        param("clear", "Clear Amount", 0.0, 20.0, 15.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Light bleeding out of the highlights through a grainy diffusion
+        // filter, which is what a stocking over the lens does. Clear
+        // Amount is the threshold: below it nothing glows, which is what
+        // keeps the shadows from fogging.
+        let graininess = v.get("graininess") / 10.0;
+        let glow = v.get("glow") / 20.0;
+        let clear = v.get("clear") / 20.0;
+        let mut bright: Vec<f32> = px
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|p| (luma(p) - clear).max(0.0) / (1.0 - clear).max(1e-3))
+            .collect();
+        blur_plane(&mut bright, w, h, 4.0 + glow * 12.0);
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let (x, y) = ((i % w) as f32, (i / w) as f32);
+            let grain = (value_noise(x, y, 5237) - 0.5) * graininess * 0.35;
+            let lift = (bright[i] * (0.6 + glow * 2.0) + grain).max(0.0);
+            for v in p.iter_mut().take(3) {
+                // Screened towards white rather than added, so the glow
+                // saturates the way light does instead of clipping.
+                *v = (1.0 - (1.0 - *v) * (1.0 - lift.min(1.0))).clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    Glass,
+    "filter.glass",
+    "Glass",
+    "Distort",
+    [
+        param("distortion", "Distortion", 0.0, 20.0, 5.0, ""),
+        param("smoothness", "Smoothness", 1.0, 15.0, 3.0, ""),
+        choice("texture", "Texture", GLASS_TEXTURES, 0),
+        param("scaling", "Scaling", 50.0, 200.0, 100.0, "%")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Seen through a sheet of textured glass: the texture is a height
+        // field, and every pixel is fetched from wherever that height
+        // field's slope bends the light. Smoothness is the polish on the
+        // glass.
+        let distortion = v.get("distortion");
+        let smoothness = v.get("smoothness");
+        let kind = v.get("texture").round().max(0.0) as u32;
+        let scaling = (v.get("scaling") / 100.0 * 10.0).max(1.0);
+        let height = |x: f32, y: f32| -> f32 {
+            match kind {
+                // Frosted: fine noise, softened by Smoothness.
+                0 => fbm(
+                    x / (smoothness * 2.0).max(1.0),
+                    y / (smoothness * 2.0).max(1.0),
+                    337,
+                    3,
+                ),
+                // Blocks: a grid of panes.
+                1 => {
+                    let (u, vv) = ((x / scaling).fract(), (y / scaling).fract());
+                    ((u - 0.5).abs() + (vv - 0.5).abs()) * 0.7
+                }
+                // Canvas and tiny lens use the shared surface generator.
+                _ => surface(kind - 2, x, y, scaling, 149),
+            }
+        };
+        warp(px, w, h, |x, y| {
+            let gx = height(x + 1.0, y) - height(x - 1.0, y);
+            let gy = height(x, y + 1.0) - height(x, y - 1.0);
+            (x + gx * distortion * 1.2, y + gy * distortion * 1.2)
+        });
+    }
+);
+
+/// Glass has its own texture list: the first two are its own, the rest
+/// are the surfaces the Texture group uses.
+const GLASS_TEXTURES: &[&str] = &[
+    "Frosted",
+    "Blocks",
+    "Canvas",
+    "Sandstone",
+    "Burlap",
+    "Brick",
+];
+
+simple_filter!(
+    OceanRipple,
+    "filter.ocean_ripple",
+    "Ocean Ripple",
+    "Distort",
+    [
+        param("size", "Ripple Size", 1.0, 15.0, 9.0, ""),
+        param("magnitude", "Ripple Magnitude", 0.0, 20.0, 9.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Randomly spaced ripples, as though the image were under moving
+        // water. Distort ▸ Ripple is regular and periodic; this one takes
+        // its offsets from a noise field, which is why it looks wet
+        // rather than corrugated.
+        let size = v.get("size").max(1.0) * 6.0;
+        let magnitude = v.get("magnitude");
+        warp(px, w, h, |x, y| {
+            let a = fbm(x / size, y / size, 1049, 2) - 0.5;
+            let b = fbm(x / size + 31.0, y / size + 17.0, 1049, 2) - 0.5;
+            (x + a * magnitude * 2.0, y + b * magnitude * 2.0)
+        });
+    }
+);
+
 pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
     registry.register_filter(Box::new(Twirl));
     registry.register_filter(Box::new(Ripple));
@@ -224,4 +349,7 @@ pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
     registry.register_filter(Box::new(PolarCoordinates));
     registry.register_filter(Box::new(Shear));
     registry.register_filter(Box::new(Displace));
+    registry.register_filter(Box::new(DiffuseGlow));
+    registry.register_filter(Box::new(Glass));
+    registry.register_filter(Box::new(OceanRipple));
 }

--- a/plugins/filters-core/src/lib.rs
+++ b/plugins/filters-core/src/lib.rs
@@ -11,13 +11,17 @@
 
 use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues, PluginManifest, PluginRegistry};
 
+pub mod artistic;
+pub mod brush;
 pub mod camera_raw;
 pub mod distort;
 pub mod neural;
 pub mod other;
 pub mod pixelate;
 pub mod render;
+pub mod sketch;
 pub mod stylize;
+pub mod texture;
 pub mod util;
 
 /// A `FilterParam` without the struct-literal noise.
@@ -490,12 +494,16 @@ impl PluginManifest for CoreFiltersPlugin {
         registry.register_filter(Box::new(UnsharpMask));
         registry.register_filter(Box::new(AddNoise));
         registry.register_filter(Box::new(Median));
+        artistic::register(registry);
+        brush::register(registry);
         camera_raw::register(registry);
         neural::register(registry);
         distort::register(registry);
         pixelate::register(registry);
         render::register(registry);
+        sketch::register(registry);
         stylize::register(registry);
+        texture::register(registry);
         other::register(registry);
     }
 }

--- a/plugins/filters-core/src/neural.rs
+++ b/plugins/filters-core/src/neural.rs
@@ -1,21 +1,28 @@
 //! Photoshop's Neural Filters.
 //!
-//! Five of the seven run a real network. Super Zoom, JPEG Artifact
-//! Removal and Colorize use models trained for this application and
-//! shipped inside the binary (`tools/train/`); Style Transfer uses the
-//! fast neural-style networks from the ONNX Model Zoo, Depth Blur uses
-//! MiDaS and Skin Smoothing uses UltraFace, all three downloaded on
+//! Twelve of them, nine of which run a real network. Super Zoom, JPEG
+//! Artifact Removal, Colorize and Photo Restoration use models trained
+//! for this application and shipped inside the binary (`tools/train/`);
+//! Style Transfer uses the fast neural-style networks from the ONNX
+//! Model Zoo, Depth Blur and Landscape Mixer use MiDaS, and Skin
+//! Smoothing and Face to Caricature use UltraFace, all downloaded on
 //! demand. Everything runs through `schist-neural`, which is `tract` --
 //! pure Rust, so there is no runtime to install.
 //!
-//! The two that are not networks are not networks for different reasons.
-//! Skin Smoothing's *smoothing* is frequency separation, which is what a
-//! retoucher does by hand; the network's job there is to say where the
-//! faces are, which is the part that needs to know what a face is.
-//! Colour Transfer is short of the real thing: Photoshop's takes the
-//! palette from a reference photograph, and this one aims at a hue,
-//! because the filter interface hands a filter one buffer and a list of
-//! numbers with no way to pass it a second image.
+//! The three that are not networks are not networks for different
+//! reasons. Skin Smoothing's *smoothing* is frequency separation, which
+//! is what a retoucher does by hand; the network's job there is to say
+//! where the faces are, which is the part that needs to know what a face
+//! is. Colour Transfer and Harmonization move one image's colour
+//! distribution onto another's, which is arithmetic -- what Adobe's
+//! networks add is matching the two *by subject*, so that a reference's
+//! sky lands on your sky rather than on your whole picture.
+//!
+//! Three of these need a second image, and the one a filter can be
+//! handed without a file picker is the layer underneath: Colour
+//! Transfer, Harmonization and Landscape Mixer take their reference from
+//! whatever the document composites to below this layer, which is asked
+//! for with [`FilterPlugin::wants_backdrop`].
 //!
 //! Every model-backed filter also works without its model, falling back
 //! to the classical path and saying so in its dialog. Nothing here is a
@@ -23,7 +30,7 @@
 
 use std::sync::{Arc, Mutex};
 
-use crate::util::{at, gaussian_rgba, luma, put, sample};
+use crate::util::{at, gaussian_rgba, luma, put, sample, warp};
 use crate::{choice, param, simple_filter};
 use schist_neural::Face;
 use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
@@ -666,34 +673,95 @@ fn colour_shift(px: &mut [f32], hue: f32, strength: f32) {
     }
 }
 
-simple_filter!(
-    ColorTransfer,
-    "filter.neural.color_transfer",
-    "Color Transfer",
-    "Neural Filters",
-    [
-        param("hue", "Target Hue", 0.0, 360.0, 30.0, "\u{b0}"),
-        param("strength", "Strength", 0.0, 100.0, 60.0, ""),
-        param("contrast", "Match Contrast", 0.0, 100.0, 50.0, "")
-    ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
-        // Reinhard-style colour transfer, aimed at a hue rather than at
-        // a reference image: shift the image's mean chroma towards the
-        // target and optionally normalise its spread. Moving one
-        // distribution onto another is arithmetic and this is that
-        // arithmetic; what Photoshop has and this does not is the
-        // reference photograph to read a distribution *from*, and a
-        // network matching the two scene by scene so that its sky lands
-        // on this sky. A filter is handed one buffer and a list of
-        // numbers, so the second picture has nowhere to arrive.
-        let _ = (w, h);
-        let strength = v.get("strength") / 100.0;
-        let match_contrast = v.get("contrast") / 100.0;
-        let hue = v.get("hue").to_radians();
+/// Colour Transfer: take another photograph's palette.
+///
+/// Photoshop's reads the palette from a reference image you choose. This
+/// reads it from the layer underneath -- the one second image a filter
+/// can be handed without a file picker -- and falls back to a hue you
+/// pick when there is nothing under it.
+///
+/// The transfer itself is Reinhard: match the mean and spread of tone
+/// and chroma. What Adobe's network adds is matching them *by subject*,
+/// so that the reference's sky lands on your sky; this moves the whole
+/// distribution at once, which is right for a mood and wrong for a
+/// scene. Landscape Mixer is the one that splits it up.
+pub struct ColorTransfer;
+
+impl FilterPlugin for ColorTransfer {
+    fn id(&self) -> &'static str {
+        "filter.neural.color_transfer"
+    }
+    fn name(&self) -> &'static str {
+        "Color Transfer"
+    }
+    fn category(&self) -> &'static str {
+        "Neural Filters"
+    }
+    fn params(&self) -> Vec<FilterParam> {
+        vec![
+            param("hue", "Target Hue", 0.0, 360.0, 30.0, "\u{b0}"),
+            param("strength", "Strength", 0.0, 100.0, 60.0, ""),
+            param("contrast", "Match Contrast", 0.0, 100.0, 50.0, ""),
+        ]
+    }
+
+    fn wants_backdrop(&self) -> bool {
+        true
+    }
+
+    fn info(&self) -> Option<String> {
+        Some(
+            "Takes its palette from the layer underneath. With nothing \
+             underneath it aims at the Target Hue instead."
+                .to_string(),
+        )
+    }
+
+    fn apply(&self, px: &mut [f32], width: usize, height: usize, values: &FilterValues) {
+        self.apply_over(px, None, width, height, values);
+    }
+
+    fn apply_over(
+        &self,
+        px: &mut [f32],
+        backdrop: Option<&[f32]>,
+        width: usize,
+        height: usize,
+        values: &FilterValues,
+    ) {
+        if width == 0 || height == 0 {
+            return;
+        }
+        let strength = (values.get("strength") / 100.0).clamp(0.0, 1.0);
+        let match_contrast = (values.get("contrast") / 100.0).clamp(0.0, 1.0);
         if strength <= 0.0 {
             return;
         }
-        // Mean and spread of luminance, and mean chroma.
+        if let Some(reference) = backdrop {
+            if let (Some(mine), Some(theirs)) =
+                (stats_of(px, |_| true), stats_of(reference, |_| true))
+            {
+                // Match Contrast decides whether the *spread* of tone
+                // comes across as well as its middle: at zero the
+                // picture keeps its own contrast and only borrows the
+                // colour.
+                let theirs = Stats {
+                    mean: theirs.mean,
+                    sd: [
+                        mine.sd[0] + (theirs.sd[0] - mine.sd[0]) * match_contrast,
+                        theirs.sd[1],
+                        theirs.sd[2],
+                    ],
+                };
+                for p in px.as_chunks_mut::<4>().0.iter_mut() {
+                    restat(p, mine, theirs, strength);
+                }
+                return;
+            }
+        }
+        // No reference: aim at the hue instead. Shift the image's mean
+        // chroma towards it and optionally normalise its spread.
+        let hue = values.get("hue").to_radians();
         let n = (px.len() / 4).max(1) as f32;
         let (mut mean_l, mut mean_a, mut mean_b) = (0.0f32, 0.0f32, 0.0f32);
         for p in px.as_chunks::<4>().0.iter() {
@@ -710,7 +778,6 @@ simple_filter!(
             var_l += (luma(p) - mean_l).powi(2);
         }
         let sd_l = (var_l / n).sqrt().max(1e-4);
-        // The target chroma direction.
         let (ta, tb) = (hue.cos() * 0.18, hue.sin() * 0.18);
         let gain = 1.0 + match_contrast * (0.25 / sd_l - 1.0).clamp(-0.5, 0.5);
         for p in px.as_chunks_mut::<4>().0.iter_mut() {
@@ -729,7 +796,7 @@ simple_filter!(
             }
         }
     }
-);
+}
 
 /// Depth Blur: throw the background out of focus.
 ///
@@ -839,6 +906,599 @@ fn defocus(px: &mut [f32], w: usize, h: usize, plane: &[f32], focus: f32, streng
     }
 }
 
+/// Mean and spread of a buffer's luminance and chroma.
+///
+/// The currency of every "make this look like that" filter: two images
+/// match when these six numbers match, which is Reinhard et al.'s
+/// observation and is why colour transfer is arithmetic rather than
+/// magic.
+#[derive(Clone, Copy)]
+struct Stats {
+    mean: [f32; 3],
+    sd: [f32; 3],
+}
+
+fn stats_of(px: &[f32], mask: impl Fn(usize) -> bool) -> Option<Stats> {
+    let (mut sum, mut n) = ([0.0f32; 3], 0.0f32);
+    for (i, p) in px.as_chunks::<4>().0.iter().enumerate() {
+        if p[3] <= 0.01 || !mask(i) {
+            continue;
+        }
+        let l = luma(p);
+        sum[0] += l;
+        sum[1] += p[0] - l;
+        sum[2] += p[2] - l;
+        n += 1.0;
+    }
+    if n < 8.0 {
+        return None;
+    }
+    let mean = [sum[0] / n, sum[1] / n, sum[2] / n];
+    let mut var = [0.0f32; 3];
+    for (i, p) in px.as_chunks::<4>().0.iter().enumerate() {
+        if p[3] <= 0.01 || !mask(i) {
+            continue;
+        }
+        let l = luma(p);
+        let v = [l - mean[0], (p[0] - l) - mean[1], (p[2] - l) - mean[2]];
+        for c in 0..3 {
+            var[c] += v[c] * v[c];
+        }
+    }
+    Some(Stats {
+        mean,
+        sd: [
+            (var[0] / n).sqrt().max(1e-4),
+            (var[1] / n).sqrt().max(1e-4),
+            (var[2] / n).sqrt().max(1e-4),
+        ],
+    })
+}
+
+/// Move a pixel from one distribution to another.
+fn restat(p: &mut [f32], from: Stats, to: Stats, amount: f32) {
+    let l = luma(p);
+    let (ca, cb) = (p[0] - l, p[2] - l);
+    let moved = [
+        (l - from.mean[0]) / from.sd[0] * to.sd[0] + to.mean[0],
+        (ca - from.mean[1]) / from.sd[1] * to.sd[1] + to.mean[1],
+        (cb - from.mean[2]) / from.sd[2] * to.sd[2] + to.mean[2],
+    ];
+    let target = schist_neural::recolour(&[moved[0], moved[0], moved[0]], [moved[1], moved[2]]);
+    for c in 0..3 {
+        p[c] = (p[c] + (target[c] - p[c]) * amount).clamp(0.0, 1.0);
+    }
+}
+
+/// Harmonization: make this layer look like it belongs on the one below.
+///
+/// Photoshop's asks you to pick the layer to match; this takes the one
+/// thing a filter can be handed without a file picker -- what the
+/// document composites to underneath -- which is the same answer for the
+/// case the filter exists for, a cut-out pasted onto a background.
+///
+/// The matching itself is Reinhard: move the layer's tone and colour
+/// distribution onto the backdrop's. What Adobe's network adds is knowing
+/// *which parts* correspond, which is the part this cannot do and does
+/// not claim to.
+pub struct Harmonization;
+
+impl FilterPlugin for Harmonization {
+    fn id(&self) -> &'static str {
+        "filter.neural.harmonization"
+    }
+    fn name(&self) -> &'static str {
+        "Harmonization"
+    }
+    fn category(&self) -> &'static str {
+        "Neural Filters"
+    }
+    fn params(&self) -> Vec<FilterParam> {
+        vec![
+            param("strength", "Strength", 0.0, 100.0, 75.0, ""),
+            param("tone", "Match Tone", 0.0, 100.0, 100.0, ""),
+        ]
+    }
+
+    fn wants_backdrop(&self) -> bool {
+        true
+    }
+
+    fn info(&self) -> Option<String> {
+        Some(
+            "Matches this layer to whatever is underneath it. With nothing \
+             underneath there is nothing to match to and this does nothing."
+                .to_string(),
+        )
+    }
+
+    fn apply(&self, px: &mut [f32], width: usize, height: usize, values: &FilterValues) {
+        self.apply_over(px, None, width, height, values);
+    }
+
+    fn apply_over(
+        &self,
+        px: &mut [f32],
+        backdrop: Option<&[f32]>,
+        width: usize,
+        height: usize,
+        values: &FilterValues,
+    ) {
+        if width == 0 || height == 0 {
+            return;
+        }
+        let strength = (values.get("strength") / 100.0).clamp(0.0, 1.0);
+        let tone = (values.get("tone") / 100.0).clamp(0.0, 1.0);
+        let Some(backdrop) = backdrop else { return };
+        let (Some(mine), Some(theirs)) = (stats_of(px, |_| true), stats_of(backdrop, |_| true))
+        else {
+            return;
+        };
+        // Match Tone at zero leaves the luminance alone and moves only
+        // the colour, which is what you want when the cut-out is lit
+        // correctly and merely the wrong temperature.
+        let theirs = Stats {
+            mean: [
+                mine.mean[0] + (theirs.mean[0] - mine.mean[0]) * tone,
+                theirs.mean[1],
+                theirs.mean[2],
+            ],
+            sd: [
+                mine.sd[0] + (theirs.sd[0] - mine.sd[0]) * tone,
+                theirs.sd[1],
+                theirs.sd[2],
+            ],
+        };
+        for p in px.as_chunks_mut::<4>().0.iter_mut() {
+            restat(p, mine, theirs, strength);
+        }
+    }
+}
+
+/// Landscape Mixer: take the season, the hour and the weather from
+/// another photograph.
+///
+/// Photoshop's generates the new landscape outright. This one moves
+/// colour, and moves it *by distance*: sky matched to sky, ground matched
+/// to ground, because a landscape's palette is stratified by depth and a
+/// single global match turns the grass the colour of the sky. The depth
+/// model is what splits the bands; without it the match is global, and
+/// the dialog says so.
+pub struct LandscapeMixer {
+    depth: Memo<Vec<f32>>,
+    reference: Memo<Vec<f32>>,
+}
+
+impl LandscapeMixer {
+    pub const fn new() -> LandscapeMixer {
+        LandscapeMixer {
+            depth: Memo::new(),
+            reference: Memo::new(),
+        }
+    }
+}
+
+impl Default for LandscapeMixer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FilterPlugin for LandscapeMixer {
+    fn id(&self) -> &'static str {
+        "filter.neural.landscape_mixer"
+    }
+    fn name(&self) -> &'static str {
+        "Landscape Mixer"
+    }
+    fn category(&self) -> &'static str {
+        "Neural Filters"
+    }
+    fn params(&self) -> Vec<FilterParam> {
+        vec![
+            param("strength", "Strength", 0.0, 100.0, 70.0, ""),
+            param("bands", "Depth Bands", 1.0, 5.0, 3.0, ""),
+        ]
+    }
+
+    fn wants_backdrop(&self) -> bool {
+        true
+    }
+
+    fn info(&self) -> Option<String> {
+        Some(if schist_neural::installed("depth") {
+            "Takes its palette from the layer underneath, matched band by \
+             band using Depth (Depth Blur)."
+                .to_string()
+        } else {
+            "Takes its palette from the layer underneath. Install Depth \
+             (Depth Blur) to match sky to sky and ground to ground rather \
+             than the picture as a whole."
+                .to_string()
+        })
+    }
+
+    fn apply(&self, px: &mut [f32], width: usize, height: usize, values: &FilterValues) {
+        self.apply_over(px, None, width, height, values);
+    }
+
+    fn apply_over(
+        &self,
+        px: &mut [f32],
+        backdrop: Option<&[f32]>,
+        width: usize,
+        height: usize,
+        values: &FilterValues,
+    ) {
+        if width == 0 || height == 0 {
+            return;
+        }
+        let strength = (values.get("strength") / 100.0).clamp(0.0, 1.0);
+        let bands = (values.get("bands").round().max(1.0) as usize).min(5);
+        let Some(backdrop) = backdrop else { return };
+
+        // Depth for both pictures, if there is a model. Two memos: the
+        // reference does not change while the sliders move either.
+        let model = schist_neural::get("depth");
+        let depth_of = |memo: &Memo<Vec<f32>>, buf: &[f32]| -> Option<Arc<Vec<f32>>> {
+            let model = model.clone()?;
+            let key = fingerprint(buf, width, height);
+            memo.get(key, || {
+                let rgb = rgb_of(buf);
+                schist_neural::depth_map(&model, &rgb, width, height)
+                    .map_err(|e| log::warn!("landscape depth: {e:#}"))
+                    .ok()
+            })
+        };
+        let mine = depth_of(&self.depth, px);
+        let theirs = depth_of(&self.reference, backdrop);
+
+        for band in 0..bands {
+            let lo = band as f32 / bands as f32;
+            let hi = (band + 1) as f32 / bands as f32;
+            // Without depth there is one band covering everything, which
+            // is an ordinary colour transfer.
+            let in_band = |map: &Option<Arc<Vec<f32>>>, i: usize| -> bool {
+                match map {
+                    Some(d) => d[i] >= lo && (d[i] < hi || hi >= 1.0),
+                    None => band == 0,
+                }
+            };
+            let (Some(from), Some(to)) = (
+                stats_of(px, |i| in_band(&mine, i)),
+                stats_of(backdrop, |i| in_band(&theirs, i)),
+            ) else {
+                continue;
+            };
+            for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+                if !in_band(&mine, i) {
+                    continue;
+                }
+                restat(p, from, to, strength);
+            }
+        }
+    }
+}
+
+/// Photo Restoration: an old photograph, cleaned up.
+///
+/// Adobe's is one network doing everything. This is the set of things
+/// that network is doing, done separately and in the order a restorer
+/// would: take the scratches out, take the grain and the compression
+/// out, put the detail back, and open the tones up again. Two of those
+/// steps are models this build already ships, which is why this filter
+/// exists here at all -- it is mostly composition.
+pub struct PhotoRestoration;
+
+impl FilterPlugin for PhotoRestoration {
+    fn id(&self) -> &'static str {
+        "filter.neural.photo_restoration"
+    }
+    fn name(&self) -> &'static str {
+        "Photo Restoration"
+    }
+    fn category(&self) -> &'static str {
+        "Neural Filters"
+    }
+    fn params(&self) -> Vec<FilterParam> {
+        vec![
+            param("enhance", "Photo Enhancement", 0.0, 100.0, 50.0, ""),
+            param("scratches", "Scratch Reduction", 0.0, 100.0, 30.0, ""),
+            param("tone", "Restore Tone", 0.0, 100.0, 60.0, ""),
+        ]
+    }
+
+    fn info(&self) -> Option<String> {
+        let mut have: Vec<&str> = Vec::new();
+        if schist_neural::installed("dejpeg") {
+            have.push("Deblock");
+        }
+        if schist_neural::installed("detail") {
+            have.push("Detail");
+        }
+        Some(if have.is_empty() {
+            "Cleaning up without a model.".to_string()
+        } else {
+            format!("Using {} \u{b7} trained for Schist.", have.join(" and "))
+        })
+    }
+
+    fn apply(&self, px: &mut [f32], width: usize, height: usize, values: &FilterValues) {
+        if width == 0 || height == 0 {
+            return;
+        }
+        let enhance = (values.get("enhance") / 100.0).clamp(0.0, 1.0);
+        let scratches = (values.get("scratches") / 100.0).clamp(0.0, 1.0);
+        let tone = (values.get("tone") / 100.0).clamp(0.0, 1.0);
+
+        if scratches > 0.0 {
+            despeckle(px, width, height, scratches);
+        }
+        if enhance > 0.0 {
+            // Grain first, then the deblocker for what a scan of a print
+            // puts in, then the detail model to put back the edges that
+            // removing them cost. In that order: sharpening before
+            // denoising sharpens the noise.
+            denoise(px, width, height, enhance);
+            if let Some(model) = schist_neural::get("dejpeg") {
+                through_rgb(px, |rgb| {
+                    schist_neural::run_tiled(&model, rgb, width, height, enhance);
+                });
+            }
+            if let Some(model) = schist_neural::get("detail") {
+                through_rgb(px, |rgb| {
+                    schist_neural::run_tiled(&model, rgb, width, height, enhance * 0.5);
+                });
+            } else {
+                edge_directed_sharpen(px, width, height, enhance * 0.5);
+            }
+        }
+        if tone > 0.0 {
+            restore_tone(px, tone);
+        }
+    }
+}
+
+/// Take out the specks and hairline scratches a print picks up.
+///
+/// A pixel that disagrees with the *median* of its neighbours is damage;
+/// one that disagrees with their mean might merely be an edge. The
+/// distinction matters here more than anywhere else in the filter set,
+/// because a scratch is a thin bright line and so is a highlight on a
+/// wire. The radius follows the slider: a speck needs one pixel of
+/// context to be outvoted, a hairline scratch needs three.
+fn despeckle(px: &mut [f32], w: usize, h: usize, amount: f32) {
+    let src = px.to_vec();
+    let radius = 1 + (amount * 2.5) as i32;
+    let threshold = 0.16 - amount * 0.1;
+    let mut ring: Vec<f32> = Vec::with_capacity(((2 * radius + 1) * (2 * radius + 1)) as usize);
+    for y in 0..h as i32 {
+        for x in 0..w as i32 {
+            let here = at(&src, w, h, x, y);
+            let mut out = here;
+            let mut damaged = 0.0f32;
+            for c in 0..3 {
+                ring.clear();
+                for dy in -radius..=radius {
+                    for dx in -radius..=radius {
+                        if dx == 0 && dy == 0 {
+                            continue;
+                        }
+                        ring.push(at(&src, w, h, x + dx, y + dy)[c]);
+                    }
+                }
+                ring.sort_by(f32::total_cmp);
+                let median = ring[ring.len() / 2];
+                damaged = damaged.max((here[c] - median).abs());
+                out[c] = median;
+            }
+            if damaged > threshold {
+                let mix = ((damaged - threshold) * 8.0).clamp(0.0, 1.0) * amount;
+                for c in 0..3 {
+                    out[c] = here[c] + (out[c] - here[c]) * mix;
+                }
+                put(px, w, x as usize, y as usize, out);
+            }
+        }
+    }
+}
+
+/// Take the grain out without taking the picture with it.
+///
+/// A print that has been scanned carries the film's grain, the paper's
+/// texture and the scanner's own noise, none of which the detail model
+/// should be asked to sharpen. Smoothing only where the difference is
+/// small enough to be noise is the cheapest thing that works.
+fn denoise(px: &mut [f32], w: usize, h: usize, amount: f32) {
+    let mut soft = px.to_vec();
+    gaussian_rgba(&mut soft, w, h, 0.6 + amount * 1.2);
+    let threshold = 0.04 + amount * 0.06;
+    for (p, s) in px
+        .as_chunks_mut::<4>()
+        .0
+        .iter_mut()
+        .zip(soft.as_chunks::<4>().0.iter())
+    {
+        for c in 0..3 {
+            let d = (p[c] - s[c]).abs();
+            if d < threshold {
+                // Fully towards the smooth version for the finest
+                // differences, tapering off as they start to look like
+                // something that was in the room.
+                let mix = (1.0 - d / threshold) * amount;
+                p[c] += (s[c] - p[c]) * mix;
+            }
+        }
+    }
+}
+
+/// Open the tones back up: an old print has faded towards its middle.
+fn restore_tone(px: &mut [f32], amount: f32) {
+    let n = (px.len() / 4).max(1) as f32;
+    let (mut lo, mut hi, mut mean) = (1.0f32, 0.0f32, 0.0f32);
+    for p in px.as_chunks::<4>().0.iter() {
+        let l = luma(p);
+        lo = lo.min(l);
+        hi = hi.max(l);
+        mean += l;
+    }
+    mean /= n;
+    let span = (hi - lo).max(1e-3);
+    for p in px.as_chunks_mut::<4>().0.iter_mut() {
+        for v in p.iter_mut().take(3) {
+            // Stretch to the full range, and take the sepia out by
+            // nudging each channel towards where the middle should be.
+            let stretched = ((*v - lo) / span).clamp(0.0, 1.0);
+            let neutral = stretched + (mean - (lo + hi) / 2.0) * 0.15;
+            *v = (*v + (neutral - *v) * amount).clamp(0.0, 1.0);
+        }
+    }
+}
+
+simple_filter!(
+    PhotoToSketch,
+    "filter.neural.photo_to_sketch",
+    "Photo to Sketch",
+    "Neural Filters",
+    [
+        param("detail", "Detail", 0.0, 100.0, 50.0, ""),
+        param("weight", "Line Weight", 0.0, 100.0, 50.0, ""),
+        param("shading", "Shading", 0.0, 100.0, 40.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // The pencil-sketch construction every drawing tutorial teaches,
+        // because it is the one that works: invert the picture, blur it,
+        // and divide the original by it. Where the two agree the quotient
+        // saturates to white and the paper is left blank; where an edge
+        // makes them disagree, a line appears exactly as wide as the
+        // blur.
+        let detail = v.get("detail") / 100.0;
+        let weight = v.get("weight") / 100.0;
+        let shading = v.get("shading") / 100.0;
+        let plane = crate::util::luma_map(px, w, h);
+        let mut soft: Vec<f32> = plane.iter().map(|l| 1.0 - l).collect();
+        crate::util::blur_plane(&mut soft, w, h, 1.0 + (1.0 - detail) * 12.0);
+        let mut out = vec![0.0f32; w * h];
+        for i in 0..w * h {
+            let dodge = (plane[i] / (1.0 - soft[i]).max(1e-3)).min(1.0);
+            // Line Weight decides how dark a disagreement has to be
+            // before it counts as a line.
+            let line = 1.0 - ((1.0 - dodge) * (0.5 + weight * 3.0)).min(1.0);
+            // Shading lays the original tone back underneath, which is
+            // the difference between a line drawing and a pencil
+            // rendering.
+            out[i] = (line - (1.0 - plane[i]) * shading * 0.6).clamp(0.0, 1.0);
+        }
+        crate::util::from_luma(px, &out, 0.0);
+    }
+);
+
+/// Face to Caricature: exaggerate what is already there.
+///
+/// Adobe's redraws the face outright. This one warps it, and warps it
+/// from the detector's box plus the proportions a face has when it is
+/// looking at the camera -- eyes a little above the middle, mouth three
+/// quarters down. So it does not *find* the features, it assumes where
+/// they usually are, which is why it works on a portrait and falls apart
+/// on a profile. Without the face model it has nothing to work from and
+/// does nothing.
+pub struct FaceToCaricature {
+    faces: Memo<Vec<Face>>,
+}
+
+impl FaceToCaricature {
+    pub const fn new() -> FaceToCaricature {
+        FaceToCaricature { faces: Memo::new() }
+    }
+}
+
+impl Default for FaceToCaricature {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FilterPlugin for FaceToCaricature {
+    fn id(&self) -> &'static str {
+        "filter.neural.face_to_caricature"
+    }
+    fn name(&self) -> &'static str {
+        "Face to Caricature"
+    }
+    fn category(&self) -> &'static str {
+        "Neural Filters"
+    }
+    fn params(&self) -> Vec<FilterParam> {
+        vec![
+            param("eyes", "Eyes", -100.0, 100.0, 60.0, ""),
+            param("mouth", "Mouth", -100.0, 100.0, 40.0, ""),
+            param("head", "Head", -100.0, 100.0, 25.0, ""),
+        ]
+    }
+
+    fn info(&self) -> Option<String> {
+        model_note(
+            "face",
+            "so this does nothing \u{2014} there is nothing to caricature.",
+        )
+    }
+
+    fn apply(&self, px: &mut [f32], width: usize, height: usize, values: &FilterValues) {
+        if width == 0 || height == 0 {
+            return;
+        }
+        let eyes = values.get("eyes") / 100.0;
+        let mouth = values.get("mouth") / 100.0;
+        let head = values.get("head") / 100.0;
+        let Some(model) = schist_neural::get("face") else {
+            return;
+        };
+        let key = fingerprint(px, width, height);
+        let faces = self.faces.get(key, || {
+            let rgb = rgb_of(px);
+            schist_neural::faces(&model, &rgb, width, height)
+                .map_err(|e| log::warn!("caricature: {e:#}"))
+                .ok()
+        });
+        let Some(faces) = faces else { return };
+        if faces.is_empty() {
+            return;
+        }
+        // Each feature is a bubble in the coordinate map: pull the
+        // sampling point towards a centre to enlarge what is there, push
+        // it away to shrink it.
+        let mut pulls: Vec<(f32, f32, f32, f32)> = Vec::new();
+        for f in faces.iter() {
+            let (cx, cy) = (f.x + f.width / 2.0, f.y + f.height / 2.0);
+            let eye_y = f.y + f.height * 0.40;
+            let mouth_y = f.y + f.height * 0.75;
+            let span = f.width.max(1.0);
+            pulls.push((cx - span * 0.22, eye_y, span * 0.30, eyes));
+            pulls.push((cx + span * 0.22, eye_y, span * 0.30, eyes));
+            pulls.push((cx, mouth_y, span * 0.32, mouth));
+            pulls.push((cx, cy, span * 0.95, head));
+        }
+        warp(px, width, height, |x, y| {
+            let (mut sx, mut sy) = (x, y);
+            for (fx, fy, radius, amount) in pulls.iter() {
+                let (dx, dy) = (x - fx, y - fy);
+                let d = dx.hypot(dy) / radius.max(1.0);
+                if d >= 1.0 {
+                    continue;
+                }
+                // A smooth bubble, strongest in the middle and zero at
+                // the rim, so the rest of the face is untouched and there
+                // is no seam.
+                let falloff = (1.0 - d * d).powi(2);
+                let scale = 1.0 - amount * 0.45 * falloff;
+                sx = fx + (sx - fx) * scale;
+                sy = fy + (sy - fy) * scale;
+            }
+            (sx, sy)
+        });
+    }
+}
+
 pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
     registry.register_filter(Box::new(SkinSmoothing::new()));
     registry.register_filter(Box::new(JpegArtifactRemoval));
@@ -847,4 +1507,9 @@ pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
     registry.register_filter(Box::new(StyleTransfer));
     registry.register_filter(Box::new(ColorTransfer));
     registry.register_filter(Box::new(DepthBlur::new()));
+    registry.register_filter(Box::new(Harmonization));
+    registry.register_filter(Box::new(LandscapeMixer::new()));
+    registry.register_filter(Box::new(PhotoRestoration));
+    registry.register_filter(Box::new(PhotoToSketch));
+    registry.register_filter(Box::new(FaceToCaricature::new()));
 }

--- a/plugins/filters-core/src/neural.rs
+++ b/plugins/filters-core/src/neural.rs
@@ -8,13 +8,14 @@
 //! demand. Everything runs through `schist-neural`, which is `tract` --
 //! pure Rust, so there is no runtime to install.
 //!
-//! The two that are not networks are not networks for a reason. Colour
-//! Transfer is a statistic -- moving one image's colour distribution onto
-//! another's is arithmetic, and a network would be a slower way to get
-//! the same numbers. Skin Smoothing's *smoothing* is frequency
-//! separation, which is what a retoucher does by hand; the network's job
-//! there is to say where the faces are, which is the part that needs to
-//! know what a face is.
+//! The two that are not networks are not networks for different reasons.
+//! Skin Smoothing's *smoothing* is frequency separation, which is what a
+//! retoucher does by hand; the network's job there is to say where the
+//! faces are, which is the part that needs to know what a face is.
+//! Colour Transfer is short of the real thing: Photoshop's takes the
+//! palette from a reference photograph, and this one aims at a hue,
+//! because the filter interface hands a filter one buffer and a list of
+//! numbers with no way to pass it a second image.
 //!
 //! Every model-backed filter also works without its model, falling back
 //! to the classical path and saying so in its dialog. Nothing here is a
@@ -676,13 +677,15 @@ simple_filter!(
         param("contrast", "Match Contrast", 0.0, 100.0, 50.0, "")
     ],
     |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
-        // Reinhard-style colour transfer, aimed at a hue rather than a
-        // reference image: shift the image's mean chroma towards the
-        // target and optionally normalise its spread. There is no model
-        // here and there is no missing one -- moving one distribution
-        // onto another is arithmetic, and Photoshop's own network is
-        // doing the *segmentation* around it, which Object Selection is
-        // the filter for.
+        // Reinhard-style colour transfer, aimed at a hue rather than at
+        // a reference image: shift the image's mean chroma towards the
+        // target and optionally normalise its spread. Moving one
+        // distribution onto another is arithmetic and this is that
+        // arithmetic; what Photoshop has and this does not is the
+        // reference photograph to read a distribution *from*, and a
+        // network matching the two scene by scene so that its sky lands
+        // on this sky. A filter is handed one buffer and a list of
+        // numbers, so the second picture has nowhere to arrive.
         let _ = (w, h);
         let strength = v.get("strength") / 100.0;
         let match_contrast = v.get("contrast") / 100.0;

--- a/plugins/filters-core/src/other.rs
+++ b/plugins/filters-core/src/other.rs
@@ -1,8 +1,8 @@
 //! Filter ▸ Other, plus the extra Blur, Sharpen and Noise entries that did
 //! not exist yet.
 
-use crate::util::{at, gaussian_rgba, premultiply, put, unpremultiply, value_noise};
-use crate::{param, simple_filter};
+use crate::util::{at, convolve3, gaussian_rgba, premultiply, put, unpremultiply, value_noise};
+use crate::{choice, param, simple_filter};
 use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
 
 simple_filter!(
@@ -446,6 +446,249 @@ simple_filter!(
     }
 );
 
+/// Photoshop's one-shot blurs: no dialog, a fixed small radius each.
+///
+/// They are the oldest filters in the program and they survive because
+/// "a bit softer" is a thing people want without deciding how much.
+/// Blur More is Blur about four times over.
+fn fixed_blur(px: &mut [f32], w: usize, h: usize, sigma: f32) {
+    // `gaussian_rgba` premultiplies for itself, as the other blurs here
+    // rely on; doing it again outside would divide the edges twice.
+    gaussian_rgba(px, w, h, sigma);
+}
+
+simple_filter!(
+    Blur,
+    "filter.blur",
+    "Blur",
+    "Blur",
+    [],
+    |px: &mut [f32], w: usize, h: usize, _v: &FilterValues| {
+        fixed_blur(px, w, h, 0.6);
+    }
+);
+
+simple_filter!(
+    BlurMore,
+    "filter.blur_more",
+    "Blur More",
+    "Blur",
+    [],
+    |px: &mut [f32], w: usize, h: usize, _v: &FilterValues| {
+        fixed_blur(px, w, h, 1.7);
+    }
+);
+
+simple_filter!(
+    SharpenMore,
+    "filter.sharpen_more",
+    "Sharpen More",
+    "Sharpen",
+    [],
+    |px: &mut [f32], w: usize, h: usize, _v: &FilterValues| {
+        // The same 3x3 Laplacian as Sharpen with the centre weighted
+        // harder, which is exactly what Photoshop's More variants are.
+        convolve3(
+            px,
+            w,
+            h,
+            [0.0, -1.0, 0.0, -1.0, 5.0, -1.0, 0.0, -1.0, 0.0],
+            0.0,
+        );
+        convolve3(
+            px,
+            w,
+            h,
+            [0.0, -0.5, 0.0, -0.5, 3.0, -0.5, 0.0, -0.5, 0.0],
+            0.0,
+        );
+    }
+);
+
+/// Filter ▸ Other ▸ Custom: a 5x5 convolution the user writes themselves.
+///
+/// Twenty-five weights, a scale to divide the sum by and an offset to add
+/// afterwards, which between them cover blur, sharpen, emboss, edge
+/// detection and every hand-rolled kernel that has been passed around on
+/// forums since Photoshop 3. It starts as the identity -- centre one,
+/// everything else zero -- so opening it and touching nothing does
+/// nothing, as it does in Photoshop.
+pub struct Custom;
+
+/// The keys of the kernel, row by row. Static so `params` can hand out
+/// `&'static str` keys.
+const CUSTOM_KEYS: [&str; 25] = [
+    "k00", "k01", "k02", "k03", "k04", "k10", "k11", "k12", "k13", "k14", "k20", "k21", "k22",
+    "k23", "k24", "k30", "k31", "k32", "k33", "k34", "k40", "k41", "k42", "k43", "k44",
+];
+const CUSTOM_LABELS: [&str; 25] = [
+    "1,1", "1,2", "1,3", "1,4", "1,5", "2,1", "2,2", "2,3", "2,4", "2,5", "3,1", "3,2", "3,3",
+    "3,4", "3,5", "4,1", "4,2", "4,3", "4,4", "4,5", "5,1", "5,2", "5,3", "5,4", "5,5",
+];
+
+impl FilterPlugin for Custom {
+    fn id(&self) -> &'static str {
+        "filter.custom"
+    }
+    fn name(&self) -> &'static str {
+        "Custom"
+    }
+    fn category(&self) -> &'static str {
+        "Other"
+    }
+    fn params(&self) -> Vec<FilterParam> {
+        let mut out: Vec<FilterParam> = (0..25)
+            .map(|i| {
+                param(
+                    CUSTOM_KEYS[i],
+                    CUSTOM_LABELS[i],
+                    -999.0,
+                    999.0,
+                    // The centre tap is the identity; the rest are silent.
+                    if i == 12 { 1.0 } else { 0.0 },
+                    "",
+                )
+            })
+            .collect();
+        out.push(param("scale", "Scale", 1.0, 999.0, 1.0, ""));
+        // In Photoshop's 0..255 units, because that is what every kernel
+        // anyone has ever written down assumes.
+        out.push(param("offset", "Offset", -255.0, 255.0, 0.0, ""));
+        out
+    }
+
+    fn apply(&self, px: &mut [f32], width: usize, height: usize, values: &FilterValues) {
+        if width == 0 || height == 0 {
+            return;
+        }
+        let mut k = [0.0f32; 25];
+        for (i, key) in CUSTOM_KEYS.iter().enumerate() {
+            k[i] = values.get(key);
+        }
+        let scale = values.get("scale").abs().max(1e-3);
+        let offset = values.get("offset") / 255.0;
+        let src = px.to_vec();
+        for y in 0..height as i32 {
+            for x in 0..width as i32 {
+                let mut acc = [0.0f32; 3];
+                for (i, weight) in k.iter().enumerate() {
+                    if *weight == 0.0 {
+                        continue;
+                    }
+                    let p = at(
+                        &src,
+                        width,
+                        height,
+                        x + (i % 5) as i32 - 2,
+                        y + (i / 5) as i32 - 2,
+                    );
+                    for c in 0..3 {
+                        acc[c] += p[c] * weight;
+                    }
+                }
+                let a = at(&src, width, height, x, y)[3];
+                put(
+                    px,
+                    width,
+                    x as usize,
+                    y as usize,
+                    [
+                        (acc[0] / scale + offset).clamp(0.0, 1.0),
+                        (acc[1] / scale + offset).clamp(0.0, 1.0),
+                        (acc[2] / scale + offset).clamp(0.0, 1.0),
+                        a,
+                    ],
+                );
+            }
+        }
+    }
+}
+
+/// Hue, saturation and brightness *as channels*.
+///
+/// Not an adjustment -- it changes nothing about how the image looks
+/// except by lying about what its channels mean. It is a utility for
+/// channel work: convert to HSB, edit the resulting "red" channel, which
+/// is now hue, and convert back. Photoshop has shipped it as a plug-in
+/// with no dialog since version 3; the round trip is why it has two
+/// directions.
+const HSB_MODES: &[&str] = &["RGB to HSB", "RGB to HSL", "HSB to RGB", "HSL to RGB"];
+
+fn to_hs(r: f32, g: f32, b: f32, lightness: bool) -> [f32; 3] {
+    let max = r.max(g).max(b);
+    let min = r.min(g).min(b);
+    let c = max - min;
+    let h = if c <= 1e-6 {
+        0.0
+    } else if max == r {
+        (((g - b) / c) % 6.0) / 6.0
+    } else if max == g {
+        ((b - r) / c + 2.0) / 6.0
+    } else {
+        ((r - g) / c + 4.0) / 6.0
+    };
+    let h = if h < 0.0 { h + 1.0 } else { h };
+    if lightness {
+        let l = (max + min) / 2.0;
+        let s = if l <= 0.0 || l >= 1.0 {
+            0.0
+        } else {
+            c / (1.0 - (2.0 * l - 1.0).abs())
+        };
+        [h, s.clamp(0.0, 1.0), l]
+    } else {
+        let s = if max <= 0.0 { 0.0 } else { c / max };
+        [h, s, max]
+    }
+}
+
+fn from_hs(h: f32, s: f32, v: f32, lightness: bool) -> [f32; 3] {
+    let (c, m) = if lightness {
+        let c = (1.0 - (2.0 * v - 1.0).abs()) * s;
+        (c, v - c / 2.0)
+    } else {
+        let c = v * s;
+        (c, v - c)
+    };
+    let hp = (h.rem_euclid(1.0)) * 6.0;
+    let x = c * (1.0 - (hp % 2.0 - 1.0).abs());
+    let (r, g, b) = match hp as u32 {
+        0 => (c, x, 0.0),
+        1 => (x, c, 0.0),
+        2 => (0.0, c, x),
+        3 => (0.0, x, c),
+        4 => (x, 0.0, c),
+        _ => (c, 0.0, x),
+    };
+    [
+        (r + m).clamp(0.0, 1.0),
+        (g + m).clamp(0.0, 1.0),
+        (b + m).clamp(0.0, 1.0),
+    ]
+}
+
+simple_filter!(
+    HsbHsl,
+    "filter.hsb_hsl",
+    "HSB/HSL",
+    "Other",
+    [choice("mode", "Mode", HSB_MODES, 0)],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        let _ = (w, h);
+        let mode = (v.get("mode").round().max(0.0) as usize).min(3);
+        let lightness = mode == 1 || mode == 3;
+        let forward = mode < 2;
+        for p in px.as_chunks_mut::<4>().0.iter_mut() {
+            let out = if forward {
+                to_hs(p[0], p[1], p[2], lightness)
+            } else {
+                from_hs(p[0], p[1], p[2], lightness)
+            };
+            p[..3].copy_from_slice(&out);
+        }
+    }
+);
+
 pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
     registry.register_filter(Box::new(HighPass));
     registry.register_filter(Box::new(Offset));
@@ -459,5 +702,10 @@ pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
     registry.register_filter(Box::new(SharpenEdges));
     registry.register_filter(Box::new(Despeckle));
     registry.register_filter(Box::new(DustAndScratches));
+    registry.register_filter(Box::new(Blur));
+    registry.register_filter(Box::new(BlurMore));
+    registry.register_filter(Box::new(SharpenMore));
+    registry.register_filter(Box::new(Custom));
+    registry.register_filter(Box::new(HsbHsl));
     registry.register_filter(Box::new(ReduceNoise));
 }

--- a/plugins/filters-core/src/render.rs
+++ b/plugins/filters-core/src/render.rs
@@ -1,7 +1,7 @@
 //! Filter ▸ Render: filters that generate rather than transform.
 
-use crate::util::{at, fbm, put};
-use crate::{param, simple_filter};
+use crate::util::{at, blur_plane, fbm, luma_map, put};
+use crate::{choice, param, simple_filter};
 use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
 
 simple_filter!(
@@ -142,9 +142,136 @@ simple_filter!(
     }
 );
 
+/// The lights this build offers, which are Photoshop's three.
+const LIGHT_TYPES: &[&str] = &["Spot", "Point", "Infinite"];
+
+// Filter ▸ Render ▸ Lighting Effects.
+//
+// Photoshop's version is a room full of controls with lights you drag
+// around on the canvas. What is underneath is simpler than the interface
+// suggests: a light is a direction and a falloff, the image doubles as a
+// bump map, and the result is Phong shading -- ambient plus diffuse plus
+// a specular highlight -- multiplied back over the colour.
+//
+// The bump map is the interesting part and the reason this filter looks
+// like nothing else: shading a photograph by *its own luminance* treated
+// as a height field is what makes a flat picture look embossed and lit
+// rather than merely brightened.
+simple_filter!(
+    LightingEffects,
+    "filter.lighting_effects",
+    "Lighting Effects",
+    "Render",
+    [
+        choice("type", "Light Type", LIGHT_TYPES, 0),
+        param("x", "Light X", 0.0, 100.0, 30.0, "%"),
+        param("y", "Light Y", 0.0, 100.0, 25.0, "%"),
+        param("angle", "Direction", 0.0, 360.0, 45.0, "\u{b0}"),
+        param("intensity", "Intensity", 0.0, 300.0, 120.0, "%"),
+        param("spread", "Spread", 5.0, 200.0, 60.0, "%"),
+        param("ambience", "Ambience", 0.0, 100.0, 35.0, "%"),
+        param("gloss", "Gloss", 0.0, 100.0, 30.0, "%"),
+        param("height", "Texture Height", 0.0, 200.0, 60.0, "%")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        let kind = (v.get("type").round().max(0.0) as usize).min(2);
+        let intensity = v.get("intensity") / 100.0;
+        let ambience = v.get("ambience") / 100.0;
+        let gloss = v.get("gloss") / 100.0;
+        let bump = v.get("height") / 100.0;
+        let spread = (v.get("spread") / 100.0).max(0.05);
+        let angle = v.get("angle").to_radians();
+        let (lx, ly) = (v.get("x") / 100.0 * w as f32, v.get("y") / 100.0 * h as f32);
+        // The height field, softened: shading straight off the pixels
+        // turns every speck of noise into a boulder.
+        let mut height: Vec<f32> = luma_map(px, w, h);
+        blur_plane(&mut height, w, h, 1.2);
+        let diagonal = (w * w + h * h) as f32;
+        let reach = (diagonal.sqrt() * spread).max(1.0);
+
+        for y in 0..h {
+            for x in 0..w {
+                // Surface normal from the height field. The scale is
+                // arbitrary and is what Texture Height sets.
+                let (gx, gy) = {
+                    let at = |xx: i32, yy: i32| -> f32 {
+                        let xx = xx.clamp(0, w as i32 - 1) as usize;
+                        let yy = yy.clamp(0, h as i32 - 1) as usize;
+                        height[yy * w + xx]
+                    };
+                    (
+                        at(x as i32 + 1, y as i32) - at(x as i32 - 1, y as i32),
+                        at(x as i32, y as i32 + 1) - at(x as i32, y as i32 - 1),
+                    )
+                };
+                let scale = 8.0 * bump;
+                let n = [-gx * scale, -gy * scale, 1.0];
+                let nl = (n[0] * n[0] + n[1] * n[1] + n[2] * n[2]).sqrt().max(1e-6);
+                let n = [n[0] / nl, n[1] / nl, n[2] / nl];
+
+                // Direction to the light, and how much of it arrives.
+                let (to_light, falloff) = match kind {
+                    // Infinite: a sun. Parallel rays, no falloff.
+                    2 => ([angle.cos(), angle.sin(), 0.8], 1.0),
+                    _ => {
+                        let (dx, dy) = (lx - x as f32, ly - y as f32);
+                        let d = dx.hypot(dy);
+                        // Spot: a cone that fades from the middle out.
+                        // Point: the same falloff without the height, so
+                        // it grazes rather than shines down.
+                        let f = (1.0 - (d / reach)).clamp(0.0, 1.0);
+                        let f = if kind == 0 { f * f } else { f };
+                        (
+                            [
+                                dx / d.max(1e-6),
+                                dy / d.max(1e-6),
+                                if kind == 0 { 1.2 } else { 0.5 },
+                            ],
+                            f,
+                        )
+                    }
+                };
+                let ll = (to_light[0] * to_light[0]
+                    + to_light[1] * to_light[1]
+                    + to_light[2] * to_light[2])
+                    .sqrt()
+                    .max(1e-6);
+                let l = [to_light[0] / ll, to_light[1] / ll, to_light[2] / ll];
+
+                let diffuse = (n[0] * l[0] + n[1] * l[1] + n[2] * l[2]).max(0.0);
+                // Specular against the eye, which is straight above.
+                let half = [l[0], l[1], l[2] + 1.0];
+                let hl = (half[0] * half[0] + half[1] * half[1] + half[2] * half[2])
+                    .sqrt()
+                    .max(1e-6);
+                let spec = ((n[0] * half[0] + n[1] * half[1] + n[2] * half[2]) / hl)
+                    .max(0.0)
+                    .powf(4.0 + gloss * 60.0)
+                    * gloss;
+
+                let lit = ambience + intensity * falloff * (diffuse + spec);
+                let p = at(px, w, h, x as i32, y as i32);
+                put(
+                    px,
+                    w,
+                    x,
+                    y,
+                    [
+                        (p[0] * lit).clamp(0.0, 1.0),
+                        (p[1] * lit).clamp(0.0, 1.0),
+                        (p[2] * lit).clamp(0.0, 1.0),
+                        p[3],
+                    ],
+                );
+            }
+        }
+    }
+);
+
 pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
     registry.register_filter(Box::new(Clouds));
     registry.register_filter(Box::new(DifferenceClouds));
     registry.register_filter(Box::new(Fibers));
     registry.register_filter(Box::new(LensFlare));
+    registry.register_filter(Box::new(LightingEffects));
 }

--- a/plugins/filters-core/src/sketch.rs
+++ b/plugins/filters-core/src/sketch.rs
@@ -1,0 +1,551 @@
+//! Filter Gallery ▸ Sketch.
+//!
+//! Fourteen effects that all end in two colours. In Photoshop those are
+//! the foreground and background from the toolbox; a filter here is
+//! handed pixels and numbers and never sees the toolbox, so these draw in
+//! black on white -- which is what the swatches are set to by default and
+//! what every one of these effects is pictured with.
+//!
+//! Nearly all of them are a *tone curve with a texture in it*: decide
+//! which pixels are ink, decide what the ink looks like where it lands,
+//! and let the paper take the rest. The ones that are not -- Bas Relief,
+//! Chrome, Note Paper, Plaster -- light the image as a surface instead,
+//! which is why they look raised rather than drawn.
+
+use crate::util::{
+    blur_plane, edges, fbm, from_luma, gradient, luma_map, streak, surface, value_noise,
+};
+use crate::{choice, param, simple_filter};
+use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
+
+/// Photoshop's eight light positions, as a direction to light from.
+pub const LIGHTS: &[&str] = &[
+    "Top",
+    "Top Right",
+    "Right",
+    "Bottom Right",
+    "Bottom",
+    "Bottom Left",
+    "Left",
+    "Top Left",
+];
+
+pub fn light_of(pick: f32) -> (f32, f32) {
+    let i = (pick.round().max(0.0) as usize).min(7);
+    let a = i as f32 * std::f32::consts::FRAC_PI_4 - std::f32::consts::FRAC_PI_2;
+    (a.cos(), a.sin())
+}
+
+/// Relief: light a plane as though it were a surface, mid grey being flat.
+///
+/// The shared core of Bas Relief, Note Paper, Plaster and Chrome. What
+/// separates those four is what they hand in as the height field.
+fn relief(plane: &[f32], w: usize, h: usize, light: (f32, f32), strength: f32) -> Vec<f32> {
+    gradient(plane, w, h)
+        .iter()
+        .map(|(gx, gy)| (0.5 + (gx * light.0 + gy * light.1) * strength).clamp(0.0, 1.0))
+        .collect()
+}
+
+simple_filter!(
+    BasRelief,
+    "filter.bas_relief",
+    "Bas Relief",
+    "Sketch",
+    [
+        param("detail", "Detail", 1.0, 15.0, 13.0, ""),
+        param("smoothness", "Smoothness", 1.0, 15.0, 3.0, ""),
+        choice("light", "Light", LIGHTS, 3)
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Carved shallowly into stone: the picture as a height field, lit
+        // from one side, with everything flat going mid grey.
+        let detail = v.get("detail");
+        let smoothness = v.get("smoothness");
+        let light = light_of(v.get("light"));
+        let mut plane = luma_map(px, w, h);
+        blur_plane(&mut plane, w, h, smoothness * 0.25);
+        let out = relief(&plane, w, h, light, detail * 0.9);
+        from_luma(px, &out, 0.0);
+    }
+);
+
+simple_filter!(
+    ChalkAndCharcoal,
+    "filter.chalk_charcoal",
+    "Chalk & Charcoal",
+    "Sketch",
+    [
+        param("charcoal", "Charcoal Area", 0.0, 20.0, 6.0, ""),
+        param("chalk", "Chalk Area", 0.0, 20.0, 6.0, ""),
+        param("pressure", "Stroke Pressure", 0.0, 5.0, 1.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Charcoal in the shadows, chalk in the highlights, mid grey
+        // paper in between -- and the two drawn at opposite diagonals,
+        // which is what stops the result reading as a posterisation.
+        let charcoal = v.get("charcoal") / 20.0;
+        let chalk = v.get("chalk") / 20.0;
+        let pressure = 0.5 + v.get("pressure") / 5.0;
+        let plane = luma_map(px, w, h);
+        let dark = streak(&plane, w, h, 4.0, |_, _| (0.707, 0.707));
+        let light = streak(&plane, w, h, 4.0, |_, _| (0.707, -0.707));
+        let mut out = vec![0.5f32; w * h];
+        for i in 0..w * h {
+            let l = plane[i];
+            if l < 0.5 {
+                // How far into the charcoal end this pixel is. The
+                // multiplier is what makes it a drawing rather than a
+                // grey wash: charcoal covers fast once it touches.
+                let t = ((0.5 - l) / 0.5 * (0.6 + charcoal * 2.0)).min(1.0) * pressure;
+                out[i] = 0.5 - t * (0.5 + (0.5 - dark[i]));
+            } else {
+                let t = ((l - 0.5) / 0.5 * (0.6 + chalk * 2.0)).min(1.0) * pressure;
+                out[i] = 0.5 + t * (0.5 + (light[i] - 0.5));
+            }
+            out[i] = out[i].clamp(0.0, 1.0);
+        }
+        from_luma(px, &out, 0.0);
+    }
+);
+
+simple_filter!(
+    Charcoal,
+    "filter.charcoal",
+    "Charcoal",
+    "Sketch",
+    [
+        param("thickness", "Charcoal Thickness", 1.0, 7.0, 1.0, ""),
+        param("detail", "Detail", 0.0, 5.0, 5.0, ""),
+        param("balance", "Light/Dark Balance", 0.0, 100.0, 50.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Smudged charcoal on paper: the edges are where the stick
+        // presses hardest, the tone is dragged along the stroke, and the
+        // balance slides the whole thing between a sketch and a
+        // silhouette.
+        let thickness = v.get("thickness");
+        let detail = v.get("detail") / 5.0;
+        let balance = v.get("balance") / 100.0;
+        let plane = luma_map(px, w, h);
+        let edge = edges(&plane, w, h);
+        let smudged = streak(&plane, w, h, thickness * 2.0, |_, _| (0.707, 0.707));
+        let mut out = vec![0.0f32; w * h];
+        for i in 0..w * h {
+            // Paper tone, darkened by the edges and by how dark the
+            // subject was.
+            let ink = (edge[i] * (2.0 + detail * 6.0)).min(1.0) * (0.5 + detail * 0.5)
+                + (1.0 - smudged[i]) * balance;
+            out[i] = (1.0 - ink).clamp(0.0, 1.0);
+        }
+        from_luma(px, &out, 0.0);
+    }
+);
+
+simple_filter!(
+    Chrome,
+    "filter.chrome",
+    "Chrome",
+    "Sketch",
+    [
+        param("detail", "Detail", 0.0, 10.0, 4.0, ""),
+        param("smoothness", "Smoothness", 0.0, 10.0, 7.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Polished metal: the picture as a surface, lit, and then its
+        // tones folded back on themselves so that every slope crosses
+        // black and white several times. The folding is the whole trick
+        // -- it is what turns shading into reflections.
+        let detail = v.get("detail");
+        let smoothness = v.get("smoothness");
+        let mut plane = luma_map(px, w, h);
+        blur_plane(&mut plane, w, h, 0.5 + smoothness * 0.5);
+        let lit = relief(&plane, w, h, (0.707, -0.707), 6.0 + detail * 3.0);
+        let mut out = vec![0.0f32; w * h];
+        for i in 0..w * h {
+            let folded = ((lit[i] - 0.5) * (2.0 + detail) * std::f32::consts::PI).sin();
+            out[i] = (0.5 + folded * 0.5).clamp(0.0, 1.0);
+        }
+        blur_plane(&mut out, w, h, 0.4);
+        from_luma(px, &out, 0.0);
+    }
+);
+
+simple_filter!(
+    ConteCrayon,
+    "filter.conte_crayon",
+    "Cont\u{e9} Crayon",
+    "Sketch",
+    [
+        param("foreground", "Foreground Level", 1.0, 15.0, 8.0, ""),
+        param("background", "Background Level", 1.0, 15.0, 8.0, ""),
+        choice("texture", "Texture", crate::artistic::SURFACES, 0),
+        param("scaling", "Scaling", 50.0, 200.0, 100.0, "%"),
+        param("relief", "Relief", 0.0, 50.0, 20.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // A dense, soft crayon that only touches the high points of the
+        // paper. Foreground Level is how far up the tones the dark
+        // crayon reaches; Background Level is how far down the light one
+        // comes to meet it.
+        let fg = v.get("foreground") / 15.0;
+        let bg = v.get("background") / 15.0;
+        let kind = v.get("texture").round().max(0.0) as u32;
+        let scaling = (v.get("scaling") / 100.0 * 6.0).max(1.0);
+        let relief_amount = v.get("relief") / 50.0;
+        let plane = luma_map(px, w, h);
+        let mut out = vec![0.0f32; w * h];
+        for y in 0..h {
+            for x in 0..w {
+                let i = y * w + x;
+                let tex = surface(kind, x as f32, y as f32, scaling, 53);
+                // The crayon lands where the paper is high. Clamped
+                // before the curve below, which raises it to a power and
+                // would otherwise be asked for the root of a negative.
+                let grip = 1.0 + (tex - 0.5) * relief_amount * 1.5;
+                let l = (plane[i] * grip).clamp(0.0, 1.0);
+                out[i] = if l < 0.5 {
+                    (l / 0.5).powf(1.0 + fg * 2.0) * 0.5
+                } else {
+                    1.0 - ((1.0 - l) / 0.5).powf(1.0 + bg * 2.0) * 0.5
+                }
+                .clamp(0.0, 1.0);
+            }
+        }
+        from_luma(px, &out, 0.15);
+    }
+);
+
+simple_filter!(
+    GraphicPen,
+    "filter.graphic_pen",
+    "Graphic Pen",
+    "Sketch",
+    [
+        param("length", "Stroke Length", 1.0, 15.0, 15.0, ""),
+        param("balance", "Light/Dark Balance", 0.0, 100.0, 50.0, ""),
+        choice("direction", "Stroke Direction", crate::brush::DIRECTIONS, 0)
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // One pen, one direction, no grey: the tone is carried entirely
+        // by how much of the paper the hatching covers. Every stroke is
+        // the same weight, which is what makes it a pen drawing rather
+        // than a wash.
+        let length = v.get("length");
+        let balance = v.get("balance") / 100.0;
+        let (dx, dy) = crate::brush::direction_of(v.get("direction"));
+        let mut plane = luma_map(px, w, h);
+        plane = streak(&plane, w, h, length * 0.5, |_, _| (dx, dy));
+        let mut out = vec![1.0f32; w * h];
+        for y in 0..h {
+            for x in 0..w {
+                let i = y * w + x;
+                // The hatch runs across the stroke direction, so a
+                // horizontal stroke draws horizontal lines.
+                let phase = (x as f32 * dy - y as f32 * dx) * 0.5;
+                let comb = (phase * std::f32::consts::PI).sin().abs();
+                let ink = (1.0 - plane[i]) * (0.4 + balance * 1.2);
+                out[i] = if comb < ink { 0.0 } else { 1.0 };
+            }
+        }
+        from_luma(px, &out, 0.0);
+    }
+);
+
+/// The three patterns Photoshop's halftone offers.
+const HALFTONE_PATTERNS: &[&str] = &["Circle", "Dot", "Line"];
+
+simple_filter!(
+    HalftonePattern,
+    "filter.halftone_pattern",
+    "Halftone Pattern",
+    "Sketch",
+    [
+        param("size", "Size", 1.0, 12.0, 1.0, ""),
+        param("contrast", "Contrast", 0.0, 50.0, 5.0, ""),
+        choice("pattern", "Pattern Type", HALFTONE_PATTERNS, 1)
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // A screen, as a newspaper would print it -- but drawn *over* the
+        // tone rather than replacing it, which is the difference between
+        // this and Pixelate ▸ Color Halftone. Circles ripple out from the
+        // middle of the image; dots and lines are a grid.
+        let size = v.get("size").max(1.0) * 4.0;
+        let contrast = v.get("contrast") / 50.0;
+        let pattern = (v.get("pattern").round().max(0.0) as usize).min(2);
+        let plane = luma_map(px, w, h);
+        let (cx, cy) = (w as f32 / 2.0, h as f32 / 2.0);
+        let mut out = vec![0.0f32; w * h];
+        for y in 0..h {
+            for x in 0..w {
+                let i = y * w + x;
+                let screen = match pattern {
+                    0 => {
+                        let d = (x as f32 - cx).hypot(y as f32 - cy);
+                        (d / size * std::f32::consts::TAU).sin() * 0.5 + 0.5
+                    }
+                    1 => {
+                        let u = (x as f32 / size * std::f32::consts::TAU).sin();
+                        let vv = (y as f32 / size * std::f32::consts::TAU).sin();
+                        (u * vv) * 0.5 + 0.5
+                    }
+                    _ => (y as f32 / size * std::f32::consts::TAU).sin() * 0.5 + 0.5,
+                };
+                // Contrast pushes the tone towards the two extremes
+                // before the screen decides.
+                let tone = ((plane[i] - 0.5) * (1.0 + contrast * 4.0) + 0.5).clamp(0.0, 1.0);
+                out[i] = if screen < tone { 1.0 } else { 0.0 };
+            }
+        }
+        from_luma(px, &out, 0.0);
+    }
+);
+
+simple_filter!(
+    NotePaper,
+    "filter.note_paper",
+    "Note Paper",
+    "Sketch",
+    [
+        param("balance", "Image Balance", 0.0, 50.0, 25.0, ""),
+        param("graininess", "Graininess", 0.0, 20.0, 10.0, ""),
+        param("relief", "Relief", 0.0, 25.0, 11.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Handmade paper with the image pressed into it: the picture is
+        // reduced to two levels, and the boundary between them is
+        // embossed as though the light paper had been pushed through the
+        // dark. The grain is in the paper, not in the image.
+        let balance = v.get("balance") / 50.0;
+        let grain = v.get("graininess") / 20.0;
+        let relief_amount = v.get("relief") / 25.0;
+        let mut plane = luma_map(px, w, h);
+        blur_plane(&mut plane, w, h, 1.5);
+        let embossed = relief(&plane, w, h, (0.707, -0.707), 6.0 * relief_amount);
+        let mut out = vec![0.0f32; w * h];
+        for y in 0..h {
+            for x in 0..w {
+                let i = y * w + x;
+                let sheet = if plane[i] > 1.0 - balance { 0.85 } else { 0.35 };
+                let g = (value_noise(x as f32 * 1.7, y as f32 * 1.7, 811) - 0.5) * grain * 0.5;
+                out[i] = (sheet + (embossed[i] - 0.5) * 0.9 + g).clamp(0.0, 1.0);
+            }
+        }
+        from_luma(px, &out, 0.0);
+    }
+);
+
+simple_filter!(
+    Photocopy,
+    "filter.photocopy",
+    "Photocopy",
+    "Sketch",
+    [
+        param("detail", "Detail", 1.0, 24.0, 7.0, ""),
+        param("darkness", "Darkness", 1.0, 50.0, 8.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // A bad photocopy: the machine holds the edges and the deepest
+        // shadows and gives up on everything in between, which is why a
+        // photocopied photograph comes back as an outline.
+        let detail = v.get("detail");
+        let darkness = v.get("darkness") / 50.0;
+        let plane = luma_map(px, w, h);
+        let mut local = plane.clone();
+        blur_plane(&mut local, w, h, 1.0 + detail * 0.5);
+        let mut out = vec![0.0f32; w * h];
+        for i in 0..w * h {
+            // Where the pixel is darker than its surroundings, ink; where
+            // it is not, paper. Plus the shadows the toner floods.
+            let below = (local[i] - plane[i]) * (4.0 + darkness * 20.0);
+            let flooded = ((0.25 - plane[i]) * 6.0 * darkness).max(0.0);
+            out[i] = (1.0 - below.max(0.0) - flooded).clamp(0.0, 1.0);
+        }
+        from_luma(px, &out, 0.0);
+    }
+);
+
+simple_filter!(
+    Plaster,
+    "filter.plaster",
+    "Plaster",
+    "Sketch",
+    [
+        param("balance", "Image Balance", 0.0, 50.0, 25.0, ""),
+        param("smoothness", "Smoothness", 1.0, 15.0, 2.0, ""),
+        choice("light", "Light", LIGHTS, 5)
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Poured and set: the dark half of the picture rises out of the
+        // light half as a smooth blob, lit from one side. Everything
+        // inside a region is flat, so it reads as moulded rather than
+        // drawn.
+        let balance = v.get("balance") / 50.0;
+        let smoothness = v.get("smoothness");
+        let light = light_of(v.get("light"));
+        let mut plane = luma_map(px, w, h);
+        blur_plane(&mut plane, w, h, smoothness * 0.8);
+        // A soft step: the height field is the picture pushed to two
+        // levels, then rounded off.
+        let mut height: Vec<f32> = plane
+            .iter()
+            .map(|l| if *l > 1.0 - balance { 1.0 } else { 0.0 })
+            .collect();
+        blur_plane(&mut height, w, h, 2.0 + smoothness);
+        let lit = relief(&height, w, h, light, 14.0);
+        let out: Vec<f32> = lit
+            .iter()
+            .zip(&height)
+            .map(|(l, hgt)| (l * 0.65 + hgt * 0.35).clamp(0.0, 1.0))
+            .collect();
+        from_luma(px, &out, 0.0);
+    }
+);
+
+simple_filter!(
+    Reticulation,
+    "filter.reticulation",
+    "Reticulation",
+    "Sketch",
+    [
+        param("density", "Density", 0.0, 50.0, 12.0, ""),
+        param("black", "Black Level", 0.0, 50.0, 40.0, ""),
+        param("white", "White Level", 0.0, 50.0, 5.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Film emulsion that has cracked and clumped -- what happens when
+        // a negative is developed at the wrong temperature. The clumps
+        // gather in the shadows and the highlights break into speckle.
+        let density = 1.0 + v.get("density") / 50.0 * 8.0;
+        let black = v.get("black") / 50.0;
+        let white = v.get("white") / 50.0;
+        let plane = luma_map(px, w, h);
+        let mut out = vec![0.0f32; w * h];
+        for y in 0..h {
+            for x in 0..w {
+                let i = y * w + x;
+                let clump = fbm(x as f32 / density, y as f32 / density, 4409, 3);
+                let l = plane[i];
+                // Dark pixels take the clumping hardest, light ones
+                // sparkle.
+                let grain = (clump - 0.5) * (black * (1.0 - l) + white * l) * 2.0;
+                out[i] = (l + grain).clamp(0.0, 1.0);
+            }
+        }
+        from_luma(px, &out, 0.0);
+    }
+);
+
+simple_filter!(
+    Stamp,
+    "filter.stamp",
+    "Stamp",
+    "Sketch",
+    [
+        param("balance", "Light/Dark Balance", 0.0, 50.0, 25.0, ""),
+        param("smoothness", "Smoothness", 1.0, 50.0, 5.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // A rubber stamp: one threshold, and enough smoothing first that
+        // the boundary could have been cut out of rubber.
+        let balance = v.get("balance") / 50.0;
+        let smoothness = v.get("smoothness");
+        let mut plane = luma_map(px, w, h);
+        blur_plane(&mut plane, w, h, smoothness * 0.4);
+        let out: Vec<f32> = plane
+            .iter()
+            .map(|l| if *l > 1.0 - balance { 1.0 } else { 0.0 })
+            .collect();
+        from_luma(px, &out, 0.0);
+    }
+);
+
+simple_filter!(
+    TornEdges,
+    "filter.torn_edges",
+    "Torn Edges",
+    "Sketch",
+    [
+        param("balance", "Image Balance", 0.0, 50.0, 25.0, ""),
+        param("smoothness", "Smoothness", 1.0, 15.0, 9.0, ""),
+        param("contrast", "Contrast", 1.0, 25.0, 12.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Stamp, but the threshold wanders: the boundary is pushed about
+        // by a noise field, so the shapes come out ragged the way torn
+        // paper is ragged rather than cut.
+        let balance = v.get("balance") / 50.0;
+        let smoothness = v.get("smoothness");
+        let contrast = v.get("contrast") / 25.0;
+        let mut plane = luma_map(px, w, h);
+        blur_plane(&mut plane, w, h, smoothness * 0.3);
+        let mut out = vec![0.0f32; w * h];
+        for y in 0..h {
+            for x in 0..w {
+                let i = y * w + x;
+                // Low frequency on purpose: a tear wanders across the
+                // sheet, it does not speckle. High-frequency noise here
+                // reads as dirt on the scanner.
+                let tear = (fbm(x as f32 / 24.0, y as f32 / 24.0, 1723, 3) - 0.5) * 0.5;
+                let edge = 1.0 - balance + tear;
+                // Contrast decides how much fibre is left in the tear:
+                // low keeps a soft fringe, high snaps to the two tones.
+                let t = ((plane[i] - edge) * (2.0 + contrast * 30.0) + 0.5).clamp(0.0, 1.0);
+                out[i] = t;
+            }
+        }
+        from_luma(px, &out, 0.0);
+    }
+);
+
+simple_filter!(
+    WaterPaper,
+    "filter.water_paper",
+    "Water Paper",
+    "Sketch",
+    [
+        param("fiber", "Fiber Length", 3.0, 50.0, 15.0, ""),
+        param("brightness", "Brightness", 0.0, 100.0, 60.0, ""),
+        param("contrast", "Contrast", 0.0, 100.0, 80.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Painted onto fibrous, wet paper: the colour runs along the
+        // fibres, which lie in whatever direction the paper was made in.
+        // The one effect in this group that keeps its colour, because
+        // that is what it is for.
+        let fiber = v.get("fiber");
+        let brightness = v.get("brightness") / 100.0;
+        let contrast = v.get("contrast") / 100.0;
+        let plane = luma_map(px, w, h);
+        // Fibres wander: the direction is a slowly varying noise field
+        // rather than a constant, which is what makes the runs look wet.
+        let run = streak(&plane, w, h, fiber * 0.3, |x, y| {
+            let a = fbm(x as f32 / 40.0, y as f32 / 40.0, 907, 2) * std::f32::consts::TAU;
+            (a.cos(), a.sin())
+        });
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            let tone = ((run[i] - 0.5) * (0.5 + contrast * 1.5) + 0.5) * (0.6 + brightness * 0.8);
+            let scale = tone.clamp(0.0, 1.0) / plane[i].max(1e-4);
+            for v in p.iter_mut().take(3) {
+                *v = (*v * scale).clamp(0.0, 1.0);
+            }
+        }
+    }
+);
+
+pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
+    registry.register_filter(Box::new(BasRelief));
+    registry.register_filter(Box::new(ChalkAndCharcoal));
+    registry.register_filter(Box::new(Charcoal));
+    registry.register_filter(Box::new(Chrome));
+    registry.register_filter(Box::new(ConteCrayon));
+    registry.register_filter(Box::new(GraphicPen));
+    registry.register_filter(Box::new(HalftonePattern));
+    registry.register_filter(Box::new(NotePaper));
+    registry.register_filter(Box::new(Photocopy));
+    registry.register_filter(Box::new(Plaster));
+    registry.register_filter(Box::new(Reticulation));
+    registry.register_filter(Box::new(Stamp));
+    registry.register_filter(Box::new(TornEdges));
+    registry.register_filter(Box::new(WaterPaper));
+}

--- a/plugins/filters-core/src/texture.rs
+++ b/plugins/filters-core/src/texture.rs
@@ -1,0 +1,361 @@
+//! Filter Gallery ▸ Texture.
+//!
+//! Six effects that put the image on, or into, a surface. Five of them
+//! are the same idea with a different surface -- cracked plaster, film
+//! grain, tiles, patches, canvas -- and the sixth, Stained Glass, builds
+//! its surface out of the picture instead of over it.
+
+use crate::util::{at, luma, put, surface, value_noise};
+use crate::{choice, param, simple_filter};
+use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
+
+/// Where a jittered grid puts the cell nearest a point, and how far away
+/// its second-nearest neighbour is.
+///
+/// The gap between the two distances is what draws the border: it goes to
+/// zero exactly along the line where two cells meet, so thresholding it
+/// gives the lead in stained glass and the grout between tiles.
+fn cell_of(x: f32, y: f32, size: f32, seed: u32) -> ([f32; 2], f32, f32) {
+    let (gx, gy) = ((x / size).floor(), (y / size).floor());
+    let mut best = (f32::INFINITY, [0.0f32; 2]);
+    let mut second = f32::INFINITY;
+    for dy in -1..=1 {
+        for dx in -1..=1 {
+            let (cx, cy) = (gx + dx as f32, gy + dy as f32);
+            // The centre of this cell, jittered inside its square.
+            let jx = value_noise(cx * 13.0, cy * 7.0, seed);
+            let jy = value_noise(cx * 7.0, cy * 13.0, seed ^ 0x9e37_79b9);
+            let px = (cx + jx) * size;
+            let py = (cy + jy) * size;
+            let d = (px - x).hypot(py - y);
+            if d < best.0 {
+                second = best.0;
+                best = (d, [px, py]);
+            } else if d < second {
+                second = d;
+            }
+        }
+    }
+    (best.1, best.0, second)
+}
+
+simple_filter!(
+    Craquelure,
+    "filter.craquelure",
+    "Craquelure",
+    "Texture",
+    [
+        param("spacing", "Crack Spacing", 2.0, 100.0, 15.0, ""),
+        param("depth", "Crack Depth", 0.0, 10.0, 6.0, ""),
+        param("brightness", "Crack Brightness", 0.0, 10.0, 9.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // An old painting whose surface has cracked. The cracks are the
+        // seams of a cell network -- the same construction as stained
+        // glass, drawn thin -- and they are shaded on both sides so the
+        // plaster looks lifted rather than drawn on.
+        let spacing = v.get("spacing").max(2.0);
+        let depth = v.get("depth") / 10.0;
+        let brightness = v.get("brightness") / 10.0;
+        for y in 0..h {
+            for x in 0..w {
+                let (_, d1, d2) = cell_of(x as f32, y as f32, spacing, 3323);
+                // How close this pixel is to the seam.
+                let seam = ((d2 - d1) / (spacing * 0.35)).min(1.0);
+                let crack = (1.0 - seam).powf(3.0);
+                // One side of the crack catches the light, the other is
+                // in shadow: sample the seam a pixel over to find out
+                // which side this is.
+                let (_, e1, e2) = cell_of(x as f32 + 1.0, y as f32 + 1.0, spacing, 3323);
+                let lean = ((e2 - e1) - (d2 - d1)).signum();
+                let p = at(px, w, h, x as i32, y as i32);
+                let shade = 1.0 - crack * depth + crack * lean * brightness * 0.35;
+                put(
+                    px,
+                    w,
+                    x,
+                    y,
+                    [
+                        (p[0] * shade).clamp(0.0, 1.0),
+                        (p[1] * shade).clamp(0.0, 1.0),
+                        (p[2] * shade).clamp(0.0, 1.0),
+                        p[3],
+                    ],
+                );
+            }
+        }
+    }
+);
+
+/// Photoshop's grain types, all ten of them.
+const GRAIN_TYPES: &[&str] = &[
+    "Regular",
+    "Soft",
+    "Sprinkles",
+    "Clumped",
+    "Contrasty",
+    "Enlarged",
+    "Stippled",
+    "Horizontal",
+    "Vertical",
+    "Speckle",
+];
+
+simple_filter!(
+    Grain,
+    "filter.grain",
+    "Grain",
+    "Texture",
+    [
+        param("intensity", "Intensity", 0.0, 100.0, 40.0, ""),
+        param("contrast", "Contrast", 0.0, 100.0, 50.0, ""),
+        choice("kind", "Grain Type", GRAIN_TYPES, 0)
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Ten grains, which are ten different noise fields rather than
+        // ten strengths of one: soft is blurred, clumped is low
+        // frequency, sprinkles and speckle are sparse and only land
+        // sometimes, horizontal and vertical are stretched.
+        let intensity = v.get("intensity") / 100.0;
+        let contrast = v.get("contrast") / 100.0;
+        let kind = (v.get("kind").round().max(0.0) as usize).min(9);
+        for y in 0..h {
+            for x in 0..w {
+                let (fx, fy) = (x as f32, y as f32);
+                let n = match kind {
+                    // Soft: a coarser field, so the grain has size.
+                    1 => value_noise(fx / 2.0, fy / 2.0, 101) - 0.5,
+                    // Sprinkles: sparse white specks only.
+                    2 => (value_noise(fx, fy, 211) - 0.85).max(0.0) * 4.0,
+                    // Clumped: low frequency, in patches.
+                    3 => crate::util::fbm(fx / 6.0, fy / 6.0, 307, 3) - 0.5,
+                    // Contrasty: pushed to its extremes.
+                    4 => ((value_noise(fx, fy, 401) - 0.5) * 3.0).clamp(-0.5, 0.5),
+                    // Enlarged: big soft blobs.
+                    5 => value_noise(fx / 4.0, fy / 4.0, 503) - 0.5,
+                    // Stippled: sparse dark specks, the opposite of
+                    // sprinkles.
+                    6 => -(value_noise(fx, fy, 601) - 0.85).max(0.0) * 4.0,
+                    7 => value_noise(fx / 6.0, fy, 701) - 0.5,
+                    8 => value_noise(fx, fy / 6.0, 809) - 0.5,
+                    // Speckle: fine and sparse in both directions.
+                    9 => (value_noise(fx * 1.7, fy * 1.7, 907) - 0.5).powi(3) * 8.0,
+                    _ => value_noise(fx, fy, 13) - 0.5,
+                };
+                let p = at(px, w, h, x as i32, y as i32);
+                let mut out = p;
+                for c in 0..3 {
+                    // Contrast in Photoshop's Grain works on the image,
+                    // not the noise: it pushes the picture apart and lets
+                    // the grain sit in what is left.
+                    let base = ((p[c] - 0.5) * (1.0 + contrast) + 0.5).clamp(0.0, 1.0);
+                    out[c] = (base + n * intensity).clamp(0.0, 1.0);
+                }
+                put(px, w, x, y, out);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    MosaicTiles,
+    "filter.mosaic_tiles",
+    "Mosaic Tiles",
+    "Texture",
+    [
+        param("size", "Tile Size", 2.0, 100.0, 22.0, ""),
+        param("grout", "Grout Width", 1.0, 15.0, 3.0, ""),
+        param("lighten", "Lighten Grout", 0.0, 10.0, 9.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Irregular tiles with grout between them. Not to be confused
+        // with Pixelate ▸ Mosaic, which squares the image off: here the
+        // picture keeps its detail and gets *grouted*.
+        let size = v.get("size").max(2.0);
+        let grout = v.get("grout");
+        let lighten = v.get("lighten") / 10.0;
+        for y in 0..h {
+            for x in 0..w {
+                let (_, d1, d2) = cell_of(x as f32, y as f32, size, 5051);
+                let seam = (d2 - d1) / (grout * 0.6).max(0.5);
+                let p = at(px, w, h, x as i32, y as i32);
+                let mut out = p;
+                if seam < 1.0 {
+                    // In the grout: towards white or towards black
+                    // depending on Lighten Grout, and hardest at the
+                    // centre line.
+                    let amount = (1.0 - seam) * 0.9;
+                    let target = if lighten >= 0.5 { 1.0 } else { 0.0 };
+                    let pull = amount * (lighten - 0.5).abs() * 2.0;
+                    for c in 0..3 {
+                        out[c] = (p[c] + (target - p[c]) * pull).clamp(0.0, 1.0);
+                    }
+                }
+                put(px, w, x, y, out);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    Patchwork,
+    "filter.patchwork",
+    "Patchwork",
+    "Texture",
+    [
+        param("size", "Square Size", 0.0, 10.0, 4.0, ""),
+        param("relief", "Relief", 0.0, 25.0, 8.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Needlepoint: the picture is squared off into stitches, and each
+        // stitch is raised or sunk by how dark it is, so the surface
+        // ripples the way canvaswork does.
+        let size = (2.0 + v.get("size") * 3.0).round().max(2.0) as usize;
+        let relief = v.get("relief") / 25.0;
+        let src = px.to_vec();
+        for by in (0..h).step_by(size) {
+            for bx in (0..w).step_by(size) {
+                // The average colour of the square is the thread colour.
+                let (mut acc, mut n) = ([0.0f32; 4], 0.0f32);
+                for y in by..(by + size).min(h) {
+                    for x in bx..(bx + size).min(w) {
+                        let p = at(&src, w, h, x as i32, y as i32);
+                        for c in 0..4 {
+                            acc[c] += p[c];
+                        }
+                        n += 1.0;
+                    }
+                }
+                for a in acc.iter_mut() {
+                    *a /= n.max(1.0);
+                }
+                let height = luma(&acc);
+                for y in by..(by + size).min(h) {
+                    for x in bx..(bx + size).min(w) {
+                        // Shade within the square so it reads as a raised
+                        // stitch: light at the top left, dark at the
+                        // bottom right, scaled by the square's height.
+                        let u = (x - bx) as f32 / size as f32 - 0.5;
+                        let vv = (y - by) as f32 / size as f32 - 0.5;
+                        let shade = 1.0 + (-(u + vv)) * relief * (0.4 + height);
+                        let mut out = acc;
+                        for c in 0..3 {
+                            out[c] = (acc[c] * shade).clamp(0.0, 1.0);
+                        }
+                        put(px, w, x, y, out);
+                    }
+                }
+            }
+        }
+    }
+);
+
+simple_filter!(
+    StainedGlass,
+    "filter.stained_glass",
+    "Stained Glass",
+    "Texture",
+    [
+        param("size", "Cell Size", 2.0, 50.0, 12.0, ""),
+        param("border", "Border Thickness", 1.0, 20.0, 4.0, ""),
+        param("light", "Light Intensity", 0.0, 10.0, 3.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Every cell takes one colour, the seams between them go to lead,
+        // and a light behind the window falls off towards the edges of
+        // the image -- which is the part that sells it, because a real
+        // window is lit from behind and unevenly.
+        let size = v.get("size").max(2.0);
+        let border = v.get("border");
+        let light = v.get("light") / 10.0;
+        let src = px.to_vec();
+        let (cx, cy) = (w as f32 / 2.0, h as f32 / 2.0);
+        let reach = cx.hypot(cy).max(1.0);
+        for y in 0..h {
+            for x in 0..w {
+                let (centre, d1, d2) = cell_of(x as f32, y as f32, size, 8191);
+                let p = at(&src, w, h, centre[0] as i32, centre[1] as i32);
+                let seam = (d2 - d1) / (border * 0.35).max(0.3);
+                let mut out = p;
+                if seam < 1.0 {
+                    // Lead: dark, and not perfectly even.
+                    let lead = 1.0 - (1.0 - seam) * 0.95;
+                    for c in 0..3 {
+                        out[c] = p[c] * lead;
+                    }
+                } else if light > 0.0 {
+                    let d = (x as f32 - cx).hypot(y as f32 - cy) / reach;
+                    let lamp = 1.0 + (1.0 - d) * light;
+                    for c in 0..3 {
+                        out[c] = (p[c] * lamp).clamp(0.0, 1.0);
+                    }
+                }
+                out[3] = at(&src, w, h, x as i32, y as i32)[3];
+                put(px, w, x, y, out);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    Texturizer,
+    "filter.texturizer",
+    "Texturizer",
+    "Texture",
+    [
+        choice("texture", "Texture", crate::artistic::SURFACES, 0),
+        param("scaling", "Scaling", 50.0, 200.0, 100.0, "%"),
+        param("relief", "Relief", 0.0, 50.0, 4.0, ""),
+        choice("light", "Light", crate::sketch::LIGHTS, 7),
+        param("invert", "Invert", 0.0, 1.0, 0.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // The plain one: the image, printed on a surface. The surface is
+        // generated rather than loaded from a file, so there is nothing
+        // to ship and nothing to go missing -- see `util::surface`.
+        let kind = v.get("texture").round().max(0.0) as u32;
+        let scaling = (v.get("scaling") / 100.0 * 8.0).max(1.0);
+        let relief = v.get("relief") / 50.0;
+        let (lx, ly) = crate::sketch::light_of(v.get("light"));
+        let invert = v.get("invert") >= 0.5;
+        for y in 0..h {
+            for x in 0..w {
+                let sample_at = |dx: f32, dy: f32| {
+                    let t = surface(kind, x as f32 + dx, y as f32 + dy, scaling, 61);
+                    if invert {
+                        1.0 - t
+                    } else {
+                        t
+                    }
+                };
+                // Light the surface by its own slope, which is what makes
+                // canvas look woven instead of merely mottled.
+                let gx = sample_at(1.0, 0.0) - sample_at(-1.0, 0.0);
+                let gy = sample_at(0.0, 1.0) - sample_at(0.0, -1.0);
+                let shade = 1.0 + (gx * lx + gy * ly) * relief * 6.0;
+                let p = at(px, w, h, x as i32, y as i32);
+                put(
+                    px,
+                    w,
+                    x,
+                    y,
+                    [
+                        (p[0] * shade).clamp(0.0, 1.0),
+                        (p[1] * shade).clamp(0.0, 1.0),
+                        (p[2] * shade).clamp(0.0, 1.0),
+                        p[3],
+                    ],
+                );
+            }
+        }
+    }
+);
+
+pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
+    registry.register_filter(Box::new(Craquelure));
+    registry.register_filter(Box::new(Grain));
+    registry.register_filter(Box::new(MosaicTiles));
+    registry.register_filter(Box::new(Patchwork));
+    registry.register_filter(Box::new(StainedGlass));
+    registry.register_filter(Box::new(Texturizer));
+}

--- a/plugins/filters-core/src/util.rs
+++ b/plugins/filters-core/src/util.rs
@@ -146,3 +146,193 @@ pub fn fbm(x: f32, y: f32, seed: u32, octaves: u32) -> f32 {
     }
     sum / norm.max(1e-6)
 }
+
+/// The luminance of every pixel, which is what most of the Filter Gallery
+/// works on: the gallery's effects are about *drawing* an image again --
+/// in charcoal, in ink, in torn paper -- and a drawing is a tone map with
+/// a technique applied to it.
+pub fn luma_map(px: &[f32], w: usize, h: usize) -> Vec<f32> {
+    let _ = (w, h);
+    px.as_chunks::<4>().0.iter().map(|p| luma(p)).collect()
+}
+
+/// Write a single-channel result back over the colour, keeping alpha.
+///
+/// `tint` mixes the original colour back in: 0 leaves the result grey,
+/// which is what the Sketch filters want, and 1 keeps the hue of the
+/// photograph under the new tone, which is what the Artistic ones do.
+pub fn from_luma(px: &mut [f32], plane: &[f32], tint: f32) {
+    for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+        let v = plane[i].clamp(0.0, 1.0);
+        if tint <= 0.0 {
+            p[0] = v;
+            p[1] = v;
+            p[2] = v;
+            continue;
+        }
+        // Keep the pixel's own chroma against the new luminance, so a
+        // yellow flower stays yellow while its tone is redrawn.
+        let l = luma(p).max(1e-4);
+        for channel in p.iter_mut().take(3) {
+            let coloured = (*channel / l * v).clamp(0.0, 1.0);
+            *channel = v + (coloured - v) * tint;
+        }
+    }
+}
+
+/// Blur a single-channel plane. The colour blur premultiplies and works
+/// on four channels; a tone map needs neither.
+pub fn blur_plane(plane: &mut [f32], w: usize, h: usize, sigma: f32) {
+    let mut rgba: Vec<f32> = plane.iter().flat_map(|v| [*v, *v, *v, 1.0]).collect();
+    gaussian_rgba(&mut rgba, w, h, sigma);
+    for (i, p) in rgba.as_chunks::<4>().0.iter().enumerate() {
+        plane[i] = p[0];
+    }
+}
+
+/// Sobel gradient of a plane: (dx, dy) per pixel.
+pub fn gradient(plane: &[f32], w: usize, h: usize) -> Vec<(f32, f32)> {
+    let get = |x: i32, y: i32| -> f32 {
+        let x = x.clamp(0, w as i32 - 1) as usize;
+        let y = y.clamp(0, h as i32 - 1) as usize;
+        plane[y * w + x]
+    };
+    let mut out = Vec::with_capacity(w * h);
+    for y in 0..h as i32 {
+        for x in 0..w as i32 {
+            let gx = get(x + 1, y - 1) + 2.0 * get(x + 1, y) + get(x + 1, y + 1)
+                - get(x - 1, y - 1)
+                - 2.0 * get(x - 1, y)
+                - get(x - 1, y + 1);
+            let gy = get(x - 1, y + 1) + 2.0 * get(x, y + 1) + get(x + 1, y + 1)
+                - get(x - 1, y - 1)
+                - 2.0 * get(x, y - 1)
+                - get(x + 1, y - 1);
+            out.push((gx / 4.0, gy / 4.0));
+        }
+    }
+    out
+}
+
+/// Edge strength, 0..=1, from the Sobel gradient.
+pub fn edges(plane: &[f32], w: usize, h: usize) -> Vec<f32> {
+    gradient(plane, w, h)
+        .iter()
+        .map(|(gx, gy)| gx.hypot(*gy).min(1.0))
+        .collect()
+}
+
+/// Sample a plane bilinearly, clamping to the edge.
+pub fn plane_at(plane: &[f32], w: usize, h: usize, fx: f32, fy: f32) -> f32 {
+    let x0 = fx.floor();
+    let y0 = fy.floor();
+    let (tx, ty) = (fx - x0, fy - y0);
+    let get = |x: f32, y: f32| -> f32 {
+        let x = (x as i32).clamp(0, w as i32 - 1) as usize;
+        let y = (y as i32).clamp(0, h as i32 - 1) as usize;
+        plane[y * w + x]
+    };
+    let top = get(x0, y0) * (1.0 - tx) + get(x0 + 1.0, y0) * tx;
+    let bot = get(x0, y0 + 1.0) * (1.0 - tx) + get(x0 + 1.0, y0 + 1.0) * tx;
+    top * (1.0 - ty) + bot * ty
+}
+
+/// Average a plane along a line through each pixel, in a direction the
+/// caller chooses per pixel.
+///
+/// This is the whole of the Brush Strokes group in one function: a stroke
+/// is what you get when you smear a picture *along* something -- the edge
+/// direction, a fixed angle, the gradient -- rather than in a circle.
+pub fn streak(
+    plane: &[f32],
+    w: usize,
+    h: usize,
+    length: f32,
+    direction: impl Fn(usize, usize) -> (f32, f32),
+) -> Vec<f32> {
+    let steps = (length.max(1.0)).round() as i32;
+    let mut out = vec![0.0f32; w * h];
+    for y in 0..h {
+        for x in 0..w {
+            let (dx, dy) = direction(x, y);
+            let n = dx.hypot(dy).max(1e-6);
+            let (dx, dy) = (dx / n, dy / n);
+            let mut sum = 0.0;
+            let mut count = 0.0;
+            for t in -steps..=steps {
+                let fx = x as f32 + dx * t as f32;
+                let fy = y as f32 + dy * t as f32;
+                sum += plane_at(plane, w, h, fx, fy);
+                count += 1.0;
+            }
+            out[y * w + x] = sum / count;
+        }
+    }
+    out
+}
+
+/// Quantise to `levels` steps, the posterisation every "drawn in N tones"
+/// effect is built on.
+#[inline]
+pub fn posterize(v: f32, levels: f32) -> f32 {
+    let n = levels.max(2.0) - 1.0;
+    (v * n).round() / n
+}
+
+/// A repeatable texture field, for the surfaces the Texture and Artistic
+/// groups draw onto: canvas weave, sandstone grain, burlap, brick.
+///
+/// Photoshop loads these from a texture file; generating them means the
+/// filter has no assets to ship and no file to be missing.
+pub fn surface(kind: u32, x: f32, y: f32, scale: f32, seed: u32) -> f32 {
+    let (u, v) = (x / scale.max(1.0), y / scale.max(1.0));
+    match kind {
+        // Canvas: two crossed sine weaves with noise in the fibres. The
+        // noise carries most of it -- a pure weave reads as a screen
+        // door rather than as cloth.
+        0 => {
+            let weave = ((u * std::f32::consts::TAU).sin() + (v * std::f32::consts::TAU).sin())
+                * 0.25
+                + 0.5;
+            weave * 0.35 + fbm(u * 2.0, v * 2.0, seed, 3) * 0.45 + value_noise(x, y, seed) * 0.2
+        }
+        // Sandstone: fine noise over a soft one.
+        1 => fbm(u, v, seed, 3) * 0.6 + value_noise(x, y, seed ^ 0x5bd1) * 0.4,
+        // Burlap: coarse crossed fibres, one direction stronger.
+        2 => {
+            let warp = ((u * std::f32::consts::TAU).sin().abs() * 0.6
+                + (v * std::f32::consts::TAU * 0.5).sin().abs() * 0.4)
+                .clamp(0.0, 1.0);
+            warp * 0.65 + value_noise(x * 1.3, y * 0.9, seed) * 0.35
+        }
+        // Brick: a running bond, mortar dark.
+        _ => {
+            let row = (v).floor();
+            let shift = if (row as i32) % 2 == 0 { 0.0 } else { 0.5 };
+            let cx = (u + shift).fract();
+            let cy = v.fract();
+            let mortar = if cx < 0.06 || cy < 0.12 { 0.25 } else { 0.85 };
+            mortar * 0.8 + value_noise(x * 0.5, y * 0.5, seed) * 0.2
+        }
+    }
+}
+
+/// Quantise a pixel to a flat tone and a coarse colour.
+///
+/// Posterising each of red, green and blue on its own -- which is what
+/// Image ▸ Adjustments ▸ Posterize does -- crosses the channels at
+/// different places and turns a smooth sky into bands of unrelated hues.
+/// The cut-paper effects want flat *areas*, not accidental colours, so
+/// the tone is quantised and the colour with it, coarsely and together.
+pub fn flatten_colour(p: &mut [f32], levels: f32, chroma_step: f32) {
+    let l = luma(p);
+    let tone = posterize(l, levels);
+    let step = chroma_step.max(1e-3);
+    let a = ((p[0] - l) / step).round() * step;
+    let b = ((p[2] - l) / step).round() * step;
+    let (r, bl) = (tone + a, tone + b);
+    let g = (tone - 0.299 * r - 0.114 * bl) / 0.587;
+    p[0] = r.clamp(0.0, 1.0);
+    p[1] = g.clamp(0.0, 1.0);
+    p[2] = bl.clamp(0.0, 1.0);
+}

--- a/plugins/filters-core/tests/all_filters.rs
+++ b/plugins/filters-core/tests/all_filters.rs
@@ -94,7 +94,21 @@ fn every_filter_does_something_at_its_defaults() {
     // Two are not: Offset defaults to no shift and Camera Raw to a
     // neutral development, exactly as Photoshop's do -- opening either
     // and touching nothing should leave the image alone.
-    const EXPECTED_NO_OPS: &[&str] = &["filter.offset", "filter.camera_raw"];
+    const EXPECTED_NO_OPS: &[&str] = &[
+        "filter.offset",
+        "filter.camera_raw",
+        // Custom starts as the identity kernel, exactly as Photoshop's
+        // does: it is a kernel editor, and the kernel it opens with is
+        // "leave this alone".
+        "filter.custom",
+        // These three need something this image does not have and no
+        // slider can supply: a layer underneath to match against, or a
+        // face to work on. Photoshop greys the first two out until there
+        // is a layer below; doing nothing is the same answer.
+        "filter.neural.harmonization",
+        "filter.neural.landscape_mixer",
+        "filter.neural.face_to_caricature",
+    ];
     let (w, h) = (33usize, 21usize);
     for f in registry().filters() {
         let before = image(w, h);
@@ -300,4 +314,48 @@ fn skin_smoothing_leaves_things_that_are_not_skin_alone() {
         .expect("skin smoothing");
     f.apply(&mut px, w, h, &FilterValues::defaults(&f.params()));
     assert_eq!(px, before, "it smoothed something that was not skin");
+}
+
+#[test]
+fn the_filters_that_ask_for_a_backdrop_use_it() {
+    // Three filters declare that they want the pixels underneath. Each
+    // has to do nothing without one -- checked by the no-op list above --
+    // and move the image towards the backdrop's colour with one.
+    let (w, h) = (48usize, 48usize);
+    let warm: Vec<f32> = (0..w * h).flat_map(|_| [0.85f32, 0.55, 0.2, 1.0]).collect();
+    let mean = |px: &[f32]| {
+        let n = (px.len() / 4) as f32;
+        let mut acc = [0.0f32; 3];
+        for p in px.as_chunks::<4>().0 {
+            for c in 0..3 {
+                acc[c] += p[c] / n;
+            }
+        }
+        acc
+    };
+    let reg = registry();
+    let mut asked = 0;
+    for f in reg.filters().filter(|f| f.wants_backdrop()) {
+        asked += 1;
+        let before = image(w, h);
+        let mut px = before.clone();
+        let values = FilterValues::defaults(&f.params());
+        f.apply_over(&mut px, Some(&warm), w, h, &values);
+        let (was, now, want) = (mean(&before), mean(&px), mean(&warm));
+        for c in 0..3 {
+            let closer = (now[c] - want[c]).abs() < (was[c] - want[c]).abs();
+            assert!(
+                closer,
+                "{} did not move channel {c} towards the backdrop: {} -> {} (backdrop {})",
+                f.id(),
+                was[c],
+                now[c],
+                want[c]
+            );
+        }
+    }
+    assert!(
+        asked >= 3,
+        "expected the three matching filters, found {asked}"
+    );
 }


### PR DESCRIPTION
Fifty-eight filters: **57 → 115**, across fourteen categories. This closes the three gaps from the last message's inventory.

Stacks on #66 — that commit is in this branch, and the README paragraph it fixed is rewritten again here, so merging this makes #66 redundant.

## The Filter Gallery — 46 effects

The Gallery was a stacker with nothing of its own to stack: it listed the filters already in the menu. These are what people open it for.

| group | effects |
|---|---|
| **Artistic** (15) | Colored Pencil, Cutout, Dry Brush, Film Grain, Fresco, Neon Glow, Paint Daubs, Palette Knife, Plastic Wrap, Poster Edges, Rough Pastels, Smudge Stick, Sponge, Underpainting, Watercolor |
| **Brush Strokes** (8) | Accented Edges, Angled Strokes, Crosshatch, Dark Strokes, Ink Outlines, Spatter, Sprayed Strokes, Sumi-e |
| **Sketch** (14) | Bas Relief, Chalk & Charcoal, Charcoal, Chrome, Conté Crayon, Graphic Pen, Halftone Pattern, Note Paper, Photocopy, Plaster, Reticulation, Stamp, Torn Edges, Water Paper |
| **Texture** (6) | Craquelure, Grain (all ten grain types), Mosaic Tiles, Patchwork, Stained Glass, Texturizer |
| **Distort** (3) | Diffuse Glow, Glass, Ocean Ripple |

They are registered as ordinary filters, so each appears in its own menu group as well — which is what Photoshop does with *Show all Filter Gallery groups and names* on — and can be stacked in the Gallery as before.

None of these are anyone's source. They are written from what each effect does to an image, and they share four ideas that now live in `util.rs`: flatten a picture into regions a brush could have painted, smear a plane along a line (that one *is* the Brush Strokes group), light a plane as though it were a surface (Bas Relief, Chrome, Note Paper, Plaster, Texturizer), and generate the canvas/sandstone/burlap/brick surfaces rather than ship texture files that could go missing.

One deliberate deviation: Photoshop's Sketch group draws in the foreground and background colours, and a filter here never sees the toolbox, so they draw black on white — which is what those swatches are set to by default and what every one of these effects is pictured with.

## Six classics

**Blur**, **Blur More**, **Sharpen More** (fixed radius, no dialog, as they have been since 1990), **Custom** (the 5×5 kernel editor, opening at the identity — so it joins Offset and Camera Raw on the list of filters that legitimately do nothing at their defaults), **HSB/HSL** (channels as hue/saturation/brightness, both directions) and **Lighting Effects** (Phong shading, with the image's own luminance as the bump map, which is what makes it look embossed rather than merely brightened).

The filter dialog scrolls now, because Custom declares twenty-seven parameters.

## Five Neural Filters — nine of twelve now run a network

**Harmonization**, **Landscape Mixer**, **Photo Restoration**, **Photo to Sketch**, **Face to Caricature**.

Three of these need a second picture, which a filter has never been able to be handed. `FilterPlugin::wants_backdrop()` is the answer: the host composites what is under the layer — hiding the layer and everything above it, compositing, putting the visibility back — and passes it to `apply_over`. So:

- **Harmonization** matches a cut-out to its background, which is what Photoshop's asks you to pick a layer for.
- **Landscape Mixer** transfers a palette *band by band* through the depth model, because a landscape's colours are stratified by distance and a single global match turns the grass the colour of the sky.
- **Color Transfer** finally has a reference image instead of a hue slider — the gap #66 admitted to. It still falls back to the hue when there is nothing underneath.

**Photo Restoration** composes what this build already ships: a median that only fires where a pixel disagrees with its neighbours (a scratch, not an edge), an edge-preserving denoise, the deblocking and detail models, then a tone stretch. **Face to Caricature** warps from the detector's box plus the proportions a face has when it is looking at the camera — it does not find your features, and the docs say so.

Harmonization, Landscape Mixer and Face to Caricature do nothing without a layer underneath or a face in the picture, and are on the test's expected-no-op list for exactly that reason.

## Checked

- The property tests run against all 115: registered, finite and in range, no panic at degenerate sizes, deterministic, and doing something at their defaults unless listed. A new test asserts the three backdrop filters actually move the image towards the backdrop.
- Whole workspace suite green, clippy and rustfmt clean.
- Every new effect eyeballed on a photograph, which is how Cutout stopped posterising each channel separately (it was banding a smooth sky into unrelated hues), Torn Edges stopped speckling and started tearing, and Sumi-e stopped being a threshold.
- Driven headlessly in the app: the Filter menu shows the fourteen groups, Neural Filters lists all twelve, and Custom's twenty-seven sliders scroll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)