### PR TITLE
The Blur Gallery, Lens Correction, and the rest of the Filter menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,22 @@ glow, satin, colour overlay, gradient overlay, outer glow and drop shadow,
 with Photoshop's Fill-vs-Opacity semantics so "Fill 0% plus a drop shadow"
 does what you expect.
 
-**Filters.** A hundred and fifteen across fourteen categories —
-Artistic, Blur, Brush Strokes, Distort, Noise, Pixelate, Render, Sharpen,
-Sketch, Stylize, Texture, Other, Camera Raw and Neural Filters — all
-previewing live on the canvas inside the selection, with Cancel restoring
-exactly. That includes the forty-six effects Photoshop keeps *inside* the
-Filter Gallery — Watercolor, Sumi-e, Chrome, Stained Glass and the rest —
-which are ordinary filters here as well, so they can be run from the menu
-or stacked in the **Filter Gallery**, which previews the result of the
-lot.
+**Filters.** A hundred and twenty-nine, which is Photoshop's Filter menu
+with nothing left out: Artistic, Blur, Blur Gallery, Brush Strokes,
+Distort, Noise, Pixelate, Render, Sharpen, Sketch, Stylize, Texture,
+Video, Other, Camera Raw and Neural Filters, plus Lens Correction and
+Adaptive Wide Angle. All preview live on the canvas inside the selection,
+with Cancel restoring exactly. The count includes the forty-six effects
+Photoshop keeps *inside* the Filter Gallery — Watercolor, Sumi-e, Chrome,
+Stained Glass, Craquelure and the rest — which are ordinary filters here
+too, so each can be run from the menu on its own or stacked in the
+**Filter Gallery**, which previews the result of the lot.
+
+The Blur Gallery's five and Photoshop's three scripted Render filters —
+Flame, Picture Frame and Tree — arrive without the canvas widgets they
+have there: a filter is handed pixels and numbers, so a blur pin is a
+pair of position sliders, and Flame rises from the bottom of the
+selection rather than following a path you drew.
 
 **Warping.** Liquify with all seven brushes, Puppet Warp (Moving Least
 Squares, so pins hold and nothing shears), Content-Aware Scale (seam

--- a/crates/app/src/panels.rs
+++ b/crates/app/src/panels.rs
@@ -236,7 +236,9 @@ pub(crate) fn menus(ws: &Workspace) -> Vec<(&'static str, Vec<MenuEntry>)> {
             // they do in Photoshop's Filter menu.
             let mut out = vec![
                 App("Filter Gallery…", FilterGalleryItem, None),
+                Filter("filter.adaptive_wide_angle"),
                 Filter("filter.camera_raw"),
+                Filter("filter.lens_correction"),
                 App("Liquify", LiquifyItem, None),
                 App("Vanishing Point", VanishingPointItem, None),
                 Sep,
@@ -398,7 +400,19 @@ const FILTER_GROUPS: &[(&str, &[&str])] = &[
             "filter.lens_blur",
             "filter.motion_blur",
             "filter.radial_blur",
+            "filter.shape_blur",
+            "filter.smart_blur",
             "filter.surface_blur",
+        ],
+    ),
+    (
+        "Blur Gallery",
+        &[
+            "filter.field_blur",
+            "filter.iris_blur",
+            "filter.tilt_shift",
+            "filter.path_blur",
+            "filter.spin_blur",
         ],
     ),
     (
@@ -456,6 +470,9 @@ const FILTER_GROUPS: &[(&str, &[&str])] = &[
     (
         "Render",
         &[
+            "filter.flame",
+            "filter.picture_frame",
+            "filter.tree",
             "filter.clouds",
             "filter.difference_clouds",
             "filter.fibers",
@@ -518,6 +535,7 @@ const FILTER_GROUPS: &[(&str, &[&str])] = &[
             "filter.texturizer",
         ],
     ),
+    ("Video", &["filter.deinterlace", "filter.ntsc_colors"]),
     (
         "Other",
         &[

--- a/plugins/filters-core/src/blurgallery.rs
+++ b/plugins/filters-core/src/blurgallery.rs
@@ -1,0 +1,520 @@
+//! Filter ▸ Blur Gallery, and the two Blur entries that were still
+//! missing.
+//!
+//! The Blur Gallery is Photoshop's answer to "blur *some* of it": five
+//! filters that all apply an ordinary blur through a mask they compute
+//! themselves. Field Blur ramps it across the frame, Iris Blur keeps an
+//! ellipse sharp, Tilt-Shift keeps a band sharp, and Spin and Path blur
+//! along a direction rather than in a circle.
+//!
+//! In Photoshop you place their pins on the canvas. A filter here is
+//! handed pixels and numbers, so the pin is a pair of position sliders --
+//! which is also how these filters worked in every program that had them
+//! before the canvas UI arrived.
+//!
+//! The graded blur underneath them is three fixed levels, blended. A
+//! true per-pixel radius costs the largest radius everywhere and these
+//! are lens effects, not measurements: what matters is that the falloff
+//! is smooth and that the sharp part is genuinely untouched.
+
+use crate::util::{at, gaussian_rgba, luma, premultiply, put, sample, unpremultiply};
+use crate::{choice, param, simple_filter};
+use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
+
+/// Blur by a per-pixel amount in 0..=1, where 1 is `radius`.
+///
+/// Three levels rather than one: blending a sharp copy against a single
+/// heavily blurred one leaves the middle of a falloff looking like a
+/// double exposure rather than like something slightly out of focus.
+fn graded_blur(px: &mut [f32], w: usize, h: usize, radius: f32, amount: impl Fn(usize) -> f32) {
+    if radius <= 0.0 || w == 0 || h == 0 {
+        return;
+    }
+    let sharp = px.to_vec();
+    let levels: Vec<Vec<f32>> = [0.34f32, 0.67, 1.0]
+        .iter()
+        .map(|k| {
+            let mut buf = sharp.clone();
+            gaussian_rgba(&mut buf, w, h, radius * k);
+            buf
+        })
+        .collect();
+    for i in 0..w * h {
+        let t = amount(i).clamp(0.0, 1.0) * levels.len() as f32;
+        // Which two levels this pixel sits between; the sharp original is
+        // level -1.
+        let lower = t.floor() as isize - 1;
+        let frac = t - t.floor();
+        let pick = |level: isize, c: usize| -> f32 {
+            if level < 0 {
+                sharp[i * 4 + c]
+            } else {
+                levels[(level as usize).min(levels.len() - 1)][i * 4 + c]
+            }
+        };
+        for c in 0..4 {
+            px[i * 4 + c] = pick(lower, c) * (1.0 - frac) + pick(lower + 1, c) * frac;
+        }
+    }
+}
+
+/// A smooth 0..=1 ramp, for the feathered edges every one of these has.
+fn feathered(distance: f32, edge: f32, feather: f32) -> f32 {
+    if feather <= 1e-4 {
+        return if distance > edge { 1.0 } else { 0.0 };
+    }
+    ((distance - edge) / feather).clamp(0.0, 1.0)
+}
+
+simple_filter!(
+    FieldBlur,
+    "filter.field_blur",
+    "Field Blur",
+    "Blur Gallery",
+    [
+        param("blur", "Blur", 0.0, 200.0, 15.0, " px"),
+        param("angle", "Direction", 0.0, 360.0, 90.0, "\u{b0}"),
+        param("position", "Sharp At", 0.0, 100.0, 50.0, "%"),
+        param("spread", "Transition", 1.0, 100.0, 50.0, "%")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // One pin's worth of Field Blur: sharp along a line across the
+        // frame and increasingly blurred away from it. With several pins
+        // Photoshop interpolates between them; with one it does this.
+        let blur = v.get("blur");
+        let angle = v.get("angle").to_radians();
+        let position = v.get("position") / 100.0;
+        let spread = (v.get("spread") / 100.0).max(0.01);
+        let (dx, dy) = (angle.cos(), angle.sin());
+        // How far the frame runs along the blur's own axis.
+        let extent = (w as f32 * dx).abs() + (h as f32 * dy).abs();
+        let centre = extent * position;
+        graded_blur(px, w, h, blur, |i| {
+            let (x, y) = ((i % w) as f32, (i / w) as f32);
+            let along = x * dx + y * dy;
+            (along - centre).abs() / (extent * spread).max(1.0)
+        });
+    }
+);
+
+simple_filter!(
+    IrisBlur,
+    "filter.iris_blur",
+    "Iris Blur",
+    "Blur Gallery",
+    [
+        param("blur", "Blur", 0.0, 200.0, 20.0, " px"),
+        param("x", "Centre X", 0.0, 100.0, 50.0, "%"),
+        param("y", "Centre Y", 0.0, 100.0, 50.0, "%"),
+        param("radius", "Radius", 1.0, 100.0, 35.0, "%"),
+        param("roundness", "Roundness", 0.0, 100.0, 100.0, "%"),
+        param("feather", "Feather", 0.0, 100.0, 50.0, "%")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // An ellipse of sharpness with everything outside it going soft,
+        // which is the portrait effect: the subject inside the iris, the
+        // room outside it.
+        let blur = v.get("blur");
+        let (cx, cy) = (v.get("x") / 100.0 * w as f32, v.get("y") / 100.0 * h as f32);
+        let reach = (w.min(h) as f32) * (v.get("radius") / 100.0);
+        // Roundness stretches the ellipse towards the frame's own shape.
+        let round = v.get("roundness") / 100.0;
+        let (rx, ry) = (
+            reach * (1.0 + (1.0 - round) * (w as f32 / h.max(1) as f32 - 1.0).max(0.0)),
+            reach * (1.0 + (1.0 - round) * (h as f32 / w.max(1) as f32 - 1.0).max(0.0)),
+        );
+        let feather = v.get("feather") / 100.0;
+        graded_blur(px, w, h, blur, |i| {
+            let (x, y) = ((i % w) as f32, (i / w) as f32);
+            let d = ((x - cx) / rx.max(1.0)).hypot((y - cy) / ry.max(1.0));
+            feathered(d, 1.0 - feather, feather.max(1e-3))
+        });
+    }
+);
+
+simple_filter!(
+    TiltShift,
+    "filter.tilt_shift",
+    "Tilt-Shift",
+    "Blur Gallery",
+    [
+        param("blur", "Blur", 0.0, 200.0, 24.0, " px"),
+        param("position", "Centre", 0.0, 100.0, 50.0, "%"),
+        param("band", "Sharp Band", 1.0, 100.0, 20.0, "%"),
+        param("feather", "Transition", 0.0, 100.0, 30.0, "%"),
+        param("angle", "Angle", 0.0, 360.0, 0.0, "\u{b0}")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // A band of the picture in focus and everything beyond it soft,
+        // which reads as a very shallow depth of field and therefore as a
+        // photograph of a model railway. That is the entire appeal.
+        let blur = v.get("blur");
+        let angle = v.get("angle").to_radians();
+        let (dx, dy) = (-angle.sin(), angle.cos());
+        let extent = (w as f32 * dx).abs() + (h as f32 * dy).abs();
+        let centre = extent * (v.get("position") / 100.0);
+        let band = extent * (v.get("band") / 100.0) / 2.0;
+        let feather = extent * (v.get("feather") / 100.0);
+        graded_blur(px, w, h, blur, |i| {
+            let (x, y) = ((i % w) as f32, (i / w) as f32);
+            let along = (x * dx + y * dy - centre).abs();
+            feathered(along, band, feather)
+        });
+    }
+);
+
+simple_filter!(
+    SpinBlur,
+    "filter.spin_blur",
+    "Spin Blur",
+    "Blur Gallery",
+    [
+        param("angle", "Blur Angle", 0.0, 60.0, 12.0, "\u{b0}"),
+        param("x", "Centre X", 0.0, 100.0, 50.0, "%"),
+        param("y", "Centre Y", 0.0, 100.0, 50.0, "%"),
+        param("radius", "Radius", 1.0, 100.0, 50.0, "%"),
+        param("feather", "Feather", 0.0, 100.0, 30.0, "%")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // A wheel turning: the smear follows the arc through each pixel,
+        // and it happens inside a feathered circle rather than over the
+        // whole frame, which is what separates this from Radial Blur's
+        // spin. The angle is in degrees of rotation, as Photoshop's is.
+        let sweep = v.get("angle").to_radians();
+        let (cx, cy) = (v.get("x") / 100.0 * w as f32, v.get("y") / 100.0 * h as f32);
+        let reach = (w.max(h) as f32) * (v.get("radius") / 100.0);
+        let feather = (v.get("feather") / 100.0).max(1e-3);
+        if sweep <= 0.0 || reach <= 0.0 {
+            return;
+        }
+        premultiply(px);
+        let src = px.to_vec();
+        const STEPS: usize = 24;
+        for y in 0..h {
+            for x in 0..w {
+                let (fx, fy) = (x as f32 + 0.5 - cx, y as f32 + 0.5 - cy);
+                let r = fx.hypot(fy);
+                // Inside the circle it spins; the feather takes it back
+                // to still by the rim.
+                let inside = 1.0 - feathered(r / reach, 1.0 - feather, feather);
+                if inside <= 0.001 {
+                    continue;
+                }
+                let theta = fy.atan2(fx);
+                let mut acc = [0.0f32; 4];
+                for s in 0..STEPS {
+                    let t = s as f32 / (STEPS - 1) as f32 - 0.5;
+                    let a = theta + t * sweep * inside;
+                    let p = sample(&src, w, h, cx + r * a.cos() - 0.5, cy + r * a.sin() - 0.5);
+                    for c in 0..4 {
+                        acc[c] += p[c] / STEPS as f32;
+                    }
+                }
+                put(px, w, x, y, acc);
+            }
+        }
+        unpremultiply(px);
+    }
+);
+
+simple_filter!(
+    PathBlur,
+    "filter.path_blur",
+    "Path Blur",
+    "Blur Gallery",
+    [
+        param("speed", "Speed", 0.0, 100.0, 50.0, "%"),
+        param("angle", "Direction", 0.0, 360.0, 0.0, "\u{b0}"),
+        param("curve", "Curvature", -100.0, 100.0, 0.0, "%"),
+        param("taper", "Taper", 0.0, 100.0, 0.0, "%")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Motion along a path rather than along a straight line: the
+        // smear starts in the chosen direction and bends as it goes, so a
+        // car blurs along the road it is on instead of along the frame.
+        // Photoshop draws the path; here it is a direction and a
+        // curvature, which covers the case the filter is used for.
+        let speed = v.get("speed") / 100.0 * 60.0;
+        let angle = v.get("angle").to_radians();
+        let curve = v.get("curve") / 100.0;
+        let taper = v.get("taper") / 100.0;
+        if speed <= 0.0 {
+            return;
+        }
+        premultiply(px);
+        let src = px.to_vec();
+        const STEPS: usize = 24;
+        for y in 0..h {
+            for x in 0..w {
+                let mut acc = [0.0f32; 4];
+                let mut total = 0.0f32;
+                for s in 0..STEPS {
+                    let t = s as f32 / (STEPS - 1) as f32;
+                    // Taper thins the trail towards its end, the way a
+                    // stroke lifts off.
+                    let weight = 1.0 - taper * t;
+                    // The path: a straight line that turns as it runs.
+                    let a = angle + curve * t * std::f32::consts::FRAC_PI_2;
+                    let d = t * speed;
+                    let p = sample(&src, w, h, x as f32 + a.cos() * d, y as f32 + a.sin() * d);
+                    for c in 0..4 {
+                        acc[c] += p[c] * weight;
+                    }
+                    total += weight;
+                }
+                let total = total.max(1e-6);
+                put(
+                    px,
+                    w,
+                    x,
+                    y,
+                    [
+                        acc[0] / total,
+                        acc[1] / total,
+                        acc[2] / total,
+                        acc[3] / total,
+                    ],
+                );
+            }
+        }
+        unpremultiply(px);
+    }
+);
+
+/// The kernel shapes Shape Blur offers.
+///
+/// Photoshop loads these from the shape presets, which is a file of
+/// vector art; these are the same silhouettes, generated.
+const SHAPES: &[&str] = &["Square", "Diamond", "Hexagon", "Cross", "Ring", "Star"];
+
+/// Whether a point inside the kernel's unit square belongs to the shape.
+fn in_shape(kind: usize, u: f32, v: f32) -> bool {
+    let (au, av) = (u.abs(), v.abs());
+    match kind {
+        0 => au <= 1.0 && av <= 1.0,
+        1 => au + av <= 1.0,
+        // A hexagon is a square with two corners cut off at 60 degrees.
+        2 => au <= 0.9 && av <= 1.0 && au * 0.5 + av * 0.866 <= 0.95,
+        3 => au <= 0.3 || av <= 0.3,
+        4 => {
+            let r = u.hypot(v);
+            (0.6..=1.0).contains(&r)
+        }
+        _ => {
+            // Five-pointed: the radius the point would need at its own
+            // angle, which oscillates five times around.
+            let r = u.hypot(v);
+            let a = v.atan2(u);
+            let spike = 0.55 + 0.45 * (a * 5.0).cos().abs();
+            r <= spike
+        }
+    }
+}
+
+simple_filter!(
+    ShapeBlur,
+    "filter.shape_blur",
+    "Shape Blur",
+    "Blur",
+    [
+        param("radius", "Radius", 1.0, 60.0, 10.0, " px"),
+        choice("shape", "Shape", SHAPES, 0)
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // An average over a kernel shaped like something other than a
+        // disc, which is what a lens with a shaped aperture does to its
+        // out-of-focus highlights. The shape is what the filter is for:
+        // at a large radius every specular highlight becomes one.
+        let radius = v.get("radius").round().max(1.0) as i32;
+        let kind = (v.get("shape").round().max(0.0) as usize).min(SHAPES.len() - 1);
+        let mut offsets: Vec<(i32, i32)> = Vec::new();
+        for dy in -radius..=radius {
+            for dx in -radius..=radius {
+                let (u, vv) = (dx as f32 / radius as f32, dy as f32 / radius as f32);
+                if in_shape(kind, u, vv) {
+                    offsets.push((dx, dy));
+                }
+            }
+        }
+        if offsets.is_empty() {
+            return;
+        }
+        premultiply(px);
+        let src = px.to_vec();
+        let n = offsets.len() as f32;
+        for y in 0..h as i32 {
+            for x in 0..w as i32 {
+                let mut acc = [0.0f32; 4];
+                for (dx, dy) in offsets.iter() {
+                    let p = at(&src, w, h, x + dx, y + dy);
+                    for c in 0..4 {
+                        acc[c] += p[c] / n;
+                    }
+                }
+                put(px, w, x as usize, y as usize, acc);
+            }
+        }
+        unpremultiply(px);
+    }
+);
+
+/// What Smart Blur does with the edges it finds.
+const SMART_MODES: &[&str] = &["Normal", "Edge Only", "Overlay Edge"];
+
+simple_filter!(
+    SmartBlur,
+    "filter.smart_blur",
+    "Smart Blur",
+    "Blur",
+    [
+        param("radius", "Radius", 0.1, 100.0, 5.0, " px"),
+        param("threshold", "Threshold", 0.1, 100.0, 25.0, ""),
+        choice("mode", "Mode", SMART_MODES, 0)
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Blur everything that is *nearly* the same as its surroundings
+        // and nothing that is not, which flattens skin and skies while
+        // leaving every edge exactly where it was. Photoshop's two other
+        // modes throw the picture away and keep the edges it found, which
+        // is the same computation read the other way round.
+        let radius = v.get("radius").round().max(1.0) as i32;
+        let threshold = v.get("threshold") / 100.0 * 0.6;
+        let mode = (v.get("mode").round().max(0.0) as usize).min(2);
+        let src = px.to_vec();
+        for y in 0..h as i32 {
+            for x in 0..w as i32 {
+                let here = at(&src, w, h, x, y);
+                let mut acc = [0.0f32; 3];
+                let mut n = 0.0f32;
+                for dy in -radius..=radius {
+                    for dx in -radius..=radius {
+                        if dx * dx + dy * dy > radius * radius {
+                            continue;
+                        }
+                        let p = at(&src, w, h, x + dx, y + dy);
+                        // Only neighbours within the threshold count, so
+                        // an edge never averages across itself.
+                        if (0..3).map(|c| (p[c] - here[c]).abs()).fold(0.0, f32::max) > threshold {
+                            continue;
+                        }
+                        for c in 0..3 {
+                            acc[c] += p[c];
+                        }
+                        n += 1.0;
+                    }
+                }
+                let n = n.max(1.0);
+                let smooth = [acc[0] / n, acc[1] / n, acc[2] / n];
+                // How much of the neighbourhood was rejected is exactly
+                // how much of an edge this pixel is on.
+                let area = ((2 * radius + 1) * (2 * radius + 1)) as f32;
+                let edge = (1.0 - n / area).clamp(0.0, 1.0);
+                let out = match mode {
+                    0 => [smooth[0], smooth[1], smooth[2], here[3]],
+                    1 => {
+                        let e = (edge * 2.5).min(1.0);
+                        [e, e, e, here[3]]
+                    }
+                    _ => {
+                        let e = (edge * 2.5).min(1.0);
+                        [
+                            (smooth[0] + e).min(1.0),
+                            (smooth[1] + e).min(1.0),
+                            (smooth[2] + e).min(1.0),
+                            here[3],
+                        ]
+                    }
+                };
+                put(px, w, x as usize, y as usize, out);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    Deinterlace,
+    "filter.deinterlace",
+    "De-Interlace",
+    "Video",
+    [
+        choice("field", "Eliminate", &["Odd Fields", "Even Fields"], 0),
+        choice(
+            "fill",
+            "Create New Fields By",
+            &["Interpolation", "Duplication"],
+            0
+        )
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Interlaced video carries half its lines from one instant and
+        // half from the next, so anything that moved comes out combed.
+        // Throwing one field away and rebuilding it is the fix, and has
+        // been since Photoshop 2.5.
+        let drop_odd = v.get("field") < 0.5;
+        let interpolate = v.get("fill") < 0.5;
+        let src = px.to_vec();
+        for y in 0..h as i32 {
+            if (y % 2 == 1) != drop_odd {
+                continue;
+            }
+            for x in 0..w as i32 {
+                let out = if interpolate {
+                    let above = at(&src, w, h, x, y - 1);
+                    let below = at(&src, w, h, x, y + 1);
+                    [
+                        (above[0] + below[0]) / 2.0,
+                        (above[1] + below[1]) / 2.0,
+                        (above[2] + below[2]) / 2.0,
+                        (above[3] + below[3]) / 2.0,
+                    ]
+                } else {
+                    at(&src, w, h, x, y - 1)
+                };
+                put(px, w, x as usize, y as usize, out);
+            }
+        }
+    }
+);
+
+simple_filter!(
+    NtscColors,
+    "filter.ntsc_colors",
+    "NTSC Colors",
+    "Video",
+    [],
+    |px: &mut [f32], w: usize, h: usize, _v: &FilterValues| {
+        // Television could not carry the corners of the RGB cube: too
+        // bright and the signal clipped, too saturated and the colour
+        // subcarrier bled into the luminance. This is the clamp broadcast
+        // engineers used to insist on, and it is why reds on old
+        // television look orange.
+        let _ = (w, h);
+        for p in px.as_chunks_mut::<4>().0.iter_mut() {
+            // The legal range, 16..235 of 255, and a ceiling on how far
+            // chroma may sit from luma.
+            for v in p.iter_mut().take(3) {
+                *v = 0.0627 + *v * (0.9216 - 0.0627);
+            }
+            let l = luma(p);
+            const MAX_CHROMA: f32 = 0.32;
+            for v in p.iter_mut().take(3) {
+                let c = *v - l;
+                if c.abs() > MAX_CHROMA {
+                    *v = l + c.signum() * MAX_CHROMA;
+                }
+            }
+        }
+    }
+);
+
+pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
+    registry.register_filter(Box::new(FieldBlur));
+    registry.register_filter(Box::new(IrisBlur));
+    registry.register_filter(Box::new(TiltShift));
+    registry.register_filter(Box::new(SpinBlur));
+    registry.register_filter(Box::new(PathBlur));
+    registry.register_filter(Box::new(ShapeBlur));
+    registry.register_filter(Box::new(SmartBlur));
+    registry.register_filter(Box::new(Deinterlace));
+    registry.register_filter(Box::new(NtscColors));
+}

--- a/plugins/filters-core/src/lens.rs
+++ b/plugins/filters-core/src/lens.rs
@@ -1,0 +1,217 @@
+//! Filter ▸ Lens Correction and Adaptive Wide Angle.
+//!
+//! Both undo what a lens did to a picture, and both are the same shape of
+//! operation as [`crate::distort`]: a coordinate remap. What makes them
+//! their own module is that the remap is a *model of an optical system*
+//! rather than an effect -- barrel distortion, the difference in
+//! magnification between red and blue, the falloff at the corners, and
+//! the projection a very wide lens uses.
+//!
+//! Photoshop reads the lens out of the file's EXIF and looks it up in a
+//! profile database. There is no database here, so the sliders are the
+//! profile: point them at a straight line that came out bent and stop
+//! when it is straight.
+
+use crate::util::{luma, premultiply, put, sample, unpremultiply};
+use crate::{choice, param, simple_filter};
+use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
+
+/// Sample one channel through its own coordinate map.
+///
+/// Chromatic aberration is a *difference in magnification* between the
+/// wavelengths, so undoing it means scaling the red and blue channels
+/// about the centre by slightly different amounts -- which is why this
+/// cannot go through the usual whole-pixel warp.
+fn remap_channels(
+    px: &mut [f32],
+    w: usize,
+    h: usize,
+    scales: [f32; 3],
+    map: impl Fn(f32, f32) -> (f32, f32),
+) {
+    premultiply(px);
+    let src = px.to_vec();
+    let (cx, cy) = (w as f32 / 2.0, h as f32 / 2.0);
+    for y in 0..h {
+        for x in 0..w {
+            let (mx, my) = map(x as f32 + 0.5, y as f32 + 0.5);
+            let mut out = [0.0f32; 4];
+            for (c, scale) in scales.iter().enumerate() {
+                let sx = cx + (mx - cx) * scale;
+                let sy = cy + (my - cy) * scale;
+                let p = sample(&src, w, h, sx - 0.5, sy - 0.5);
+                out[c] = p[c];
+                // Alpha follows green, which is the channel that is not
+                // being moved for the fringes.
+                if c == 1 {
+                    out[3] = p[3];
+                }
+            }
+            put(px, w, x, y, out);
+        }
+    }
+    unpremultiply(px);
+}
+
+simple_filter!(
+    LensCorrection,
+    "filter.lens_correction",
+    "Lens Correction",
+    "Other",
+    [
+        param("distortion", "Remove Distortion", -100.0, 100.0, 0.0, ""),
+        param("red", "Fix Red/Cyan Fringe", -50.0, 50.0, 0.0, ""),
+        param("blue", "Fix Blue/Yellow Fringe", -50.0, 50.0, 0.0, ""),
+        param("vignette", "Vignette Amount", -100.0, 100.0, 0.0, ""),
+        param("midpoint", "Vignette Midpoint", 0.0, 100.0, 50.0, ""),
+        param("vertical", "Vertical Perspective", -100.0, 100.0, 0.0, ""),
+        param(
+            "horizontal",
+            "Horizontal Perspective",
+            -100.0,
+            100.0,
+            0.0,
+            ""
+        ),
+        param("angle", "Angle", -180.0, 180.0, 0.0, "\u{b0}"),
+        param("scale", "Scale", 50.0, 200.0, 100.0, "%")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // Everything a lens profile carries, as sliders. Positive
+        // Distortion pulls the corners in, which straightens the barrel
+        // a wide lens leaves; negative pushes them out for pincushion.
+        let distortion = v.get("distortion") / 100.0;
+        let red = 1.0 + v.get("red") / 50.0 * 0.006;
+        let blue = 1.0 + v.get("blue") / 50.0 * 0.006;
+        let vignette = v.get("vignette") / 100.0;
+        let midpoint = (v.get("midpoint") / 100.0).clamp(0.05, 1.0);
+        let vertical = v.get("vertical") / 100.0;
+        let horizontal = v.get("horizontal") / 100.0;
+        let angle = v.get("angle").to_radians();
+        let scale = (v.get("scale") / 100.0).max(0.05);
+        let (cx, cy) = (w as f32 / 2.0, h as f32 / 2.0);
+        let norm = cx.hypot(cy).max(1.0);
+
+        // With every correction at zero the map is the identity, and
+        // resampling an image through the identity is not free: it costs
+        // a premultiply round trip, which flattens the colour under
+        // fully transparent pixels. Leave it alone instead.
+        let corrected = distortion != 0.0
+            || red != 1.0
+            || blue != 1.0
+            || vertical != 0.0
+            || horizontal != 0.0
+            || angle != 0.0
+            || (scale - 1.0).abs() > 1e-6;
+        if corrected {
+            remap_channels(px, w, h, [red, 1.0, blue], |x, y| {
+                // Work in a square-ish space centred on the frame, so the
+                // corrections do not depend on the aspect ratio.
+                let (mut u, mut v) = ((x - cx) / norm, (y - cy) / norm);
+                // Rotation and scale first: they are what the corrections
+                // below are measured against.
+                let (s, c) = angle.sin_cos();
+                let (ru, rv) = (u * c - v * s, u * s + v * c);
+                u = ru / scale;
+                v = rv / scale;
+                // Perspective: divide by a plane tilted away from the
+                // viewer, which is what a keystone correction is.
+                let denom = (1.0 + vertical * v + horizontal * u).max(0.05);
+                u /= denom;
+                v /= denom;
+                // Radial distortion, the usual quadratic term.
+                let r2 = u * u + v * v;
+                let k = 1.0 - distortion * r2 * 0.5;
+                (cx + u * k * norm, cy + v * k * norm)
+            });
+        }
+
+        if vignette != 0.0 {
+            for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+                let (x, y) = ((i % w) as f32 + 0.5, (i / w) as f32 + 0.5);
+                let r = ((x - cx) / norm).hypot((y - cy) / norm);
+                // Nothing happens inside the midpoint; beyond it the
+                // correction ramps up with the square of the distance,
+                // which is roughly how the falloff arrives.
+                let t = ((r - midpoint) / (1.0 - midpoint).max(1e-3)).clamp(0.0, 1.0);
+                let gain = 1.0 + vignette * t * t;
+                for c in p.iter_mut().take(3) {
+                    *c = (*c * gain).clamp(0.0, 1.0);
+                }
+            }
+        }
+    }
+);
+
+/// The projections Adaptive Wide Angle knows how to undo.
+const PROJECTIONS: &[&str] = &["Fisheye", "Perspective", "Full Spherical"];
+
+simple_filter!(
+    AdaptiveWideAngle,
+    "filter.adaptive_wide_angle",
+    "Adaptive Wide Angle",
+    "Other",
+    [
+        choice("projection", "Correction", PROJECTIONS, 0),
+        param("focal", "Focal Length", 4.0, 60.0, 14.0, " mm"),
+        param("crop", "Crop Factor", 0.5, 3.0, 1.0, "\u{d7}"),
+        param("scale", "Scale", 50.0, 200.0, 100.0, "%")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        // A very wide lens does not project the world the way a normal
+        // one does, so straightening it is a change of projection rather
+        // than a polynomial: map each pixel back to the angle it came
+        // from, then re-project that angle rectilinearly.
+        //
+        // Photoshop gets the angle from the lens profile. Here it comes
+        // from the focal length and the crop factor, which is the same
+        // arithmetic every field-of-view calculator does.
+        let projection = (v.get("projection").round().max(0.0) as usize).min(2);
+        let focal = v.get("focal").max(1.0);
+        let crop = v.get("crop").max(0.1);
+        let scale = (v.get("scale") / 100.0).max(0.05);
+        // Half the diagonal field of view, from a 43.3 mm full-frame
+        // diagonal divided by the crop factor.
+        let half_fov = ((43.27 / crop) / (2.0 * focal)).atan();
+        let (cx, cy) = (w as f32 / 2.0, h as f32 / 2.0);
+        let norm = cx.hypot(cy).max(1.0);
+        // How far a ray at the edge of the frame lands under each
+        // projection, so the corrected picture still fills the frame.
+        let edge = match projection {
+            0 => half_fov,
+            1 => half_fov.tan(),
+            _ => 2.0 * (half_fov / 2.0).sin(),
+        };
+        crate::util::warp(px, w, h, |x, y| {
+            let (u, vv) = ((x - cx) / norm / scale, (y - cy) / norm / scale);
+            let r = u.hypot(vv);
+            if r < 1e-6 {
+                return (x, y);
+            }
+            // The angle this output pixel is asking about, rectilinear.
+            let theta = (r * half_fov.tan()).atan();
+            // Where the lens actually put that angle.
+            let rs = match projection {
+                // Equidistant: radius proportional to angle.
+                0 => theta,
+                // Rectilinear already: only the scale changes.
+                1 => theta.tan(),
+                // Equisolid, which is what most fisheyes really are.
+                _ => 2.0 * (theta / 2.0).sin(),
+            } / edge;
+            (cx + u / r * rs * norm, cy + vv / r * rs * norm)
+        });
+    }
+);
+
+/// A quick brightness reading, for the frame and flame filters that want
+/// to sit against the picture rather than on top of it.
+pub fn mean_luma(px: &[f32]) -> f32 {
+    let n = (px.len() / 4).max(1) as f32;
+    px.as_chunks::<4>().0.iter().map(|p| luma(p) / n).sum()
+}
+
+pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
+    registry.register_filter(Box::new(LensCorrection));
+    registry.register_filter(Box::new(AdaptiveWideAngle));
+}

--- a/plugins/filters-core/src/lib.rs
+++ b/plugins/filters-core/src/lib.rs
@@ -12,9 +12,11 @@
 use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues, PluginManifest, PluginRegistry};
 
 pub mod artistic;
+pub mod blurgallery;
 pub mod brush;
 pub mod camera_raw;
 pub mod distort;
+pub mod lens;
 pub mod neural;
 pub mod other;
 pub mod pixelate;
@@ -495,8 +497,10 @@ impl PluginManifest for CoreFiltersPlugin {
         registry.register_filter(Box::new(AddNoise));
         registry.register_filter(Box::new(Median));
         artistic::register(registry);
+        blurgallery::register(registry);
         brush::register(registry);
         camera_raw::register(registry);
+        lens::register(registry);
         neural::register(registry);
         distort::register(registry);
         pixelate::register(registry);

--- a/plugins/filters-core/src/render.rs
+++ b/plugins/filters-core/src/render.rs
@@ -1,6 +1,6 @@
 //! Filter ▸ Render: filters that generate rather than transform.
 
-use crate::util::{at, blur_plane, fbm, luma_map, put};
+use crate::util::{at, blur_plane, fbm, luma_map, put, value_noise};
 use crate::{choice, param, simple_filter};
 use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
 
@@ -268,10 +268,398 @@ simple_filter!(
     }
 );
 
+/// The frame styles this build draws.
+///
+/// Photoshop's Picture Frame is a script with about forty presets built
+/// out of vector art. These five are generated, which means they scale to
+/// any size and there is no art file to ship.
+const FRAME_STYLES: &[&str] = &["Plain", "Beveled", "Matted", "Rounded", "Ornate"];
+
+// Filter ▸ Render ▸ Picture Frame.
+//
+// Draws inside the edges of the selection rather than around them,
+// because a filter cannot make its buffer bigger. That is also how it
+// behaves in Photoshop when you run it on a layer rather than on a new
+// document.
+simple_filter!(
+    PictureFrame,
+    "filter.picture_frame",
+    "Picture Frame",
+    "Render",
+    [
+        choice("style", "Style", FRAME_STYLES, 1),
+        param("width", "Frame Width", 1.0, 40.0, 8.0, "%"),
+        param("tone", "Tone", 0.0, 100.0, 25.0, ""),
+        param("relief", "Relief", 0.0, 100.0, 60.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        let style = (v.get("style").round().max(0.0) as usize).min(FRAME_STYLES.len() - 1);
+        let width = (v.get("width") / 100.0 * w.min(h) as f32).max(1.0);
+        let tone = v.get("tone") / 100.0;
+        let relief = v.get("relief") / 100.0;
+        for y in 0..h {
+            for x in 0..w {
+                // How far inside the frame this pixel is, 0 at the outer
+                // edge and 1 at the inner one. Everything past 1 is the
+                // picture and is left alone.
+                let edge = (x as f32)
+                    .min(y as f32)
+                    .min((w - 1 - x) as f32)
+                    .min((h - 1 - y) as f32);
+                let t = edge / width;
+                if t >= 1.0 {
+                    continue;
+                }
+                // Which way this pixel's bit of moulding faces, so the
+                // light can catch one side of it.
+                let facing = {
+                    let (l, r) = (x as f32, (w - 1 - x) as f32);
+                    let u = y as f32;
+                    let m = edge;
+                    if m == l {
+                        (-1.0, 0.0)
+                    } else if m == r {
+                        (1.0, 0.0)
+                    } else if m == u {
+                        (0.0, -1.0)
+                    } else {
+                        (0.0, 1.0)
+                    }
+                };
+                // The moulding's profile across its width: each style is
+                // a different height field, lit from the upper left.
+                let (height, slope) = match style {
+                    // Plain: flat.
+                    0 => (1.0, 0.0),
+                    // Beveled: a ramp up and a step down at the picture.
+                    1 => (t, 1.0),
+                    // Matted: a wide flat mat with a lip at the opening.
+                    2 => {
+                        if t > 0.75 {
+                            ((t - 0.75) * 4.0, 1.0)
+                        } else {
+                            (0.15, 0.0)
+                        }
+                    }
+                    // Rounded: a half-round moulding.
+                    3 => {
+                        let a = (t * std::f32::consts::PI).sin();
+                        (a, (t * std::f32::consts::PI).cos())
+                    }
+                    // Ornate: rounded with beading cut into it.
+                    _ => {
+                        let a = (t * std::f32::consts::PI).sin();
+                        let bead = (t * 18.0).sin() * 0.12;
+                        (a + bead, (t * std::f32::consts::PI).cos() + bead * 3.0)
+                    }
+                };
+                // Light from the upper left: a face pointing that way is
+                // lit, one pointing away is in shadow.
+                let lit = 1.0 + slope * (facing.0 + facing.1) * -0.5 * relief;
+                let shade = (tone + 0.35) * lit + height * 0.12 * relief;
+                let a = at(px, w, h, x as i32, y as i32)[3];
+                put(
+                    px,
+                    w,
+                    x,
+                    y,
+                    [
+                        shade.clamp(0.0, 1.0),
+                        (shade * 0.94).clamp(0.0, 1.0),
+                        (shade * 0.86).clamp(0.0, 1.0),
+                        a.max(1.0),
+                    ],
+                );
+            }
+        }
+    }
+);
+
+/// One branch waiting to be drawn: where it starts, which way it goes,
+/// how long and how thick it is, and how many splits are left in it.
+struct Branch {
+    x: f32,
+    y: f32,
+    angle: f32,
+    length: f32,
+    thickness: f32,
+    depth: u32,
+}
+
+/// Draw a line of a given thickness into the buffer, darkening as it
+/// goes: bark is not flat, and a tree drawn in one tone looks like a
+/// diagram.
+#[allow(clippy::too_many_arguments)]
+fn limb(px: &mut [f32], w: usize, h: usize, b: &Branch, light: f32, colour: [f32; 3]) {
+    let (dx, dy) = (b.angle.cos(), b.angle.sin());
+    let steps = b.length.max(1.0) as i32;
+    let half = b.thickness.max(1.0) / 2.0;
+    for s in 0..=steps {
+        let t = s as f32 / steps as f32;
+        let (cx, cy) = (b.x + dx * b.length * t, b.y + dy * b.length * t);
+        let r = half * (1.0 - t * 0.35);
+        let ri = r.ceil() as i32;
+        for oy in -ri..=ri {
+            for ox in -ri..=ri {
+                let d = (ox as f32).hypot(oy as f32);
+                if d > r {
+                    continue;
+                }
+                let (ix, iy) = (cx as i32 + ox, cy as i32 + oy);
+                if ix < 0 || iy < 0 || ix >= w as i32 || iy >= h as i32 {
+                    continue;
+                }
+                // Round the limb: the side away from the light is dark.
+                let across = (ox as f32 * dy - oy as f32 * dx) / r.max(1e-3);
+                let shade = 1.0 - (across * light).clamp(-0.8, 0.8) * 0.45;
+                let a = at(px, w, h, ix, iy)[3];
+                put(
+                    px,
+                    w,
+                    ix as usize,
+                    iy as usize,
+                    [
+                        (colour[0] * shade).clamp(0.0, 1.0),
+                        (colour[1] * shade).clamp(0.0, 1.0),
+                        (colour[2] * shade).clamp(0.0, 1.0),
+                        a.max(1.0),
+                    ],
+                );
+            }
+        }
+    }
+}
+
+// Filter ▸ Render ▸ Tree.
+//
+// Photoshop's is a script with a species list; this is the thing under
+// every one of them, which is a recursive branching rule: a trunk splits
+// into two, each of those splits again, shorter and thinner each time,
+// and leaves go on whatever is left at the end.
+//
+// Everything about how it looks is in four numbers -- how far it leans,
+// how much it splits, how fast it thins, and how much randomness is in
+// each -- which is why the species presets are presets rather than
+// different code.
+simple_filter!(
+    Tree,
+    "filter.tree",
+    "Tree",
+    "Render",
+    [
+        param("height", "Branches Height", 20.0, 100.0, 70.0, "%"),
+        param("thickness", "Branches Thickness", 1.0, 100.0, 30.0, ""),
+        param("spread", "Branches Spread", 5.0, 90.0, 32.0, "\u{b0}"),
+        param("leaves", "Leaves Amount", 0.0, 100.0, 70.0, ""),
+        param("size", "Leaves Size", 1.0, 100.0, 40.0, ""),
+        param("light", "Light Direction", -100.0, 100.0, -50.0, ""),
+        param("seed", "Randomness", 0.0, 999.0, 7.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        let trunk = v.get("height") / 100.0 * h as f32 * 0.42;
+        let thickness = v.get("thickness") / 100.0 * (w.min(h) as f32) * 0.06;
+        let spread = v.get("spread").to_radians();
+        let leaves = v.get("leaves") / 100.0;
+        let leaf_size = 1.0 + v.get("size") / 100.0 * (w.min(h) as f32) * 0.03;
+        let light = v.get("light") / 100.0;
+        let seed = v.get("seed") as u32;
+
+        // A hash rather than a generator: a filter has to give the same
+        // tree twice, and the preview runs it on every keystroke.
+        let mut n = 0u32;
+        let mut rand = |lo: f32, hi: f32| {
+            n = n.wrapping_add(1);
+            lo + value_noise(n as f32 * 7.3, (n % 13) as f32 * 3.1, seed) * (hi - lo)
+        };
+
+        let bark = [0.32f32, 0.24, 0.17];
+        let leaf = [0.24f32, 0.45, 0.16];
+        let mut queue = vec![Branch {
+            x: w as f32 / 2.0,
+            y: h as f32,
+            angle: -std::f32::consts::FRAC_PI_2,
+            length: trunk,
+            thickness: thickness.max(1.5),
+            depth: 7,
+        }];
+        let mut tips: Vec<(f32, f32, f32)> = Vec::new();
+        while let Some(b) = queue.pop() {
+            limb(px, w, h, &b, light, bark);
+            let (ex, ey) = (
+                b.x + b.angle.cos() * b.length,
+                b.y + b.angle.sin() * b.length,
+            );
+            if b.depth == 0 || b.length < 3.0 {
+                tips.push((ex, ey, b.thickness));
+                continue;
+            }
+            for side in [-1.0f32, 1.0] {
+                let wobble = rand(-0.35, 0.35);
+                queue.push(Branch {
+                    x: ex,
+                    y: ey,
+                    angle: b.angle + side * spread + wobble * spread,
+                    // Each generation is shorter and thinner, which is
+                    // the whole of why it reads as a tree.
+                    length: b.length * rand(0.62, 0.78),
+                    thickness: b.thickness * 0.7,
+                    depth: b.depth - 1,
+                });
+            }
+        }
+
+        // Leaves cluster at the tips, thinning outwards.
+        if leaves > 0.0 {
+            for (tx, ty, _) in tips.iter() {
+                let count = (leaves * 14.0) as i32;
+                for _ in 0..count {
+                    let a = rand(0.0, std::f32::consts::TAU);
+                    let d = rand(0.0, leaf_size * 2.2);
+                    let (lx, ly) = (tx + a.cos() * d, ty + a.sin() * d);
+                    let r = leaf_size * rand(0.35, 0.8);
+                    let ri = r.ceil() as i32;
+                    let tint = rand(0.75, 1.25);
+                    for oy in -ri..=ri {
+                        for ox in -ri..=ri {
+                            if (ox as f32).hypot(oy as f32) > r {
+                                continue;
+                            }
+                            let (ix, iy) = (lx as i32 + ox, ly as i32 + oy);
+                            if ix < 0 || iy < 0 || ix >= w as i32 || iy >= h as i32 {
+                                continue;
+                            }
+                            let a = at(px, w, h, ix, iy)[3];
+                            put(
+                                px,
+                                w,
+                                ix as usize,
+                                iy as usize,
+                                [
+                                    (leaf[0] * tint).clamp(0.0, 1.0),
+                                    (leaf[1] * tint).clamp(0.0, 1.0),
+                                    (leaf[2] * tint).clamp(0.0, 1.0),
+                                    a.max(1.0),
+                                ],
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+);
+
+// Filter ▸ Render ▸ Flame.
+//
+// Photoshop's runs along a path you drew. A filter never sees the
+// document's paths, so these rise from the bottom of the selection --
+// which is where a fire is -- and the sliders decide how many, how tall
+// and how wild.
+//
+// A flame is drawn the way one behaves: a column of hot gas that rises,
+// narrows, wanders, and cools from white through yellow to red as it
+// goes. Sampling that as a field and colouring by temperature gets much
+// closer than drawing tongues would.
+simple_filter!(
+    Flame,
+    "filter.flame",
+    "Flame",
+    "Render",
+    [
+        param("count", "Flames", 1.0, 24.0, 5.0, ""),
+        param("height", "Length", 10.0, 100.0, 55.0, "%"),
+        param("width", "Width", 5.0, 100.0, 30.0, ""),
+        param("angle", "Angle", -60.0, 60.0, 0.0, "\u{b0}"),
+        param("turbulence", "Turbulent", 0.0, 100.0, 45.0, ""),
+        param("opacity", "Opacity", 0.0, 100.0, 100.0, ""),
+        param("seed", "Randomness", 0.0, 999.0, 3.0, "")
+    ],
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+        let count = v.get("count").round().max(1.0) as usize;
+        let height = v.get("height") / 100.0 * h as f32;
+        let width = v.get("width") / 100.0 * (w as f32 / count as f32) * 0.9;
+        let lean = v.get("angle").to_radians().tan();
+        let turbulence = v.get("turbulence") / 100.0;
+        let opacity = v.get("opacity") / 100.0;
+        let seed = v.get("seed") as u32;
+        if height <= 0.0 || width <= 0.0 || opacity <= 0.0 {
+            return;
+        }
+        for y in 0..h {
+            for x in 0..w {
+                let (fx, fy) = (x as f32, y as f32);
+                // How far up this pixel is inside the flame's own space.
+                let rise = (h as f32 - fy) / height;
+                if !(0.0..=1.0).contains(&rise) {
+                    continue;
+                }
+                let mut heat = 0.0f32;
+                for f in 0..count {
+                    // Where this flame's column is at this height: it
+                    // leans, and it wanders more the higher it goes.
+                    let base = (f as f32 + 0.5) * w as f32 / count as f32;
+                    let wander = (fbm(
+                        fy / (18.0 + 30.0 * (1.0 - turbulence)),
+                        f as f32 * 9.0,
+                        seed,
+                        3,
+                    ) - 0.5)
+                        * turbulence
+                        * width
+                        * 3.0
+                        * rise;
+                    let cx = base + lean * (h as f32 - fy) + wander;
+                    // The column narrows as it rises and dies out at the
+                    // top, which is what gives a flame its shape.
+                    let taper = (1.0 - rise).powf(0.65) * (1.0 - (rise - 0.05).max(0.0) * 0.35);
+                    let reach = (width * taper).max(0.5);
+                    let d = ((fx - cx) / reach).abs();
+                    if d < 1.0 {
+                        // Licks: the flame is not solid, it is torn into
+                        // tongues by the same noise field.
+                        let tongue = fbm(fx / 9.0, (fy - rise * 60.0) / 7.0, seed ^ 0x51ed, 3);
+                        let body = (1.0 - d * d) * (1.0 - rise * 0.85);
+                        heat = heat.max((body * (0.55 + tongue * 0.9)).max(0.0));
+                    }
+                }
+                if heat <= 0.01 {
+                    continue;
+                }
+                // Colour by temperature: white at the heart, then yellow,
+                // then orange, then a red that fades out.
+                let t = heat.min(1.0);
+                let fire = [
+                    (t * 3.0).min(1.0),
+                    (t * 2.0 - 0.35).clamp(0.0, 1.0),
+                    (t * 3.2 - 2.1).clamp(0.0, 1.0),
+                ];
+                let cover = (t * 1.6).min(1.0) * opacity;
+                let p = at(px, w, h, x as i32, y as i32);
+                put(
+                    px,
+                    w,
+                    x,
+                    y,
+                    [
+                        // Screened over what is there: fire adds light.
+                        (p[0] + fire[0] * cover).min(1.0),
+                        (p[1] + fire[1] * cover).min(1.0),
+                        (p[2] + fire[2] * cover).min(1.0),
+                        p[3].max(cover),
+                    ],
+                );
+            }
+        }
+    }
+);
+
 pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
     registry.register_filter(Box::new(Clouds));
     registry.register_filter(Box::new(DifferenceClouds));
     registry.register_filter(Box::new(Fibers));
     registry.register_filter(Box::new(LensFlare));
     registry.register_filter(Box::new(LightingEffects));
+    registry.register_filter(Box::new(PictureFrame));
+    registry.register_filter(Box::new(Tree));
+    registry.register_filter(Box::new(Flame));
 }

--- a/plugins/filters-core/tests/all_filters.rs
+++ b/plugins/filters-core/tests/all_filters.rs
@@ -108,6 +108,11 @@ fn every_filter_does_something_at_its_defaults() {
         "filter.neural.harmonization",
         "filter.neural.landscape_mixer",
         "filter.neural.face_to_caricature",
+        // Lens Correction opens with every correction at zero, because
+        // there is no lens profile to prefill it from and guessing would
+        // be worse than leaving it alone. Photoshop's does the same
+        // without a profile.
+        "filter.lens_correction",
     ];
     let (w, h) = (33usize, 21usize);
     for f in registry().filters() {


### PR DESCRIPTION
Fourteen filters — **115 → 129** — and with them Photoshop's Filter menu has nothing left out.

| where | what | note |
|---|---|---|
| **Blur Gallery** (new) | Field Blur, Iris Blur, Tilt-Shift, Path Blur, Spin Blur | the five that were the biggest remaining hole |
| **Blur** | Shape Blur, Smart Blur | completes the group |
| **Video** (new) | De-Interlace, NTSC Colors | unchanged since Photoshop 2.5, four lines each |
| **Render** | Flame, Picture Frame, Tree | Adobe ships these three as scripts |
| **top level** | Lens Correction, Adaptive Wide Angle | where Photoshop keeps them, next to Liquify |

## The interesting bits

**One blur, five masks.** The Blur Gallery filters are all the same operation — an ordinary blur applied through a mask each one computes for itself — so they share a graded blur of three fixed levels rather than a per-pixel radius. A true variable radius costs the largest radius everywhere and these are lens effects, not measurements; what matters is that the falloff is smooth and the sharp part is genuinely untouched. Three levels rather than one because blending a sharp copy against a single heavily blurred one leaves the middle of a falloff looking like a double exposure.

In Photoshop the pins live on the canvas. A filter here is handed pixels and numbers, so a pin is a pair of position sliders — which is how these filters worked everywhere before the canvas UI arrived.

**Smart Blur's three modes are one computation.** It averages only the neighbours inside its threshold, so an edge never averages across itself. How much of the neighbourhood it *rejected* is exactly how much of an edge the pixel is on — which is what Edge Only and Overlay Edge draw.

**Chromatic aberration cannot use the ordinary warp.** It is a difference in magnification between wavelengths, so undoing it means resampling red and blue about the centre at slightly different scales; `remap_channels` does that, and alpha follows green.

**Adaptive Wide Angle is a change of projection**, not a polynomial: map each output pixel back to the angle it is asking about, find where an equidistant, rectilinear or equisolid lens actually put that angle, and sample there. Photoshop gets the field of view from a profile database; here it comes from focal length and crop factor, which is the same arithmetic every FOV calculator does.

**Tree is the rule under all of Adobe's species presets** — a trunk that splits, shorter and thinner each generation, with leaves clustered on whatever is left at the tips. **Flame** is a temperature field rising, narrowing, wandering and cooling from white through yellow to red; Photoshop's follows a path you drew, and since a filter never sees the document's paths, this one rises from the bottom of the selection.

**Lens Correction opens as a no-op** and is on the test's expected-no-op list for it: with no lens profile to prefill from, guessing would be worse than leaving it alone, which is what Photoshop does without a profile too. It also skips the resample entirely when every slider is at zero — running an image through the identity map is not free, it costs a premultiply round trip that flattens the colour under transparent pixels.

## Checked

- Property tests over all 129: registered, finite and in range, no panic at degenerate sizes, deterministic, and doing something at defaults unless listed.
- A menu cross-check confirms every registered filter is reachable and every menu entry is registered.
- Whole workspace suite green, clippy and rustfmt clean.
- Each new filter eyeballed on a photograph.
- Driven headlessly in the app: the Filter menu now reads Filter Gallery… / Adaptive Wide Angle… / Camera Raw Filter… / Lens Correction… / Liquify / Vanishing Point over sixteen groups, and Tilt-Shift previews live on the canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)