### PR TITLE
Filters read the toolbox, a map file and the active path

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,12 +132,24 @@ Their dialogs match as well, which is most of what makes a filter feel
 like the one you know: Mezzotint's ten screens, Lens Blur's iris shapes,
 Smart Sharpen's choice of which blur it is undoing, Wave's several
 generators, Diffuse's anisotropic mode, Extrude's pyramids, Wind's blast
-and stagger. Where a control cannot exist here it is because a filter is
-handed pixels and numbers and nothing else: no foreground and background
-colours, so the Sketch group draws black on white; no file picker, so
-Displace uses a noise field rather than a map file; no canvas widgets, so
-a blur pin is a pair of position sliders and Flame rises from the bottom
-of the selection rather than following a path.
+and stagger.
+
+And they read the same things Photoshop's read. The Sketch group draws in
+the **foreground and background colours**, as do Clouds, Fibers, Tiles,
+Neon Glow, Colored Pencil's paper and Diffuse Glow's glow — set the
+swatches to sepia and Stamp comes out as a sepia print. **Displace**
+warps through a map you pick from a file, red for horizontal and green
+for vertical, stretched or tiled. **Flame** burns along the active path
+when the document has one. **Lens Blur** can take its depth from the
+layer's transparency or from what is underneath it, so part of the
+picture stays sharp. Harmonization, Colour Transfer and Landscape Mixer
+match against the layer below. Everything a filter needs beyond its own
+pixels is gathered by the host and handed over, which is what
+`FilterPlugin::wants_map`, `wants_path` and `wants_backdrop` are for.
+
+What is left is ergonomic rather than functional: Photoshop puts blur
+pins, light gizmos and flame paths on the canvas, and here they are
+position sliders and the path you already drew.
 
 **Warping.** Liquify with all seven brushes, Puppet Warp (Moving Least
 Squares, so pins hold and nothing shears), Content-Aware Scale (seam

--- a/crates/app/src/dialogs.rs
+++ b/crates/app/src/dialogs.rs
@@ -57,7 +57,8 @@ pub fn render(ws: &mut Workspace, cx: &mut Context<Workspace>) -> Option<gpui::A
             id,
             values,
             preview,
-        } => filter_dialog(ws, &state, id, values, preview, cx).into_any_element(),
+            map,
+        } => filter_dialog(ws, &state, id, values, preview, map, cx).into_any_element(),
         Modal::Adjustment {
             layer,
             params,
@@ -645,7 +646,10 @@ pub(crate) fn param_slider(
             .child(ui::slider_track(
                 id,
                 ratio,
-                120.0,
+                // A choice's name takes the room its track gives up: the
+                // track is only there to step through half a dozen
+                // options, and the name is the part being read.
+                if snap { 92.0 } else { 120.0 },
                 move |ws, r, cx| {
                     let v = min + r * span;
                     set(ws, if snap { v.round() } else { v }, cx)
@@ -654,7 +658,10 @@ pub(crate) fn param_slider(
             ))
             .child(
                 div()
-                    .w(px(56.0))
+                    // A number needs little room; the name of a choice
+                    // needs enough not to wrap "Repeat Edge Pixels" onto
+                    // three lines, which is what it did.
+                    .w(px(if snap { 146.0 } else { 56.0 }))
                     .flex_none()
                     .text_size(px(11.0))
                     .child(display),
@@ -669,6 +676,7 @@ fn filter_dialog(
     id: &'static str,
     values: schist_plugin_api::FilterValues,
     preview: bool,
+    map: Option<std::sync::Arc<schist_plugin_api::FilterImage>>,
     cx: &mut Context<Workspace>,
 ) -> impl IntoElement {
     let (name, specs) = ws
@@ -720,6 +728,51 @@ fn filter_dialog(
             cx,
         ));
     }
+    // A filter that takes an image gets a row to choose one with. This
+    // is Photoshop's "Choose a displacement map" dialog, except that it
+    // opens from inside the filter rather than in front of it, so the
+    // sliders can be set first and the map swapped without starting
+    // over.
+    if let Some(label) = ws
+        .registry
+        .filters()
+        .find(|f| f.id() == id)
+        .and_then(|f| f.wants_map())
+    {
+        let chosen = map
+            .as_ref()
+            .map(|m| format!("{} \u{d7} {}", m.width, m.height))
+            .unwrap_or_else(|| "None".to_string());
+        body = body.child(
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap_2()
+                .py_1()
+                .child(
+                    div()
+                        .w(px(150.0))
+                        .flex_none()
+                        .text_size(px(12.0))
+                        .child(SharedString::from(label)),
+                )
+                .child(
+                    div()
+                        .flex_1()
+                        .text_size(px(11.0))
+                        .text_color(gpui::rgb(ui::palette().text_dim))
+                        .child(SharedString::from(chosen)),
+                )
+                .child(ui::button(
+                    "Choose\u{2026}",
+                    false,
+                    move |ws, window, cx| ws.choose_filter_map(id, window, cx),
+                    cx,
+                )),
+        );
+    }
+
     // Anything the filter wants the user to know before running it --
     // for the neural ones, whether they found their model.
     if let Some(note) = ws

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -597,6 +597,13 @@ pub enum Modal {
         values: schist_plugin_api::FilterValues,
         /// Show the result on the canvas while the dialog is open.
         preview: bool,
+        /// The image picked for a filter that takes one -- Displace's
+        /// map. Kept on the modal because it belongs to this run of the
+        /// dialog and nothing else. Compared by identity: two decodes of
+        /// the same file are the same picture, and comparing a few
+        /// megapixels to find that out would be absurd.
+        #[allow(clippy::type_complexity)]
+        map: Option<Arc<schist_plugin_api::FilterImage>>,
     },
     /// Layer effects for one layer. Boxed because the style is by far the
     /// largest thing any dialog carries.
@@ -2647,7 +2654,15 @@ impl Workspace {
             let Some(filter) = self.registry.filters().find(|f| f.id() == entry.id) else {
                 continue;
             };
-            filter.apply(buf, w, h, &entry.values);
+            // The gallery hands over the toolbox colours and nothing
+            // else: a stack has no one layer to read a backdrop for, and
+            // choosing a map per entry would need a picker per entry.
+            let context = schist_plugin_api::FilterContext {
+                foreground: self.editor.foreground,
+                background: self.editor.background,
+                ..Default::default()
+            };
+            filter.apply_with(buf, w, h, &entry.values, &context);
         }
     }
 
@@ -5060,6 +5075,137 @@ impl Workspace {
         Some(buf)
     }
 
+    /// Pick an image for a filter that takes one, and re-preview with it.
+    ///
+    /// Decoded through the same codecs that open documents -- so a map
+    /// can be a PSD, a PNG, or anything else this build reads -- and
+    /// composited flat, because a filter wants pixels and not a layer
+    /// tree.
+    pub fn choose_filter_map(
+        &mut self,
+        id: &'static str,
+        window: &mut gpui::Window,
+        cx: &mut Context<Self>,
+    ) {
+        let rx = cx.prompt_for_paths(gpui::PathPromptOptions {
+            files: true,
+            directories: false,
+            multiple: false,
+            prompt: Some("Choose".into()),
+        });
+        let codecs = self.registry.shared_codecs();
+        cx.spawn_in(window, async move |this, cx| {
+            let Ok(Ok(Some(mut paths))) = rx.await else {
+                return;
+            };
+            let Some(path) = paths.pop() else { return };
+            let decoded = cx
+                .background_executor()
+                .spawn(async move {
+                    let doc = decode_file(&codecs, &path)?;
+                    let rect = doc.canvas_rect();
+                    anyhow::Ok(schist_plugin_api::FilterImage {
+                        width: rect.width().max(0) as usize,
+                        height: rect.height().max(0) as usize,
+                        pixels: schist_compositor::composite_region_f32(&doc, rect),
+                    })
+                })
+                .await;
+            this.update_in(cx, |ws, _window, cx| {
+                match decoded {
+                    Ok(image) => {
+                        let image = Arc::new(image);
+                        let mut values = None;
+                        ws.update_modal(|m| {
+                            if let Modal::Filter {
+                                map,
+                                values: v,
+                                preview,
+                                ..
+                            } = m
+                            {
+                                *map = Some(image.clone());
+                                if *preview {
+                                    values = Some(v.clone());
+                                }
+                            }
+                        });
+                        if let Some(values) = values {
+                            ws.preview_filter(id, Some(&values), cx);
+                        }
+                    }
+                    Err(e) => ws.status = format!("{e}").into(),
+                }
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    /// The image the open filter dialog has been given, if any.
+    fn filter_map(&self) -> Option<Arc<schist_plugin_api::FilterImage>> {
+        match &self.modal {
+            Some(Modal::Filter { map, .. }) => map.clone(),
+            _ => None,
+        }
+    }
+
+    /// Everything a filter asked for, gathered.
+    ///
+    /// Each piece costs something -- compositing the layers below,
+    /// flattening a path -- so nothing is fetched for a filter that did
+    /// not ask. The colours are free and are always passed: they are two
+    /// numbers the toolbox already has, and half the Sketch group is
+    /// wrong without them.
+    fn filter_context<'a>(
+        &mut self,
+        filter: &dyn schist_plugin_api::FilterPlugin,
+        layer: schist_core::LayerId,
+        region: IntRect,
+        backdrop: &'a mut Option<Vec<f32>>,
+        path: &'a mut Option<Vec<(f32, f32)>>,
+        map: Option<&'a schist_plugin_api::FilterImage>,
+    ) -> schist_plugin_api::FilterContext<'a> {
+        if filter.wants_backdrop() {
+            *backdrop = self.read_backdrop(layer, region);
+        }
+        if filter.wants_path() {
+            *path = self.active_path_points(region);
+        }
+        schist_plugin_api::FilterContext {
+            backdrop: backdrop.as_deref(),
+            foreground: self.editor.foreground,
+            background: self.editor.background,
+            map,
+            path: path.as_deref(),
+        }
+    }
+
+    /// The document's active path, flattened and moved into the filter's
+    /// own coordinates.
+    ///
+    /// A filter works on a region of a layer and knows nothing about
+    /// where that region sits, so the points arrive already relative to
+    /// it -- and points outside it are kept rather than clipped, because
+    /// a curve that leaves the selection and comes back is still one
+    /// curve.
+    fn active_path_points(&self, region: IntRect) -> Option<Vec<(f32, f32)>> {
+        let doc = self.doc.as_ref()?;
+        let path = doc.active_path.and_then(|i| doc.paths.get(i))?;
+        let flat = schist_tools_vector::paths::flatten(path);
+        // Subpaths run together: a filter drawing along the path wants a
+        // list of points, and where one subpath ends and the next begins
+        // is a distinction none of them make.
+        let points: Vec<(f32, f32)> = flat
+            .subpaths
+            .iter()
+            .flat_map(|sub| sub.iter())
+            .map(|(x, y)| (x - region.left as f32, y - region.top as f32))
+            .collect();
+        (points.len() >= 2).then_some(points)
+    }
+
     /// What the document composites to *under* a layer, over a region.
     ///
     /// Produced by hiding the layer and everything above it, compositing,
@@ -5206,18 +5352,20 @@ impl Workspace {
                 preview.region.width() as usize,
                 preview.region.height() as usize,
             );
-            let Some(filter) = self.registry.filters().find(|f| f.id() == id) else {
+            let Some(filter) = self.registry.shared_filter(id) else {
                 return;
             };
-            let backdrop = if filter.wants_backdrop() {
-                self.read_backdrop(preview.layer, preview.region)
-            } else {
-                None
-            };
-            let Some(filter) = self.registry.filters().find(|f| f.id() == id) else {
-                return;
-            };
-            filter.apply_over(&mut buf, backdrop.as_deref(), w, h, values);
+            let map = self.filter_map();
+            let (mut backdrop, mut path) = (None, None);
+            let context = self.filter_context(
+                filter.as_ref(),
+                preview.layer,
+                preview.region,
+                &mut backdrop,
+                &mut path,
+                map.as_deref(),
+            );
+            filter.apply_with(&mut buf, w, h, values, &context);
         }
         self.write_region(
             preview.layer,
@@ -5319,20 +5467,25 @@ impl Workspace {
             .detach();
             return;
         }
-        let backdrop = if filter.wants_backdrop() {
-            self.read_backdrop(layer_id, region)
-        } else {
-            None
-        };
-        let Some(filter) = self.registry.filters().find(|f| f.id() == id) else {
+        let Some(filter) = self.registry.shared_filter(id) else {
             return;
         };
-        filter.apply_over(
+        let map = self.filter_map();
+        let (mut backdrop, mut path) = (None, None);
+        let context = self.filter_context(
+            filter.as_ref(),
+            layer_id,
+            region,
+            &mut backdrop,
+            &mut path,
+            map.as_deref(),
+        );
+        filter.apply_with(
             &mut buf,
-            backdrop.as_deref(),
             region.width() as usize,
             region.height() as usize,
             values,
+            &context,
         );
         // A Photoshop plug-in runs in another process and can refuse, or
         // be cancelled from its own dialog. Recording an edit for a run
@@ -5669,6 +5822,7 @@ impl Workspace {
                 id,
                 values,
                 preview: true,
+                map: None,
             },
             cx,
         );

--- a/crates/plugin-api/src/lib.rs
+++ b/crates/plugin-api/src/lib.rs
@@ -393,6 +393,98 @@ pub struct FilterParam {
     pub choices: &'static [&'static str],
 }
 
+/// An image handed to a filter alongside the layer it is working on.
+///
+/// Straight-alpha RGBA, the same layout as the buffer a filter is given,
+/// but any size: a displacement map is whatever file somebody picked.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct FilterImage {
+    pub width: usize,
+    pub height: usize,
+    pub pixels: Vec<f32>,
+}
+
+impl FilterImage {
+    /// Sample at a fraction of the image, stretching it to whatever it is
+    /// being used over. Photoshop calls this Stretch To Fit.
+    pub fn stretched(&self, u: f32, v: f32) -> [f32; 4] {
+        self.texel(u * self.width as f32, v * self.height as f32)
+    }
+
+    /// Sample in the map's own pixels, repeating it. Photoshop calls this
+    /// Tile.
+    pub fn tiled(&self, x: f32, y: f32) -> [f32; 4] {
+        self.texel(
+            x.rem_euclid(self.width.max(1) as f32),
+            y.rem_euclid(self.height.max(1) as f32),
+        )
+    }
+
+    fn texel(&self, x: f32, y: f32) -> [f32; 4] {
+        if self.width == 0 || self.height == 0 {
+            return [0.0; 4];
+        }
+        let x = (x as usize).min(self.width - 1);
+        let y = (y as usize).min(self.height - 1);
+        let i = (y * self.width + x) * 4;
+        [
+            self.pixels[i],
+            self.pixels[i + 1],
+            self.pixels[i + 2],
+            self.pixels[i + 3],
+        ]
+    }
+}
+
+/// Everything a filter can be given beyond its own pixels and numbers.
+///
+/// Photoshop's filters read the toolbox and the open document as freely
+/// as they read the layer: the Sketch group paints in the foreground and
+/// background colours, Clouds renders in them, Displace warps through a
+/// file somebody picked, Flame follows the current path. A filter here is
+/// a plug-in with none of that in reach, so the host gathers whatever
+/// each one asks for and hands it over.
+#[derive(Clone, Copy)]
+pub struct FilterContext<'a> {
+    /// What the document composites to under the layer being filtered.
+    pub backdrop: Option<&'a [f32]>,
+    /// The toolbox's two colours.
+    pub foreground: Rgba,
+    pub background: Rgba,
+    /// The image picked for this run, for filters that take one.
+    pub map: Option<&'a FilterImage>,
+    /// The document's active path, flattened into the filter's own
+    /// coordinates.
+    pub path: Option<&'a [(f32, f32)]>,
+}
+
+impl Default for FilterContext<'_> {
+    fn default() -> Self {
+        FilterContext {
+            backdrop: None,
+            // The swatches a fresh Photoshop opens with, and what every
+            // one of these filters is pictured with.
+            foreground: Rgba::BLACK,
+            background: Rgba::WHITE,
+            map: None,
+            path: None,
+        }
+    }
+}
+
+impl FilterContext<'_> {
+    /// The foreground as a plain array, which is what a filter mixing
+    /// colours wants.
+    pub fn fg(&self) -> [f32; 3] {
+        [self.foreground.r, self.foreground.g, self.foreground.b]
+    }
+
+    /// The background, likewise.
+    pub fn bg(&self) -> [f32; 3] {
+        [self.background.r, self.background.g, self.background.b]
+    }
+}
+
 /// Parameter values keyed by [`FilterParam::key`].
 #[derive(Debug, Clone, Default, PartialEq)]
 pub struct FilterValues(pub Vec<(&'static str, f32)>);
@@ -437,30 +529,43 @@ pub trait FilterPlugin: Send + Sync {
     ///
     /// Most do not: a filter is a function of its own pixels. The ones
     /// that match one image to another -- Harmonization, Colour
-    /// Transfer -- need something to match *to*, and the only second
-    /// image a filter dialog can offer without a file picker is the one
-    /// already in the document. Photoshop's Harmonization asks for a
-    /// layer the same way.
+    /// Transfer -- need something to match *to*, and the nearest thing
+    /// to hand is what the document composites to below. Photoshop's
+    /// Harmonization asks for a layer the same way.
     fn wants_backdrop(&self) -> bool {
         false
     }
 
-    /// Apply with the pixels underneath the layer, when the host has
-    /// them.
+    /// The label of the image this filter takes, if it takes one.
     ///
-    /// `backdrop` is the same size as `pixels` and is what the document
-    /// composites to under this layer, or `None` when there is nothing
-    /// below or the host cannot produce one. The default ignores it,
-    /// which is right for every filter that did not ask.
-    fn apply_over(
+    /// Displace warps through a map somebody chose from a file, and
+    /// Photoshop asks for it with a file dialog before the filter runs.
+    /// Returning a label here is what makes the host offer one.
+    fn wants_map(&self) -> Option<&'static str> {
+        None
+    }
+
+    /// Whether this filter wants the document's active path.
+    ///
+    /// Flame draws along one. A filter cannot reach into the document,
+    /// so the host flattens the path and passes the points.
+    fn wants_path(&self) -> bool {
+        false
+    }
+
+    /// Apply with everything the host was able to gather.
+    ///
+    /// The default ignores the context, which is right for every filter
+    /// that asked for nothing -- most of them.
+    fn apply_with(
         &self,
         pixels: &mut [f32],
-        backdrop: Option<&[f32]>,
         width: usize,
         height: usize,
         values: &FilterValues,
+        context: &FilterContext,
     ) {
-        let _ = backdrop;
+        let _ = context;
         self.apply(pixels, width, height, values);
     }
 

--- a/plugins/filters-core/src/artistic.rs
+++ b/plugins/filters-core/src/artistic.rs
@@ -17,8 +17,8 @@ use crate::util::{
     at, blur_plane, edges, flatten_colour, from_luma, gaussian_rgba, luma, luma_map, put, sample,
     streak, surface, value_noise,
 };
-use crate::{choice, param, simple_filter};
-use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
+use crate::{choice, context_filter, param, simple_filter};
+use schist_plugin_api::{FilterContext, FilterParam, FilterPlugin, FilterValues};
 
 /// Flatten an image into regions a brush could have painted.
 ///
@@ -69,7 +69,7 @@ fn flatten(px: &mut [f32], w: usize, h: usize, radius: f32, tolerance: f32) {
     }
 }
 
-simple_filter!(
+context_filter!(
     ColoredPencil,
     "filter.colored_pencil",
     "Colored Pencil",
@@ -79,10 +79,12 @@ simple_filter!(
         param("pressure", "Stroke Pressure", 0.0, 15.0, 8.0, ""),
         param("paper", "Paper Brightness", 0.0, 50.0, 25.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // Crosshatched pencil: the edges become strokes, the paper shows
         // through everywhere else, and the hatching runs at a fixed
-        // diagonal the way a right-handed hand draws it.
+        // diagonal the way a right-handed hand draws it. The paper is
+        // the background colour, which is what Photoshop's Paper
+        // Brightness is brightening.
         let width = v.get("width").max(1.0);
         let pressure = v.get("pressure") / 15.0;
         let paper = v.get("paper") / 50.0;
@@ -103,8 +105,17 @@ simple_filter!(
                 out[i] = (drawn * (0.75 + paper * 0.25)).clamp(0.0, 1.0);
             }
         }
-        // A pencil keeps a little of the subject's colour, not all of it.
+        // A pencil keeps a little of the subject's colour, not all of
+        // it -- and lays it on paper of the background colour.
         from_luma(px, &out, 0.35);
+        let paper = ctx.bg();
+        for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+            // Where the pencil did not press, the sheet shows through.
+            let bare = out[i].clamp(0.0, 1.0);
+            for c in 0..3 {
+                p[c] = (p[c] * (1.0 - bare) + paper[c] * bare).clamp(0.0, 1.0);
+            }
+        }
     }
 );
 
@@ -231,29 +242,22 @@ simple_filter!(
     }
 );
 
-simple_filter!(
+context_filter!(
     NeonGlow,
     "filter.neon_glow",
     "Neon Glow",
     "Artistic",
     [
         param("size", "Glow Size", 1.0, 24.0, 5.0, ""),
-        param("brightness", "Glow Brightness", 0.0, 50.0, 15.0, ""),
-        param("hue", "Glow Colour", 0.0, 360.0, 200.0, "\u{b0}")
+        param("brightness", "Glow Brightness", 0.0, 50.0, 15.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // The image collapses to a dark ghost of itself and its edges
-        // light up in one colour. Photoshop takes the colour from the
-        // colour picker; there is no picker in a filter dialog, so it is
-        // a hue here.
+        // light up in one colour -- the foreground, which is where
+        // Photoshop's Glow Color well takes it from.
         let size = v.get("size");
         let brightness = v.get("brightness") / 50.0;
-        let hue = v.get("hue").to_radians();
-        let glow_rgb = [
-            (hue.cos() * 0.5 + 0.5).clamp(0.0, 1.0),
-            ((hue - 2.094).cos() * 0.5 + 0.5).clamp(0.0, 1.0),
-            ((hue + 2.094).cos() * 0.5 + 0.5).clamp(0.0, 1.0),
-        ];
+        let glow_rgb = ctx.fg();
         let plane = luma_map(px, w, h);
         let mut glow = edges(&plane, w, h);
         blur_plane(&mut glow, w, h, size);

--- a/plugins/filters-core/src/distort.rs
+++ b/plugins/filters-core/src/distort.rs
@@ -2,8 +2,8 @@
 //! [`warp`], so they differ only in the mapping.
 
 use crate::util::{blur_plane, fbm, luma, surface, value_noise, warp};
-use crate::{choice, param, simple_filter};
-use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
+use crate::{choice, context_filter, param, simple_filter};
+use schist_plugin_api::{FilterContext, FilterParam, FilterPlugin, FilterValues};
 
 simple_filter!(
     Twirl,
@@ -310,38 +310,94 @@ simple_filter!(
     }
 );
 
-simple_filter!(
-    Displace,
-    "filter.displace",
-    "Displace",
-    "Distort",
-    [
-        param("scale", "Horizontal Scale", 0.0, 200.0, 20.0, " px"),
-        param("vscale", "Vertical Scale", 0.0, 200.0, 20.0, " px"),
-        param("detail", "Detail", 1.0, 64.0, 16.0, " px"),
-        param("seed", "Randomness", 0.0, 999.0, 1.0, ""),
-        choice(
-            "undefined",
-            "Undefined Areas",
-            &["Repeat Edge Pixels", "Wrap Around"],
-            0
+/// How a map that is not the layer's size gets used.
+const MAP_FIT: &[&str] = &["Stretch To Fit", "Tile"];
+
+/// What happens where the displacement sends a pixel off the edge.
+const MAP_UNDEFINED: &[&str] = &["Repeat Edge Pixels", "Wrap Around"];
+
+/// Filter ▸ Distort ▸ Displace.
+///
+/// Photoshop reads the displacement out of a file you pick: the red
+/// channel moves each pixel horizontally, the green channel vertically,
+/// with mid grey meaning "stay". That is exactly what this does when it
+/// is given a map -- the dialog has a Choose button for it -- and when
+/// it is not, it falls back to a noise field of its own, which is what
+/// the filter is most often used for anyway.
+pub struct Displace;
+
+impl FilterPlugin for Displace {
+    fn id(&self) -> &'static str {
+        "filter.displace"
+    }
+    fn name(&self) -> &'static str {
+        "Displace"
+    }
+    fn category(&self) -> &'static str {
+        "Distort"
+    }
+    fn params(&self) -> Vec<FilterParam> {
+        vec![
+            param("scale", "Horizontal Scale", 0.0, 200.0, 20.0, " px"),
+            param("vscale", "Vertical Scale", 0.0, 200.0, 20.0, " px"),
+            param("detail", "Detail", 1.0, 64.0, 16.0, " px"),
+            param("seed", "Randomness", 0.0, 999.0, 1.0, ""),
+            choice("fit", "Map Fit", MAP_FIT, 0),
+            choice("undefined", "Undefined Areas", MAP_UNDEFINED, 0),
+        ]
+    }
+
+    fn wants_map(&self) -> Option<&'static str> {
+        Some("Displacement Map")
+    }
+
+    fn info(&self) -> Option<String> {
+        Some(
+            "With no map chosen this displaces through a noise field of \
+             its own; Detail and Randomness shape it."
+                .to_string(),
         )
-    ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
-        // Photoshop displaces through a separate map file, chosen from a
-        // file picker a filter does not have. This uses its own noise
-        // field instead, with the same two scales and the same choice
-        // about what happens at the edges.
-        let scale = v.get("scale");
-        let vscale = v.get("vscale");
-        let detail = v.get("detail").max(1.0);
-        let seed = v.get("seed") as u32;
-        let wrap = v.get("undefined") >= 0.5;
-        let (ww, hh) = (w as f32, h as f32);
-        warp(px, w, h, move |x, y| {
-            let u = fbm(x / detail, y / detail, 11 + seed, 3) - 0.5;
-            let vv = fbm(x / detail + 37.0, y / detail - 19.0, 23 + seed, 3) - 0.5;
-            let (sx, sy) = (x + u * scale * 2.0, y + vv * vscale * 2.0);
+    }
+
+    fn apply(&self, px: &mut [f32], width: usize, height: usize, values: &FilterValues) {
+        self.apply_with(px, width, height, values, &FilterContext::default());
+    }
+
+    fn apply_with(
+        &self,
+        px: &mut [f32],
+        width: usize,
+        height: usize,
+        values: &FilterValues,
+        context: &FilterContext,
+    ) {
+        let scale = values.get("scale");
+        let vscale = values.get("vscale");
+        let detail = values.get("detail").max(1.0);
+        let seed = values.get("seed") as u32;
+        let tile = values.get("fit") >= 0.5;
+        let wrap = values.get("undefined") >= 0.5;
+        let (ww, hh) = (width as f32, height as f32);
+        let map = context.map;
+        warp(px, width, height, move |x, y| {
+            let (u, v) = match map {
+                // Photoshop's convention, and every displacement map
+                // ever drawn for it: red is horizontal, green is
+                // vertical, and mid grey is no movement at all.
+                Some(map) => {
+                    let p = if tile {
+                        map.tiled(x, y)
+                    } else {
+                        map.stretched(x / ww, y / hh)
+                    };
+                    (p[0] - 0.5, p[1] - 0.5)
+                }
+                None => (
+                    fbm(x / detail, y / detail, 11 + seed, 3) - 0.5,
+                    fbm(x / detail + 37.0, y / detail - 19.0, 23 + seed, 3) - 0.5,
+                ),
+            };
+            let (sx, sy) = (x + u * scale * 2.0, y + v * vscale * 2.0);
             if wrap {
                 (sx.rem_euclid(ww), sy.rem_euclid(hh))
             } else {
@@ -349,15 +405,9 @@ simple_filter!(
             }
         });
     }
-);
+}
 
-// The three Distort effects that live in the Filter Gallery rather than
-// in the Filter menu. They are distortions in the same sense as the rest
-// of this module -- Glass and Ocean Ripple are coordinate remaps -- with
-// the exception of Diffuse Glow, which Adobe filed here because it is
-// what happens when you distort *light* instead of position.
-
-simple_filter!(
+context_filter!(
     DiffuseGlow,
     "filter.diffuse_glow",
     "Diffuse Glow",
@@ -367,11 +417,13 @@ simple_filter!(
         param("glow", "Glow Amount", 0.0, 20.0, 10.0, ""),
         param("clear", "Clear Amount", 0.0, 20.0, 15.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // Light bleeding out of the highlights through a grainy diffusion
         // filter, which is what a stocking over the lens does. Clear
         // Amount is the threshold: below it nothing glows, which is what
-        // keeps the shadows from fogging.
+        // keeps the shadows from fogging. The glow is the background
+        // colour, as Photoshop's is -- white by default, which is why
+        // nobody notices until they change it.
         let graininess = v.get("graininess") / 10.0;
         let glow = v.get("glow") / 20.0;
         let clear = v.get("clear") / 20.0;
@@ -385,11 +437,13 @@ simple_filter!(
         for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
             let (x, y) = ((i % w) as f32, (i / w) as f32);
             let grain = (value_noise(x, y, 5237) - 0.5) * graininess * 0.35;
-            let lift = (bright[i] * (0.6 + glow * 2.0) + grain).max(0.0);
-            for v in p.iter_mut().take(3) {
-                // Screened towards white rather than added, so the glow
-                // saturates the way light does instead of clipping.
-                *v = (1.0 - (1.0 - *v) * (1.0 - lift.min(1.0))).clamp(0.0, 1.0);
+            let lift = (bright[i] * (0.6 + glow * 2.0) + grain).clamp(0.0, 1.0);
+            let colour = ctx.bg();
+            for (c, v) in p.iter_mut().take(3).enumerate() {
+                // Screened towards the glow colour rather than added, so
+                // the light saturates the way light does instead of
+                // clipping.
+                *v = (colour[c] - (colour[c] - *v) * (1.0 - lift)).clamp(0.0, 1.0);
             }
         }
     }

--- a/plugins/filters-core/src/lib.rs
+++ b/plugins/filters-core/src/lib.rs
@@ -105,6 +105,66 @@ macro_rules! simple_filter {
     };
 }
 
+/// The same, for a filter that reads its
+/// [`FilterContext`](schist_plugin_api::FilterContext) -- the toolbox
+/// colours, a chosen image, the active path.
+///
+/// The body takes one more argument than [`simple_filter`]'s does. Run
+/// with no host to gather a context -- from a test, or a plug-in host
+/// that predates the idea -- it gets the default one, which is black on
+/// white and nothing else, and that is what these filters were pictured
+/// with anyway.
+#[macro_export]
+macro_rules! context_filter {
+    ($ty:ident, $id:expr, $name:expr, $category:expr, [$($param:expr),* $(,)?], $body:expr) => {
+        pub struct $ty;
+
+        impl FilterPlugin for $ty {
+            fn id(&self) -> &'static str {
+                $id
+            }
+            fn name(&self) -> &'static str {
+                $name
+            }
+            fn category(&self) -> &'static str {
+                $category
+            }
+            fn params(&self) -> Vec<FilterParam> {
+                vec![$($param),*]
+            }
+            fn apply(
+                &self,
+                pixels: &mut [f32],
+                width: usize,
+                height: usize,
+                values: &FilterValues,
+            ) {
+                self.apply_with(
+                    pixels,
+                    width,
+                    height,
+                    values,
+                    &schist_plugin_api::FilterContext::default(),
+                )
+            }
+            fn apply_with(
+                &self,
+                pixels: &mut [f32],
+                width: usize,
+                height: usize,
+                values: &FilterValues,
+                context: &schist_plugin_api::FilterContext,
+            ) {
+                if width == 0 || height == 0 {
+                    return;
+                }
+                #[allow(clippy::redundant_closure_call)]
+                ($body)(pixels, width, height, values, context)
+            }
+        }
+    };
+}
+
 use schist_fx::{gaussian_rgba as gaussian_blur, premultiply, unpremultiply};
 
 pub struct GaussianBlur;

--- a/plugins/filters-core/src/neural.rs
+++ b/plugins/filters-core/src/neural.rs
@@ -33,7 +33,7 @@ use std::sync::{Arc, Mutex};
 use crate::util::{at, gaussian_rgba, luma, put, sample, warp};
 use crate::{choice, param, simple_filter};
 use schist_neural::Face;
-use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
+use schist_plugin_api::{FilterContext, FilterParam, FilterPlugin, FilterValues};
 
 /// Copy the RGB of a filter buffer out, run `f` on it, and blend the
 /// result back. Models work on RGB; the filter buffer is RGBA.
@@ -718,17 +718,18 @@ impl FilterPlugin for ColorTransfer {
     }
 
     fn apply(&self, px: &mut [f32], width: usize, height: usize, values: &FilterValues) {
-        self.apply_over(px, None, width, height, values);
+        self.apply_with(px, width, height, values, &FilterContext::default());
     }
 
-    fn apply_over(
+    fn apply_with(
         &self,
         px: &mut [f32],
-        backdrop: Option<&[f32]>,
         width: usize,
         height: usize,
         values: &FilterValues,
+        context: &FilterContext,
     ) {
+        let backdrop = context.backdrop;
         if width == 0 || height == 0 {
             return;
         }
@@ -1013,17 +1014,18 @@ impl FilterPlugin for Harmonization {
     }
 
     fn apply(&self, px: &mut [f32], width: usize, height: usize, values: &FilterValues) {
-        self.apply_over(px, None, width, height, values);
+        self.apply_with(px, width, height, values, &FilterContext::default());
     }
 
-    fn apply_over(
+    fn apply_with(
         &self,
         px: &mut [f32],
-        backdrop: Option<&[f32]>,
         width: usize,
         height: usize,
         values: &FilterValues,
+        context: &FilterContext,
     ) {
+        let backdrop = context.backdrop;
         if width == 0 || height == 0 {
             return;
         }
@@ -1119,17 +1121,18 @@ impl FilterPlugin for LandscapeMixer {
     }
 
     fn apply(&self, px: &mut [f32], width: usize, height: usize, values: &FilterValues) {
-        self.apply_over(px, None, width, height, values);
+        self.apply_with(px, width, height, values, &FilterContext::default());
     }
 
-    fn apply_over(
+    fn apply_with(
         &self,
         px: &mut [f32],
-        backdrop: Option<&[f32]>,
         width: usize,
         height: usize,
         values: &FilterValues,
+        context: &FilterContext,
     ) {
+        let backdrop = context.backdrop;
         if width == 0 || height == 0 {
             return;
         }

--- a/plugins/filters-core/src/other.rs
+++ b/plugins/filters-core/src/other.rs
@@ -4,8 +4,8 @@
 use crate::util::{
     at, convolve3, gaussian_rgba, luma, premultiply, put, sample, unpremultiply, value_noise,
 };
-use crate::{choice, param, simple_filter};
-use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
+use crate::{choice, context_filter, param, simple_filter};
+use schist_plugin_api::{FilterContext, FilterParam, FilterPlugin, FilterValues};
 
 simple_filter!(
     HighPass,
@@ -303,7 +303,10 @@ const IRIS_SHAPES: &[&str] = &[
 /// off it and the filter takes its own path.
 const FX_THRESHOLD: f32 = 0.75;
 
-simple_filter!(
+/// Where Lens Blur reads its depth from, which decides what stays sharp.
+const DEPTH_SOURCES: &[&str] = &["None", "Transparency", "Layer Below"];
+
+context_filter!(
     LensBlur,
     "filter.lens_blur",
     "Lens Blur",
@@ -315,9 +318,12 @@ simple_filter!(
         param("rotation", "Rotation", 0.0, 360.0, 0.0, "\u{b0}"),
         param("brightness", "Specular Brightness", 0.0, 100.0, 0.0, ""),
         param("threshold", "Specular Threshold", 0.0, 100.0, 75.0, ""),
-        param("noise", "Noise", 0.0, 100.0, 0.0, "")
+        param("noise", "Noise", 0.0, 100.0, 0.0, ""),
+        choice("depth", "Depth Map", DEPTH_SOURCES, 0),
+        param("focal", "Blur Focal Distance", 0.0, 100.0, 0.0, ""),
+        param("invert_depth", "Invert Depth Map", 0.0, 1.0, 0.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // A flat kernel rather than a Gaussian, which is what makes
         // out-of-focus highlights come out as discs instead of smears --
         // and, at radius 60, eleven thousand taps a pixel.
@@ -333,6 +339,9 @@ simple_filter!(
         // shared blur implements -- and the one the GPU knows -- so the
         // default settings stay on the fast path. Anything else is a
         // different kernel and runs here.
+        // Kept for the depth map below, which needs the picture as it
+        // was to hold anything back at.
+        let sharp = px.to_vec();
         if blades == 0 && curvature <= 0.0 && (threshold - FX_THRESHOLD).abs() < 0.01 {
             schist_fx::lens_blur_rgba(px, w, h, radius, boost);
         } else {
@@ -387,6 +396,35 @@ simple_filter!(
                 }
             }
             unpremultiply(px);
+        }
+
+        // A depth map holds part of the picture back at its original
+        // sharpness: everything at the focal distance stays, everything
+        // away from it takes the blur. Photoshop reads the map from a
+        // channel or a layer mask; the two sources a filter can reach
+        // are the layer's own transparency and whatever is underneath
+        // it.
+        let source = (v.get("depth").round().max(0.0) as usize).min(2);
+        if source > 0 {
+            let focal = v.get("focal") / 100.0;
+            let invert = v.get("invert_depth") >= 0.5;
+            let depth: Option<Vec<f32>> = match source {
+                1 => Some(sharp.as_chunks::<4>().0.iter().map(|p| p[3]).collect()),
+                _ => ctx
+                    .backdrop
+                    .map(|b| b.as_chunks::<4>().0.iter().map(|p| luma(p)).collect()),
+            };
+            if let Some(depth) = depth {
+                for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+                    let d = if invert { 1.0 - depth[i] } else { depth[i] };
+                    // In focus at the focal distance, blurred away from
+                    // it -- the same reading Depth Blur gives its map.
+                    let keep = 1.0 - (d - focal).abs().min(1.0);
+                    for c in 0..4 {
+                        p[c] += (sharp[i * 4 + c] - p[c]) * keep;
+                    }
+                }
+            }
         }
 
         // Grain, added last: a lens blur is the one place a picture ends

--- a/plugins/filters-core/src/render.rs
+++ b/plugins/filters-core/src/render.rs
@@ -1,10 +1,10 @@
 //! Filter ▸ Render: filters that generate rather than transform.
 
 use crate::util::{at, blur_plane, fbm, luma_map, put, value_noise};
-use crate::{choice, param, simple_filter};
-use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
+use crate::{choice, context_filter, param, simple_filter};
+use schist_plugin_api::{FilterContext, FilterParam, FilterPlugin, FilterValues};
 
-simple_filter!(
+context_filter!(
     Clouds,
     "filter.clouds",
     "Clouds",
@@ -14,24 +14,35 @@ simple_filter!(
         param("detail", "Detail", 1.0, 8.0, 5.0, ""),
         param("seed", "Seed", 0.0, 999.0, 1.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
-        // Photoshop draws clouds in the foreground and background colours;
-        // filters do not see those, so this renders greyscale, which is
-        // what Clouds is used as a source for anyway.
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
+        // Rendered between the foreground and background colours, which
+        // is what makes Clouds a sky rather than a grey field.
         let scale = v.get("scale").max(4.0);
         let octaves = v.get("detail").max(1.0) as u32;
         let seed = v.get("seed") as u32;
+        let (fg, bg) = (ctx.fg(), ctx.bg());
         for y in 0..h {
             for x in 0..w {
                 let n = fbm(x as f32 / scale, y as f32 / scale, seed, octaves);
                 let a = at(px, w, h, x as i32, y as i32)[3];
-                put(px, w, x, y, [n, n, n, a.max(1.0)]);
+                put(
+                    px,
+                    w,
+                    x,
+                    y,
+                    [
+                        fg[0] + (bg[0] - fg[0]) * n,
+                        fg[1] + (bg[1] - fg[1]) * n,
+                        fg[2] + (bg[2] - fg[2]) * n,
+                        a.max(1.0),
+                    ],
+                );
             }
         }
     }
 );
 
-simple_filter!(
+context_filter!(
     DifferenceClouds,
     "filter.difference_clouds",
     "Difference Clouds",
@@ -41,15 +52,22 @@ simple_filter!(
         param("detail", "Detail", 1.0, 8.0, 5.0, ""),
         param("seed", "Seed", 0.0, 999.0, 1.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // Same field, differenced against what is already there, which is
         // what gives the veined look when applied repeatedly.
         let scale = v.get("scale").max(4.0);
         let octaves = v.get("detail").max(1.0) as u32;
         let seed = v.get("seed") as u32;
+        let (fg, bg) = (ctx.fg(), ctx.bg());
         for y in 0..h {
             for x in 0..w {
-                let n = fbm(x as f32 / scale, y as f32 / scale, seed, octaves);
+                let t = fbm(x as f32 / scale, y as f32 / scale, seed, octaves);
+                let n = crate::util::luma(&[
+                    fg[0] + (bg[0] - fg[0]) * t,
+                    fg[1] + (bg[1] - fg[1]) * t,
+                    fg[2] + (bg[2] - fg[2]) * t,
+                    1.0,
+                ]);
                 let p = at(px, w, h, x as i32, y as i32);
                 put(
                     px,
@@ -63,7 +81,7 @@ simple_filter!(
     }
 );
 
-simple_filter!(
+context_filter!(
     Fibers,
     "filter.fibers",
     "Fibers",
@@ -73,18 +91,31 @@ simple_filter!(
         param("strength", "Strength", 1.0, 64.0, 4.0, ""),
         param("seed", "Randomize", 0.0, 999.0, 0.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
-        // Vertical streaks: noise that varies fast across and slowly down.
-        // Photoshop's Randomize is a button that reseeds; a filter has to
-        // be a function of its settings, so it is a number here.
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
+        // Vertical streaks between the two colours: noise that varies
+        // fast across and slowly down. Photoshop's Randomize is a button
+        // that reseeds; a filter has to be a function of its settings, so
+        // it is a number here.
         let variance = v.get("variance").max(1.0);
         let strength = v.get("strength").max(1.0);
         let seed = 977 + v.get("seed") as u32;
+        let (fg, bg) = (ctx.fg(), ctx.bg());
         for y in 0..h {
             for x in 0..w {
                 let n = fbm(x as f32 * variance / 16.0, y as f32 / strength, seed, 4);
                 let a = at(px, w, h, x as i32, y as i32)[3];
-                put(px, w, x, y, [n, n, n, a.max(1.0)]);
+                put(
+                    px,
+                    w,
+                    x,
+                    y,
+                    [
+                        fg[0] + (bg[0] - fg[0]) * n,
+                        fg[1] + (bg[1] - fg[1]) * n,
+                        fg[2] + (bg[2] - fg[2]) * n,
+                        a.max(1.0),
+                    ],
+                );
             }
         }
     }
@@ -588,46 +619,149 @@ simple_filter!(
 // narrows, wanders, and cools from white through yellow to red as it
 // goes. Sampling that as a field and colouring by temperature gets much
 // closer than drawing tongues would.
-simple_filter!(
-    Flame,
-    "filter.flame",
-    "Flame",
-    "Render",
-    [
-        param("count", "Flames", 1.0, 24.0, 5.0, ""),
-        param("height", "Length", 10.0, 100.0, 55.0, "%"),
-        param("width", "Width", 5.0, 100.0, 30.0, ""),
-        param("angle", "Angle", -60.0, 60.0, 0.0, "\u{b0}"),
-        param("turbulence", "Turbulent", 0.0, 100.0, 45.0, ""),
-        param("opacity", "Opacity", 0.0, 100.0, 100.0, ""),
-        param("seed", "Randomness", 0.0, 999.0, 3.0, "")
-    ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+/// Filter ▸ Render ▸ Flame.
+///
+/// Photoshop's runs along a path you drew, and so does this one when the
+/// document has an active path: the host flattens it and hands over the
+/// points. With no path the flames rise from the bottom of the
+/// selection, which is where a fire is.
+///
+/// A flame is drawn the way one behaves: a column of hot gas that rises,
+/// narrows, wanders, and cools from white through yellow to red as it
+/// goes. Sampling that as a field and colouring by temperature gets much
+/// closer than drawing tongues would.
+pub struct Flame;
+
+impl FilterPlugin for Flame {
+    fn id(&self) -> &'static str {
+        "filter.flame"
+    }
+    fn name(&self) -> &'static str {
+        "Flame"
+    }
+    fn category(&self) -> &'static str {
+        "Render"
+    }
+    fn params(&self) -> Vec<FilterParam> {
+        vec![
+            param("count", "Flames", 1.0, 24.0, 5.0, ""),
+            param("height", "Length", 10.0, 100.0, 55.0, "%"),
+            param("width", "Width", 5.0, 100.0, 30.0, ""),
+            param("angle", "Angle", -60.0, 60.0, 0.0, "\u{b0}"),
+            param("turbulence", "Turbulent", 0.0, 100.0, 45.0, ""),
+            param("opacity", "Opacity", 0.0, 100.0, 100.0, ""),
+            param("seed", "Randomness", 0.0, 999.0, 3.0, ""),
+        ]
+    }
+
+    fn wants_path(&self) -> bool {
+        true
+    }
+
+    fn info(&self) -> Option<String> {
+        Some(
+            "Burns along the active path when there is one, and up from \
+             the bottom of the selection when there is not."
+                .to_string(),
+        )
+    }
+
+    fn apply(&self, px: &mut [f32], width: usize, height: usize, values: &FilterValues) {
+        self.apply_with(px, width, height, values, &FilterContext::default());
+    }
+
+    fn apply_with(
+        &self,
+        px: &mut [f32],
+        w: usize,
+        h: usize,
+        v: &FilterValues,
+        context: &FilterContext,
+    ) {
+        if w == 0 || h == 0 {
+            return;
+        }
         let count = v.get("count").round().max(1.0) as usize;
-        let height = v.get("height") / 100.0 * h as f32;
+        let length = v.get("height") / 100.0 * h as f32;
         let width = v.get("width") / 100.0 * (w as f32 / count as f32) * 0.9;
         let lean = v.get("angle").to_radians().tan();
         let turbulence = v.get("turbulence") / 100.0;
         let opacity = v.get("opacity") / 100.0;
         let seed = v.get("seed") as u32;
-        if height <= 0.0 || width <= 0.0 || opacity <= 0.0 {
+        if length <= 0.0 || width <= 0.0 || opacity <= 0.0 {
             return;
         }
+
+        // Where each flame starts and which way is up for it. Along a
+        // path that is a point on the curve and the curve's own normal,
+        // so a flame on a diagonal leans off the diagonal rather than off
+        // the frame.
+        let roots: Vec<(f32, f32, f32, f32)> = match context.path {
+            Some(points) if points.len() >= 2 => (0..count)
+                .map(|i| {
+                    let t = if count == 1 {
+                        0.5
+                    } else {
+                        i as f32 / (count - 1) as f32
+                    };
+                    let last = points.len() - 1;
+                    let at = t * last as f32;
+                    // The segment this root sits on. The final root lands
+                    // exactly on the last point, where there is no
+                    // segment ahead of it, so it takes the one behind --
+                    // without which its direction is (0, 0), its normal
+                    // is nothing, and it sets the whole frame alight.
+                    let i0 = (at.floor() as usize).min(last.saturating_sub(1));
+                    let frac = at - i0 as f32;
+                    let (p0, p1) = (points[i0], points[i0 + 1]);
+                    let (x, y) = (p0.0 + (p1.0 - p0.0) * frac, p0.1 + (p1.1 - p0.1) * frac);
+                    // The normal, pointing up-ish: fire leaves a surface
+                    // at right angles to it.
+                    let (dx, dy) = (p1.0 - p0.0, p1.1 - p0.1);
+                    let n = dx.hypot(dy);
+                    let (mut nx, mut ny) = if n < 1e-3 {
+                        // A segment with no length says nothing about
+                        // which way is up; straight up it is.
+                        (0.0, -1.0)
+                    } else {
+                        (dy / n, -dx / n)
+                    };
+                    if ny > 0.0 {
+                        nx = -nx;
+                        ny = -ny;
+                    }
+                    (x, y, nx, ny)
+                })
+                .collect(),
+            // No path: evenly along the bottom edge, burning straight up.
+            _ => (0..count)
+                .map(|i| {
+                    (
+                        (i as f32 + 0.5) * w as f32 / count as f32,
+                        h as f32,
+                        0.0,
+                        -1.0,
+                    )
+                })
+                .collect(),
+        };
+
         for y in 0..h {
             for x in 0..w {
                 let (fx, fy) = (x as f32, y as f32);
-                // How far up this pixel is inside the flame's own space.
-                let rise = (h as f32 - fy) / height;
-                if !(0.0..=1.0).contains(&rise) {
-                    continue;
-                }
                 let mut heat = 0.0f32;
-                for f in 0..count {
-                    // Where this flame's column is at this height: it
-                    // leans, and it wanders more the higher it goes.
-                    let base = (f as f32 + 0.5) * w as f32 / count as f32;
+                for (f, &(rx, ry, nx, ny)) in roots.iter().enumerate() {
+                    // How far up this flame's own axis the pixel is, and
+                    // how far off it.
+                    let (dx, dy) = (fx - rx, fy - ry);
+                    let up = dx * nx + dy * ny;
+                    let rise = up / length;
+                    if !(0.0..=1.0).contains(&rise) {
+                        continue;
+                    }
+                    let across = dx * -ny + dy * nx + lean * up;
                     let wander = (fbm(
-                        fy / (18.0 + 30.0 * (1.0 - turbulence)),
+                        up / (18.0 + 30.0 * (1.0 - turbulence)),
                         f as f32 * 9.0,
                         seed,
                         3,
@@ -636,16 +770,23 @@ simple_filter!(
                         * width
                         * 3.0
                         * rise;
-                    let cx = base + lean * (h as f32 - fy) + wander;
                     // The column narrows as it rises and dies out at the
                     // top, which is what gives a flame its shape.
                     let taper = (1.0 - rise).powf(0.65) * (1.0 - (rise - 0.05).max(0.0) * 0.35);
                     let reach = (width * taper).max(0.5);
-                    let d = ((fx - cx) / reach).abs();
+                    let d = ((across - wander) / reach).abs();
                     if d < 1.0 {
                         // Licks: the flame is not solid, it is torn into
-                        // tongues by the same noise field.
-                        let tongue = fbm(fx / 9.0, (fy - rise * 60.0) / 7.0, seed ^ 0x51ed, 3);
+                        // tongues by the same noise field -- sampled in
+                        // the flame's own frame rather than the
+                        // picture's, so the tongues run *up* it whichever
+                        // way it is pointing.
+                        let tongue = fbm(
+                            (across - wander) / 9.0,
+                            (up - rise * 60.0) / 7.0,
+                            seed ^ 0x51ed,
+                            3,
+                        );
                         let body = (1.0 - d * d) * (1.0 - rise * 0.85);
                         heat = heat.max((body * (0.55 + tongue * 0.9)).max(0.0));
                     }
@@ -679,7 +820,7 @@ simple_filter!(
             }
         }
     }
-);
+}
 
 pub fn register(registry: &mut schist_plugin_api::PluginRegistry) {
     registry.register_filter(Box::new(Clouds));

--- a/plugins/filters-core/src/sketch.rs
+++ b/plugins/filters-core/src/sketch.rs
@@ -13,10 +13,10 @@
 //! which is why they look raised rather than drawn.
 
 use crate::util::{
-    blur_plane, edges, fbm, from_luma, gradient, luma_map, streak, surface, value_noise,
+    blur_plane, edges, fbm, from_luma_between, gradient, luma_map, streak, surface, value_noise,
 };
-use crate::{choice, param, simple_filter};
-use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
+use crate::{choice, context_filter, param};
+use schist_plugin_api::{FilterContext, FilterParam, FilterPlugin, FilterValues};
 
 /// Photoshop's eight light positions, as a direction to light from.
 pub const LIGHTS: &[&str] = &[
@@ -47,7 +47,7 @@ fn relief(plane: &[f32], w: usize, h: usize, light: (f32, f32), strength: f32) -
         .collect()
 }
 
-simple_filter!(
+context_filter!(
     BasRelief,
     "filter.bas_relief",
     "Bas Relief",
@@ -57,7 +57,7 @@ simple_filter!(
         param("smoothness", "Smoothness", 1.0, 15.0, 3.0, ""),
         choice("light", "Light", LIGHTS, 3)
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // Carved shallowly into stone: the picture as a height field, lit
         // from one side, with everything flat going mid grey.
         let detail = v.get("detail");
@@ -66,11 +66,11 @@ simple_filter!(
         let mut plane = luma_map(px, w, h);
         blur_plane(&mut plane, w, h, smoothness * 0.25);
         let out = relief(&plane, w, h, light, detail * 0.9);
-        from_luma(px, &out, 0.0);
+        from_luma_between(px, &out, ctx.fg(), ctx.bg());
     }
 );
 
-simple_filter!(
+context_filter!(
     ChalkAndCharcoal,
     "filter.chalk_charcoal",
     "Chalk & Charcoal",
@@ -80,7 +80,7 @@ simple_filter!(
         param("chalk", "Chalk Area", 0.0, 20.0, 6.0, ""),
         param("pressure", "Stroke Pressure", 0.0, 5.0, 1.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // Charcoal in the shadows, chalk in the highlights, mid grey
         // paper in between -- and the two drawn at opposite diagonals,
         // which is what stops the result reading as a posterisation.
@@ -105,11 +105,11 @@ simple_filter!(
             }
             out[i] = out[i].clamp(0.0, 1.0);
         }
-        from_luma(px, &out, 0.0);
+        from_luma_between(px, &out, ctx.fg(), ctx.bg());
     }
 );
 
-simple_filter!(
+context_filter!(
     Charcoal,
     "filter.charcoal",
     "Charcoal",
@@ -119,7 +119,7 @@ simple_filter!(
         param("detail", "Detail", 0.0, 5.0, 5.0, ""),
         param("balance", "Light/Dark Balance", 0.0, 100.0, 50.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // Smudged charcoal on paper: the edges are where the stick
         // presses hardest, the tone is dragged along the stroke, and the
         // balance slides the whole thing between a sketch and a
@@ -138,11 +138,11 @@ simple_filter!(
                 + (1.0 - smudged[i]) * balance;
             out[i] = (1.0 - ink).clamp(0.0, 1.0);
         }
-        from_luma(px, &out, 0.0);
+        from_luma_between(px, &out, ctx.fg(), ctx.bg());
     }
 );
 
-simple_filter!(
+context_filter!(
     Chrome,
     "filter.chrome",
     "Chrome",
@@ -151,7 +151,7 @@ simple_filter!(
         param("detail", "Detail", 0.0, 10.0, 4.0, ""),
         param("smoothness", "Smoothness", 0.0, 10.0, 7.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // Polished metal: the picture as a surface, lit, and then its
         // tones folded back on themselves so that every slope crosses
         // black and white several times. The folding is the whole trick
@@ -167,11 +167,11 @@ simple_filter!(
             out[i] = (0.5 + folded * 0.5).clamp(0.0, 1.0);
         }
         blur_plane(&mut out, w, h, 0.4);
-        from_luma(px, &out, 0.0);
+        from_luma_between(px, &out, ctx.fg(), ctx.bg());
     }
 );
 
-simple_filter!(
+context_filter!(
     ConteCrayon,
     "filter.conte_crayon",
     "Cont\u{e9} Crayon",
@@ -183,7 +183,7 @@ simple_filter!(
         param("scaling", "Scaling", 50.0, 200.0, 100.0, "%"),
         param("relief", "Relief", 0.0, 50.0, 20.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // A dense, soft crayon that only touches the high points of the
         // paper. Foreground Level is how far up the tones the dark
         // crayon reaches; Background Level is how far down the light one
@@ -212,11 +212,11 @@ simple_filter!(
                 .clamp(0.0, 1.0);
             }
         }
-        from_luma(px, &out, 0.15);
+        from_luma_between(px, &out, ctx.fg(), ctx.bg());
     }
 );
 
-simple_filter!(
+context_filter!(
     GraphicPen,
     "filter.graphic_pen",
     "Graphic Pen",
@@ -226,7 +226,7 @@ simple_filter!(
         param("balance", "Light/Dark Balance", 0.0, 100.0, 50.0, ""),
         choice("direction", "Stroke Direction", crate::brush::DIRECTIONS, 0)
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // One pen, one direction, no grey: the tone is carried entirely
         // by how much of the paper the hatching covers. Every stroke is
         // the same weight, which is what makes it a pen drawing rather
@@ -248,14 +248,14 @@ simple_filter!(
                 out[i] = if comb < ink { 0.0 } else { 1.0 };
             }
         }
-        from_luma(px, &out, 0.0);
+        from_luma_between(px, &out, ctx.fg(), ctx.bg());
     }
 );
 
 /// The three patterns Photoshop's halftone offers.
 const HALFTONE_PATTERNS: &[&str] = &["Circle", "Dot", "Line"];
 
-simple_filter!(
+context_filter!(
     HalftonePattern,
     "filter.halftone_pattern",
     "Halftone Pattern",
@@ -265,7 +265,7 @@ simple_filter!(
         param("contrast", "Contrast", 0.0, 50.0, 5.0, ""),
         choice("pattern", "Pattern Type", HALFTONE_PATTERNS, 1)
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // A screen, as a newspaper would print it -- but drawn *over* the
         // tone rather than replacing it, which is the difference between
         // this and Pixelate ▸ Color Halftone. Circles ripple out from the
@@ -297,11 +297,11 @@ simple_filter!(
                 out[i] = if screen < tone { 1.0 } else { 0.0 };
             }
         }
-        from_luma(px, &out, 0.0);
+        from_luma_between(px, &out, ctx.fg(), ctx.bg());
     }
 );
 
-simple_filter!(
+context_filter!(
     NotePaper,
     "filter.note_paper",
     "Note Paper",
@@ -311,7 +311,7 @@ simple_filter!(
         param("graininess", "Graininess", 0.0, 20.0, 10.0, ""),
         param("relief", "Relief", 0.0, 25.0, 11.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // Handmade paper with the image pressed into it: the picture is
         // reduced to two levels, and the boundary between them is
         // embossed as though the light paper had been pushed through the
@@ -331,11 +331,11 @@ simple_filter!(
                 out[i] = (sheet + (embossed[i] - 0.5) * 0.9 + g).clamp(0.0, 1.0);
             }
         }
-        from_luma(px, &out, 0.0);
+        from_luma_between(px, &out, ctx.fg(), ctx.bg());
     }
 );
 
-simple_filter!(
+context_filter!(
     Photocopy,
     "filter.photocopy",
     "Photocopy",
@@ -344,7 +344,7 @@ simple_filter!(
         param("detail", "Detail", 1.0, 24.0, 7.0, ""),
         param("darkness", "Darkness", 1.0, 50.0, 8.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // A bad photocopy: the machine holds the edges and the deepest
         // shadows and gives up on everything in between, which is why a
         // photocopied photograph comes back as an outline.
@@ -361,11 +361,11 @@ simple_filter!(
             let flooded = ((0.25 - plane[i]) * 6.0 * darkness).max(0.0);
             out[i] = (1.0 - below.max(0.0) - flooded).clamp(0.0, 1.0);
         }
-        from_luma(px, &out, 0.0);
+        from_luma_between(px, &out, ctx.fg(), ctx.bg());
     }
 );
 
-simple_filter!(
+context_filter!(
     Plaster,
     "filter.plaster",
     "Plaster",
@@ -375,7 +375,7 @@ simple_filter!(
         param("smoothness", "Smoothness", 1.0, 15.0, 2.0, ""),
         choice("light", "Light", LIGHTS, 5)
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // Poured and set: the dark half of the picture rises out of the
         // light half as a smooth blob, lit from one side. Everything
         // inside a region is flat, so it reads as moulded rather than
@@ -398,11 +398,11 @@ simple_filter!(
             .zip(&height)
             .map(|(l, hgt)| (l * 0.65 + hgt * 0.35).clamp(0.0, 1.0))
             .collect();
-        from_luma(px, &out, 0.0);
+        from_luma_between(px, &out, ctx.fg(), ctx.bg());
     }
 );
 
-simple_filter!(
+context_filter!(
     Reticulation,
     "filter.reticulation",
     "Reticulation",
@@ -412,7 +412,7 @@ simple_filter!(
         param("black", "Black Level", 0.0, 50.0, 40.0, ""),
         param("white", "White Level", 0.0, 50.0, 5.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // Film emulsion that has cracked and clumped -- what happens when
         // a negative is developed at the wrong temperature. The clumps
         // gather in the shadows and the highlights break into speckle.
@@ -432,11 +432,11 @@ simple_filter!(
                 out[i] = (l + grain).clamp(0.0, 1.0);
             }
         }
-        from_luma(px, &out, 0.0);
+        from_luma_between(px, &out, ctx.fg(), ctx.bg());
     }
 );
 
-simple_filter!(
+context_filter!(
     Stamp,
     "filter.stamp",
     "Stamp",
@@ -445,7 +445,7 @@ simple_filter!(
         param("balance", "Light/Dark Balance", 0.0, 50.0, 25.0, ""),
         param("smoothness", "Smoothness", 1.0, 50.0, 5.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // A rubber stamp: one threshold, and enough smoothing first that
         // the boundary could have been cut out of rubber.
         let balance = v.get("balance") / 50.0;
@@ -456,11 +456,11 @@ simple_filter!(
             .iter()
             .map(|l| if *l > 1.0 - balance { 1.0 } else { 0.0 })
             .collect();
-        from_luma(px, &out, 0.0);
+        from_luma_between(px, &out, ctx.fg(), ctx.bg());
     }
 );
 
-simple_filter!(
+context_filter!(
     TornEdges,
     "filter.torn_edges",
     "Torn Edges",
@@ -470,7 +470,7 @@ simple_filter!(
         param("smoothness", "Smoothness", 1.0, 15.0, 9.0, ""),
         param("contrast", "Contrast", 1.0, 25.0, 12.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // Stamp, but the threshold wanders: the boundary is pushed about
         // by a noise field, so the shapes come out ragged the way torn
         // paper is ragged rather than cut.
@@ -494,11 +494,11 @@ simple_filter!(
                 out[i] = t;
             }
         }
-        from_luma(px, &out, 0.0);
+        from_luma_between(px, &out, ctx.fg(), ctx.bg());
     }
 );
 
-simple_filter!(
+context_filter!(
     WaterPaper,
     "filter.water_paper",
     "Water Paper",
@@ -508,7 +508,7 @@ simple_filter!(
         param("brightness", "Brightness", 0.0, 100.0, 60.0, ""),
         param("contrast", "Contrast", 0.0, 100.0, 80.0, "")
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, _ctx: &FilterContext| {
         // Painted onto fibrous, wet paper: the colour runs along the
         // fibres, which lie in whatever direction the paper was made in.
         // The one effect in this group that keeps its colour, because

--- a/plugins/filters-core/src/stylize.rs
+++ b/plugins/filters-core/src/stylize.rs
@@ -1,8 +1,8 @@
 //! Filter ▸ Stylize: filters built on edges and local contrast.
 
 use crate::util::{at, convolve3, gaussian_rgba, luma, put, value_noise};
-use crate::{choice, param, simple_filter};
-use schist_plugin_api::{FilterParam, FilterPlugin, FilterValues};
+use crate::{choice, context_filter, param, simple_filter};
+use schist_plugin_api::{FilterContext, FilterParam, FilterPlugin, FilterValues};
 
 /// Sobel gradient magnitude of the luminance at every pixel, 0..~1.
 fn edges(px: &[f32], w: usize, h: usize) -> Vec<f32> {
@@ -258,13 +258,13 @@ simple_filter!(
 /// What Photoshop leaves in the gaps between the tiles.
 const TILE_FILLS: &[&str] = &[
     "Transparent",
-    "Black",
-    "White",
+    "Background Color",
+    "Foreground Color",
     "Inverse Image",
     "Unaltered Image",
 ];
 
-simple_filter!(
+context_filter!(
     Tiles,
     "filter.tiles",
     "Tiles",
@@ -274,7 +274,7 @@ simple_filter!(
         param("offset", "Maximum Offset", 1.0, 99.0, 10.0, "%"),
         choice("fill", "Fill Empty Area With", TILE_FILLS, 0)
     ],
-    |px: &mut [f32], w: usize, h: usize, v: &FilterValues| {
+    |px: &mut [f32], w: usize, h: usize, v: &FilterValues, ctx: &FilterContext| {
         // Break the image into tiles and shove each one off its place.
         let count = v.get("count").max(2.0) as usize;
         let offset = v.get("offset") / 100.0;
@@ -282,14 +282,13 @@ simple_filter!(
         let tw = w.div_ceil(count);
         let th = h.div_ceil(count);
         let src = px.to_vec();
-        // What shows through the gaps the tiles leave. Photoshop offers
-        // the foreground and background colours, which a filter cannot
-        // see, so those are black and white here.
+        let (fg, bg) = (ctx.fg(), ctx.bg());
+        // What shows through the gaps the tiles leave.
         for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
             match fill {
                 0 => *p = [0.0, 0.0, 0.0, 0.0],
-                1 => *p = [0.0, 0.0, 0.0, 1.0],
-                2 => *p = [1.0, 1.0, 1.0, 1.0],
+                1 => *p = [bg[0], bg[1], bg[2], 1.0],
+                2 => *p = [fg[0], fg[1], fg[2], 1.0],
                 3 => {
                     let o = &src[i * 4..i * 4 + 4];
                     *p = [1.0 - o[0], 1.0 - o[1], 1.0 - o[2], o[3]];

--- a/plugins/filters-core/src/util.rs
+++ b/plugins/filters-core/src/util.rs
@@ -336,3 +336,20 @@ pub fn flatten_colour(p: &mut [f32], levels: f32, chroma_step: f32) {
     p[1] = g.clamp(0.0, 1.0);
     p[2] = bl.clamp(0.0, 1.0);
 }
+
+/// Write a tone map back as a duotone between two colours.
+///
+/// Photoshop's Sketch filters draw in the foreground and background
+/// colours rather than in black and white: the ink is the foreground,
+/// the paper is the background, and everything between is a mix. With
+/// the swatches at their defaults that *is* black on white, which is why
+/// the difference is invisible until somebody changes them -- and then
+/// it is the difference between a photocopy and a sepia print.
+pub fn from_luma_between(px: &mut [f32], plane: &[f32], ink: [f32; 3], paper: [f32; 3]) {
+    for (i, p) in px.as_chunks_mut::<4>().0.iter_mut().enumerate() {
+        let t = plane[i].clamp(0.0, 1.0);
+        for c in 0..3 {
+            p[c] = ink[c] + (paper[c] - ink[c]) * t;
+        }
+    }
+}

--- a/plugins/filters-core/tests/all_filters.rs
+++ b/plugins/filters-core/tests/all_filters.rs
@@ -355,7 +355,11 @@ fn the_filters_that_ask_for_a_backdrop_use_it() {
         let before = image(w, h);
         let mut px = before.clone();
         let values = FilterValues::defaults(&f.params());
-        f.apply_over(&mut px, Some(&warm), w, h, &values);
+        let context = schist_plugin_api::FilterContext {
+            backdrop: Some(&warm),
+            ..Default::default()
+        };
+        f.apply_with(&mut px, w, h, &values, &context);
         let (was, now, want) = (mean(&before), mean(&px), mean(&warm));
         for c in 0..3 {
             let closer = (now[c] - want[c]).abs() < (was[c] - want[c]).abs();
@@ -373,4 +377,106 @@ fn the_filters_that_ask_for_a_backdrop_use_it() {
         asked >= 3,
         "expected the three matching filters, found {asked}"
     );
+}
+
+#[test]
+fn the_two_tone_filters_draw_in_the_colours_they_are_given() {
+    // Photoshop's Sketch group renders in the foreground and background
+    // colours, and Clouds and Fibers render *between* them. With the
+    // swatches at their defaults that is black on white, which is why
+    // the difference is invisible until somebody changes them -- so the
+    // check is that a filter handed two unmistakable colours produces
+    // neither black nor white.
+    let (w, h) = (32usize, 32usize);
+    let context = schist_plugin_api::FilterContext {
+        foreground: schist_color::Rgba {
+            r: 0.8,
+            g: 0.1,
+            b: 0.1,
+            a: 1.0,
+        },
+        background: schist_color::Rgba {
+            r: 0.1,
+            g: 0.2,
+            b: 0.7,
+            a: 1.0,
+        },
+        ..Default::default()
+    };
+    let reg = registry();
+    let mut checked = 0;
+    for f in reg
+        .filters()
+        .filter(|f| f.category() == "Sketch" || matches!(f.id(), "filter.clouds" | "filter.fibers"))
+    {
+        // Water Paper keeps the photograph's own colour, as Photoshop's
+        // does; it is in the Sketch menu but is not a two-tone filter.
+        if f.id() == "filter.water_paper" {
+            continue;
+        }
+        checked += 1;
+        let mut px = image(w, h);
+        let values = FilterValues::defaults(&f.params());
+        f.apply_with(&mut px, w, h, &values, &context);
+        // Every pixel should sit between the two colours, so nothing
+        // should be more green than either of them is.
+        let greenest = px
+            .as_chunks::<4>()
+            .0
+            .iter()
+            .map(|p| p[1])
+            .fold(0.0f32, f32::max);
+        assert!(
+            greenest <= 0.45,
+            "{} ignored the colours it was given: greenest channel {greenest:.2}",
+            f.id()
+        );
+    }
+    assert!(checked >= 14, "expected the two-tone set, found {checked}");
+}
+
+#[test]
+fn displace_uses_the_map_it_is_given() {
+    // A map that is mid grey on the left and hard right on the red
+    // channel should leave the left alone and shove the right sideways.
+    let (w, h) = (64usize, 32usize);
+    let map = schist_plugin_api::FilterImage {
+        width: w,
+        height: h,
+        pixels: (0..w * h)
+            .flat_map(|i| {
+                let right = (i % w) > w / 2;
+                [if right { 1.0f32 } else { 0.5 }, 0.5, 0.5, 1.0]
+            })
+            .collect(),
+    };
+    let reg = registry();
+    let f = reg
+        .filters()
+        .find(|f| f.id() == "filter.displace")
+        .expect("displace");
+    let before = image(w, h);
+    let mut px = before.clone();
+    let mut values = FilterValues::defaults(&f.params());
+    values.set("scale", 20.0);
+    values.set("vscale", 0.0);
+    let context = schist_plugin_api::FilterContext {
+        map: Some(&map),
+        ..Default::default()
+    };
+    f.apply_with(&mut px, w, h, &values, &context);
+
+    let moved = |x: usize| {
+        (0..h)
+            .map(|y| {
+                let i = (y * w + x) * 4;
+                (px[i] - before[i]).abs()
+            })
+            .sum::<f32>()
+    };
+    assert!(
+        moved(w / 4) < 1e-3,
+        "mid grey in the map should mean no movement"
+    );
+    assert!(moved(w * 3 / 4) > 0.1, "the map's push was ignored");
 }


### PR DESCRIPTION
The last three functional gaps, closed. Every "a filter here cannot see that" left in the README was a decision about the plugin API, not about the filters — so the API changed.

`FilterContext` is what a filter gets beyond its own pixels and numbers: the two toolbox colours, what the document composites to underneath, an image somebody picked, and the active path flattened into the filter's own coordinates. `apply_with` replaces `apply_over`, `wants_map` and `wants_path` join `wants_backdrop`, and a filter that asks for nothing still implements one method.

## The toolbox colours

The whole **Sketch** group draws in them — ink is the foreground, paper the background — as do **Clouds**, **Difference Clouds**, **Fibers**, **Tiles**' gaps, **Neon Glow**'s glow, **Colored Pencil**'s paper and **Diffuse Glow**'s glow.

With the swatches at their defaults that is black on white, exactly as before, which is why the group has looked right until now. Set them to sepia and Stamp comes out as a sepia print — which it could not do before at any setting.

## A displacement map

**Displace** takes the file Photoshop asks for: red for horizontal, green for vertical, mid grey meaning stay, stretched to fit or tiled. The dialog grew a Choose button that decodes through the same codecs that open documents, so a map can be a PSD, a PNG, or anything else this build reads. With no map it still falls back to its own noise field, and says so.

## The active path

**Flame** burns along it, each flame leaving the curve at right angles to it, and the licks are sampled in the flame's own frame rather than the picture's so they run *up* it whichever way it points. With no path they rise from the bottom of the selection as before.

## A depth map

**Lens Blur** can take one from the layer's transparency or from what is underneath it, holding part of the picture at its original sharpness — Photoshop's Depth Map, minus the channel picker.

## Two things fell out

- The filter dialog gave a choice's name the same 56 pixels it gives a number, so "Repeat Edge Pixels" wrapped onto **three lines**. Choices now take the room from their own track, which they barely need.
- Flame's last root sat exactly on the last point of the path, where there is no segment ahead of it — so its direction was (0, 0), its normal was nothing, `across` was zero everywhere, and it **set the entire frame alight**. Caught by rendering it; the fix takes the segment behind, and a zero-length segment now means straight up.

## Checked

New tests: that the two-tone filters actually use the colours they are given (handed red and blue, nothing may come out green), and that Displace moves pixels where its map says and leaves them where it says stay. Full workspace suite green, clippy and rustfmt clean. Every changed filter eyeballed — sepia Stamp, cream-paper Colored Pencil, blue-and-cream Clouds, a warm Diffuse Glow, Displace through a real map, Flame along an arc. And the app driven headlessly to confirm the Displace dialog's Choose row and that the long choice names now fit.

The README's "here is what a filter cannot see" paragraph is gone. What remains is ergonomic, not functional: Photoshop puts blur pins, light gizmos and flame paths on the canvas; here they are position sliders and the path you already drew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)