### PR TITLE
Update in place on macOS and Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5620,6 +5620,7 @@ dependencies = [
  "schist-vector",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "smallvec",
  "ureq",
 ]

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -15,8 +15,10 @@ log.workspace = true
 env_logger.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-# Only used by the opt-in "Check for Updates" request.
+# Update checks, font downloads and update downloads.
 ureq = { version = "3", default-features = false, features = ["rustls", "json"] }
+# Verifies a downloaded update against the digest the release records.
+sha2 = "0.10"
 image.workspace = true
 smallvec.workspace = true
 rustc-hash.workspace = true

--- a/crates/app/src/crash.rs
+++ b/crates/app/src/crash.rs
@@ -1,10 +1,9 @@
-//! Opt-in crash reporting and update checks.
+//! Opt-in crash reporting.
 //!
-//! Both are off until the user turns them on, and neither sends anything
-//! anywhere by default: a crash writes a local report file, and the update
-//! check is an explicit HTTPS request the user asks for. That keeps the
-//! privacy story simple — an image editor has no business phoning home
-//! unasked.
+//! Off until the user turns it on, and nothing is sent anywhere even
+//! then: a crash writes a local report file next to the recovery
+//! snapshots and that is all. Update checks, the one thing here that
+//! ever spoke to the network, live in [`crate::update`].
 
 use std::path::PathBuf;
 
@@ -84,115 +83,9 @@ fn write_report(info: &std::panic::PanicHookInfo<'_>) {
     eprintln!("schist: crash report written to {}", path.display());
 }
 
-/// A release published upstream.
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
-pub struct Release {
-    pub tag_name: String,
-    #[serde(default)]
-    pub html_url: String,
-}
-
-/// Compare two `x.y.z` version strings. Returns true when `candidate` is
-/// newer than `current`; anything unparseable compares as "not newer" so a
-/// malformed tag never nags the user.
-pub fn is_newer(current: &str, candidate: &str) -> bool {
-    fn parts(v: &str) -> Option<(u32, u32, u32)> {
-        let v = v.trim().trim_start_matches('v');
-        let mut it = v.split('.');
-        let major = it.next()?.parse().ok()?;
-        let minor = it.next().unwrap_or("0").parse().ok()?;
-        // Trailing pre-release suffixes ("1.2.3-beta") are ignored.
-        let patch = it
-            .next()
-            .unwrap_or("0")
-            .split(['-', '+'])
-            .next()?
-            .parse()
-            .ok()?;
-        Some((major, minor, patch))
-    }
-    match (parts(current), parts(candidate)) {
-        (Some(a), Some(b)) => b > a,
-        _ => false,
-    }
-}
-
-/// This build's version.
-pub fn current_version() -> &'static str {
-    env!("CARGO_PKG_VERSION")
-}
-
-/// Where releases are published.
-const RELEASES_API: &str = "https://api.github.com/repos/Infrawrench/schist/releases/latest";
-pub const RELEASES_PAGE: &str = "https://github.com/Infrawrench/schist/releases";
-
-/// The outcome of an update check.
-#[derive(Debug, Clone, PartialEq)]
-pub enum UpdateStatus {
-    UpToDate,
-    Available { version: String, url: String },
-    Failed(String),
-}
-
-/// Ask GitHub for the latest release. Blocking — call it off the UI thread.
-///
-/// One of the two requests Schist makes over the network — the other
-/// fetches a missing font — and, like it, only when the user asks.
-pub fn check_for_update() -> UpdateStatus {
-    let response = ureq::get(RELEASES_API)
-        .header("User-Agent", "schist-update-check")
-        .header("Accept", "application/vnd.github+json")
-        .call();
-    let release: Release = match response {
-        Ok(mut r) => match r.body_mut().read_json() {
-            Ok(v) => v,
-            Err(err) => return UpdateStatus::Failed(format!("unreadable response: {err}")),
-        },
-        Err(err) => return UpdateStatus::Failed(format!("{err}")),
-    };
-    if is_newer(current_version(), &release.tag_name) {
-        UpdateStatus::Available {
-            version: release.tag_name.trim_start_matches('v').to_string(),
-            url: if release.html_url.is_empty() {
-                RELEASES_PAGE.to_string()
-            } else {
-                release.html_url
-            },
-        }
-    } else {
-        UpdateStatus::UpToDate
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
-
-    #[test]
-    fn version_comparison() {
-        assert!(is_newer("0.1.0", "0.2.0"));
-        assert!(is_newer("0.1.0", "v0.1.1"));
-        assert!(is_newer("1.9.0", "1.10.0"));
-        assert!(!is_newer("0.2.0", "0.1.9"));
-        assert!(!is_newer("0.1.0", "0.1.0"));
-        // Pre-release suffixes compare on the numeric part.
-        assert!(is_newer("0.1.0", "0.1.1-beta"));
-    }
-
-    #[test]
-    fn malformed_versions_never_claim_an_update() {
-        assert!(!is_newer("0.1.0", "not-a-version"));
-        assert!(!is_newer("", "1.0.0"));
-        assert!(!is_newer("0.1.0", ""));
-    }
-
-    #[test]
-    fn release_json_parses() {
-        let json = r#"{"tag_name":"v0.3.0","html_url":"https://example.com/r"}"#;
-        let release: Release = serde_json::from_str(json).unwrap();
-        assert_eq!(release.tag_name, "v0.3.0");
-        assert!(is_newer("0.2.0", &release.tag_name));
-    }
+    use super::crash_dir;
 
     #[test]
     fn crash_dir_is_under_the_state_directory() {

--- a/crates/app/src/dialogs.rs
+++ b/crates/app/src/dialogs.rs
@@ -2,7 +2,7 @@
 //! adjustments, export options and preferences.
 
 use crate::ui;
-use crate::workspace::{ColorTarget, Modal, NewDocBackground, Popup, Workspace};
+use crate::workspace::{ColorTarget, Modal, NewDocBackground, Popup, UpdateProgress, Workspace};
 use gpui::{
     div, px, Context, InteractiveElement as _, IntoElement, ParentElement as _, SharedString,
     StatefulInteractiveElement as _, Styled as _,
@@ -106,6 +106,7 @@ pub fn render(ws: &mut Workspace, cx: &mut Context<Workspace>) -> Option<gpui::A
         Modal::ConfirmCloseTab => confirm_close_tab(ws, cx).into_any_element(),
         Modal::DropImage { path } => drop_image(path, cx).into_any_element(),
         Modal::HeifSupport { path } => heif_support(ws, path, cx).into_any_element(),
+        Modal::UpdateAvailable { update } => update_available(ws, update, cx).into_any_element(),
         Modal::PluginManager => plugin_manager(ws, cx).into_any_element(),
         Modal::ModelManager => model_manager(ws, cx).into_any_element(),
         Modal::MissingFonts { fonts } => missing_fonts(ws, &fonts, cx).into_any_element(),
@@ -239,6 +240,126 @@ fn heif_support(
                 cx,
             )),
     )
+}
+
+/// A newer release than this build.
+///
+/// Where Schist can replace itself — a macOS bundle, a Windows install —
+/// it offers to, and restarts into the new one. Where it cannot, the
+/// copy belongs to whatever installed it, so the dialog says where the
+/// release is and gets out of the way.
+fn update_available(
+    ws: &Workspace,
+    update: crate::update::Update,
+    cx: &mut Context<Workspace>,
+) -> impl IntoElement {
+    let progress = ws.update_progress.clone();
+    let page = update.page.clone();
+    let installer = update.install.clone();
+
+    let body = div()
+        .flex()
+        .flex_col()
+        .gap_2()
+        .text_size(px(12.0))
+        .child(format!(
+            "Schist {} is available. This copy is {}.",
+            update.version,
+            crate::update::current_version()
+        ));
+    let body = match (&installer, &progress) {
+        (_, Some(UpdateProgress::Downloading { received, total })) => body
+            .child(format!(
+                "Downloading\u{2026} {} of {}",
+                megabytes(*received),
+                megabytes(*total)
+            ))
+            .child(progress_bar(*received as f32 / (*total).max(1) as f32)),
+        (_, Some(UpdateProgress::Installing)) => body
+            .child("Installing the update\u{2026}".to_string())
+            .child(progress_bar(1.0)),
+        (Some(installer), None) => body.child(format!(
+            "Schist can download it ({}) and install it over this copy. It \
+             restarts once the update is in place, and asks about any \
+             unsaved documents on the way.",
+            megabytes(installer.size)
+        )),
+        (None, None) => body.child(
+            "This copy came from somewhere that owns it \u{2014} a package \
+             manager, an AppImage, a build of your own \u{2014} so it updates \
+             the way it was installed."
+                .to_string(),
+        ),
+    };
+
+    let actions = div().flex().flex_row().gap_2();
+    let actions = match progress {
+        // Nothing to press while the bundle is being swapped: it takes a
+        // moment and there is no half of it to back out to.
+        Some(UpdateProgress::Installing) => actions,
+        Some(UpdateProgress::Downloading { .. }) => actions.child(ui::button(
+            "Cancel",
+            false,
+            |ws, _window, cx| ws.cancel_update(cx),
+            cx,
+        )),
+        None => {
+            let actions = actions.child(ui::button(
+                "Later",
+                false,
+                |ws, _window, cx| ws.close_modal(cx),
+                cx,
+            ));
+            match installer {
+                Some(_) => actions
+                    .child(ui::button(
+                        "Release Notes",
+                        false,
+                        move |_ws, _window, cx| cx.open_url(&page),
+                        cx,
+                    ))
+                    .child(ui::button(
+                        "Update and Restart",
+                        true,
+                        move |ws, _window, cx| ws.start_update(update.clone(), cx),
+                        cx,
+                    )),
+                None => actions.child(ui::button(
+                    "Open Release Page",
+                    true,
+                    move |_ws, _window, cx| cx.open_url(&page),
+                    cx,
+                )),
+            }
+        }
+    };
+    ui::modal_frame("Update Available", UPDATE_DIALOG_WIDTH, body, actions)
+}
+
+/// The update dialog's width, which its progress bar has to match.
+const UPDATE_DIALOG_WIDTH: f32 = 420.0;
+
+/// A download's size, in the megabytes a release page would quote.
+fn megabytes(bytes: u64) -> String {
+    format!("{:.1} MB", bytes as f64 / 1_000_000.0)
+}
+
+/// A filled bar, `fraction` of the way across the dialog.
+fn progress_bar(fraction: f32) -> impl IntoElement {
+    // The frame's width less its padding, which is `p_3` on both sides.
+    let width = UPDATE_DIALOG_WIDTH - 24.0;
+    div()
+        .w(px(width))
+        .h(px(6.0))
+        .rounded_sm()
+        .bg(gpui::rgb(ui::palette().button_bg))
+        .child(
+            div()
+                .h_full()
+                .w(px(width * fraction.clamp(0.0, 1.0)))
+                .rounded_sm()
+                .bg(gpui::rgb(ui::palette().accent)),
+        )
 }
 
 /// "Save changes before closing?" for the active tab. Save falls back to
@@ -2299,6 +2420,18 @@ fn preferences(
                 cx,
             ),
         ))
+        .child(ui::field_row(
+            "Updates",
+            ui::checkbox(
+                "Check for new releases at launch",
+                view.check_updates,
+                |ws, _cx| {
+                    ws.view.check_updates = !ws.view.check_updates;
+                    ws.save_view_options();
+                },
+                cx,
+            ),
+        ))
         .child(
             div()
                 .text_size(px(11.0))
@@ -2309,7 +2442,7 @@ fn preferences(
             div()
                 .text_size(px(11.0))
                 .text_color(gpui::rgb(ui::palette().text_dim))
-                .child(format!("Version {}", crate::crash::current_version())),
+                .child(format!("Version {}", crate::update::current_version())),
         );
 
     let actions = div()

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -13,6 +13,7 @@ mod native_menu;
 mod panels;
 mod style_dialog;
 mod ui;
+mod update;
 mod workspace;
 
 use actions::{HideApp, HideOthers, Quit, ShowAll};

--- a/crates/app/src/update.rs
+++ b/crates/app/src/update.rs
@@ -1,0 +1,682 @@
+//! Update checks, and installing one over this copy where the platform
+//! allows it.
+//!
+//! Nothing here runs unasked in the sense that matters: the check is
+//! either the Check for Updates menu item or the launch-time check the
+//! "Check for new releases at launch" preference governs, and it asks
+//! GitHub for one JSON document and nothing else. No identifier is sent,
+//! and a download only starts once the user has pressed Update.
+//!
+//! What "installing" means depends on how the build got here:
+//!
+//! * **macOS** — the release's `Schist.zip` is unpacked next to the
+//!   running bundle and swapped in with a rename, after its signature is
+//!   checked against this copy's. The relauncher waits for this process
+//!   to exit and then opens the new bundle.
+//! * **Windows** — the release's `Schist-<version>-setup.exe` is handed
+//!   to a detached process that waits for this one to exit (a running
+//!   `schist.exe` cannot be overwritten), runs the installer silently
+//!   and starts the result.
+//! * **Everywhere else** — nothing. Linux copies come from a package
+//!   manager, an AppImage or a distro build, none of which want an
+//!   editor rewriting them, so the dialog only points at the release.
+
+use anyhow::Context as _;
+use std::io::{Read as _, Write as _};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Where releases are published.
+const RELEASES_API: &str = "https://api.github.com/repos/Infrawrench/schist/releases/latest";
+pub const RELEASES_PAGE: &str = "https://github.com/Infrawrench/schist/releases";
+
+/// This build's version.
+pub fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+/// One file attached to a release.
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+pub struct Asset {
+    pub name: String,
+    #[serde(default)]
+    pub browser_download_url: String,
+    #[serde(default)]
+    pub size: u64,
+    /// `sha256:…`, on releases new enough for GitHub to have recorded
+    /// one. Absent on older ones, so it is checked when present rather
+    /// than required.
+    #[serde(default)]
+    pub digest: Option<String>,
+}
+
+/// A release published upstream.
+#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
+pub struct Release {
+    pub tag_name: String,
+    #[serde(default)]
+    pub html_url: String,
+    #[serde(default)]
+    pub assets: Vec<Asset>,
+}
+
+/// A newer release than this build.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Update {
+    pub version: String,
+    /// The release's own page — "what's new", and where someone whose
+    /// copy we must not touch goes to get it.
+    pub page: String,
+    /// The asset this copy can install over itself, when there is one.
+    /// `None` on Linux, and on any build that isn't where its installer
+    /// would have put it.
+    pub install: Option<Installer>,
+}
+
+/// The release asset that updates this platform.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Installer {
+    pub url: String,
+    pub file_name: String,
+    /// What the release says the download weighs, for the progress bar
+    /// and as the cap on what we will read.
+    pub size: u64,
+    /// Lower-case hex, when the release recorded one.
+    pub sha256: Option<String>,
+}
+
+/// The outcome of an update check.
+#[derive(Debug, Clone, PartialEq)]
+pub enum UpdateStatus {
+    UpToDate,
+    Available(Update),
+    Failed(String),
+}
+
+/// Compare two `x.y.z` version strings. Returns true when `candidate` is
+/// newer than `current`; anything unparseable compares as "not newer" so a
+/// malformed tag never nags the user.
+pub fn is_newer(current: &str, candidate: &str) -> bool {
+    fn parts(v: &str) -> Option<(u32, u32, u32)> {
+        let v = v.trim().trim_start_matches('v');
+        let mut it = v.split('.');
+        let major = it.next()?.parse().ok()?;
+        let minor = it.next().unwrap_or("0").parse().ok()?;
+        // Trailing pre-release suffixes ("1.2.3-beta") are ignored.
+        let patch = it
+            .next()
+            .unwrap_or("0")
+            .split(['-', '+'])
+            .next()?
+            .parse()
+            .ok()?;
+        Some((major, minor, patch))
+    }
+    match (parts(current), parts(candidate)) {
+        (Some(a), Some(b)) => b > a,
+        _ => false,
+    }
+}
+
+/// Ask GitHub for the latest release. Blocking — call it off the UI thread.
+///
+/// One of the three requests Schist makes over the network — the others
+/// fetch a missing font and a Neural Filters model — and, like them, only
+/// when the user asks.
+pub fn check() -> UpdateStatus {
+    let response = ureq::get(RELEASES_API)
+        .header("User-Agent", "schist-update-check")
+        .header("Accept", "application/vnd.github+json")
+        .call();
+    let release: Release = match response {
+        Ok(mut r) => match r.body_mut().read_json() {
+            Ok(v) => v,
+            Err(err) => return UpdateStatus::Failed(format!("unreadable response: {err}")),
+        },
+        Err(err) => return UpdateStatus::Failed(format!("{err}")),
+    };
+    if !is_newer(current_version(), &release.tag_name) {
+        return UpdateStatus::UpToDate;
+    }
+    UpdateStatus::Available(Update {
+        version: release.tag_name.trim_start_matches('v').to_string(),
+        page: if release.html_url.is_empty() {
+            RELEASES_PAGE.to_string()
+        } else {
+            release.html_url.clone()
+        },
+        // Offer to install only when this copy is one we can replace;
+        // otherwise the dialog is a pointer at the release page.
+        install: if self_installable() {
+            installer_for(&release)
+        } else {
+            None
+        },
+    })
+}
+
+/// The release asset that would update this platform, ignoring whether
+/// this particular copy is one we may replace.
+fn installer_for(release: &Release) -> Option<Installer> {
+    let asset = release.assets.iter().find(|a| is_platform_asset(&a.name))?;
+    if asset.browser_download_url.is_empty() {
+        return None;
+    }
+    Some(Installer {
+        url: asset.browser_download_url.clone(),
+        file_name: asset.name.clone(),
+        size: asset.size,
+        sha256: asset.digest.as_deref().and_then(sha256_from_digest),
+    })
+}
+
+/// Whether a release asset is the one that installs this platform.
+///
+/// The names come from `.github/workflows/release.yml`; changing them
+/// there without changing them here silently ends self-updating.
+fn is_platform_asset(name: &str) -> bool {
+    if cfg!(target_os = "macos") {
+        name == "Schist.zip"
+    } else if cfg!(windows) {
+        // Schist-0.6.0-setup.exe — the version moves, so match the ends.
+        name.starts_with("Schist-") && name.ends_with("-setup.exe")
+    } else {
+        false
+    }
+}
+
+/// The hex digest out of GitHub's `sha256:…` field, if it holds one.
+fn sha256_from_digest(digest: &str) -> Option<String> {
+    let hex = digest.strip_prefix("sha256:")?;
+    (hex.len() == 64 && hex.chars().all(|c| c.is_ascii_hexdigit()))
+        .then(|| hex.to_ascii_lowercase())
+}
+
+/// Whether this copy is one Schist can replace in place: an application
+/// bundle we can write next to on macOS, an installed tree on Windows.
+pub fn self_installable() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        bundle_path().is_some_and(|app| app.parent().is_some_and(is_writable))
+    }
+    #[cfg(windows)]
+    {
+        install_dir().is_some()
+    }
+    #[cfg(not(any(target_os = "macos", windows)))]
+    {
+        false
+    }
+}
+
+/// Fetch the installer, counting bytes into `received` as they land.
+/// Blocking; the caller runs it on a background thread.
+pub fn download(installer: &Installer, received: &AtomicU64) -> anyhow::Result<PathBuf> {
+    use sha2::Digest as _;
+
+    let dir = download_dir().context("no temporary directory to download into")?;
+    // A previous attempt's half-file must not be mistaken for this one.
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir)?;
+    let name = Path::new(&installer.file_name)
+        .file_name()
+        .context("the release names its asset with a path")?;
+    let path = dir.join(name);
+
+    let mut response = ureq::get(&installer.url)
+        .header("User-Agent", "schist-update")
+        .call()
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let mut reader = response.body_mut().as_reader();
+    let mut file = std::fs::File::create(&path)?;
+    // A guard against a redirect to something enormous. The release
+    // tells us the size, so this is only a fallback for one that didn't.
+    let cap = if installer.size > 0 {
+        installer.size
+    } else {
+        1 << 30
+    };
+    let mut hasher = sha2::Sha256::new();
+    let mut buf = vec![0u8; 64 * 1024];
+    let mut total = 0u64;
+    loop {
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        total += n as u64;
+        anyhow::ensure!(total <= cap, "the download is bigger than the release says");
+        hasher.update(&buf[..n]);
+        file.write_all(&buf[..n])?;
+        received.store(total, Ordering::Relaxed);
+    }
+    file.sync_all()?;
+    drop(file);
+
+    if installer.size > 0 {
+        anyhow::ensure!(
+            total == installer.size,
+            "the download stopped at {total} of {} bytes",
+            installer.size
+        );
+    }
+    if let Some(want) = &installer.sha256 {
+        let got = format!("{:x}", hasher.finalize());
+        anyhow::ensure!(&got == want, "the download hashes to {got}, not {want}");
+    }
+    Ok(path)
+}
+
+/// Where the installer is downloaded to. Not the install location: on
+/// macOS the bundle is unpacked next to the one it replaces, since a
+/// rename across volumes is not one.
+fn download_dir() -> Option<PathBuf> {
+    Some(std::env::temp_dir().join("schist-update"))
+}
+
+/// Throw away whatever [`download`] left behind.
+pub fn clean_downloads() {
+    if let Some(dir) = download_dir() {
+        let _ = std::fs::remove_dir_all(dir);
+    }
+}
+
+// ---------------------------------------------------------------- macOS
+
+/// The application bundle this build is running out of.
+#[cfg(target_os = "macos")]
+pub fn bundle_path() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    // …/Schist.app/Contents/MacOS/schist
+    let app = exe
+        .ancestors()
+        .find(|p| p.extension().is_some_and(|e| e == "app"))?;
+    Some(app.to_path_buf())
+}
+
+/// Whether we may create things in `dir`. `Permissions::readonly` reads
+/// the mode bits rather than what this user can actually do with them,
+/// so ask the filesystem instead.
+#[cfg(target_os = "macos")]
+fn is_writable(dir: &Path) -> bool {
+    let probe = dir.join(format!(".schist-write-probe-{}", std::process::id()));
+    match std::fs::create_dir(&probe) {
+        Ok(()) => {
+            let _ = std::fs::remove_dir(&probe);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// Unpack `zip` over the running bundle and arrange for the new one to
+/// start once this process exits.
+#[cfg(target_os = "macos")]
+pub fn install_and_restart(zip: &Path) -> anyhow::Result<()> {
+    let app = bundle_path().context("this copy is not inside an application bundle")?;
+    let parent = app
+        .parent()
+        .context("the application bundle has no parent directory")?;
+    // Staged beside the bundle, not in the temporary directory: the swap
+    // below is a rename, and a rename cannot cross volumes.
+    let stage = parent.join(format!(".schist-update-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&stage);
+    std::fs::create_dir(&stage).with_context(|| format!("cannot write to {}", parent.display()))?;
+
+    let unpacked = unpack(zip, &stage).and_then(|new_app| {
+        verify_signature(&app, &new_app)?;
+        Ok(new_app)
+    });
+    let new_app = match unpacked {
+        Ok(app) => app,
+        Err(err) => {
+            let _ = std::fs::remove_dir_all(&stage);
+            return Err(err);
+        }
+    };
+
+    // The running bundle steps aside rather than being deleted, so a
+    // failed swap can be undone.
+    let backup = parent.join(format!(".Schist.app.old-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&backup);
+    std::fs::rename(&app, &backup)
+        .with_context(|| format!("cannot move {} aside", app.display()))?;
+    if let Err(err) = std::fs::rename(&new_app, &app) {
+        let _ = std::fs::rename(&backup, &app);
+        let _ = std::fs::remove_dir_all(&stage);
+        return Err(anyhow::Error::new(err).context("cannot move the new bundle into place"));
+    }
+    let _ = std::fs::remove_dir_all(&backup);
+    let _ = std::fs::remove_dir_all(&stage);
+    clean_downloads();
+
+    relaunch(&app)
+}
+
+/// Extract the release zip into `stage`, returning the bundle inside it.
+#[cfg(target_os = "macos")]
+fn unpack(zip: &Path, stage: &Path) -> anyhow::Result<PathBuf> {
+    // ditto, not unzip: it is what wrote the archive, and it is the only
+    // one of the two that keeps the symlinks and modes a signature is
+    // taken over.
+    let out = std::process::Command::new("/usr/bin/ditto")
+        .arg("-x")
+        .arg("-k")
+        .arg(zip)
+        .arg(stage)
+        .output()
+        .context("cannot run /usr/bin/ditto")?;
+    anyhow::ensure!(
+        out.status.success(),
+        "unpacking the download failed: {}",
+        String::from_utf8_lossy(&out.stderr).trim()
+    );
+    let app = stage.join("Schist.app");
+    anyhow::ensure!(
+        app.join("Contents/MacOS/schist").is_file(),
+        "the download holds no Schist.app"
+    );
+    Ok(app)
+}
+
+/// A bundle's signing team: `None` when it carries no signature at all,
+/// `Some(None)` when it is signed without one (an ad-hoc or local build).
+#[cfg(target_os = "macos")]
+fn signing_team(app: &Path) -> Option<Option<String>> {
+    let out = std::process::Command::new("/usr/bin/codesign")
+        .args(["-dv", "--verbose=4"])
+        .arg(app)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    // codesign prints the description on stderr.
+    let text = String::from_utf8_lossy(&out.stderr);
+    let team = text
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("TeamIdentifier="))
+        .map(str::trim)
+        .filter(|t| *t != "not set")
+        .map(str::to_string);
+    Some(team)
+}
+
+/// Refuse a download that is signed worse than what it would replace.
+///
+/// This is the check that makes the swap safe: a signed copy only ever
+/// takes an update signed by the same team, so a hijacked download
+/// cannot install itself over a release build.
+#[cfg(target_os = "macos")]
+fn verify_signature(app: &Path, new_app: &Path) -> anyhow::Result<()> {
+    let theirs = signing_team(new_app);
+    if theirs.is_some() {
+        let out = std::process::Command::new("/usr/bin/codesign")
+            .args(["--verify", "--strict"])
+            .arg(new_app)
+            .output()
+            .context("cannot run /usr/bin/codesign")?;
+        anyhow::ensure!(
+            out.status.success(),
+            "the download's signature does not verify: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        );
+    }
+    let Some(ours) = signing_team(app) else {
+        // An unsigned build — a local one, or a fork's. It has no
+        // identity to hold the download to.
+        return Ok(());
+    };
+    let Some(theirs) = theirs else {
+        anyhow::bail!("this copy is signed and the download is not");
+    };
+    anyhow::ensure!(
+        ours == theirs,
+        "the download is signed by a different developer"
+    );
+    Ok(())
+}
+
+/// Start the new bundle once this process is gone.
+#[cfg(target_os = "macos")]
+fn relaunch(app: &Path) -> anyhow::Result<()> {
+    let script = format!(
+        "while kill -0 {pid} 2>/dev/null; do sleep 0.2; done; exec /usr/bin/open {app}",
+        pid = std::process::id(),
+        app = sh_quote(&app.to_string_lossy()),
+    );
+    std::process::Command::new("/bin/sh")
+        .arg("-c")
+        .arg(script)
+        .spawn()
+        .context("cannot start the relauncher")?;
+    Ok(())
+}
+
+/// `s` as one single-quoted `sh` word.
+#[cfg(target_os = "macos")]
+fn sh_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', r"'\''"))
+}
+
+// -------------------------------------------------------------- Windows
+
+/// The directory the installer put this copy in, if it did.
+///
+/// `uninstall.exe` is what tells the two apart: the installer writes one
+/// next to `schist.exe`, and a loose build has none. Running the
+/// installer over a loose build would install a second copy elsewhere
+/// and leave the one the user is looking at untouched.
+#[cfg(windows)]
+pub fn install_dir() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    let dir = exe.parent()?;
+    dir.join("uninstall.exe")
+        .exists()
+        .then(|| dir.to_path_buf())
+}
+
+/// Queue the downloaded installer behind this process's exit.
+///
+/// Nothing is installed while we are still running: Windows holds a lock
+/// on the running `schist.exe`, so the installer would fail to replace
+/// it. The detached process waits for us, installs silently, and starts
+/// the new build.
+#[cfg(windows)]
+pub fn install_and_restart(setup: &Path) -> anyhow::Result<()> {
+    use std::os::windows::process::CommandExt as _;
+    /// DETACHED_PROCESS | CREATE_NO_WINDOW — no console flashes up, and
+    /// the waiter outlives us.
+    const DETACHED_NO_WINDOW: u32 = 0x0000_0008 | 0x0800_0000;
+
+    let dir = install_dir().context("this copy was not put here by the installer")?;
+    let exe = dir.join("schist.exe");
+    // The installer is elevated (its manifest asks for admin), so the
+    // relaunch has to be a separate, unelevated Start-Process — starting
+    // the editor from inside the elevated one would leave it running as
+    // administrator.
+    let script = format!(
+        "Wait-Process -Id {pid} -ErrorAction SilentlyContinue; \
+         $p = Start-Process -FilePath {setup} -ArgumentList '/S' -Verb RunAs -PassThru -Wait; \
+         if ($p.ExitCode -eq 0) {{ Start-Process -FilePath {exe} }}",
+        pid = std::process::id(),
+        setup = ps_quote(&setup.to_string_lossy()),
+        exe = ps_quote(&exe.to_string_lossy()),
+    );
+    std::process::Command::new("powershell.exe")
+        .args(["-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden"])
+        .arg("-Command")
+        .arg(script)
+        .creation_flags(DETACHED_NO_WINDOW)
+        .spawn()
+        .context("cannot start the installer")?;
+    Ok(())
+}
+
+/// `s` as one single-quoted PowerShell string.
+#[cfg(windows)]
+fn ps_quote(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "''"))
+}
+
+// ---------------------------------------------------------------- Linux
+
+/// Linux copies come from a package manager, an AppImage or a distro
+/// build. [`self_installable`] is false there, so this is unreachable;
+/// it exists so the rest compiles.
+#[cfg(not(any(target_os = "macos", windows)))]
+pub fn install_and_restart(_file: &Path) -> anyhow::Result<()> {
+    anyhow::bail!("updates on this platform are installed the way Schist was")
+}
+
+// -------------------------------------------------- launch-time checking
+
+/// How long a launch-time check waits after the last one.
+const CHECK_INTERVAL_SECS: u64 = 24 * 60 * 60;
+
+fn stamp_path() -> Option<PathBuf> {
+    Some(crate::crash::state_dir()?.join("schist/last-update-check"))
+}
+
+fn now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Whether a launch-time check is due. Once a day: an editor that asked
+/// GitHub on every launch would be a nuisance to anyone who opens files
+/// from the file manager.
+pub fn check_due() -> bool {
+    let Some(path) = stamp_path() else {
+        return false;
+    };
+    match std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|t| t.trim().parse::<u64>().ok())
+    {
+        Some(then) => now_secs().saturating_sub(then) >= CHECK_INTERVAL_SECS,
+        None => true,
+    }
+}
+
+/// Record that a check just happened.
+pub fn mark_checked() {
+    let Some(path) = stamp_path() else { return };
+    if let Some(dir) = path.parent() {
+        let _ = std::fs::create_dir_all(dir);
+    }
+    let _ = std::fs::write(path, now_secs().to_string());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_comparison() {
+        assert!(is_newer("0.1.0", "0.2.0"));
+        assert!(is_newer("0.1.0", "v0.1.1"));
+        assert!(is_newer("1.9.0", "1.10.0"));
+        assert!(!is_newer("0.2.0", "0.1.9"));
+        assert!(!is_newer("0.1.0", "0.1.0"));
+        // Pre-release suffixes compare on the numeric part.
+        assert!(is_newer("0.1.0", "0.1.1-beta"));
+    }
+
+    #[test]
+    fn malformed_versions_never_claim_an_update() {
+        assert!(!is_newer("0.1.0", "not-a-version"));
+        assert!(!is_newer("", "1.0.0"));
+        assert!(!is_newer("0.1.0", ""));
+    }
+
+    /// One release with everything the workflow attaches to it.
+    fn release() -> Release {
+        let json = r#"{
+            "tag_name": "v0.7.0",
+            "html_url": "https://example.com/r",
+            "assets": [
+                {"name": "schist-linux-x86_64", "browser_download_url": "https://e/l", "size": 1},
+                {"name": "Schist-0.7.0-setup.exe", "browser_download_url": "https://e/w", "size": 2,
+                 "digest": "sha256:0000000000000000000000000000000000000000000000000000000000000001"},
+                {"name": "schist-mcp-macos.zip", "browser_download_url": "https://e/m", "size": 3},
+                {"name": "Schist.zip", "browser_download_url": "https://e/a", "size": 4}
+            ]
+        }"#;
+        serde_json::from_str(json).expect("the release JSON parses")
+    }
+
+    #[test]
+    fn release_json_parses() {
+        let release = release();
+        assert_eq!(release.tag_name, "v0.7.0");
+        assert!(is_newer("0.6.0", &release.tag_name));
+        assert_eq!(release.assets.len(), 4);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn the_app_bundle_is_the_macos_asset() {
+        let installer = installer_for(&release()).expect("macOS has an installable asset");
+        // Not schist-mcp-macos.zip, which is the other zip in there.
+        assert_eq!(installer.file_name, "Schist.zip");
+        assert_eq!(installer.size, 4);
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn the_setup_exe_is_the_windows_asset() {
+        let installer = installer_for(&release()).expect("Windows has an installable asset");
+        // Matched on both ends, since the version in the middle moves.
+        assert_eq!(installer.file_name, "Schist-0.7.0-setup.exe");
+        assert_eq!(
+            installer.sha256.as_deref(),
+            Some("0000000000000000000000000000000000000000000000000000000000000001")
+        );
+    }
+
+    #[test]
+    #[cfg(not(any(target_os = "macos", windows)))]
+    fn linux_installs_nothing_itself() {
+        assert_eq!(installer_for(&release()), None);
+        assert!(!self_installable());
+    }
+
+    #[test]
+    fn digests_are_taken_only_when_they_are_sha256() {
+        let sha = "a".repeat(64);
+        assert_eq!(sha256_from_digest(&format!("sha256:{sha}")), Some(sha));
+        // Upper case is the same digest.
+        assert_eq!(
+            sha256_from_digest(&format!("sha256:{}", "AB".repeat(32))),
+            Some("ab".repeat(32))
+        );
+        assert_eq!(sha256_from_digest("sha512:beef"), None);
+        assert_eq!(sha256_from_digest("sha256:beef"), None);
+        assert_eq!(sha256_from_digest(""), None);
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn paths_survive_the_shell() {
+        assert_eq!(
+            sh_quote("/Applications/Schist.app"),
+            "'/Applications/Schist.app'"
+        );
+        // A quote in the path must not end the word.
+        assert_eq!(sh_quote("/tmp/it's here"), r"'/tmp/it'\''s here'");
+    }
+
+    #[test]
+    #[cfg(windows)]
+    fn paths_survive_powershell() {
+        assert_eq!(
+            ps_quote(r"C:\Program Files\Schist"),
+            r"'C:\Program Files\Schist'"
+        );
+        // Doubling is how a single quote goes inside a quoted string.
+        assert_eq!(ps_quote("C:\\it's"), "'C:\\it''s'");
+    }
+}

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -178,6 +178,10 @@ pub struct Workspace {
     /// Whether the HEIC decode library is currently downloading, so a
     /// second HEIC open does not start a second download.
     pub heif_download: bool,
+    /// How far along the update the user asked for is, if one is
+    /// running. Its presence is also what stops a second click starting
+    /// a second download.
+    pub update_progress: Option<UpdateProgress>,
     /// Families already offered this session. Opening three documents
     /// that all want the same missing font should ask once, not thrice.
     pub fonts_offered: std::collections::HashSet<String>,
@@ -490,6 +494,11 @@ pub struct ViewOptions {
     /// GPU path can't express, and entirely when this is off.
     #[serde(default = "default_true")]
     pub gpu_compositing: bool,
+    /// Ask GitHub for the latest release at launch, at most once a day.
+    /// The one request Schist makes without being clicked, which is why
+    /// it is a preference; it sends nothing but the request itself.
+    #[serde(default = "default_true")]
+    pub check_updates: bool,
 }
 
 fn default_true() -> bool {
@@ -509,6 +518,7 @@ impl Default for ViewOptions {
             zoom_with_scroll: false,
             crash_reports: false,
             gpu_compositing: true,
+            check_updates: true,
         }
     }
 }
@@ -575,6 +585,17 @@ struct ViewportKey {
     /// The surround outside the document is baked into the image, so a
     /// theme change must invalidate it.
     surround: u32,
+}
+
+/// How far along an update the user asked for is.
+#[derive(Debug, Clone, PartialEq)]
+pub enum UpdateProgress {
+    /// `total` is what the release says the download weighs; it is never
+    /// zero, since an asset that lists no size is not offered.
+    Downloading { received: u64, total: u64 },
+    /// Unpacking and swapping the bundle (macOS), or handing the
+    /// installer over (Windows). Short, and not interruptible.
+    Installing,
 }
 
 /// Which modal dialog is open.
@@ -674,6 +695,10 @@ pub enum Modal {
     /// offer to download it (with its LGPL license texts), then retry
     /// opening `path`.
     HeifSupport { path: PathBuf },
+    /// A release newer than this build. On macOS and Windows it offers
+    /// to install itself and restart; everywhere else it points at the
+    /// release page, since the copy came from a package manager.
+    UpdateAvailable { update: crate::update::Update },
     /// The third-party plugin manager.
     PluginManager,
     /// Neural Filters model downloads.
@@ -844,6 +869,7 @@ impl Workspace {
             model_downloads: Vec::new(),
             font_downloads: Vec::new(),
             heif_download: false,
+            update_progress: None,
             fonts_offered: std::collections::HashSet::new(),
             ant_phase: 0,
             tool_has_overlay: false,
@@ -888,6 +914,20 @@ impl Workspace {
             proof_transform: None,
         };
         ws.rebuild_tool_groups();
+        // A launch-time update check, when the preference allows one and
+        // the last one was long enough ago. Delayed: the first seconds
+        // after launch belong to opening whatever the user
+        // double-clicked, not to a network round trip.
+        if ws.view.check_updates && crate::update::check_due() {
+            cx.spawn(async move |this, cx| {
+                cx.background_executor()
+                    .timer(std::time::Duration::from_secs(5))
+                    .await;
+                this.update(cx, |ws, cx| ws.check_for_update_quietly(cx))
+                    .ok();
+            })
+            .detach();
+        }
         // The workspace starts empty; File ▸ New asks for the document's
         // settings before creating anything.
         // Periodic crash-recovery snapshot; the task ends with the entity.
@@ -4026,6 +4066,12 @@ impl Workspace {
         if matches!(self.modal, Some(Modal::Preferences)) {
             self.revert_preferences(cx);
         }
+        // Same for escaping the update dialog while its download is
+        // running: dismissing the thing that asked must not leave an
+        // update to land on its own.
+        if matches!(self.modal, Some(Modal::UpdateAvailable { .. })) {
+            self.update_progress = None;
+        }
         // Closing the picker uncovers the dialog it was opened from.
         self.modal = self.modal_stack.pop();
         self.default_action = None;
@@ -4258,6 +4304,7 @@ impl Workspace {
             | Modal::Preferences
             | Modal::Export { .. }
             | Modal::MissingFonts { .. }
+            | Modal::UpdateAvailable { .. }
             | Modal::Profile { .. } => {}
         });
     }
@@ -5695,33 +5742,187 @@ impl Workspace {
     pub fn check_for_update(&mut self, cx: &mut Context<Self>) {
         self.status = "Checking for updates…".into();
         cx.notify();
+        self.run_update_check(false, cx);
+    }
+
+    /// The launch-time check. Silent unless there is something to say:
+    /// nobody opening a document wants to be told their editor is
+    /// current, and a machine that is offline at login should not be
+    /// shown a failure it never asked for.
+    pub fn check_for_update_quietly(&mut self, cx: &mut Context<Self>) {
+        self.run_update_check(true, cx);
+    }
+
+    fn run_update_check(&mut self, quiet: bool, cx: &mut Context<Self>) {
         cx.spawn(async move |this, cx| {
             let status = cx
                 .background_executor()
-                .spawn(async { crate::crash::check_for_update() })
+                .spawn(async {
+                    let status = crate::update::check();
+                    // A check that never reached GitHub is not one, so a
+                    // machine that was offline at launch tries again at
+                    // the next one rather than in a day.
+                    if !matches!(status, crate::update::UpdateStatus::Failed(_)) {
+                        crate::update::mark_checked();
+                    }
+                    status
+                })
                 .await;
             this.update(cx, |ws, cx| {
-                ws.status = match status {
-                    crate::crash::UpdateStatus::UpToDate => {
-                        format!("Schist {} is up to date", crate::crash::current_version()).into()
+                match status {
+                    crate::update::UpdateStatus::Available(update) => {
+                        log::info!("update {} available at {}", update.version, update.page);
+                        ws.status = format!("Schist {} is available", update.version).into();
+                        // The launch-time check lands five seconds in,
+                        // by which time the user may be in a dialog of
+                        // their own. Theirs wins; the status line still
+                        // says an update is there, and File ▸ Check for
+                        // Updates brings this back.
+                        if !quiet || ws.modal.is_none() {
+                            ws.open_modal(Modal::UpdateAvailable { update }, cx);
+                        }
                     }
-                    crate::crash::UpdateStatus::Available { version, url } => {
-                        log::info!("update {version} available at {url}");
-                        format!(
-                            "Version {version} is available — see {}",
-                            crate::crash::RELEASES_PAGE
-                        )
-                        .into()
+                    crate::update::UpdateStatus::UpToDate if !quiet => {
+                        ws.status =
+                            format!("Schist {} is up to date", crate::update::current_version())
+                                .into();
                     }
-                    crate::crash::UpdateStatus::Failed(err) => {
-                        format!("Update check failed: {err}").into()
+                    crate::update::UpdateStatus::Failed(err) if !quiet => {
+                        ws.status = format!("Update check failed: {err}").into();
                     }
-                };
+                    _ => {}
+                }
                 cx.notify();
             })
             .ok();
         })
         .detach();
+    }
+
+    /// Download the release and install it over this copy, then quit so
+    /// the relauncher can start the new build.
+    ///
+    /// The dialog stays up throughout: it is what shows the progress,
+    /// and there is nothing useful to do in an editor whose executable
+    /// is being replaced underneath it.
+    pub fn start_update(&mut self, update: crate::update::Update, cx: &mut Context<Self>) {
+        let Some(installer) = update.install.clone() else {
+            return;
+        };
+        if self.update_progress.is_some() {
+            return;
+        }
+        self.update_progress = Some(UpdateProgress::Downloading {
+            received: 0,
+            total: installer.size,
+        });
+        self.status = format!("Downloading Schist {}\u{2026}", update.version).into();
+        cx.notify();
+
+        // The download runs on a background thread and counts bytes into
+        // this; the dialog reads it on a timer, rather than that thread
+        // reaching into the entity once per 64 KiB.
+        let received = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        cx.spawn({
+            let received = received.clone();
+            async move |this, cx| loop {
+                cx.background_executor()
+                    .timer(std::time::Duration::from_millis(200))
+                    .await;
+                let downloading = this.update(cx, |ws, cx| {
+                    let Some(UpdateProgress::Downloading { received: got, .. }) =
+                        ws.update_progress.as_mut()
+                    else {
+                        return false;
+                    };
+                    *got = received.load(std::sync::atomic::Ordering::Relaxed);
+                    cx.notify();
+                    true
+                });
+                if !matches!(downloading, Ok(true)) {
+                    break;
+                }
+            }
+        })
+        .detach();
+
+        cx.spawn(async move |this, cx| {
+            let fetched = {
+                let received = received.clone();
+                cx.background_executor()
+                    .spawn(async move { crate::update::download(&installer, &received) })
+                    .await
+            };
+            let file = match fetched {
+                Ok(file) => file,
+                Err(err) => {
+                    this.update(cx, |ws, cx| ws.update_failed(&format!("{err:#}"), cx))
+                        .ok();
+                    return;
+                }
+            };
+            // Nothing is installed if the user cancelled while it was
+            // coming down: `update_progress` is cleared by Cancel, and
+            // that is what says the download was still wanted.
+            let wanted = this.update(cx, |ws, cx| {
+                if ws.update_progress.is_none() {
+                    return false;
+                }
+                ws.update_progress = Some(UpdateProgress::Installing);
+                ws.status = "Installing the update\u{2026}".into();
+                cx.notify();
+                true
+            });
+            if !matches!(wanted, Ok(true)) {
+                crate::update::clean_downloads();
+                return;
+            }
+            let installed = cx
+                .background_executor()
+                .spawn(async move { crate::update::install_and_restart(&file) })
+                .await;
+            this.update(cx, |ws, cx| {
+                ws.update_progress = None;
+                match installed {
+                    Ok(()) => {
+                        ws.close_modal(cx);
+                        // Quitting takes the usual route, so unsaved work
+                        // is still asked about. Backing out of one of
+                        // those prompts leaves the update staged rather
+                        // than lost: it lands whenever this process does
+                        // exit.
+                        ws.status =
+                            format!("Restarting into Schist {}\u{2026}", update.version).into();
+                        ws.request_quit(cx);
+                    }
+                    Err(err) => ws.update_failed(&format!("{err:#}"), cx),
+                }
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    /// Abandon a download in progress.
+    ///
+    /// The transfer itself is left to run out into the temporary
+    /// directory, since a blocking read cannot be interrupted, but its
+    /// result is dropped and nothing is installed.
+    pub fn cancel_update(&mut self, cx: &mut Context<Self>) {
+        self.update_progress = None;
+        self.status = "Update cancelled".into();
+        self.close_modal(cx);
+        cx.notify();
+    }
+
+    /// Give up on an update, leaving the user where they were.
+    fn update_failed(&mut self, err: &str, cx: &mut Context<Self>) {
+        log::error!("update failed: {err}");
+        crate::update::clean_downloads();
+        self.update_progress = None;
+        self.status = format!("Update failed: {err}").into();
+        self.close_modal(cx);
+        cx.notify();
     }
 
     /// Fetch a font family and set every layer that wanted it.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -27,6 +27,43 @@ they will not break the plugin ABI or saved files.
 * Releases are cut by tagging `vX.Y.Z` on `main`, which triggers
   `.github/workflows/release.yml` to build and attach installers.
 
+## Updating
+
+Schist checks GitHub for the latest release from Check for Updates —
+under File, or the application menu on macOS — and once a day at launch while the "Check for new releases at
+launch" preference is on (it is on by default; turning it off stops every
+unattended request). The check sends nothing but the request, and a
+download only starts when the user presses Update.
+
+What happens next depends on the platform:
+
+* **macOS** downloads `Schist.zip`, unpacks it beside the running bundle
+  with `ditto`, and swaps it in with a rename. The new bundle is refused
+  unless it is signed at least as well as the one it replaces: a signed
+  copy only takes an update signed by the same team, and a signature that
+  fails `codesign --verify --strict` is never installed. A relauncher
+  waits for the editor to exit and opens the new bundle.
+* **Windows** downloads `Schist-<version>-setup.exe` and hands it to a
+  detached process that waits for the editor to exit — a running
+  `schist.exe` cannot be overwritten — then runs it silently (`/S`,
+  elevated, which is one UAC prompt) and starts the result. The installer
+  is unsigned for now, so the download is only as good as its HTTPS
+  connection and the SHA-256 GitHub records for the asset, which is
+  checked when present.
+* **Linux** installs nothing itself. A copy from `pacman`, `apt`, `dnf` or
+  an AppImage belongs to whatever put it there, so the dialog names the
+  new version and links to the release.
+
+Self-updating only offers itself where the copy is one Schist may
+replace: inside a writable `.app` bundle on macOS, and next to the
+`uninstall.exe` the installer writes on Windows. A loose `schist.exe` or a
+`cargo run` build is left alone.
+
+The updater picks its download out of the release by asset name —
+`Schist.zip` and `Schist-<version>-setup.exe`, matched in
+`crates/app/src/update.rs`. Renaming either in `release.yml` without
+changing it there ends self-updating silently, so keep the two together.
+
 ## Releasing
 
 1. Update the version in the root `Cargo.toml`, `packaging/macos/Info.plist`


### PR DESCRIPTION
The update check knew how to say a release existed and nothing else — the status line named a version and pointed at a URL, and the rest was the user's problem. It now downloads and installs the release on the two platforms where Schist owns its own install, and stays out of the way on the one where it does not.

## What it does

**macOS** unpacks the release's `Schist.zip` beside the running bundle (a rename cannot cross volumes) and swaps it in with a rename. The download is held to this copy's signature first: a signed bundle only takes an update signed by the same team, and any signature present must pass `codesign --verify --strict`. The old bundle steps aside rather than being deleted, so a failed swap rolls back. A relauncher waits on our PID and `open`s the new bundle.

**Windows** hands `Schist-<version>-setup.exe` to a detached process that waits for this one to exit — a running `schist.exe` cannot be overwritten — then runs it `/S` elevated and starts the result unelevated.

**Linux** installs nothing. A copy from `pacman`, `apt` or an AppImage belongs to whatever put it there, so the dialog names the new version and links to the release.

Self-updating only offers itself where the copy is one Schist may replace: a writable `.app` bundle, or the directory holding the `uninstall.exe` the NSIS installer writes. A loose `schist.exe` or a `cargo run` build is left alone, and gets the Linux treatment.

## The dialog

`Later` · `Release Notes` · **`Update and Restart`**, with a progress bar while the download runs and a Cancel that abandons it. Escaping the dialog mid-download is a cancel too — dismissing the thing that asked must not leave an update to land on its own. Restarting goes through `request_quit`, so unsaved documents are still prompted for; backing out of one of those prompts leaves the update staged rather than lost.

Preferences gains "Check for new releases at launch" (on by default). That check runs at most once a day, does not consume the day when it fails to reach GitHub, and yields to any dialog the user already has open.

## Notes

* Update handling moves out of `crash.rs` into `crates/app/src/update.rs`; what is left there is crash reporting, which is all its name claimed.
* The downloaded file is checked against the SHA-256 GitHub records for the asset, when the release has one. The Windows installer is still unsigned, so that download rests on HTTPS plus the digest, where macOS gets a real signature check.
* The updater matches release assets **by name** (`Schist.zip`, `Schist-<version>-setup.exe`). Renaming either in `release.yml` without changing `update.rs` would silently end self-updating — written down in the new "Updating" section of `docs/versioning.md`.

## Testing

`cargo fmt --check`, `cargo clippy -p schist-app --all-targets -- -D warnings` and `cargo test -p schist-app` (40 passed) are green. Both platform paths that Linux compiles away were type-checked as well: macOS by retargeting its `cfg`, Windows through the `x86_64-pc-windows-gnu` cross-check. Neither install path has been exercised against a real release yet — that wants a tagged build on each platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)