### PR TITLE
Crash reports can go to Sentry, with symbols from the release build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,14 @@
+# --build-id: the note that ties a shipped binary to the debug info uploaded
+# for it. The Linux release is stripped before it is packaged, so without a
+# build id in both halves nothing on the Sentry side can be symbolicated.
+# It is pinned rather than left to the toolchain: mold writes one by default
+# and Ubuntu's GNU ld does not, and the two Linux jobs use one linker each.
+
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+rustflags = ["-C", "link-arg=-fuse-ld=mold", "-C", "link-arg=-Wl,--build-id=sha1"]
+
+# The aarch64 runner links with the default cc, not mold -- only the flag
+# that has to be there either way is set here.
+[target.aarch64-unknown-linux-gnu]
+rustflags = ["-C", "link-arg=-Wl,--build-id=sha1"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,20 @@ jobs:
           - os: windows-latest
             artifact: schist-windows-x86_64
     runs-on: ${{ matrix.os }}
+    env:
+      # Compiled into the app by crates/app/src/crash.rs. In a fork, or any
+      # repository without the secret, this arrives as an empty string --
+      # which that code reads as "no DSN", so the build still succeeds and
+      # simply has nothing to upload to and no preference to offer.
+      SCHIST_SENTRY_DSN: ${{ secrets.SCHIST_SENTRY_DSN }}
+      # Where the debug info goes. `vars`, not `secrets`: an org and project
+      # slug are not secret, and putting them in `secrets` would only get
+      # them masked out of the logs that diagnose a failed upload.
+      SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+      # The one switch for all of it: with no token every Sentry step below
+      # is skipped and the release comes out as it did before any of this.
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -87,6 +101,26 @@ jobs:
         # The MCP server ships next to the app, so it is built in the same
         # invocation -- the two share nearly every dependency.
         run: cargo build --release -p schist-app -p schist-mcp
+
+      # Installed from npm rather than the shell installer: it is the one
+      # source with a binary for all four runners, arm64 Linux included.
+      - name: Install sentry-cli
+        if: env.SENTRY_AUTH_TOKEN != ''
+        run: npm install -g @sentry/cli@2
+
+      - name: Upload debug info to Sentry (Linux)
+        if: runner.os == 'Linux' && env.SENTRY_AUTH_TOKEN != ''
+        run: |
+          # Before the Package step strips them. ELF carries DWARF inside
+          # the executable, so this is the last moment it exists at all --
+          # what ships keeps only its build id, and that id is what a crash
+          # report is matched against these uploads on.
+          #
+          # schist-mcp is here even though only the app links the SDK: the
+          # strip is destructive, so this is the one chance to keep anything
+          # that could make sense of a fault in the server later.
+          sentry-cli debug-files upload --include-sources \
+            target/release/schist target/release/schist-mcp
 
       - name: Package (Linux)
         if: runner.os == 'Linux'
@@ -187,6 +221,21 @@ jobs:
           # bundle's permissions or symlinks, which would void the signature.
           rm -rf dist/Schist.app
 
+      - name: Upload debug info to Sentry (macOS)
+        if: runner.os == 'macOS' && env.SENTRY_AUTH_TOKEN != ''
+        run: |
+          # After packaging, not before: bundle.sh runs cargo again, and a
+          # relink there would give the shipped binary a UUID no dSYM made
+          # earlier would match. Signing is safe to have happened already --
+          # codesign appends a signature and leaves LC_UUID alone.
+          #
+          # Nothing is stripped on macOS; the debug info simply lives in the
+          # object files rather than the executable, and dsymutil is what
+          # gathers it into a form that can be uploaded.
+          dsymutil target/release/schist target/release/schist-mcp
+          sentry-cli debug-files upload --include-sources \
+            target/release/schist.dSYM target/release/schist-mcp.dSYM
+
       - name: Package (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
@@ -216,10 +265,59 @@ jobs:
           if (-not (Test-Path $out)) { throw "installer not produced: $out" }
           if ((Get-Item $out).Length -eq 0) { throw "installer is empty: $out" }
 
+      - name: Upload debug info to Sentry (Windows)
+        if: runner.os == 'Windows' && env.SENTRY_AUTH_TOKEN != ''
+        shell: pwsh
+        run: |
+          # MSVC keeps debug info in a .pdb beside the executable, so unlike
+          # Linux nothing had to be stripped and the shipped .exe is exactly
+          # what these describe. Matched rather than named: rustc derives the
+          # .pdb name from the binary's, and the only .pdb files that land
+          # directly in target/release are the two binaries' -- dependencies
+          # and build scripts write theirs into deps/ and build/.
+          $pdbs = Get-ChildItem target/release/*.pdb
+          if (-not $pdbs) { throw 'no .pdb beside the release binaries' }
+          sentry-cli debug-files upload --include-sources @($pdbs.FullName)
+
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
           path: dist/*
+
+  # Registers the version the app reports under, so an uploaded crash lands
+  # on a release with a commit range attached rather than on a bare string.
+  # Separate from `build` because it happens once, not once per platform.
+  sentry-release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    env:
+      SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # set-commits works out what changed by reading the log; the
+          # default shallow clone has none to read.
+          fetch-depth: 0
+      - name: Register the release with Sentry
+        if: env.SENTRY_AUTH_TOKEN != ''
+        run: |
+          set -eo pipefail
+          npm install -g @sentry/cli@2
+          # The same name crash.rs sends events under, or they land nowhere
+          # -- and it builds that from CARGO_PKG_VERSION, so this reads the
+          # manifest rather than the tag. The two agree on a correctly cut
+          # release; if they ever do not, the manifest is what shipped.
+          release="schist@$(grep -m1 '^version = ' Cargo.toml | cut -d'"' -f2)"
+          sentry-cli releases new "$release"
+          # Needs a repository integration configured on the Sentry side.
+          # Without one this is the only part that fails, and it costs only
+          # the commit list, so it must not take the release down with it.
+          sentry-cli releases set-commits "$release" --auto --ignore-missing \
+            || echo "no repository integration; release created without commits"
+          sentry-cli releases finalize "$release"
 
   publish:
     needs: build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,20 @@ version = 4
 
 [[package]]
 name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli 0.32.3",
+]
+
+[[package]]
+name = "addr2line"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
 dependencies = [
- "gimli",
+ "gimli 0.33.0",
 ]
 
 [[package]]
@@ -152,7 +161,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
 dependencies = [
- "object",
+ "object 0.39.1",
 ]
 
 [[package]]
@@ -548,6 +557,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
 dependencies = [
  "arrayvec",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line 0.25.1",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object 0.37.3",
+ "rustc-demangle",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -972,6 +1019,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,6 +1118,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "command-fds"
@@ -1400,7 +1466,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.33.0",
  "hashbrown 0.17.1",
  "libm",
  "log",
@@ -1582,6 +1648,16 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
 
 [[package]]
 name = "deflate64"
@@ -2079,6 +2155,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,6 +2339,12 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futf"
@@ -2446,6 +2540,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "gimli"
@@ -2989,6 +3089,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "http"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,6 +3137,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
@@ -3079,13 +3196,16 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3403,6 +3523,36 @@ dependencies = [
  "jiff-core",
  "proc-macro2",
  "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.20",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
  "syn 2.0.119",
 ]
 
@@ -4208,6 +4358,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4216,6 +4387,51 @@ dependencies = [
  "bitflags 2.13.1",
  "dispatch2",
  "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.1",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
 ]
 
 [[package]]
@@ -4229,6 +4445,19 @@ name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.13.1",
  "objc2",
@@ -4267,10 +4496,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.13.1",
+ "block2",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
  "objc2-foundation",
  "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4289,6 +4536,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
 dependencies = [
  "objc",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4389,6 +4645,22 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.31.3",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4867,6 +5139,7 @@ version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.4.3",
  "lru-slab",
@@ -5245,6 +5518,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resvg"
 version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5396,6 +5708,7 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5437,11 +5750,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.0",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5618,6 +5959,7 @@ dependencies = [
  "schist-tools-vector",
  "schist-tools-warp",
  "schist-vector",
+ "sentry",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -6124,6 +6466,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "sentry"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a88b65feb368d9dde5d531a2b59b25016e36fd6e4978432371a3ee77746ca2"
+dependencies = [
+ "cfg_aliases",
+ "httpdate",
+ "reqwest",
+ "rustls",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-debug-images",
+ "sentry-panic",
+ "sentry-tracing",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c51511d67ed670266a93afeaa26a08019b04ad1420cb9191da30f2338d22c48"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b757ac1f335856e8d7f5062a1fd9bc07a05a7eb3cc48247db79bf2618a490bd"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d889520a375e5b93efb0a66def1630d21d168b0251eb55b286b03fa940ccfc84"
+dependencies = [
+ "rand 0.9.5",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656487fd5f7b7c0105b2e82171982aac64489e0cb679436038febf070f2f76d6"
+dependencies = [
+ "findshlibs",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0fe456a7380e9df875a1ef4df1e468d35b19b9051599845fab9d8f0c71c4ae"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77796d14eedbef22c2fe78e9c69fb09f14c7ad607e624d48dce92eedc17a136e"
+dependencies = [
+ "bitflags 2.13.1",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.49.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc71f5ca55942d9b2901af95d5df5c5d65c164134c22a83682cac3d0b6c7ef2d"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand 0.9.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "time",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6298,6 +6747,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6305,6 +6764,12 @@ checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
 dependencies = [
  "quote",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simplecss"
@@ -7111,6 +7576,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7151,6 +7634,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "tracing-core",
 ]
 
 [[package]]
@@ -7421,6 +7914,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7622,6 +8124,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"
@@ -7833,7 +8341,7 @@ version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c80ca6098e0d4d06886d91d7f2cc3cb6623eb583c4c0ab3c89cbfb6098c8586c"
 dependencies = [
- "addr2line",
+ "addr2line 0.26.1",
  "async-trait",
  "bitflags 2.13.1",
  "bumpalo",
@@ -7844,7 +8352,7 @@ dependencies = [
  "log",
  "mach2",
  "memfd",
- "object",
+ "object 0.39.1",
  "once_cell",
  "postcard",
  "pulley-interpreter",
@@ -7876,11 +8384,11 @@ dependencies = [
  "cranelift-bforest",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli",
+ "gimli 0.33.0",
  "hashbrown 0.17.1",
  "indexmap",
  "log",
- "object",
+ "object 0.39.1",
  "postcard",
  "rustc-demangle",
  "semver",
@@ -7925,10 +8433,10 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli",
+ "gimli 0.33.0",
  "itertools 0.14.0",
  "log",
- "object",
+ "object 0.39.1",
  "pulley-interpreter",
  "smallvec",
  "target-lexicon",
@@ -7986,7 +8494,7 @@ dependencies = [
  "cfg-if",
  "cranelift-codegen",
  "log",
- "object",
+ "object 0.39.1",
  "wasmtime-environ",
 ]
 
@@ -8116,6 +8624,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,19 @@ log = "0.4"
 wgpu = "27"
 pollster = "0.4"
 env_logger = "0.11"
+# Opt-in crash reporting. No default features: they would pull reqwest and
+# native-tls (an OpenSSL build) and turn on release-health sessions, logs and
+# metrics -- all of which report on a *running* editor, not a crashed one.
+# The ureq/rustls transport is the same HTTP stack the update check already
+# links, so this adds no new way of talking to the network.
+sentry = { version = "0.49", default-features = false, features = [
+    "backtrace",
+    "contexts",
+    "debug-images",
+    "panic",
+    "ureq",
+    "rustls",
+] }
 
 [profile.dev]
 opt-level = 1

--- a/README.md
+++ b/README.md
@@ -271,6 +271,25 @@ Remap anything in `~/.config/schist/keymap.json`:
   below a couple of megapixels, where its row-by-row scan costs more in
   dispatches than it saves.
 
+## Diagnostics
+
+Schist does not phone home. There are three things it can send over the
+network and each is off until you turn it on: **Check for Updates**, the
+on-demand font and model downloads, and crash reporting.
+
+Crash reporting is two separate ticks in **Preferences ▸ Diagnostics**.
+The first writes a report next to the crash-recovery snapshot in
+`~/.local/state/schist/crashes/` and sends nothing anywhere. The second
+also uploads it to the project's Sentry, and only appears on the official
+releases — a build from source is given no DSN, so the code that would
+report has nowhere to report to and never starts. Uploads carry no
+personal data, no hostname and no breadcrumbs, and the panic message has
+your home directory rewritten to `~` before it leaves, because a panic
+tends to quote the path it choked on and that path is your work.
+
+Set `SCHIST_CRASH_REPORTS=1` or `SCHIST_CRASH_UPLOAD=1` to turn either on
+for a single run without changing preferences.
+
 ## Plugins
 
 Third-party plugins are sandboxed WebAssembly — no filesystem, network or

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -19,6 +19,8 @@ serde_json.workspace = true
 ureq = { version = "3", default-features = false, features = ["rustls", "json"] }
 # Verifies a downloaded update against the digest the release records.
 sha2 = "0.10"
+# Only used by the opt-in crash upload, and only in a build handed a DSN.
+sentry.workspace = true
 image.workspace = true
 smallvec.workspace = true
 rustc-hash.workspace = true

--- a/crates/app/src/crash.rs
+++ b/crates/app/src/crash.rs
@@ -1,9 +1,15 @@
 //! Opt-in crash reporting.
 //!
-//! Off until the user turns it on, and nothing is sent anywhere even
-//! then: a crash writes a local report file next to the recovery
-//! snapshots and that is all. Update checks, the one thing here that
-//! ever spoke to the network, live in [`crate::update`].
+//! Off until the user turns it on: a crash writes a local report file next
+//! to the recovery snapshots, and uploading that report to Sentry is a
+//! second, separate opt-in — writing a file to this machine and sending one
+//! to us are not the same decision. Update checks, the other thing here that
+//! speaks to the network, live in [`crate::update`].
+//!
+//! The upload has a second lock on it. It needs a DSN, and a DSN is baked
+//! in at build time from `SCHIST_SENTRY_DSN`, which only the release
+//! workflow sets. A build from source has none, so the preference does not
+//! even appear, and `sentry::init` is never reached.
 
 use std::path::PathBuf;
 
@@ -83,9 +89,218 @@ fn write_report(info: &std::panic::PanicHookInfo<'_>) {
     eprintln!("schist: crash report written to {}", path.display());
 }
 
+/// This build's home for uploaded crashes, or `None` if it has not got one.
+///
+/// A runtime `SCHIST_SENTRY_DSN` beats the compiled-in value, which is how
+/// the upload path gets exercised against a scratch project without cutting
+/// a release. Cargo re-runs the compile when the build-time variable
+/// changes: rustc records `option_env!` reads in its dep-info.
+fn dsn() -> Option<String> {
+    std::env::var("SCHIST_SENTRY_DSN")
+        .ok()
+        .or_else(|| option_env!("SCHIST_SENTRY_DSN").map(str::to_owned))
+        .map(|d| d.trim().to_string())
+        .filter(|d| !d.is_empty())
+}
+
+/// Whether this build could upload a crash at all.
+///
+/// The Preferences checkbox is hidden when this is false — offering to send
+/// reports from a build that has nowhere to send them would be a lie.
+pub fn reporting_available() -> bool {
+    dsn().is_some()
+}
+
+/// A live Sentry client. Holding it is what keeps uploads working; dropping
+/// it flushes whatever is still queued, so `main` keeps it until it exits.
+pub struct Reporter(#[allow(dead_code)] sentry::ClientInitGuard);
+
+/// Start uploading crashes, if the user asked for it and this build can.
+///
+/// Returns `None` when either is untrue, and in that case nothing is
+/// initialised — no client, no transport thread, no network.
+///
+/// Call this *before* [`install_handler`]: both chain themselves in front of
+/// whichever panic hook they find, so calling them in this order leaves the
+/// local report being written first and the upload attempted second — a
+/// network that is down or slow then cannot cost the user the report on
+/// disk.
+pub fn start_reporting(enabled: bool) -> Option<Reporter> {
+    if !enabled {
+        return None;
+    }
+    let dsn = dsn()?;
+    // Checked here rather than left to `ClientOptions::dsn`, which panics on
+    // anything it cannot parse. A crash reporter that takes the editor down
+    // over its own configuration would be worse than no crash reporter.
+    if dsn.parse::<sentry::types::Dsn>().is_err() {
+        log::warn!("SCHIST_SENTRY_DSN is not a DSN; crash uploads stay off");
+        return None;
+    }
+    // Not the version alone: Sentry matches an event to its uploaded debug
+    // files by debug id, but groups and charts it by release, and
+    // "schist@0.6.0" is the name the release workflow registers.
+    let release = format!("schist@{}", crate::update::current_version());
+    // Which build of that release. The four we publish differ in what is
+    // even reachable — the GPU compositor, the .8bf helpers — so a crash is
+    // much easier to place with this than without.
+    let dist = format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH);
+    let home = home_dir().and_then(|h| h.to_str().map(str::to_owned));
+
+    let guard = sentry::init(
+        sentry::ClientOptions::new()
+            .dsn(&dsn)
+            .release(release)
+            // `sentry-contexts` fills this with the machine's hostname when
+            // it is left unset, and a hostname is very often a person's
+            // name. Setting it stops that lookup happening at all.
+            .server_name("redacted")
+            .send_default_pii(false)
+            // Schist records no breadcrumbs, and this makes sure a
+            // dependency cannot start doing so on its behalf.
+            .max_breadcrumbs(0)
+            .before_send(move |mut event| {
+                if let Some(home) = home.as_deref() {
+                    redact_paths(&mut event, home);
+                }
+                event.dist = Some(dist.clone().into());
+                Some(event)
+            }),
+    );
+    // A DSN that parsed but was rejected leaves a disabled client behind;
+    // there is nothing to hold on to in that case.
+    if !guard.is_enabled() {
+        return None;
+    }
+    // The SDK hands the event to a background thread and counts on its guard
+    // being dropped to flush the queue. A crash in a GUI often never gets
+    // that far — GPUI unwinds through platform callbacks, and an unwind
+    // across one of those aborts the process outright — so the flush is
+    // forced from inside the hook instead, where there is still certainly a
+    // process to do it in. Two seconds, the same as the guard would wait.
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        previous(info);
+        if let Some(client) = sentry::Hub::current().client() {
+            client.flush(Some(std::time::Duration::from_secs(2)));
+        }
+    }));
+    Some(Reporter(guard))
+}
+
+/// This user's home directory, by the same variables [`state_dir`] uses.
+fn home_dir() -> Option<PathBuf> {
+    if cfg!(windows) {
+        std::env::var("USERPROFILE").ok().map(PathBuf::from)
+    } else {
+        std::env::var("HOME").ok().map(PathBuf::from)
+    }
+}
+
+/// Replace the user's home directory with `~` throughout an event.
+///
+/// A panic message routinely quotes the path it choked on, and for an image
+/// editor that path is a document someone opened — `/home/astrid/clients/…`
+/// names both them and their work. The rest of the event is safe as it
+/// stands: frame filenames are the *build* machine's source paths, and the
+/// module list is addresses and debug ids.
+fn redact_paths(event: &mut sentry::protocol::Event<'static>, home: &str) {
+    // "/" and "" would rewrite every path in the event into nonsense.
+    if home.len() < 2 {
+        return;
+    }
+    if let Some(message) = event.message.as_mut() {
+        *message = redact(message, home);
+    }
+    for exception in &mut event.exception.values {
+        if let Some(value) = exception.value.as_mut() {
+            *value = redact(value, home);
+        }
+    }
+}
+
+/// `redact_paths` for one string.
+fn redact(text: &str, home: &str) -> String {
+    // Backslashes as well as forward, because a Windows panic message may
+    // quote either: `Path::display` gives `C:\Users\a`, but a path built
+    // from a `file://` URL keeps the slashes it arrived with.
+    if cfg!(windows) && home.contains('\\') {
+        let slashed = home.replace('\\', "/");
+        return text.replace(home, "~").replace(&slashed, "~");
+    }
+    text.replace(home, "~")
+}
+
 #[cfg(test)]
 mod tests {
-    use super::crash_dir;
+    use super::{crash_dir, redact, redact_paths, reporting_available, start_reporting};
+
+    #[test]
+    fn home_paths_are_redacted_out_of_reports() {
+        assert_eq!(
+            redact(
+                "failed to open /home/astrid/clients/acme.psd",
+                "/home/astrid"
+            ),
+            "failed to open ~/clients/acme.psd"
+        );
+        // Every occurrence, not just the first: a message often names both
+        // the source and the destination of an operation.
+        assert_eq!(
+            redact("/home/astrid/a.psd -> /home/astrid/b.psd", "/home/astrid"),
+            "~/a.psd -> ~/b.psd"
+        );
+        // A message that never mentions the home directory is untouched.
+        assert_eq!(
+            redact("index out of bounds", "/home/astrid"),
+            "index out of bounds"
+        );
+    }
+
+    #[test]
+    fn a_degenerate_home_redacts_nothing() {
+        let mut event = sentry::protocol::Event {
+            message: Some("/usr/share/schist".into()),
+            ..Default::default()
+        };
+        redact_paths(&mut event, "/");
+        assert_eq!(event.message.as_deref(), Some("/usr/share/schist"));
+    }
+
+    #[test]
+    fn redaction_reaches_the_exception_value() {
+        let mut event = sentry::protocol::Event {
+            exception: vec![sentry::protocol::Exception {
+                ty: "panic".into(),
+                value: Some("no such file: /home/astrid/a.psd".into()),
+                ..Default::default()
+            }]
+            .into(),
+            ..Default::default()
+        };
+        redact_paths(&mut event, "/home/astrid");
+        assert_eq!(
+            event.exception.values[0].value.as_deref(),
+            Some("no such file: ~/a.psd")
+        );
+    }
+
+    #[test]
+    fn a_build_without_a_dsn_never_starts_a_client() {
+        // The test binary is compiled without SCHIST_SENTRY_DSN, so this
+        // stands in for every build but the official releases: asking for
+        // uploads has to be a no-op rather than a half-configured client.
+        if option_env!("SCHIST_SENTRY_DSN").is_none() && std::env::var("SCHIST_SENTRY_DSN").is_err()
+        {
+            assert!(!reporting_available());
+            assert!(start_reporting(true).is_none());
+        }
+    }
+
+    #[test]
+    fn uploads_stay_off_when_the_preference_is_off() {
+        assert!(start_reporting(false).is_none());
+    }
 
     #[test]
     fn crash_dir_is_under_the_state_directory() {

--- a/crates/app/src/dialogs.rs
+++ b/crates/app/src/dialogs.rs
@@ -2420,6 +2420,29 @@ fn preferences(
                 cx,
             ),
         ))
+        // Only the official releases are built with a DSN. Everywhere else
+        // this would be a checkbox that sends reports nowhere, so it is not
+        // offered -- and the preference it would set stays false.
+        .children(crate::crash::reporting_available().then(|| {
+            ui::field_row(
+                "",
+                ui::checkbox(
+                    "Also send it to the developers",
+                    view.crash_upload,
+                    |ws, _cx| {
+                        ws.view.crash_upload = !ws.view.crash_upload;
+                        ws.save_view_options();
+                    },
+                    cx,
+                ),
+            )
+        }))
+        .child(
+            div()
+                .text_size(px(11.0))
+                .text_color(gpui::rgb(ui::palette().text_dim))
+                .child("Diagnostics take effect when Schist next starts."),
+        )
         .child(ui::field_row(
             "Updates",
             ui::checkbox(

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -65,24 +65,10 @@ impl PluginManifest for PsdPlugin {
     }
 }
 
-/// Crash reporting stays off unless the user opts in.
-fn crash_reports_enabled() -> bool {
-    if std::env::var("SCHIST_CRASH_REPORTS").is_ok_and(|v| v == "1") {
-        return true;
-    }
-    std::env::var("XDG_CONFIG_HOME")
-        .ok()
-        .map(std::path::PathBuf::from)
-        .or_else(|| {
-            std::env::var("HOME")
-                .ok()
-                .map(|h| std::path::PathBuf::from(h).join(".config"))
-        })
-        .map(|d| d.join("schist/preferences.json"))
-        .and_then(|p| std::fs::read_to_string(p).ok())
-        .and_then(|text| serde_json::from_str::<serde_json::Value>(&text).ok())
-        .and_then(|v| v.get("crash_reports").and_then(|b| b.as_bool()))
-        .unwrap_or(false)
+/// Whether an opt-in diagnostic is on: the preference, or the environment
+/// variable that overrides it for one run.
+fn opted_in(preference: bool, var: &str) -> bool {
+    preference || std::env::var(var).is_ok_and(|v| v == "1")
 }
 
 /// Assemble the first-party plugin set. Every entry here is optional — the
@@ -205,10 +191,20 @@ fn path_from_url(url: &str) -> Option<PathBuf> {
 
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
-    // Opt-in: SCHIST_CRASH_REPORTS=1, or the preference file's
-    // crash_reports flag once the user enables it in Preferences.
-    crash::install_handler(crash_reports_enabled());
-    workspace::init_compositor_backend(workspace::load_view_options().gpu_compositing);
+    let options = workspace::load_view_options();
+    // Both diagnostics are opt-in, and separately so: writing a report to
+    // this machine and sending one to ours are not the same decision.
+    // SCHIST_CRASH_REPORTS=1 and SCHIST_CRASH_UPLOAD=1 turn them on for a
+    // single run without touching preferences.
+    //
+    // Sentry goes first because it installs a panic hook and
+    // `install_handler` chains in front of whichever hook it finds: the
+    // local report is written before the upload is attempted, so a failing
+    // network never costs the user the report on disk. `_reporter` has to
+    // outlive the app -- dropping it is what flushes the queue.
+    let _reporter = crash::start_reporting(opted_in(options.crash_upload, "SCHIST_CRASH_UPLOAD"));
+    crash::install_handler(opted_in(options.crash_reports, "SCHIST_CRASH_REPORTS"));
+    workspace::init_compositor_backend(options.gpu_compositing);
     let (registry, plugin_manager, photoshop_plugins) = build_registry();
 
     let requests: Rc<RefCell<OpenRequests>> = Rc::default();

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -489,6 +489,12 @@ pub struct ViewOptions {
     /// nothing is ever transmitted.
     #[serde(default)]
     pub crash_reports: bool,
+    /// Also upload that crash to the project's Sentry. Opt-in separately
+    /// from the local report — writing a file here and sending one to us
+    /// are not the same decision — and inert in any build that was not
+    /// given a DSN, which is every build but the official releases.
+    #[serde(default)]
+    pub crash_upload: bool,
     /// Composite and resample on the GPU when an adapter exists. On by
     /// default; the CPU reference takes over per-frame for anything the
     /// GPU path can't express, and entirely when this is off.
@@ -517,6 +523,7 @@ impl Default for ViewOptions {
             theme: Theme::Dark,
             zoom_with_scroll: false,
             crash_reports: false,
+            crash_upload: false,
             gpu_compositing: true,
             check_updates: true,
         }

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -85,7 +85,10 @@ changing it there ends self-updating silently, so keep the two together.
    `schist-mcp-linux-aarch64`), a loose binary on Windows, and on macOS
    `schist-mcp-macos.zip`, signed and notarized on its own. See
    [mcp.md](mcp.md).
-5. Update the AUR package from `packaging/linux/aur/PKGBUILD`: bump
+5. When the Sentry settings below are present, the same workflow uploads
+   each platform's debug info and registers the release. Nothing about the
+   published artifacts changes either way.
+6. Update the AUR package from `packaging/linux/aur/PKGBUILD`: bump
    `pkgver` to the new version, reset `pkgrel=1`, then in an Arch
    environment run `updpkgsums` (re-pins the tag tarball's sha256), test
    with `makepkg -s` + `namcap`, and regenerate `.SRCINFO` with
@@ -132,3 +135,60 @@ without that entitlement a notarized build dies as soon as it loads one.
 
 Windows builds are not signed — there is no certificate for them yet, so
 the installer triggers SmartScreen on first download.
+
+## Crash reporting and symbols
+
+Schist can upload a crash to Sentry. It is off twice over: the user has to
+tick **Preferences ▸ Diagnostics ▸ Also send it to the developers**, *and*
+the build has to have been given a DSN. Only the release workflow supplies
+one, so a build from source — or from a distribution's packaging — has no
+DSN, never starts the SDK, and does not even show the checkbox. See
+`crates/app/src/crash.rs`.
+
+Events are scrubbed before they leave: no PII, no breadcrumbs, no session
+tracking, `server_name` set to `redacted` rather than the machine's
+hostname, and the user's home directory rewritten to `~` in the panic
+message — an image editor panic tends to quote the path it choked on, and
+that path is somebody's document.
+
+### Settings
+
+| Name | Kind | What it is |
+| --- | --- | --- |
+| `SENTRY_AUTH_TOKEN` | secret | A token with `project:releases`. It is the switch for all of this: without it every Sentry step is skipped and the release is built exactly as it was before. |
+| `SCHIST_SENTRY_DSN` | secret | The DSN compiled into the app. Not really secret — it ships inside the binary — but it lives here so forks get an empty one and produce a build that cannot report. |
+| `SENTRY_ORG` | variable | The organisation slug. |
+| `SENTRY_PROJECT` | variable | The project slug. |
+
+The two slugs are repository *variables*, not secrets: they are not
+sensitive, and as secrets they would be masked out of exactly the log lines
+that explain a failed upload.
+
+### Debug info
+
+The release profile builds with `debug = 1`, and each platform hands that
+to Sentry in the form its object format keeps it in:
+
+* **Linux** — DWARF lives inside the executable, and the workflow strips it
+  before packaging so the AppImage does not carry it. The upload therefore
+  happens *before* the strip, on the unstripped binary. What ships keeps its
+  build id, and that is what Sentry matches the upload against; both Linux
+  targets pin `--build-id=sha1` in `.cargo/config.toml`, since mold writes
+  one by default and Ubuntu's GNU ld does not.
+* **macOS** — the debug info stays in the object files, so `dsymutil`
+  gathers it into a `.dSYM` and that is uploaded. It runs after packaging,
+  because `bundle.sh` invokes cargo again and a relink there would change
+  the binary's `LC_UUID`. Code signing is harmless: it appends a signature
+  and leaves `LC_UUID` alone.
+* **Windows** — MSVC writes a `.pdb` beside the executable. Nothing is
+  stripped and the `.pdb` is uploaded as it is.
+
+All three upload with `--include-sources`, which bundles the source the
+debug info points at so stack frames come back with code beside them. The
+sources are this repository and public crates, so there is nothing in that
+bundle that is not already published.
+
+A tagged build also registers `schist@X.Y.Z` as a Sentry release, which is
+the name `crash.rs` reports under. Attaching the commit range to it needs a
+repository integration configured on the Sentry side; without one that step
+alone is skipped and the release is still created.


### PR DESCRIPTION
Schist could already write a crash report to the user's own machine and that was all it could do with one. On a stripped Linux release the result is nearly useless anyway — the backtrace is addresses. This adds an upload, and the symbols to read it against.

## Two locks, not one

The upload needs both:

- the user ticks it in **Preferences ▸ Diagnostics**, separately from the local report — writing a file to their machine and sending one to us are not the same decision;
- and the build was given a DSN, which only the release workflow does. A build from source, or from a distribution's packaging, has none, never reaches `sentry::init`, and hides the checkbox rather than offering one that sends reports nowhere.

## What leaves

No PII, no breadcrumbs, and no release-health sessions, logs or metrics — the SDK is taken with `default-features = false` and only the four integrations a crash needs. `server_name` is set rather than left alone, because `sentry-contexts` otherwise fills it with the machine's hostname, and a hostname is very often a person's name. The panic message has the home directory rewritten to `~`: an image editor panic tends to quote the path it choked on, and that path is somebody's document.

Transport is ureq over rustls — the stack the update check already links — so this adds a reason to talk to the network but no new means of doing it, and no C dependency.

The flush is forced from inside the panic hook rather than left to the guard's `Drop`. A crash in a GUI often never gets as far as `main` returning: GPUI unwinds through platform callbacks, and an unwind across one of those aborts outright, so by then there may be no process left to flush in.

## Symbols

Each platform in the form its object format keeps them:

- **Linux** — uploaded before the strip that already happens, since ELF carries DWARF inside the executable and that is the last moment it exists. What ships keeps its build id, which is what the upload is matched on. That id is now pinned with `--build-id=sha1` on both Linux targets instead of left to the toolchain: mold writes one by default and Ubuntu's GNU ld does not, and the two Linux jobs use one linker each.
- **macOS** — `dsymutil` after packaging, because `bundle.sh` invokes cargo again and a relink would change the `LC_UUID` the dSYM is matched on. Signing is harmless; it appends a signature and leaves the UUID alone.
- **Windows** — the `.pdb`s MSVC writes beside the executables, matched rather than named because rustc derives their names from the binaries'.

`SENTRY_AUTH_TOKEN` is the one switch for all of it. Without it every step here is skipped and the release is built exactly as before, so forks and any repository without the secrets are unaffected.

## Before this does anything

The Sentry project does not exist yet, and neither do the settings. Until they are added the pipeline runs green and uploads nothing:

| Name | Kind | What it is |
| --- | --- | --- |
| `SENTRY_AUTH_TOKEN` | secret | Token with `project:releases`. The master switch. |
| `SCHIST_SENTRY_DSN` | secret | The DSN compiled into the app. |
| `SENTRY_ORG` | variable | Organisation slug. |
| `SENTRY_PROJECT` | variable | Project slug. |

Full mechanics in `docs/versioning.md` § *Crash reporting and symbols*.

## Testing

`cargo fmt --check`, `clippy -D warnings` and all 43 tests pass. Five new unit tests cover the redaction and the fails-closed behaviour.

Verified by hand: the build id is byte-identical before and after `strip --strip-debug` and the DWARF is gone after; and a DSN produces an enabled client actually carrying `server_name=redacted`, no PII and no breadcrumbs.

**Not verified, and not verifiable from here:** the upload itself, and whether a stripped Linux release really symbolicates. The first tagged release after the settings land is the first real test of that path.

## One judgement call worth a look

`schist-mcp`'s debug files are uploaded too, though only the app links the SDK — the Linux strip is destructive, so it is the one chance to keep anything that could explain a fault there later. It costs quota for symbols nothing currently reports against. Easy to cut to `schist` alone if you would rather.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
