### PR TITLE
fix: marquee drags show marching ants, and the elliptical one an ellipse

### DIFF
--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -6926,7 +6926,7 @@ impl Workspace {
         // Active tool overlays.
         for overlay in overlays {
             match overlay {
-                Overlay::Rect(r) | Overlay::AntsRect(r) => {
+                Overlay::Rect(r) => {
                     job.outlines.push((
                         Bounds {
                             origin: to_screen(r.left as f32, r.top as f32),
@@ -6934,6 +6934,17 @@ impl Workspace {
                         },
                         gpui::rgb(0x44AAFF).into(),
                     ));
+                }
+                Overlay::AntsRect(r) => {
+                    let (l, t) = (r.left as f32, r.top as f32);
+                    let (rt, b) = (r.right as f32, r.bottom as f32);
+                    // Closed: the last point repeats the first so the
+                    // dashes carry round the final corner.
+                    let pts: Vec<Point<Pixels>> = [(l, t), (rt, t), (rt, b), (l, b), (l, t)]
+                        .iter()
+                        .map(|&(x, y)| to_screen(x, y))
+                        .collect();
+                    push_ants(&mut job.ants, &pts, ant_phase);
                 }
                 Overlay::AntsPolygon(points) => {
                     let pts: Vec<Point<Pixels>> =

--- a/plugins/tools-select/src/lib.rs
+++ b/plugins/tools-select/src/lib.rs
@@ -150,6 +150,25 @@ fn drag_rect(ax: f32, ay: f32, bx: f32, by: f32, square: bool) -> IntRect {
     )
 }
 
+/// The ellipse inscribed in `rect`, as a closed polygon in document
+/// space, for the drag overlay to trace with marching ants.
+///
+/// Segment count follows the rect's size so a small ellipse costs little
+/// and a large one still reads as a curve rather than a polygon.
+fn ellipse_points(rect: IntRect) -> Vec<(f32, f32)> {
+    let rx = rect.width() as f32 / 2.0;
+    let ry = rect.height() as f32 / 2.0;
+    let cx = rect.left as f32 + rx;
+    let cy = rect.top as f32 + ry;
+    let steps = ((rx + ry) as usize).clamp(24, 256);
+    (0..=steps)
+        .map(|i| {
+            let a = i as f32 / steps as f32 * std::f32::consts::TAU;
+            (cx + rx * a.cos(), cy + ry * a.sin())
+        })
+        .collect()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MarqueeShape {
     Rect,
@@ -284,9 +303,15 @@ impl ToolPlugin for MarqueeTool {
     }
 
     fn overlays(&self, _doc: &Document, _state: &EditorState) -> Vec<Overlay> {
-        match self.current {
-            Some(rect) => vec![Overlay::AntsRect(rect)],
-            None => Vec::new(),
+        // The overlay shows the shape that will be committed, so the
+        // elliptical marquee traces its ellipse rather than the rect it
+        // was dragged out of.
+        match (self.current, self.shape) {
+            (Some(rect), MarqueeShape::Rect) => vec![Overlay::AntsRect(rect)],
+            (Some(rect), MarqueeShape::Ellipse) if !rect.is_empty() => {
+                vec![Overlay::AntsPolygon(ellipse_points(rect))]
+            }
+            _ => Vec::new(),
         }
     }
 }


### PR DESCRIPTION
Dragging a marquee drew a solid blue rectangle instead of the marching ants the rest of the app uses for selections — and the elliptical marquee drew that rectangle even though it commits an ellipse.

- `Overlay::AntsRect` is documented as "dashed marching ants", but the canvas painted it through the same match arm as `Overlay::Rect`, i.e. a solid `0x44AAFF` outline. It gets its own arm now, tracing the four corners through `push_ants` (closed, so the dashes carry round the last corner). `Overlay::Rect` keeps the solid outline, which is what layer bounds during a move, artboards and the transform box want.
- The elliptical marquee emitted `AntsRect` of the rect it was dragged out of. It now emits an `AntsPolygon` of the inscribed ellipse — same centre and radii as `Selection::select_ellipse`, segment count scaled from the rect size and clamped to 24..256 — so the preview matches the outline that appears on mouse-up.

The same blue box was on the crop tool, the slice tool and the patch/retouch drag, which all emit `AntsRect`; they get ants now too.

Verified in the app (headless X, fixture PNG): the rectangular drag shows ants with no blue box, and the elliptical drag shows an ellipse that lands exactly on the committed selection outline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)