### PR TITLE
fix: cut and copy do something, and reach other applications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2687,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "gpui"
 version = "0.2.2"
-source = "git+https://github.com/IAmJSD/gpui?rev=84bdb01b29887ca09b6c437dad9a0ae838fe48e8#84bdb01b29887ca09b6c437dad9a0ae838fe48e8"
+source = "git+https://github.com/IAmJSD/gpui?rev=4ab83c7d970241f8b3027dc4ce614f3062f99843#4ab83c7d970241f8b3027dc4ce614f3062f99843"
 dependencies = [
  "anyhow",
  "as-raw-xcb-connection",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,9 +91,11 @@ schist-commands-core = { path = "plugins/commands-core" }
 # external
 # Fork of gpui 0.2.2 adding PinchEvent/on_pinch and stylus pressure on the
 # mouse events, which upstream has no equivalent of; needed for trackpad
-# pinch-to-zoom and pressure-sensitive painting on the canvas.
+# pinch-to-zoom and pressure-sensitive painting on the canvas. It also
+# carries images to the Linux clipboards, which upstream writes as an
+# empty string.
 # Pinned by rev so a push to the fork cannot silently change builds.
-gpui = { git = "https://github.com/IAmJSD/gpui", rev = "84bdb01b29887ca09b6c437dad9a0ae838fe48e8" }
+gpui = { git = "https://github.com/IAmJSD/gpui", rev = "4ab83c7d970241f8b3027dc4ce614f3062f99843" }
 anyhow = "1"
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -7704,7 +7704,7 @@ fn builtin_index(name: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::{PNG_CODEC_ID, builtin_index, hex_field_after, numeric_accepts};
+    use super::{builtin_index, hex_field_after, numeric_accepts, PNG_CODEC_ID};
     use schist_plugin_api::{PluginManifest, PluginRegistry};
     use std::time::{Duration, SystemTime};
 

--- a/crates/app/src/workspace.rs
+++ b/crates/app/src/workspace.rs
@@ -87,6 +87,11 @@ pub(crate) fn load_view_options() -> ViewOptions {
 /// How often a dirty document is snapshotted for crash recovery.
 const AUTOSAVE_SECS: u64 = 30;
 
+/// The registry id of the PNG codec. Codecs are registered as
+/// `codec.<format>`; looking one up by the bare format name silently finds
+/// nothing.
+const PNG_CODEC_ID: &str = "codec.png";
+
 /// A document open in another tab, parked with its view transform so
 /// switching back lands on the same spot at the same zoom.
 struct DocTab {
@@ -2911,7 +2916,7 @@ impl Workspace {
                 .map(|c| if c.is_alphanumeric() { c } else { '-' })
                 .collect();
             let out = dir.join(format!("{stem}-{safe}.png"));
-            let Some(codec) = self.registry.codecs().find(|c| c.id() == "png") else {
+            let Some(codec) = self.png_codec() else {
                 continue;
             };
             match codec.export(&region_doc) {
@@ -2927,6 +2932,16 @@ impl Workspace {
         cx.notify();
     }
 
+    /// The PNG codec, which is how anything leaves the app as a flat image.
+    ///
+    /// Both callers used to look for the id `"png"`; every codec is
+    /// registered as `codec.<format>`, so the lookup never matched and
+    /// exporting slices and copying to the system clipboard both returned
+    /// early without a word.
+    fn png_codec(&self) -> Option<&dyn schist_plugin_api::CodecPlugin> {
+        self.registry.codecs().find(|c| c.id() == PNG_CODEC_ID)
+    }
+
     /// Push the internal clipboard out to the system clipboard as a PNG.
     ///
     /// Schist's own copy/paste has always worked between its documents;
@@ -2939,7 +2954,7 @@ impl Workspace {
         if w == 0 || h == 0 {
             return;
         }
-        let Some(codec) = self.registry.codecs().find(|c| c.id() == "png") else {
+        let Some(codec) = self.png_codec() else {
             return;
         };
         // Codecs export documents, so the clipboard becomes a one-layer one.
@@ -7689,8 +7704,23 @@ fn builtin_index(name: &str) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use super::{builtin_index, hex_field_after, numeric_accepts};
+    use super::{PNG_CODEC_ID, builtin_index, hex_field_after, numeric_accepts};
+    use schist_plugin_api::{PluginManifest, PluginRegistry};
     use std::time::{Duration, SystemTime};
+
+    /// Copying to the system clipboard and exporting slices both look the
+    /// PNG codec up by id, and both looked for `"png"` -- which nothing is
+    /// registered as, so each returned early and did nothing at all.
+    #[test]
+    fn the_png_codec_answers_to_the_id_it_is_looked_up_by() {
+        let mut registry = PluginRegistry::new();
+        schist_codecs_common::CommonCodecsPlugin.register(&mut registry);
+        let codec = registry
+            .codecs()
+            .find(|c| c.id() == PNG_CODEC_ID)
+            .expect("nothing is registered under the id the PNG lookups use");
+        assert!(codec.can_export(), "the PNG codec has to be able to export");
+    }
 
     #[test]
     fn numeric_fields_take_fractions_and_negatives() {

--- a/crates/core/src/document.rs
+++ b/crates/core/src/document.rs
@@ -311,9 +311,7 @@ impl Document {
                     }
                     Direction::Undo => {
                         self.tree.remove_at(path);
-                        if self.active_layer == Some(layer.id) {
-                            self.active_layer = None;
-                        }
+                        self.reselect_after_removal(layer.id, path);
                     }
                 }
                 self.add_damage(layer.content_bounds());
@@ -323,9 +321,7 @@ impl Document {
                 match dir {
                     Direction::Redo => {
                         self.tree.remove_at(path);
-                        if self.active_layer == Some(layer.id) {
-                            self.active_layer = None;
-                        }
+                        self.reselect_after_removal(layer.id, path);
                     }
                     Direction::Undo => {
                         self.tree.insert_at(path, (**layer).clone());
@@ -474,6 +470,20 @@ impl Document {
         }
     }
 
+    /// Keep the panel pointed at something after `removed` (which sat at
+    /// `path`) leaves the tree.
+    ///
+    /// Nulling `active_layer` left the document with no active layer at
+    /// all, and every command that edits pixels -- copy, cut, fill, the
+    /// brush -- became a silent no-op until you clicked a row. Undoing a
+    /// paste was enough to get there.
+    fn reselect_after_removal(&mut self, removed: LayerId, path: &LayerPath) {
+        self.selected.retain(|&id| id != removed);
+        if self.active_layer == Some(removed) {
+            self.active_layer = self.tree.neighbour_of(path);
+        }
+    }
+
     fn structure_changed(&mut self) {
         self.revision += 1;
     }
@@ -605,9 +615,7 @@ impl<'a> EditBuilder<'a> {
             return false;
         };
         self.damage = self.damage.union(&layer.content_bounds());
-        if self.doc.active_layer == Some(id) {
-            self.doc.active_layer = None;
-        }
+        self.doc.reselect_after_removal(id, &path);
         self.ops.push(EditOp::LayerRemove {
             path,
             layer: Box::new(layer),
@@ -1323,6 +1331,64 @@ mod tests {
         doc.redo();
         assert_eq!(doc.mode, schist_color::ColorMode::Grayscale);
     }
+    /// Removing the active layer -- by deleting it, or by undoing the
+    /// insert that created it -- used to leave `active_layer` at None,
+    /// and every pixel command silently did nothing until a row was
+    /// clicked. Photoshop moves the selection to the layer below.
+    #[test]
+    fn removing_the_active_layer_selects_a_neighbour() {
+        let mut doc = Document::new("t", 8, 8, Depth::Eight);
+        let bottom = doc.push_layer(Layer::new_raster("bottom"));
+        let top = doc.push_layer(Layer::new_raster("top"));
+        assert_eq!(doc.active_layer, Some(top));
+
+        let mut edit = doc.begin_edit("Delete Layer");
+        edit.remove_layer(top);
+        edit.commit();
+        assert_eq!(doc.active_layer, Some(bottom), "delete left nothing active");
+
+        doc.undo().unwrap();
+        doc.active_layer = Some(top);
+        doc.redo().unwrap();
+        assert_eq!(doc.active_layer, Some(bottom), "redo left nothing active");
+
+        // Undoing an insert is the paste case: the layer that was there
+        // before the new one comes back as the active one.
+        let mut edit = doc.begin_edit("Paste");
+        let pasted = edit.insert_layer(LayerPath(vec![1]), Layer::new_raster("pasted"));
+        edit.commit();
+        doc.active_layer = Some(pasted);
+        doc.undo().unwrap();
+        assert_eq!(doc.active_layer, Some(bottom), "undo left nothing active");
+    }
+
+    /// The last layer in a group leaves the group itself selected, and the
+    /// last layer in the document leaves nothing -- there is nothing else.
+    #[test]
+    fn removing_the_only_layer_falls_back_to_its_group() {
+        let mut doc = Document::new("t", 8, 8, Depth::Eight);
+        let mut group = Layer::new_group("group");
+        let child = Layer::new_raster("child");
+        let child_id = child.id;
+        let group_id = group.id;
+        match &mut group.kind {
+            crate::layer::LayerKind::Group(g) => g.children.push(child),
+            _ => unreachable!(),
+        }
+        doc.push_layer(group);
+        doc.active_layer = Some(child_id);
+
+        let mut edit = doc.begin_edit("Delete Layer");
+        edit.remove_layer(child_id);
+        edit.commit();
+        assert_eq!(doc.active_layer, Some(group_id));
+
+        let mut edit = doc.begin_edit("Delete Layer");
+        edit.remove_layer(group_id);
+        edit.commit();
+        assert_eq!(doc.active_layer, None, "an empty document has no layer");
+    }
+
     #[test]
     fn undoing_back_to_the_save_point_is_no_longer_dirty() {
         // Undo used to set `dirty = true` unconditionally, so a document

--- a/crates/core/src/layer.rs
+++ b/crates/core/src/layer.rs
@@ -469,6 +469,26 @@ impl LayerTree {
         }
     }
 
+    /// Which layer to select once whatever sat at `path` is gone.
+    ///
+    /// Call it *after* the removal: the sibling below the hole, or the
+    /// layer that fell into it when the hole was at the bottom, or the
+    /// group that held it once it holds nothing else.
+    pub fn neighbour_of(&self, path: &LayerPath) -> Option<LayerId> {
+        let (&ix, parents) = path.0.split_last()?;
+        let mut layers: &[Layer] = &self.layers;
+        let mut parent: Option<&Layer> = None;
+        for &p in parents {
+            let layer = layers.get(p)?;
+            layers = layer.children()?;
+            parent = Some(layer);
+        }
+        match layers.is_empty() {
+            true => parent.map(|l| l.id),
+            false => Some(layers[ix.saturating_sub(1).min(layers.len() - 1)].id),
+        }
+    }
+
     pub fn remove(&mut self, id: LayerId) -> Option<(LayerPath, Layer)> {
         let path = self.path_of(id)?;
         let layer = self.remove_at(&path)?;

--- a/plugins/commands-core/src/lib.rs
+++ b/plugins/commands-core/src/lib.rs
@@ -155,6 +155,10 @@ fn reid(layer: &mut Layer) {
     }
 }
 
+/// Why copy and cut decline: no active layer, or one made of something
+/// other than pixels.
+const NOTHING_TO_COPY: &str = "Select a pixel layer to copy from";
+
 /// Copy the active layer's pixels within the selection to a ClipboardImage.
 fn copy_pixels(doc: &Document, merged: bool) -> Option<ClipboardImage> {
     let canvas = doc.canvas_rect();
@@ -459,24 +463,30 @@ impl CommandPlugin for CoreCommandsPlugin {
                 ctx.doc.redo();
             }),
             cmd("edit.copy", "Copy", Some("cmd-c"), |ctx| {
-                if let Some(clip) = copy_pixels(ctx.doc, false) {
-                    ctx.state.clipboard = Some(Arc::new(clip));
+                match copy_pixels(ctx.doc, false) {
+                    Some(clip) => ctx.state.clipboard = Some(Arc::new(clip)),
+                    // Saying nothing while the clipboard kept its previous
+                    // contents read as "copied", and the next paste looked
+                    // like it had pasted the wrong thing.
+                    None => ctx.refuse(NOTHING_TO_COPY),
                 }
             }),
             cmd(
                 "edit.copy_merged",
                 "Copy Merged",
                 Some("cmd-shift-c"),
-                |ctx| {
-                    if let Some(clip) = copy_pixels(ctx.doc, true) {
-                        ctx.state.clipboard = Some(Arc::new(clip));
-                    }
+                |ctx| match copy_pixels(ctx.doc, true) {
+                    Some(clip) => ctx.state.clipboard = Some(Arc::new(clip)),
+                    None => ctx.refuse(NOTHING_TO_COPY),
                 },
             ),
             cmd("edit.cut", "Cut", Some("cmd-x"), |ctx| {
-                if let Some(clip) = copy_pixels(ctx.doc, false) {
-                    ctx.state.clipboard = Some(Arc::new(clip));
-                    clear_selection(ctx);
+                match copy_pixels(ctx.doc, false) {
+                    Some(clip) => {
+                        ctx.state.clipboard = Some(Arc::new(clip));
+                        clear_selection(ctx);
+                    }
+                    None => ctx.refuse(NOTHING_TO_COPY),
                 }
             }),
             cmd("edit.paste", "Paste", Some("cmd-v"), |ctx| {
@@ -1015,6 +1025,42 @@ mod tests {
         );
     }
 
+    /// Undoing a paste used to null `active_layer`, and copy, cut and
+    /// every other pixel command then did nothing at all -- while the
+    /// status line still reported them as having run.
+    #[test]
+    fn undoing_a_paste_leaves_a_layer_active() {
+        let reg = registry();
+        let mut doc = doc_with_pixels();
+        let mut state = EditorState::default();
+        let background = doc.tree.layers[0].id;
+        doc.selection
+            .select_rect(IntRect::from_xywh(10, 10, 20, 20), SelectOp::Replace);
+        run(&reg, "edit.copy", &mut doc, &mut state);
+        run(&reg, "edit.paste_in_place", &mut doc, &mut state);
+        run(&reg, "edit.undo", &mut doc, &mut state);
+        assert_eq!(doc.tree.layers.len(), 1);
+        assert_eq!(
+            doc.active_layer,
+            Some(background),
+            "undo left nothing active"
+        );
+
+        state.clipboard = None;
+        run(&reg, "edit.cut", &mut doc, &mut state);
+        assert!(state.clipboard.is_some(), "cut after undo copied nothing");
+        assert_eq!(
+            doc.tree.layers[0]
+                .as_raster()
+                .unwrap()
+                .tiles
+                .pixel(15, 15)
+                .to_u8()[3],
+            0,
+            "cut after undo cleared nothing"
+        );
+    }
+
     #[test]
     fn cut_clears_selection_region() {
         let reg = registry();
@@ -1166,6 +1212,22 @@ mod tests {
             run_for_refusal(&reg, "edit.paste", &mut doc, &mut state).as_deref(),
             Some("Nothing on the clipboard"),
             "Paste with an empty clipboard"
+        );
+
+        let mut doc = doc_with_pixels();
+        doc.active_layer = None;
+        assert_eq!(
+            run_for_refusal(&reg, "edit.copy", &mut doc, &mut state).as_deref(),
+            Some(NOTHING_TO_COPY),
+            "Copy with no active layer"
+        );
+
+        let mut doc = doc_with_pixels();
+        doc.active_layer = None;
+        assert_eq!(
+            run_for_refusal(&reg, "edit.cut", &mut doc, &mut state).as_deref(),
+            Some(NOTHING_TO_COPY),
+            "Cut with no active layer"
         );
 
         let mut doc = doc_with_pixels();


### PR DESCRIPTION
Reported as "cut and copy on a marquee seem broken". Two separate faults, plus one in the gpui fork.

## Copy and cut were silent no-ops after an undo

The marquee itself is fine — it commits the selection correctly, and `copy_pixels` clips to it correctly. What breaks them is losing the active layer:

- undoing a layer insert (`Document::apply_op`, `LayerInsert`/Undo)
- redoing a layer removal (`LayerRemove`/Redo)
- `EditBuilder::remove_layer`, i.e. Delete Layer

all set `active_layer` to `None` and left it there. So **marquee → copy → paste → undo → cut** left the document with no active layer, `copy_pixels` returned `None` at its first line, copy silently kept the previous clipboard and cut did nothing — while the status bar reported "Copy"/"Cut" as though they had run. Reproduced in the running app: after the undo no layer row is selected, and Ctrl+X adds no history entry and clears no pixels.

`LayerTree::neighbour_of` now names the replacement — the sibling below the hole, the layer that fell into it if the hole was at the bottom, or the enclosing group once it is empty — and `Document::reselect_after_removal` applies it at all three sites, pruning `selected` as it goes. That is Photoshop's rule: deleting a layer selects the one below it, never nothing.

Copy, Copy Merged and Cut now refuse with "Select a pixel layer to copy from" when there is genuinely nothing to copy (an adjustment or text layer active), instead of reporting success.

## Copying never reached the system clipboard at all

`sync_clipboard_out` looked the exporter up with `c.id() == "png"`. Every codec registers as `codec.<format>`, so the lookup never matched and the function returned before touching the system clipboard — on every platform. The slice/artboard PNG export had the same wrong id and was dead in the same way. Both now go through one `png_codec()` keyed on `PNG_CODEC_ID`.

The other half of that was in gpui: both Linux backends serialised a clipboard item as `item.text().unwrap_or_default()`, so an image went out as an empty string. Fixed in the fork (IAmJSD/gpui@4ab83c7, "Put images on the Linux clipboards, not an empty string") and the pin moves to it.

## Tests

- `removing_the_active_layer_selects_a_neighbour`, `removing_the_only_layer_falls_back_to_its_group` (`crates/core`)
- `undoing_a_paste_leaves_a_layer_active` plus refusal coverage (`plugins/commands-core`)
- `the_png_codec_answers_to_the_id_it_is_looked_up_by` (`crates/app`)
- `cargo test --workspace` green.

Verified in the app under Xvfb: after the undo the Background is active again and Ctrl+X clears the marquee region; and with a standalone x11rb requestor, a copied marquee leaves `TARGETS: TARGETS SAVE_TARGETS image/png` on the CLIPBOARD and hands over a 100×80 PNG of the region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)