### PR TITLE
Publish every tool, command, filter and adjustment over MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,9 +327,10 @@ and a format example: [docs/plugin-guide.md](docs/plugin-guide.md).
 
 `schist-mcp` is a [Model Context
 Protocol](https://modelcontextprotocol.io) server that drives Schist
-headless — sessions instead of windows, with every tool, command, filter
-and codec reachable through the same registry the app uses, plus inline
-PNG rendering. It ships with every release; `cargo build --release -p
+headless — sessions instead of windows. Every canvas tool, menu command,
+filter and adjustment in the registry the app uses is published as its
+own MCP tool, with its own parameters described, plus inline PNG
+rendering. It ships with every release; `cargo build --release -p
 schist-mcp` builds it from source. See [docs/mcp.md](docs/mcp.md).
 
 ## Documentation

--- a/crates/mcp/src/catalog.rs
+++ b/crates/mcp/src/catalog.rs
@@ -1,0 +1,790 @@
+//! Every installed feature published as its own MCP tool.
+//!
+//! The server used to expose a handful of generic invokers -- `run_command`,
+//! `select_tool`, `apply_filter` -- plus a `describe` call that listed what
+//! they could be pointed at. That put a caller two round trips away from
+//! doing anything, and left a filter's parameters undiscoverable until it
+//! had asked for them by name: nothing in the tool list said that
+//! `apply_filter` would take a `radius` between 0 and 250 for one id and
+//! `cell_size` for another.
+//!
+//! The registry is already a catalog of everything installed, so this
+//! projects it straight into MCP: one tool per canvas tool, menu command,
+//! filter and adjustment, each carrying its own typed parameters with the
+//! label, range, default and choices the options bar would have shown. A
+//! third-party plugin dropped into the plugins folder is published the same
+//! way, because it goes through the same registry.
+//!
+//! It is a big tool list -- a couple of hundred entries -- which is the
+//! honest size of the application.
+
+use crate::session;
+use schist_adjustments::Params;
+use schist_core::AdjustmentKind;
+use schist_plugin_api::{FilterParam, OptionKind, PluginRegistry, ToolOption, ToolPlugin};
+use serde_json::{json, Map, Value};
+use std::collections::HashMap;
+
+/// The adjustments Image ▸ Adjustments offers, in menu order.
+pub const ADJUSTMENT_KINDS: [AdjustmentKind; 18] = [
+    AdjustmentKind::Levels,
+    AdjustmentKind::Curves,
+    AdjustmentKind::HueSaturation,
+    AdjustmentKind::BrightnessContrast,
+    AdjustmentKind::BlackWhite,
+    AdjustmentKind::SolidColor,
+    AdjustmentKind::GradientFill,
+    AdjustmentKind::PatternFill,
+    AdjustmentKind::Invert,
+    AdjustmentKind::Posterize,
+    AdjustmentKind::Threshold,
+    AdjustmentKind::ColorBalance,
+    AdjustmentKind::Vibrance,
+    AdjustmentKind::Exposure,
+    AdjustmentKind::PhotoFilter,
+    AdjustmentKind::GradientMap,
+    AdjustmentKind::SelectiveColor,
+    AdjustmentKind::ChannelMixer,
+];
+
+/// What calling one published tool actually does.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Action {
+    /// A server-level tool implemented directly in `main`.
+    Builtin(String),
+    /// Activate a canvas tool and apply any options passed with it.
+    Tool(String),
+    /// Run a menu command.
+    Command(String),
+    /// Run a filter on the active layer.
+    Filter(String),
+    /// Apply an adjustment destructively to the active layer.
+    Adjustment(AdjustmentKind),
+}
+
+/// The published tool list, and what each name maps back to.
+pub struct Catalog {
+    defs: Vec<Value>,
+    actions: HashMap<String, Action>,
+}
+
+impl Catalog {
+    /// Assemble the list from a registry built the way a session builds
+    /// one. The registry itself is dropped afterwards: everything the
+    /// catalog needs has been copied into owned JSON, and a session
+    /// builds its own anyway (tools carry per-gesture state).
+    pub fn build() -> Catalog {
+        let (registry, _wasm, _photoshop) = session::build_registry();
+        Catalog::from_registry(&registry)
+    }
+
+    pub fn from_registry(registry: &PluginRegistry) -> Catalog {
+        let mut b = Builder::default();
+        for (name, def, action) in builtins(registry) {
+            b.push(name, def, action);
+        }
+        for tool in registry.tools() {
+            b.push(
+                format!("tool_{}", slug(tool.id())),
+                tool_def(tool),
+                Action::Tool(tool.id().to_string()),
+            );
+        }
+        for command in registry.commands() {
+            b.push(
+                format!("cmd_{}", slug(command.id)),
+                json!({
+                    "description": format!(
+                        "{}{} Menu command {:?}{}.",
+                        command.title,
+                        end(command.description),
+                        command.id,
+                        match command.keybind {
+                            Some(k) => format!(", bound to {k} in the app"),
+                            None => String::new(),
+                        },
+                    ),
+                    "inputSchema": schema(json!({"session": session_prop()}), &["session"]),
+                }),
+                Action::Command(command.id.to_string()),
+            );
+        }
+        for filter in registry.filters() {
+            let params = filter.params();
+            let mut props = json!({"session": session_prop()});
+            let object = props.as_object_mut().unwrap();
+            for param in &params {
+                object.insert(param.key.to_string(), filter_param_prop(param));
+            }
+            b.push(
+                format!("filter_{}", slug(filter.id().trim_start_matches("filter."))),
+                json!({
+                    "description": format!(
+                        "{} — Filter ▸ {}. Runs on the active raster layer, feathered through \
+                         the selection when there is one, as one undoable edit.{}{}",
+                        filter.name(),
+                        filter.category(),
+                        if params.is_empty() {
+                            String::new()
+                        } else {
+                            " Omitted parameters keep their defaults.".to_string()
+                        },
+                        match filter.info() {
+                            Some(info) => format!(" {info}"),
+                            None => String::new(),
+                        },
+                    ),
+                    "inputSchema": schema(props, &["session"]),
+                }),
+                Action::Filter(filter.id().to_string()),
+            );
+        }
+        for kind in ADJUSTMENT_KINDS {
+            b.push(
+                format!("adjust_{}", slug(kind.display_name())),
+                adjustment_def(kind),
+                Action::Adjustment(kind),
+            );
+        }
+        Catalog {
+            defs: b.defs,
+            actions: b.actions,
+        }
+    }
+
+    /// The `tools/list` payload.
+    pub fn defs(&self) -> &[Value] {
+        &self.defs
+    }
+
+    pub fn action(&self, name: &str) -> Option<&Action> {
+        self.actions.get(name)
+    }
+}
+
+#[derive(Default)]
+struct Builder {
+    defs: Vec<Value>,
+    actions: HashMap<String, Action>,
+}
+
+impl Builder {
+    /// Publish one tool, under a name nothing else has taken. Two
+    /// plugins are free to pick ids that sanitize to the same thing;
+    /// silently publishing one of them and dropping the other would make
+    /// a feature disappear, so the loser is numbered instead.
+    fn push(&mut self, mut name: String, mut def: Value, action: Action) {
+        if self.actions.contains_key(&name) {
+            let base = name.clone();
+            let mut n = 2;
+            while self.actions.contains_key(&name) {
+                name = format!("{base}_{n}");
+                n += 1;
+            }
+        }
+        def.as_object_mut()
+            .unwrap()
+            .insert("name".into(), json!(name.clone()));
+        self.defs.push(def);
+        self.actions.insert(name, action);
+    }
+}
+
+/// A registry id as an MCP tool name: `marquee.rect` → `marquee_rect`.
+fn slug(id: &str) -> String {
+    let mut out = String::with_capacity(id.len());
+    for c in id.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+        } else if !out.ends_with('_') {
+            out.push('_');
+        }
+    }
+    out.trim_matches('_').to_string()
+}
+
+/// A sentence, spaced off from whatever precedes it, or nothing.
+fn end(description: &str) -> String {
+    if description.is_empty() {
+        String::new()
+    } else {
+        format!(" — {description}")
+    }
+}
+
+fn session_prop() -> Value {
+    json!({"type": "string", "description": "Session id from create_session"})
+}
+
+fn schema(properties: Value, required: &[&str]) -> Value {
+    json!({"type": "object", "properties": properties, "required": required})
+}
+
+fn modifiers_prop() -> Value {
+    json!({
+        "type": "object",
+        "description": "Held modifier keys",
+        "properties": {
+            "shift": {"type": "boolean"},
+            "alt": {"type": "boolean"},
+            "ctrl": {"type": "boolean", "description": "Ctrl/Cmd"},
+        },
+    })
+}
+
+/// One canvas tool: selecting it, and its options bar as parameters.
+fn tool_def(tool: &dyn ToolPlugin) -> Value {
+    let options = tool.options();
+    let mut props = json!({"session": session_prop()});
+    let object = props.as_object_mut().unwrap();
+    for option in &options {
+        object.insert(option.key.to_string(), tool_option_prop(option));
+    }
+    let description = format!(
+        "{} tool{} Makes it the active tool for this session and applies any options passed \
+         with it; drive it afterwards with tool_stroke (pointer gestures in document pixels) \
+         and tool_input (Enter, Escape or raw keys).{}",
+        tool.name(),
+        end(tool.description()),
+        match tool.shortcut() {
+            Some(key) => format!(" Its shortcut in the app is {key:?}."),
+            None => String::new(),
+        },
+    );
+    json!({
+        "description": description,
+        "inputSchema": schema(props, &["session"]),
+    })
+}
+
+/// An options-bar control as a JSON Schema property.
+fn tool_option_prop(option: &ToolOption) -> Value {
+    let label = if option.label.is_empty() {
+        option.key
+    } else {
+        option.label
+    };
+    match option.kind {
+        OptionKind::Slider { min, max, suffix } => json!({
+            "type": "number",
+            "minimum": min,
+            "maximum": max,
+            "description": format!(
+                "{label}. {min}..{max}{}, currently {}",
+                suffix.trim_end(),
+                option.value.num(),
+            ),
+        }),
+        OptionKind::Toggle => json!({
+            "type": "boolean",
+            "description": format!("{label}, currently {}", option.value.bool()),
+        }),
+        OptionKind::Choice(names) => json!({
+            "type": "string",
+            "enum": names,
+            "description": format!(
+                "{label}, currently {:?}",
+                names.get(option.value.index()).copied().unwrap_or_default(),
+            ),
+        }),
+    }
+}
+
+/// A filter tunable as a JSON Schema property.
+fn filter_param_prop(param: &FilterParam) -> Value {
+    if param.choices.is_empty() {
+        json!({
+            "type": "number",
+            "minimum": param.min,
+            "maximum": param.max,
+            "description": format!(
+                "{}. {}..{}{} (default {})",
+                param.label,
+                param.min,
+                param.max,
+                param.suffix.trim_end(),
+                param.default,
+            ),
+        })
+    } else {
+        json!({
+            "type": "string",
+            "enum": param.choices,
+            "description": format!(
+                "{} (default {:?})",
+                param.label,
+                param
+                    .choices
+                    .get(param.default.max(0.0) as usize)
+                    .copied()
+                    .unwrap_or_default(),
+            ),
+        })
+    }
+}
+
+/// One adjustment: its sliders, its flags, and a raw escape hatch.
+///
+/// The sliders come from the same `param_specs` the adjustment dialog
+/// renders. The flags -- Monochrome, Preserve Luminosity, Colorize --
+/// are not in that list because the dialog draws them itself, so they
+/// are read out of the serialized default instead; that also keeps them
+/// working for whatever an adjustment grows next.
+fn adjustment_def(kind: AdjustmentKind) -> Value {
+    let defaults = Params::default_for(kind);
+    let mut props = json!({"session": session_prop()});
+    let object = props.as_object_mut().unwrap();
+    for spec in defaults.param_specs() {
+        object.insert(
+            spec.key.to_string(),
+            json!({
+                "type": "number",
+                "minimum": spec.min,
+                "maximum": spec.max,
+                "description": format!(
+                    "{}. {}..{}{} (default {})",
+                    spec.label,
+                    spec.min,
+                    spec.max,
+                    spec.suffix.trim_end(),
+                    spec.value,
+                ),
+            }),
+        );
+    }
+    for (key, value) in flags(&defaults) {
+        object.insert(
+            key.clone(),
+            json!({
+                "type": "boolean",
+                "description": format!("{} (default {value})", label(&key)),
+            }),
+        );
+    }
+    // A unit variant (Invert) serializes as a bare string: there is
+    // nothing to pass, so it gets no escape hatch either.
+    let serialized = serde_json::to_value(&defaults).unwrap_or_default();
+    if serialized.is_object() {
+        object.insert(
+            "params".into(),
+            json!({
+                "type": "object",
+                "description": format!(
+                    "The whole parameter set at once, in the adjustment's serde form: {}. \
+                     Anything the properties above cannot reach -- curve points, gradient \
+                     stops, per-range tables -- goes here, and the properties are applied \
+                     on top of it.",
+                    serialized,
+                ),
+            }),
+        );
+    }
+    json!({
+        "description": format!(
+            "Image ▸ Adjustments ▸ {}: applied destructively to the active layer's pixels, \
+             feathered through the selection when there is one, as one undoable edit.",
+            kind.display_name(),
+        ),
+        "inputSchema": schema(props, &["session"]),
+    })
+}
+
+/// A payload field name as something to read: `preserve_luminosity`
+/// becomes "Preserve luminosity".
+fn label(key: &str) -> String {
+    let spaced = key.replace('_', " ");
+    let mut chars = spaced.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => spaced,
+    }
+}
+
+/// The boolean fields of an adjustment's payload, by name.
+pub fn flags(params: &Params) -> Vec<(String, bool)> {
+    let Ok(Value::Object(outer)) = serde_json::to_value(params) else {
+        return Vec::new();
+    };
+    // Externally tagged: {"ChannelMixer": {...}}. A unit variant (Invert)
+    // serializes as a bare string and never reaches here.
+    let Some(Value::Object(fields)) = outer.values().next() else {
+        return Vec::new();
+    };
+    fields
+        .iter()
+        .filter_map(|(k, v)| v.as_bool().map(|b| (k.clone(), b)))
+        .collect()
+}
+
+/// Set one boolean field in an adjustment's payload.
+///
+/// `Params` is an enum of a dozen shapes with no field-level setter, and
+/// adding one per flag would mean touching the adjustments crate every
+/// time an adjustment grows a checkbox. Round-tripping through the
+/// serialized form reaches all of them and keeps working.
+pub fn set_flag(params: &Params, key: &str, value: bool) -> Option<Params> {
+    let Ok(Value::Object(mut outer)) = serde_json::to_value(params) else {
+        return None;
+    };
+    let variant = outer.keys().next()?.clone();
+    let Some(Value::Object(fields)) = outer.get_mut(&variant) else {
+        return None;
+    };
+    if !fields.get(key).is_some_and(Value::is_boolean) {
+        return None;
+    }
+    fields.insert(key.to_string(), json!(value));
+    serde_json::from_value(Value::Object(outer)).ok()
+}
+
+/// The server's own tools: sessions, state, rendering and files.
+fn builtins(registry: &PluginRegistry) -> Vec<(String, Value, Action)> {
+    let readable: Vec<&str> = registry
+        .codecs()
+        .flat_map(|c| c.extensions().iter().copied())
+        .collect();
+    let writable: Vec<&str> = registry
+        .codecs()
+        .filter(|c| c.can_export())
+        .flat_map(|c| c.extensions().iter().copied())
+        .collect();
+    let blend_modes: Vec<String> = crate::BLEND_MODES
+        .iter()
+        .map(|m| format!("{m:?}"))
+        .collect();
+    let def = |name: &str, description: String, props: Value, required: &[&str]| {
+        (
+            name.to_string(),
+            json!({"description": description, "inputSchema": schema(props, required)}),
+            Action::Builtin(name.to_string()),
+        )
+    };
+    vec![
+        def(
+            "create_session",
+            format!(
+                "Create an editing session: open an image file ({}) or start a blank \
+                 document with a white Background layer. Returns the session id every other \
+                 tool takes, and the document's initial state.",
+                readable.join(", "),
+            ),
+            json!({
+                "path": {"type": "string", "description": "File to open; omit for a blank document"},
+                "width": {"type": "integer", "description": "Blank document width (default 1280)"},
+                "height": {"type": "integer", "description": "Blank document height (default 800)"},
+                "depth": {"type": "integer", "enum": [8, 16, 32], "description": "Bits per channel (default 8)"},
+                "title": {"type": "string"},
+            }),
+            &[],
+        ),
+        def(
+            "list_sessions",
+            "List the open sessions: id, title, path, size, and whether each has unsaved \
+             changes."
+                .to_string(),
+            json!({}),
+            &[],
+        ),
+        def(
+            "close_session",
+            "Close a session, discarding unsaved changes.".to_string(),
+            json!({"session": session_prop()}),
+            &["session"],
+        ),
+        def(
+            "get_state",
+            "Document info, the full layer tree with layer ids, the selection, undo/redo \
+             state, and editor state including the active tool's current options."
+                .to_string(),
+            json!({"session": session_prop()}),
+            &["session"],
+        ),
+        def(
+            "tool_stroke",
+            "Drive the active tool through one pointer gesture in document pixels: down on \
+             the first point, drag through the rest, up on the last. One point clicks. A \
+             brush stroke, a marquee drag, a transform-handle drag and a text-layer click \
+             are all one call. Modal tools (crop, transform, type) keep a pending state \
+             afterwards — finish with tool_input."
+                .to_string(),
+            json!({
+                "session": session_prop(),
+                "points": {
+                    "type": "array",
+                    "items": {"type": "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2},
+                    "description": "[[x, y], …] in document pixels",
+                },
+                "pressure": {"type": "number", "description": "Stylus pressure 0..1 (default 1)"},
+                "modifiers": modifiers_prop(),
+            }),
+            &["session", "points"],
+        ),
+        def(
+            "tool_input",
+            "Non-pointer input for the active tool: commit (Enter) or cancel (Escape) a \
+             pending crop/transform/text gesture, or send a raw key — the type tool takes \
+             text through action \"key\" with the character in \"text\"."
+                .to_string(),
+            json!({
+                "session": session_prop(),
+                "action": {"type": "string", "enum": ["key", "commit", "cancel"]},
+                "key": {"type": "string", "description": "Physical key name for action \"key\", e.g. \"a\", \"enter\", \"backspace\""},
+                "text": {"type": "string", "description": "Character the key types, when it types one"},
+                "modifiers": modifiers_prop(),
+            }),
+            &["session", "action"],
+        ),
+        def(
+            "set_active_layer",
+            "Make a layer the target of tools, filters and layer commands (layer ids come \
+             from get_state)."
+                .to_string(),
+            json!({
+                "session": session_prop(),
+                "id": {"type": "integer", "description": "Layer id"},
+            }),
+            &["session", "id"],
+        ),
+        def(
+            "set_layer_props",
+            "Change a layer's name, visibility, opacity, fill opacity, blend mode, lock or \
+             clipping flag, as one undoable edit."
+                .to_string(),
+            json!({
+                "session": session_prop(),
+                "id": {"type": "integer"},
+                "name": {"type": "string"},
+                "visible": {"type": "boolean"},
+                "opacity": {"type": "number", "description": "0..1"},
+                "fill_opacity": {"type": "number", "description": "0..1"},
+                "blend": {"type": "string", "enum": blend_modes},
+                "locked": {"type": "boolean"},
+                "clipping": {"type": "boolean"},
+            }),
+            &["session", "id"],
+        ),
+        def(
+            "set_editor",
+            "Set shared editor state: foreground/background colours, brush size and \
+             hardness, tool opacity, magic-wand tolerance, transform resampling."
+                .to_string(),
+            json!({
+                "session": session_prop(),
+                "foreground": {"type": "string", "description": "#rrggbb or #rrggbbaa"},
+                "background": {"type": "string"},
+                "brush_size": {"type": "number", "description": "Pixels"},
+                "brush_hardness": {"type": "number", "description": "0 soft .. 1 hard"},
+                "tool_opacity": {"type": "number", "description": "0..1"},
+                "tolerance": {"type": "integer", "description": "0..255"},
+                "resample": {"type": "string", "enum": ["nearest", "bilinear", "bicubic"]},
+            }),
+            &["session"],
+        ),
+        def(
+            "render",
+            "Composite the document (or a region) and return it as a PNG image, downscaled \
+             to max_dim for viewing. Pass path to also write the full-resolution PNG to disk."
+                .to_string(),
+            json!({
+                "session": session_prop(),
+                "x": {"type": "integer"},
+                "y": {"type": "integer"},
+                "width": {"type": "integer"},
+                "height": {"type": "integer"},
+                "max_dim": {"type": "integer", "description": "Longest edge of the returned preview (default 1024)"},
+                "path": {"type": "string", "description": "Also write full-resolution PNG here"},
+            }),
+            &["session"],
+        ),
+        def(
+            "save",
+            format!(
+                "Save the document, codec chosen by the extension ({}; .psd/.psb keep \
+                 layers, raster formats flatten). Defaults to the path it was opened from.",
+                writable.join(", "),
+            ),
+            json!({
+                "session": session_prop(),
+                "path": {"type": "string", "description": "Target path; optional when the document already has one"},
+            }),
+            &["session"],
+        ),
+        def(
+            "export",
+            "Export a flattened copy with encoder settings, leaving the document's own path \
+             untouched."
+                .to_string(),
+            json!({
+                "session": session_prop(),
+                "path": {"type": "string"},
+                "quality": {"type": "integer", "description": "1..100 for lossy formats (default 90)"},
+                "bit_depth": {"type": "integer", "description": "Bits per channel where the format supports a choice (default 8)"},
+                "dither": {"type": "boolean", "description": "Dither when reducing depth (default true)"},
+            }),
+            &["session", "path"],
+        ),
+        def(
+            "photoshop_plugins",
+            "Which Photoshop `.8bf` plug-ins were found, and why any of them is unavailable. \
+             The ones that loaded are published as filter tools like any other; this is for \
+             the ones that did not."
+                .to_string(),
+            json!({"session": session_prop()}),
+            &["session"],
+        ),
+    ]
+}
+
+/// The arguments of a call that are not the session, i.e. the ones a
+/// published tool's own parameters were built from.
+pub fn parameters(args: &Value) -> Map<String, Value> {
+    let mut out = args.as_object().cloned().unwrap_or_default();
+    out.remove("session");
+    out.retain(|_, v| !v.is_null());
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn find<'a>(catalog: &'a Catalog, name: &str) -> &'a Value {
+        catalog
+            .defs()
+            .iter()
+            .find(|d| d["name"] == name)
+            .unwrap_or_else(|| panic!("{name} was not published"))
+    }
+
+    /// A name a client cannot call is a feature that is not there.
+    #[test]
+    fn names_are_unique_and_callable() {
+        let catalog = Catalog::build();
+        let mut seen = std::collections::HashSet::new();
+        for def in catalog.defs() {
+            let name = def["name"].as_str().expect("every tool has a name");
+            assert!(seen.insert(name), "{name} was published twice");
+            assert!(
+                !name.is_empty() && name.len() <= 64,
+                "{name} is a bad length"
+            );
+            assert!(
+                name.bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-'),
+                "{name} has characters a tool name cannot have"
+            );
+            assert!(
+                catalog.action(name).is_some(),
+                "{name} maps back to nothing"
+            );
+            assert!(
+                def["description"].as_str().is_some_and(|d| d.len() > 20),
+                "{name} says nothing about itself"
+            );
+        }
+    }
+
+    /// The whole point: a filter's tunables are in the tool list, not
+    /// behind a second call.
+    #[test]
+    fn a_filter_publishes_its_parameters() {
+        let catalog = Catalog::build();
+        let blur = find(&catalog, "filter_gaussian_blur");
+        let radius = &blur["inputSchema"]["properties"]["radius"];
+        assert_eq!(radius["type"], "number");
+        assert!(radius["maximum"].as_f64().unwrap() > 0.0);
+        assert!(radius["description"].as_str().unwrap().contains("default"));
+        assert_eq!(
+            catalog.action("filter_gaussian_blur"),
+            Some(&Action::Filter("filter.gaussian_blur".into()))
+        );
+        // A choice reads as its names, not as an index.
+        let noise = find(&catalog, "filter_add_noise");
+        assert_eq!(
+            noise["inputSchema"]["properties"]["distribution"]["enum"],
+            json!(["Uniform", "Gaussian"])
+        );
+    }
+
+    #[test]
+    fn a_tool_publishes_its_options_bar() {
+        let catalog = Catalog::build();
+        let marquee = find(&catalog, "tool_marquee_rect");
+        let props = &marquee["inputSchema"]["properties"];
+        assert_eq!(props["marquee-feather"]["type"], "number");
+        assert!(props["marquee-mode"]["enum"].is_array());
+        assert_eq!(
+            catalog.action("tool_marquee_rect"),
+            Some(&Action::Tool("marquee.rect".into()))
+        );
+    }
+
+    /// "Grow" is a menu label; on its own it tells a caller nothing.
+    #[test]
+    fn a_command_describes_itself_beyond_its_title() {
+        let catalog = Catalog::build();
+        let grow = find(&catalog, "cmd_select_grow");
+        let text = grow["description"].as_str().unwrap();
+        assert!(text.contains("tolerance"), "{text}");
+        assert_eq!(
+            catalog.action("cmd_select_grow"),
+            Some(&Action::Command("select.grow".into()))
+        );
+    }
+
+    #[test]
+    fn an_adjustment_publishes_sliders_flags_and_an_escape_hatch() {
+        let catalog = Catalog::build();
+        let mixer = find(&catalog, "adjust_channel_mixer");
+        let props = &mixer["inputSchema"]["properties"];
+        assert_eq!(props["r_r"]["type"], "number");
+        assert_eq!(props["monochrome"]["type"], "boolean");
+        assert_eq!(props["params"]["type"], "object");
+        // Curves has no sliders at all, so the escape hatch is the whole
+        // of its interface.
+        let curves = find(&catalog, "adjust_curves");
+        assert!(curves["inputSchema"]["properties"]["params"].is_object());
+        // Invert has no parameters in any form.
+        let invert = find(&catalog, "adjust_invert");
+        assert_eq!(
+            invert["inputSchema"]["properties"]
+                .as_object()
+                .unwrap()
+                .len(),
+            1,
+            "invert should take nothing but the session"
+        );
+    }
+
+    #[test]
+    fn flags_are_read_and_written_through_the_serialized_form() {
+        let params = Params::default_for(AdjustmentKind::ChannelMixer);
+        assert_eq!(flags(&params), vec![("monochrome".to_string(), false)]);
+        let flipped = set_flag(&params, "monochrome", true).expect("set monochrome");
+        assert_eq!(flags(&flipped), vec![("monochrome".to_string(), true)]);
+        // Sliders survive the round trip the flag takes.
+        assert_eq!(flipped.param_specs(), params.param_specs());
+        assert!(set_flag(&params, "nonexistent", true).is_none());
+        assert!(flags(&Params::default_for(AdjustmentKind::Invert)).is_empty());
+    }
+
+    #[test]
+    fn ids_become_names_a_client_can_type() {
+        assert_eq!(slug("marquee.rect"), "marquee_rect");
+        assert_eq!(slug("layer.add_mask"), "layer_add_mask");
+        assert_eq!(slug("Hue/Saturation"), "hue_saturation");
+        assert_eq!(slug("Brightness/Contrast"), "brightness_contrast");
+        assert_eq!(slug("  odd  id  "), "odd_id");
+    }
+
+    /// Two ids that sanitize alike must both stay reachable.
+    #[test]
+    fn colliding_names_are_numbered_rather_than_dropped() {
+        let mut b = Builder::default();
+        b.push("filter_x".into(), json!({}), Action::Filter("a".into()));
+        b.push("filter_x".into(), json!({}), Action::Filter("b".into()));
+        assert_eq!(b.defs[0]["name"], "filter_x");
+        assert_eq!(b.defs[1]["name"], "filter_x_2");
+        assert_eq!(b.actions.len(), 2);
+    }
+}

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -1,15 +1,19 @@
 //! `schist-mcp` — a Model Context Protocol server over stdio.
 //!
 //! Create a session (a blank document or an opened file), then drive it by
-//! session id: every registered tool, menu command, filter, adjustment and
-//! codec — the same plugin registry the GPUI app assembles — plus document
-//! introspection and PNG rendering. JSON-RPC 2.0, newline-delimited, on
-//! stdin/stdout; logs go to stderr so they never corrupt the stream.
+//! session id. Every registered canvas tool, menu command, filter and
+//! adjustment — the same plugin registry the GPUI app assembles — is
+//! published as its own MCP tool with its own documented parameters (see
+//! `catalog`), alongside document introspection and PNG rendering.
+//! JSON-RPC 2.0, newline-delimited, on stdin/stdout; logs go to stderr so
+//! they never corrupt the stream.
 
+mod catalog;
 mod session;
 
 use anyhow::{anyhow, bail, Result};
 use base64::Engine as _;
+use catalog::{Action, Catalog};
 use schist_core::color::{Depth, Rgba};
 use schist_core::{AdjustmentKind, BlendMode, IntRect, Layer, LayerId, LayerKind};
 use schist_plugin_api::{ExportOptions, Modifiers, OptionKind, OptionValue, ToolOption};
@@ -76,6 +80,10 @@ struct RpcError(i64, String);
 struct Server {
     sessions: HashMap<String, Session>,
     next_id: u64,
+    /// Built on the first `tools/list` or `tools/call` rather than at
+    /// startup: assembling it scans the plugin folders, and a client that
+    /// only pings should not pay for that.
+    catalog: Option<Catalog>,
 }
 
 impl Server {
@@ -95,15 +103,16 @@ impl Server {
                     },
                     "instructions": "Headless Schist image editor. Call create_session first \
                         (blank document or open a file) and pass the returned session id to every \
-                        other tool. Use describe to enumerate the session's canvas tools, menu \
-                        commands, filters, adjustments and codecs; get_state for the document and \
-                        layer tree; render to see the canvas as a PNG. Edits go through the same \
-                        plugin registry and undo history as the GUI (undo/redo are the edit.undo \
-                        and edit.redo commands).",
+                        other tool. Everything the editor can do is its own tool: cmd_* are the \
+                        menu commands (cmd_edit_undo, cmd_edit_redo…), tool_* select a canvas \
+                        tool and set its options before you drive it with tool_stroke and \
+                        tool_input, filter_* run filters, adjust_* apply adjustments. get_state \
+                        gives the document and layer tree; render returns the canvas as a PNG. \
+                        Edits go through the same plugin registry and undo history as the GUI.",
                 }))
             }
             "ping" => Ok(json!({})),
-            "tools/list" => Ok(json!({"tools": tool_defs()})),
+            "tools/list" => Ok(json!({"tools": self.catalog().defs()})),
             "tools/call" => {
                 let name = params
                     .get("name")
@@ -122,7 +131,34 @@ impl Server {
         }
     }
 
+    /// Everything the server publishes is a name in the catalog, so this
+    /// is the only place a name turns back into work.
     fn call_tool(&mut self, name: &str, args: &Value) -> Result<Value> {
+        let action = self
+            .catalog()
+            .action(name)
+            .cloned()
+            .ok_or_else(|| anyhow!("unknown tool {name:?}"))?;
+        match action {
+            Action::Builtin(name) => self.call_builtin(&name, args),
+            Action::Tool(id) => self.select_tool(&id, args),
+            Action::Command(id) => {
+                let sess = self.session(args)?;
+                let title = sess.run_command(&id)?;
+                text(title)
+            }
+            Action::Filter(id) => self.apply_filter(&id, args),
+            Action::Adjustment(kind) => self.apply_adjustment(kind, args),
+        }
+    }
+
+    fn catalog(&mut self) -> &Catalog {
+        self.catalog.get_or_insert_with(Catalog::build)
+    }
+
+    /// The server's own tools: the ones that are about sessions, state and
+    /// files rather than about something in the registry.
+    fn call_builtin(&mut self, name: &str, args: &Value) -> Result<Value> {
         match name {
             "create_session" => self.create_session(args),
             "list_sessions" => self.list_sessions(),
@@ -133,27 +169,11 @@ impl Server {
                     .ok_or_else(|| anyhow!("no session {id:?}"))?;
                 text(format!("closed {id}"))
             }
-            "describe" => {
-                let sess = self.session(args)?;
-                let what = args.get("what").and_then(|v| v.as_str()).unwrap_or("all");
-                text_json(describe(sess, what)?)
-            }
             "get_state" => {
                 let id = arg_str(args, "session")?.to_string();
                 let sess = self.session(args)?;
                 text_json(state_json(&id, sess))
             }
-            "run_command" => {
-                let sess = self.session(args)?;
-                let title = sess.run_command(arg_str(args, "id")?)?;
-                text(title)
-            }
-            "select_tool" => {
-                let sess = self.session(args)?;
-                let id = sess.activate_tool(arg_str(args, "id")?)?;
-                text(format!("active tool: {id}"))
-            }
-            "set_tool_options" => self.set_tool_options(args),
             "tool_stroke" => self.tool_stroke(args),
             "tool_input" => {
                 let modifiers = parse_modifiers(args.get("modifiers"));
@@ -165,38 +185,6 @@ impl Server {
                     modifiers,
                 )?;
                 text(if consumed { "consumed" } else { "not consumed" }.to_string())
-            }
-            "apply_filter" => {
-                let values: Vec<(String, f64)> = args
-                    .get("params")
-                    .and_then(|v| v.as_object())
-                    .map(|m| {
-                        m.iter()
-                            .map(|(k, v)| {
-                                v.as_f64()
-                                    .map(|n| (k.clone(), n))
-                                    .ok_or_else(|| anyhow!("parameter {k:?} must be a number"))
-                            })
-                            .collect::<Result<Vec<_>>>()
-                    })
-                    .transpose()?
-                    .unwrap_or_default();
-                let sess = self.session(args)?;
-                let name = sess.apply_filter(arg_str(args, "id")?, &values)?;
-                text(format!("applied {name}"))
-            }
-            "apply_adjustment" => {
-                let kind = parse_adjustment_kind(arg_str(args, "kind")?)?;
-                let params = match args.get("params") {
-                    Some(v) if !v.is_null() => Some(
-                        serde_json::from_value::<schist_adjustments::Params>(v.clone())
-                            .map_err(|e| anyhow!("bad adjustment params: {e}"))?,
-                    ),
-                    _ => None,
-                };
-                let sess = self.session(args)?;
-                let name = sess.apply_adjustment(kind, params)?;
-                text(format!("applied {name}"))
             }
             "set_active_layer" => {
                 let id = args
@@ -250,8 +238,137 @@ impl Server {
                 sess.export(&path, &options)?;
                 text(format!("exported {}", path.display()))
             }
-            _ => bail!("unknown tool {name:?}"),
+            "photoshop_plugins" => {
+                let sess = self.session(args)?;
+                text_json(photoshop_json(sess))
+            }
+            other => bail!("unknown tool {other:?}"),
         }
+    }
+
+    /// Make a canvas tool active and apply the options passed with it.
+    ///
+    /// Options are read fresh between writes because a tool's options bar
+    /// can change shape as it is set: the move tool only offers its
+    /// auto-select target once auto-select is on.
+    fn select_tool(&mut self, id: &str, args: &Value) -> Result<Value> {
+        let sess = self.session(args)?;
+        let id = sess.activate_tool(id)?;
+        for (key, value) in catalog::parameters(args) {
+            let declared = sess
+                .registry
+                .tools()
+                .find(|t| t.id() == id)
+                .map(|t| t.options())
+                .unwrap_or_default();
+            let kind = declared
+                .iter()
+                .find(|o| o.key == key)
+                .map(|o| o.kind)
+                .ok_or_else(|| {
+                    anyhow!(
+                        "tool {id:?} has no option {key:?} (has: {:?})",
+                        declared.iter().map(|o| o.key).collect::<Vec<_>>()
+                    )
+                })?;
+            sess.set_tool_option(&key, coerce_option(&value, kind)?)?;
+        }
+        let options: Vec<Value> = sess
+            .registry
+            .tools()
+            .find(|t| t.id() == id)
+            .map(|t| t.options().iter().map(option_json).collect())
+            .unwrap_or_default();
+        text_json(json!({"active_tool": id, "options": options}))
+    }
+
+    fn apply_filter(&mut self, id: &str, args: &Value) -> Result<Value> {
+        let sess = self.session(args)?;
+        let params = sess
+            .registry
+            .filters()
+            .find(|f| f.id() == id)
+            .map(|f| f.params())
+            .ok_or_else(|| anyhow!("unknown filter {id:?}"))?;
+        let mut values: Vec<(String, f64)> = Vec::new();
+        for (key, value) in catalog::parameters(args) {
+            let param = params.iter().find(|p| p.key == key).ok_or_else(|| {
+                anyhow!(
+                    "filter {id:?} has no parameter {key:?} (has: {:?})",
+                    params.iter().map(|p| p.key).collect::<Vec<_>>()
+                )
+            })?;
+            // A choice reads as its name here, the way the dialog shows
+            // it, but the filter only ever sees the index.
+            let number = match &value {
+                Value::String(name) if !param.choices.is_empty() => param
+                    .choices
+                    .iter()
+                    .position(|c| c.eq_ignore_ascii_case(name))
+                    .map(|i| i as f64)
+                    .ok_or_else(|| {
+                        anyhow!(
+                            "no choice {name:?} for {key:?} (choices: {:?})",
+                            param.choices
+                        )
+                    })?,
+                other => other
+                    .as_f64()
+                    .ok_or_else(|| anyhow!("parameter {key:?} must be a number"))?,
+            };
+            values.push((key, number));
+        }
+        let name = sess.apply_filter(id, &values)?;
+        text(format!("applied {name}"))
+    }
+
+    fn apply_adjustment(&mut self, kind: AdjustmentKind, args: &Value) -> Result<Value> {
+        let mut params = match args.get("params") {
+            Some(v) if !v.is_null() => {
+                serde_json::from_value::<schist_adjustments::Params>(v.clone())
+                    .map_err(|e| anyhow!("bad adjustment params: {e}"))?
+            }
+            _ => schist_adjustments::Params::default_for(kind),
+        };
+        let mut arguments = catalog::parameters(args);
+        arguments.remove("params");
+        // Flags first: setting one round-trips through serde, which would
+        // undo slider values written before it.
+        for (key, value) in &arguments {
+            let Some(flag) = value.as_bool() else {
+                continue;
+            };
+            params = catalog::set_flag(&params, key, flag).ok_or_else(|| {
+                anyhow!(
+                    "{} has no flag {key:?} (has: {:?})",
+                    kind.display_name(),
+                    catalog::flags(&params)
+                        .iter()
+                        .map(|(k, _)| k.clone())
+                        .collect::<Vec<_>>()
+                )
+            })?;
+        }
+        let specs = params.param_specs();
+        for (key, value) in &arguments {
+            if value.is_boolean() {
+                continue;
+            }
+            let number = value
+                .as_f64()
+                .ok_or_else(|| anyhow!("parameter {key:?} must be a number"))?;
+            if !specs.iter().any(|s| s.key == key) {
+                bail!(
+                    "{} has no parameter {key:?} (has: {:?})",
+                    kind.display_name(),
+                    specs.iter().map(|s| s.key).collect::<Vec<_>>()
+                );
+            }
+            params.set_param(key, number as f32);
+        }
+        let sess = self.session(args)?;
+        let name = sess.apply_adjustment(kind, Some(params))?;
+        text(format!("applied {name}"))
     }
 
     fn session(&mut self, args: &Value) -> Result<&mut Session> {
@@ -303,37 +420,6 @@ impl Server {
             .collect();
         sessions.sort_by(|a, b| a["session"].as_str().cmp(&b["session"].as_str()));
         text_json(json!({"sessions": sessions}))
-    }
-
-    fn set_tool_options(&mut self, args: &Value) -> Result<Value> {
-        let options = args
-            .get("options")
-            .and_then(|v| v.as_object())
-            .ok_or_else(|| anyhow!("missing options object"))?
-            .clone();
-        let sess = self.session(args)?;
-        let active = sess.state.active_tool;
-        let declared: Vec<ToolOption> = sess
-            .registry
-            .tools()
-            .find(|t| t.id() == active)
-            .map(|t| t.options())
-            .unwrap_or_default();
-        for (key, value) in &options {
-            let kind = declared
-                .iter()
-                .find(|o| o.key == key.as_str())
-                .map(|o| o.kind)
-                .ok_or_else(|| {
-                    anyhow!(
-                        "tool {active:?} has no option {key:?} (has: {:?})",
-                        declared.iter().map(|o| o.key).collect::<Vec<_>>()
-                    )
-                })?;
-            let value = coerce_option(value, kind)?;
-            sess.set_tool_option(key, value)?;
-        }
-        text(format!("set {} option(s) on {active}", options.len()))
     }
 
     fn tool_stroke(&mut self, args: &Value) -> Result<Value> {
@@ -635,41 +721,6 @@ fn normalize(name: &str) -> String {
         .to_ascii_lowercase()
 }
 
-const ADJUSTMENT_KINDS: [AdjustmentKind; 18] = [
-    AdjustmentKind::Levels,
-    AdjustmentKind::Curves,
-    AdjustmentKind::HueSaturation,
-    AdjustmentKind::BrightnessContrast,
-    AdjustmentKind::BlackWhite,
-    AdjustmentKind::SolidColor,
-    AdjustmentKind::GradientFill,
-    AdjustmentKind::PatternFill,
-    AdjustmentKind::Invert,
-    AdjustmentKind::Posterize,
-    AdjustmentKind::Threshold,
-    AdjustmentKind::ColorBalance,
-    AdjustmentKind::Vibrance,
-    AdjustmentKind::Exposure,
-    AdjustmentKind::PhotoFilter,
-    AdjustmentKind::GradientMap,
-    AdjustmentKind::SelectiveColor,
-    AdjustmentKind::ChannelMixer,
-];
-
-fn parse_adjustment_kind(name: &str) -> Result<AdjustmentKind> {
-    let wanted = normalize(name);
-    ADJUSTMENT_KINDS
-        .iter()
-        .find(|k| normalize(k.display_name()) == wanted)
-        .copied()
-        .ok_or_else(|| {
-            anyhow!(
-                "unknown adjustment {name:?} (kinds: {})",
-                ADJUSTMENT_KINDS.map(|k| k.display_name()).join(", ")
-            )
-        })
-}
-
 const BLEND_MODES: [BlendMode; 28] = [
     BlendMode::PassThrough,
     BlendMode::Normal,
@@ -840,402 +891,133 @@ fn state_json(id: &str, sess: &Session) -> Value {
     })
 }
 
-fn describe(sess: &Session, what: &str) -> Result<Value> {
-    let tools = || -> Value {
-        sess.registry
-            .tools()
-            .map(|t| {
-                json!({
-                    "id": t.id(),
-                    "name": t.name(),
-                    "group": t.group(),
-                    "shortcut": t.shortcut(),
-                    "in_toolbar": t.in_toolbar(),
-                    "options": t.options().iter().map(option_json).collect::<Vec<_>>(),
-                })
-            })
-            .collect()
-    };
-    let commands = || -> Value {
-        sess.registry
-            .commands()
+/// What the Photoshop plug-in scan found.
+///
+/// The plug-ins that loaded are published as filter tools like any
+/// other, so this is really about the ones that did not: which folders
+/// were searched, and what stopped each entry.
+fn photoshop_json(sess: &Session) -> Value {
+    json!({
+        "folders": sess
+            .photoshop
+            .dirs
             .iter()
-            .map(|c| json!({"id": c.id, "title": c.title, "keybind": c.keybind}))
-            .collect()
-    };
-    let filters = || -> Value {
-        sess.registry
-            .filters()
-            .map(|f| {
-                json!({
-                    "id": f.id(),
-                    "name": f.name(),
-                    "category": f.category(),
-                    "info": f.info(),
-                    "params": f
-                        .params()
-                        .iter()
-                        .map(|p| {
-                            json!({
-                                "key": p.key,
-                                "label": p.label,
-                                "min": p.min,
-                                "max": p.max,
-                                "default": p.default,
-                                "suffix": p.suffix,
-                                "choices": p.choices,
-                            })
-                        })
-                        .collect::<Vec<_>>(),
-                })
-            })
-            .collect()
-    };
-    let codecs = || -> Value {
-        sess.registry
-            .codecs()
-            .map(|c| {
-                json!({
-                    "id": c.id(),
-                    "name": c.name(),
-                    "extensions": c.extensions(),
-                    "can_export": c.can_export(),
-                    "supports_quality": c.supports_quality(),
-                })
-            })
-            .collect()
-    };
-    let adjustments = || -> Value {
-        ADJUSTMENT_KINDS
+            .map(|d| d.display().to_string())
+            .collect::<Vec<_>>(),
+        "plugins": sess
+            .photoshop
+            .entries
             .iter()
-            .map(|k| {
+            .map(|e| {
                 json!({
-                    "kind": k.display_name(),
-                    "default_params": serde_json::to_value(
-                        schist_adjustments::Params::default_for(*k)
-                    )
-                    .unwrap_or(Value::Null),
+                    "id": e.id,
+                    "name": e.name,
+                    "file": e.container.display().to_string(),
+                    "architecture": e.architecture,
+                    "enabled": e.enabled,
+                    "available": e.blocker.is_none() && e.enabled,
+                    "unavailable_because": e.blocker,
                 })
             })
-            .collect()
-    };
-    // Photoshop plug-ins are ordinary filters once loaded, so they are
-    // already in `filters`. This section is the other half: what was
-    // found, and why anything missing from that list is missing.
-    let photoshop_plugins = || -> Value {
-        json!({
-            "folders": sess
-                .photoshop
-                .dirs
-                .iter()
-                .map(|d| d.display().to_string())
-                .collect::<Vec<_>>(),
-            "plugins": sess
-                .photoshop
-                .entries
-                .iter()
-                .map(|e| {
-                    json!({
-                        "id": e.id,
-                        "name": e.name,
-                        "file": e.container.display().to_string(),
-                        "architecture": e.architecture,
-                        "enabled": e.enabled,
-                        "available": e.blocker.is_none() && e.enabled,
-                        "unavailable_because": e.blocker,
-                    })
-                })
-                .collect::<Vec<_>>(),
-        })
-    };
-    let blend_modes = || -> Value {
-        BLEND_MODES
-            .iter()
-            .map(|m| json!(format!("{m:?}")))
-            .collect()
-    };
-    Ok(match what {
-        "tools" => json!({"tools": tools()}),
-        "commands" => json!({"commands": commands()}),
-        "filters" => json!({"filters": filters()}),
-        "codecs" => json!({"codecs": codecs()}),
-        "adjustments" => json!({"adjustments": adjustments()}),
-        "blend_modes" => json!({"blend_modes": blend_modes()}),
-        "photoshop_plugins" => json!({"photoshop_plugins": photoshop_plugins()}),
-        "all" => json!({
-            "tools": tools(),
-            "commands": commands(),
-            "filters": filters(),
-            "codecs": codecs(),
-            "adjustments": adjustments(),
-            "blend_modes": blend_modes(),
-            "photoshop_plugins": photoshop_plugins(),
-        }),
-        other => bail!(
-            "unknown section {other:?} (tools, commands, filters, codecs, adjustments, \
-             blend_modes, photoshop_plugins or all)"
-        ),
+            .collect::<Vec<_>>(),
     })
-}
-
-// ----- tool definitions -----
-
-fn tool_defs() -> Value {
-    let session_prop = json!({"type": "string", "description": "Session id from create_session"});
-    let modifiers_prop = json!({
-        "type": "object",
-        "description": "Held modifier keys",
-        "properties": {
-            "shift": {"type": "boolean"},
-            "alt": {"type": "boolean"},
-            "ctrl": {"type": "boolean", "description": "Ctrl/Cmd"},
-        },
-    });
-    let def = |name: &str, description: &str, props: Value, required: &[&str]| {
-        json!({
-            "name": name,
-            "description": description,
-            "inputSchema": {
-                "type": "object",
-                "properties": props,
-                "required": required,
-            },
-        })
-    };
-    json!([
-        def(
-            "create_session",
-            "Create an editing session: open an image file (PSD/PSB, PNG, JPEG, WebP, TIFF, \
-             Affinity .af/.afphoto/.afdesign/.afpub) or start a blank document with a white \
-             Background layer. Returns the session id and initial state.",
-            json!({
-                "path": {"type": "string", "description": "File to open; omit for a blank document"},
-                "width": {"type": "integer", "description": "Blank document width (default 1280)"},
-                "height": {"type": "integer", "description": "Blank document height (default 800)"},
-                "depth": {"type": "integer", "enum": [8, 16, 32], "description": "Bits per channel (default 8)"},
-                "title": {"type": "string"},
-            }),
-            &[],
-        ),
-        def("list_sessions", "List open sessions.", json!({}), &[]),
-        def(
-            "close_session",
-            "Close a session, discarding unsaved changes.",
-            json!({"session": session_prop}),
-            &["session"],
-        ),
-        def(
-            "describe",
-            "Enumerate what the session can do: canvas tools (with their options), menu \
-             commands (run with run_command), filters, destructive adjustments (with default \
-             parameter shapes), codecs and blend modes.",
-            json!({
-                "session": session_prop,
-                "what": {
-                    "type": "string",
-                    "enum": [
-                        "tools",
-                        "commands",
-                        "filters",
-                        "codecs",
-                        "adjustments",
-                        "blend_modes",
-                        "photoshop_plugins",
-                        "all"
-                    ],
-                    "description": "Section to list (default all)",
-                },
-            }),
-            &["session"],
-        ),
-        def(
-            "get_state",
-            "Document info, full layer tree (with layer ids), selection, undo/redo state, and \
-             editor state including the active tool's options.",
-            json!({"session": session_prop}),
-            &["session"],
-        ),
-        def(
-            "run_command",
-            "Run a menu command by id (see describe): edit.undo, edit.redo, select.all, \
-             layer.new, layer.duplicate, image.crop and everything else in the menus.",
-            json!({
-                "session": session_prop,
-                "id": {"type": "string", "description": "Command id, e.g. \"layer.duplicate\""},
-            }),
-            &["session", "id"],
-        ),
-        def(
-            "select_tool",
-            "Activate a canvas tool by id (see describe): brush, eraser, marquee, lasso, wand, \
-             gradient, move, crop, transform, text, shapes, pen…",
-            json!({
-                "session": session_prop,
-                "id": {"type": "string", "description": "Tool id, e.g. \"brush\""},
-            }),
-            &["session", "id"],
-        ),
-        def(
-            "set_tool_options",
-            "Set options-bar values on the active tool. Numbers for sliders, booleans for \
-             toggles, and either an index or the choice's name for dropdowns.",
-            json!({
-                "session": session_prop,
-                "options": {
-                    "type": "object",
-                    "description": "Option key to value, e.g. {\"wand-tolerance\": 40}",
-                    "additionalProperties": true,
-                },
-            }),
-            &["session", "options"],
-        ),
-        def(
-            "tool_stroke",
-            "Drive the active tool through one pointer gesture in document pixels: down on the \
-             first point, drag through the rest, up on the last. One point clicks. A brush \
-             stroke, a marquee drag, a transform-handle drag and a text-layer click are all one \
-             call. Modal tools (crop, transform, text) keep a pending state afterwards — finish \
-             with tool_input.",
-            json!({
-                "session": session_prop,
-                "points": {
-                    "type": "array",
-                    "items": {"type": "array", "items": {"type": "number"}, "minItems": 2, "maxItems": 2},
-                    "description": "[[x, y], …] in document pixels",
-                },
-                "pressure": {"type": "number", "description": "Stylus pressure 0..1 (default 1)"},
-                "modifiers": modifiers_prop,
-            }),
-            &["session", "points"],
-        ),
-        def(
-            "tool_input",
-            "Non-pointer input for the active tool: commit (Enter) or cancel (Escape) a pending \
-             crop/transform/text gesture, or send a raw key — the type tool takes text through \
-             action \"key\" with the character in \"text\".",
-            json!({
-                "session": session_prop,
-                "action": {"type": "string", "enum": ["key", "commit", "cancel"]},
-                "key": {"type": "string", "description": "Physical key name for action \"key\", e.g. \"a\", \"enter\", \"backspace\""},
-                "text": {"type": "string", "description": "Character the key types, when it types one"},
-                "modifiers": modifiers_prop,
-            }),
-            &["session", "action"],
-        ),
-        def(
-            "apply_filter",
-            "Run a destructive filter on the active pixel layer (through the selection when one \
-             exists), as one undoable edit. Omitted parameters use their defaults (see describe).",
-            json!({
-                "session": session_prop,
-                "id": {"type": "string", "description": "Filter id, e.g. \"filter.gaussian-blur\""},
-                "params": {
-                    "type": "object",
-                    "description": "Parameter key to number",
-                    "additionalProperties": {"type": "number"},
-                },
-            }),
-            &["session", "id"],
-        ),
-        def(
-            "apply_adjustment",
-            "Image ▸ Adjustments: apply an adjustment destructively to the active layer's \
-             pixels. For a non-destructive adjustment layer use the layer.adjustment.* commands \
-             instead. params follows the shape shown by describe(adjustments); omit for defaults.",
-            json!({
-                "session": session_prop,
-                "kind": {"type": "string", "description": "e.g. \"Levels\", \"Hue/Saturation\", \"Brightness/Contrast\""},
-                "params": {"type": "object", "description": "Serde form of the adjustment's parameters"},
-            }),
-            &["session", "kind"],
-        ),
-        def(
-            "set_active_layer",
-            "Make a layer the target of tools, filters and layer commands (layer ids come from \
-             get_state).",
-            json!({
-                "session": session_prop,
-                "id": {"type": "integer", "description": "Layer id"},
-            }),
-            &["session", "id"],
-        ),
-        def(
-            "set_layer_props",
-            "Change a layer's name, visibility, opacity, fill opacity, blend mode, lock or \
-             clipping flag, as one undoable edit.",
-            json!({
-                "session": session_prop,
-                "id": {"type": "integer"},
-                "name": {"type": "string"},
-                "visible": {"type": "boolean"},
-                "opacity": {"type": "number", "description": "0..1"},
-                "fill_opacity": {"type": "number", "description": "0..1"},
-                "blend": {"type": "string", "description": "Blend mode name, e.g. \"Multiply\""},
-                "locked": {"type": "boolean"},
-                "clipping": {"type": "boolean"},
-            }),
-            &["session", "id"],
-        ),
-        def(
-            "set_editor",
-            "Set shared editor state: foreground/background colours, brush size and hardness, \
-             tool opacity, magic-wand tolerance, transform resampling.",
-            json!({
-                "session": session_prop,
-                "foreground": {"type": "string", "description": "#rrggbb or #rrggbbaa"},
-                "background": {"type": "string"},
-                "brush_size": {"type": "number", "description": "Pixels"},
-                "brush_hardness": {"type": "number", "description": "0 soft .. 1 hard"},
-                "tool_opacity": {"type": "number", "description": "0..1"},
-                "tolerance": {"type": "integer", "description": "0..255"},
-                "resample": {"type": "string", "enum": ["nearest", "bilinear", "bicubic"]},
-            }),
-            &["session"],
-        ),
-        def(
-            "render",
-            "Composite the document (or a region) and return it as a PNG image, downscaled to \
-             max_dim for viewing. Pass path to also write the full-resolution PNG to disk.",
-            json!({
-                "session": session_prop,
-                "x": {"type": "integer"},
-                "y": {"type": "integer"},
-                "width": {"type": "integer"},
-                "height": {"type": "integer"},
-                "max_dim": {"type": "integer", "description": "Longest edge of the returned preview (default 1024)"},
-                "path": {"type": "string", "description": "Also write full-resolution PNG here"},
-            }),
-            &["session"],
-        ),
-        def(
-            "save",
-            "Save the document, codec chosen by extension (.psd/.psb keeps layers; raster \
-             formats flatten). Defaults to the path it was opened from.",
-            json!({
-                "session": session_prop,
-                "path": {"type": "string", "description": "Target path; optional when the document already has one"},
-            }),
-            &["session"],
-        ),
-        def(
-            "export",
-            "Export a flattened copy with encoder settings, leaving the document's own path \
-             untouched.",
-            json!({
-                "session": session_prop,
-                "path": {"type": "string"},
-                "quality": {"type": "integer", "description": "1..100 for lossy formats (default 90)"},
-                "bit_depth": {"type": "integer", "description": "Bits per channel where the format supports a choice (default 8)"},
-                "dither": {"type": "boolean", "description": "Dither when reducing depth (default true)"},
-            }),
-            &["session", "path"],
-        ),
-    ])
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every name in the tool list has to lead somewhere. A builtin that
+    /// is published but not implemented reports "unknown tool" to the
+    /// caller and nothing at all to us.
+    #[test]
+    fn every_published_name_dispatches() {
+        let mut server = Server::default();
+        let names: Vec<String> = server
+            .catalog()
+            .defs()
+            .iter()
+            .map(|d| d["name"].as_str().unwrap().to_string())
+            .collect();
+        assert!(names.len() > 100, "only {} tools published", names.len());
+        for name in names {
+            if let Err(e) = server.call_tool(&name, &json!({})) {
+                let e = format!("{e:#}");
+                assert!(!e.contains("unknown tool"), "{name}: {e}");
+            }
+        }
+    }
+
+    /// A filter's choice parameter reads as the name the dialog shows.
+    #[test]
+    fn a_choice_reaches_the_filter_as_its_index() {
+        let mut server = Server::default();
+        server
+            .call_tool("create_session", &json!({"width": 32, "height": 32}))
+            .expect("session");
+        let args = json!({"session": "s1", "amount": 10, "distribution": "Gaussian"});
+        server.call_tool("filter_add_noise", &args).expect("filter");
+        let bad = json!({"session": "s1", "distribution": "Poisson"});
+        let e = format!(
+            "{:#}",
+            server.call_tool("filter_add_noise", &bad).unwrap_err()
+        );
+        assert!(e.contains("no choice"), "{e}");
+    }
+
+    /// Selecting a tool and setting its options is one call, and the
+    /// options that arrive with it are checked against that tool.
+    #[test]
+    fn a_tool_is_selected_and_configured_together() {
+        let mut server = Server::default();
+        server
+            .call_tool("create_session", &json!({"width": 32, "height": 32}))
+            .expect("session");
+        let args = json!({"session": "s1", "marquee-feather": 3.0});
+        server
+            .call_tool("tool_marquee_rect", &args)
+            .expect("select");
+        let sess = server.sessions.get("s1").unwrap();
+        assert_eq!(sess.state.active_tool, "marquee.rect");
+        let feather = sess
+            .registry
+            .tools()
+            .find(|t| t.id() == "marquee.rect")
+            .unwrap()
+            .options()
+            .iter()
+            .find(|o| o.key == "marquee-feather")
+            .map(|o| o.value.num());
+        assert_eq!(feather, Some(3.0));
+        let e = format!(
+            "{:#}",
+            server
+                .call_tool("tool_marquee_rect", &json!({"session": "s1", "nope": 1}))
+                .unwrap_err()
+        );
+        assert!(e.contains("no option"), "{e}");
+    }
+
+    /// An adjustment takes its checkbox as a boolean and its sliders as
+    /// numbers, and the two do not undo each other.
+    #[test]
+    fn an_adjustment_takes_flags_and_sliders_at_once() {
+        let mut server = Server::default();
+        server
+            .call_tool("create_session", &json!({"width": 32, "height": 32}))
+            .expect("session");
+        let args = json!({"session": "s1", "monochrome": true, "r_r": 50.0});
+        server
+            .call_tool("adjust_channel_mixer", &args)
+            .expect("adjustment");
+        let e = format!(
+            "{:#}",
+            server
+                .call_tool("adjust_levels", &json!({"session": "s1", "bogus": 1.0}))
+                .unwrap_err()
+        );
+        assert!(e.contains("no parameter"), "{e}");
+    }
 
     #[test]
     fn colours_parse_in_every_hex_form() {
@@ -1266,16 +1048,7 @@ mod tests {
     }
 
     #[test]
-    fn names_normalize_to_kinds_and_modes() {
-        assert_eq!(
-            parse_adjustment_kind("Hue/Saturation").unwrap(),
-            AdjustmentKind::HueSaturation
-        );
-        assert_eq!(
-            parse_adjustment_kind("brightness-contrast").unwrap(),
-            AdjustmentKind::BrightnessContrast
-        );
-        assert!(parse_adjustment_kind("sepia").is_err());
+    fn names_normalize_to_modes() {
         assert_eq!(
             parse_blend_mode("soft light").unwrap(),
             BlendMode::SoftLight

--- a/crates/mcp/src/session.rs
+++ b/crates/mcp/src/session.rs
@@ -65,7 +65,7 @@ type Hosts = (
     schist_plugin_host_8bf::manager::PluginManager,
 );
 
-fn build_registry() -> Hosts {
+pub fn build_registry() -> Hosts {
     let mut registry = PluginRegistry::new();
     let manifests: Vec<Box<dyn PluginManifest>> = vec![
         Box::new(schist_tools_basic::BasicToolsPlugin),

--- a/crates/plugin-api/src/lib.rs
+++ b/crates/plugin-api/src/lib.rs
@@ -139,6 +139,14 @@ pub trait ToolPlugin: Send {
     /// Stable identifier, e.g. "brush".
     fn id(&self) -> &'static str;
     fn name(&self) -> &'static str;
+    /// A sentence saying what the tool does and how it is driven, for
+    /// hosts that have no toolbar to point at: the MCP server publishes
+    /// one tool per canvas tool and this is its description. Defaulted
+    /// so a third-party plugin still compiles; it then falls back to
+    /// the name.
+    fn description(&self) -> &'static str {
+        ""
+    }
     /// Icon asset name (the app shell renders `icons/<name>.svg`).
     fn icon(&self) -> &'static str;
     /// Default activation key, e.g. "b". Registered into the keymap.
@@ -391,6 +399,11 @@ impl CommandCtx<'_> {
 pub struct Command {
     pub id: &'static str,
     pub title: &'static str,
+    /// What the command does, in a sentence. The title is a menu label
+    /// ("Grow", "Similar") and says nothing on its own to a caller that
+    /// cannot see the menu it sits in -- the MCP server publishes every
+    /// command as its own tool and this is its description.
+    pub description: &'static str,
     /// Default keybinding in GPUI keystroke syntax, e.g. "cmd-shift-e"
     /// ("cmd" is mapped to ctrl on Linux/Windows by the app shell).
     pub keybind: Option<&'static str>,

--- a/docs/8bf-host.md
+++ b/docs/8bf-host.md
@@ -272,9 +272,10 @@ Two hosts, one difference. A `.8bf` publishes no parameter list — its own
 dialog is its entire UI — so the app runs it with `show_dialog` on and
 the MCP server runs it off, where nobody could dismiss one. That is what
 `manager::Interactive` selects, and it is the only thing the two callers
-disagree about. Over MCP the plug-ins appear in `describe filters` like
-any other, and `describe photoshop_plugins` reports the folders scanned,
-each plug-in's architecture, and why anything unavailable is unavailable.
+disagree about. Over MCP a loaded plug-in is published as its own
+`filter_*` tool like any other filter, and the `photoshop_plugins` tool
+reports the folders scanned, each plug-in's architecture, and why
+anything unavailable is unavailable.
 
 **Settings survive between runs.** The descriptor suites are null, so
 nothing records through them — but plug-ins fall back to the `parameters`

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -47,23 +47,38 @@ state, selection and history, like the app's tabs.
 
 ## What a session can do
 
-The surface is deliberately generic rather than one MCP tool per
-feature: `describe` enumerates what is installed, and four invokers
-cover all of it, so a third-party plugin dropped into
-`~/.config/schist/plugins` is as reachable as a built-in.
+Everything installed is published as its own MCP tool, with its own
+parameters, taken from the same plugin registry the app builds its
+menus from. There is no catalog call to make first: the tool list *is*
+the catalog, so a filter arrives with its sliders already described —
+names, ranges, defaults, units and the choices of any dropdown — and a
+third-party plugin dropped into `~/.config/schist/plugins` is published
+the same way the built-ins are.
 
-| MCP tool | covers |
+| published as | covers |
 |---|---|
-| `run_command` | every menu command, `edit.undo`/`edit.redo` included |
-| `select_tool`, `set_tool_options`, `tool_stroke`, `tool_input` | all 55 canvas tools, driven by document-space pointer gestures and commit/cancel/key input |
-| `apply_filter` | every filter, applied through the selection as one history entry |
-| `apply_adjustment` | Image ▸ Adjustments, destructively on the active layer |
+| `cmd_*` | every menu command, `cmd_edit_undo`/`cmd_edit_redo` included — 34 of them |
+| `tool_*` | all 55 canvas tools; the call selects the tool and sets any of its options-bar values passed with it |
+| `filter_*` | every filter, 134 of them, applied through the selection as one history entry |
+| `adjust_*` | Image ▸ Adjustments, destructively on the active layer |
 
-Around those: `get_state` (document, layer tree, selection, history,
+That is around 250 tools, which is the honest size of the application;
+clients that page or filter their tool list will want to know.
+
+A canvas tool is *driven* separately from being selected: `tool_stroke`
+plays a pointer gesture through it in document pixels, and `tool_input`
+sends Enter, Escape or raw keys to the modal ones (crop, transform,
+type). Adjustments take their sliders as plain numbers, their
+checkboxes as booleans, and anything with no slider for it — curve
+points, gradient stops, per-range tables — through a `params` object in
+the adjustment's own serde form.
+
+Around all that: `get_state` (document, layer tree, selection, history,
 editor state), `set_active_layer` and `set_layer_props`, `set_editor`
 (colours, brush, tolerance), `render` (PNG of the canvas or a region,
-returned inline and optionally written to disk), and `save`/`export`
-choosing the codec by extension.
+returned inline and optionally written to disk), `save`/`export`
+choosing the codec by extension, and `photoshop_plugins` for why a
+`.8bf` in the plug-ins folder did not turn into a filter.
 
 The semantics match the app shell: filters read the active raster
 layer, write back feathered through the selection, and land as single

--- a/plugins/commands-core/src/lib.rs
+++ b/plugins/commands-core/src/lib.rs
@@ -13,12 +13,14 @@ use std::sync::Arc;
 fn cmd(
     id: &'static str,
     title: &'static str,
+    description: &'static str,
     keybind: Option<&'static str>,
     run: impl Fn(&mut CommandCtx) + Send + 'static,
 ) -> Command {
     Command {
         id,
         title,
+        description,
         keybind,
         run: Box::new(run),
     }
@@ -456,13 +458,16 @@ impl CommandPlugin for CoreCommandsPlugin {
     fn commands(&self) -> Vec<Command> {
         vec![
             // --- Edit ---
-            cmd("edit.undo", "Undo", Some("cmd-z"), |ctx| {
+            cmd("edit.undo", "Undo",
+                "Step back one entry in the document's undo history.", Some("cmd-z"), |ctx| {
                 ctx.doc.undo();
             }),
-            cmd("edit.redo", "Redo", Some("cmd-shift-z"), |ctx| {
+            cmd("edit.redo", "Redo",
+                "Redo the edit that was last undone.", Some("cmd-shift-z"), |ctx| {
                 ctx.doc.redo();
             }),
-            cmd("edit.copy", "Copy", Some("cmd-c"), |ctx| {
+            cmd("edit.copy", "Copy",
+                "Copy the active layer's selected pixels to the internal clipboard (the whole layer when nothing is selected).", Some("cmd-c"), |ctx| {
                 match copy_pixels(ctx.doc, false) {
                     Some(clip) => ctx.state.clipboard = Some(Arc::new(clip)),
                     // Saying nothing while the clipboard kept its previous
@@ -474,13 +479,15 @@ impl CommandPlugin for CoreCommandsPlugin {
             cmd(
                 "edit.copy_merged",
                 "Copy Merged",
+                "Copy the selection as every visible layer composites it, rather than from the active layer alone.",
                 Some("cmd-shift-c"),
                 |ctx| match copy_pixels(ctx.doc, true) {
                     Some(clip) => ctx.state.clipboard = Some(Arc::new(clip)),
                     None => ctx.refuse(NOTHING_TO_COPY),
                 },
             ),
-            cmd("edit.cut", "Cut", Some("cmd-x"), |ctx| {
+            cmd("edit.cut", "Cut",
+                "Copy the selected pixels to the clipboard and erase them from the active layer.", Some("cmd-x"), |ctx| {
                 match copy_pixels(ctx.doc, false) {
                     Some(clip) => {
                         ctx.state.clipboard = Some(Arc::new(clip));
@@ -489,34 +496,40 @@ impl CommandPlugin for CoreCommandsPlugin {
                     None => ctx.refuse(NOTHING_TO_COPY),
                 }
             }),
-            cmd("edit.paste", "Paste", Some("cmd-v"), |ctx| {
+            cmd("edit.paste", "Paste",
+                "Paste the clipboard into a new layer above the active one, centred on the canvas.", Some("cmd-v"), |ctx| {
                 paste(ctx, false)
             }),
             cmd(
                 "edit.paste_in_place",
                 "Paste in Place",
+                "Paste the clipboard into a new layer at the coordinates it was copied from.",
                 Some("cmd-shift-v"),
                 |ctx| paste(ctx, true),
             ),
             cmd(
                 "edit.fill_foreground",
                 "Fill with Foreground",
+                "Fill the selection (or the whole canvas when nothing is selected) with the foreground colour.",
                 Some("alt-backspace"),
                 |ctx| fill_selection(ctx, false),
             ),
             cmd(
                 "edit.fill_background",
                 "Fill with Background",
+                "Fill the selection (or the whole canvas when nothing is selected) with the background colour.",
                 Some("cmd-backspace"),
                 |ctx| fill_selection(ctx, true),
             ),
             // --- Select ---
-            cmd("select.all", "Select All", Some("cmd-a"), |ctx| {
+            cmd("select.all", "Select All",
+                "Select the entire canvas.", Some("cmd-a"), |ctx| {
                 let mut edit = ctx.doc.begin_edit("Select All");
                 edit.change_selection(|sel, canvas| sel.select_all(canvas));
                 edit.commit();
             }),
-            cmd("select.deselect", "Deselect", Some("cmd-d"), |ctx| {
+            cmd("select.deselect", "Deselect",
+                "Drop the selection, so edits apply to the whole layer again.", Some("cmd-d"), |ctx| {
                 let mut edit = ctx.doc.begin_edit("Deselect");
                 edit.change_selection(|sel, _| sel.deselect());
                 edit.commit();
@@ -524,6 +537,7 @@ impl CommandPlugin for CoreCommandsPlugin {
             cmd(
                 "select.inverse",
                 "Select Inverse",
+                "Swap selected and unselected areas.",
                 Some("cmd-shift-i"),
                 |ctx| {
                     // Nothing selected means nothing to invert; without
@@ -538,7 +552,8 @@ impl CommandPlugin for CoreCommandsPlugin {
                 },
             ),
             // --- Layer ---
-            cmd("layer.new", "New Layer", Some("cmd-shift-n"), |ctx| {
+            cmd("layer.new", "New Layer",
+                "Add an empty raster layer above the active one and make it active.", Some("cmd-shift-n"), |ctx| {
                 let path = insert_path_above_active(ctx.doc);
                 let n = ctx.doc.tree.len() + 1;
                 let mut layer = Layer::new_raster(format!("Layer {n}"));
@@ -549,7 +564,8 @@ impl CommandPlugin for CoreCommandsPlugin {
                 edit.commit();
                 ctx.doc.active_layer = Some(id);
             }),
-            cmd("layer.duplicate", "Duplicate Layer", Some("cmd-j"), |ctx| {
+            cmd("layer.duplicate", "Duplicate Layer",
+                "Copy the active layer, contents and all, onto a new layer above it.", Some("cmd-j"), |ctx| {
                 let Some(id) = ctx.doc.active_layer else {
                     return;
                 };
@@ -569,6 +585,7 @@ impl CommandPlugin for CoreCommandsPlugin {
             cmd(
                 "layer.smart_object",
                 "Convert to Smart Object",
+                "Wrap the active raster layer's pixels in a smart object, so later transforms and filters resample the untouched source.",
                 None,
                 |ctx| {
                     let Some(id) = ctx.doc.active_layer else {
@@ -592,7 +609,8 @@ impl CommandPlugin for CoreCommandsPlugin {
                     edit.commit();
                 },
             ),
-            cmd("layer.rasterize", "Rasterize Layer", None, |ctx| {
+            cmd("layer.rasterize", "Rasterize Layer",
+                "Bake a shape, text or smart-object layer down to plain pixels.", None, |ctx| {
                 let Some(id) = ctx.doc.active_layer else {
                     return;
                 };
@@ -611,7 +629,8 @@ impl CommandPlugin for CoreCommandsPlugin {
                 edit.set_smart_object(id, None);
                 edit.commit();
             }),
-            cmd("layer.delete", "Delete Layer", None, |ctx| {
+            cmd("layer.delete", "Delete Layer",
+                "Delete the selected layers.", None, |ctx| {
                 // Deletes the panel's whole multi-selection as one edit.
                 let ids = selection_roots(ctx.doc);
                 if ids.is_empty() {
@@ -627,7 +646,8 @@ impl CommandPlugin for CoreCommandsPlugin {
                 }
                 edit.commit();
             }),
-            cmd("layer.group", "Group Layers", Some("cmd-g"), |ctx| {
+            cmd("layer.group", "Group Layers",
+                "Wrap the selected layers in a new group, in place.", Some("cmd-g"), |ctx| {
                 // Wraps the selected layers in a group, which lands where
                 // the topmost of them was.
                 let ids = selection_roots(ctx.doc);
@@ -671,7 +691,8 @@ impl CommandPlugin for CoreCommandsPlugin {
                 ctx.doc.active_layer = Some(group_id);
                 ctx.doc.selected = vec![group_id];
             }),
-            cmd("select.reselect", "Reselect", Some("cmd-shift-d"), |ctx| {
+            cmd("select.reselect", "Reselect",
+                "Bring back the selection that was last dropped.", Some("cmd-shift-d"), |ctx| {
                 let Some(previous) = ctx.doc.last_selection.clone() else {
                     ctx.refuse("Nothing to reselect");
                     return;
@@ -680,18 +701,22 @@ impl CommandPlugin for CoreCommandsPlugin {
                 edit.change_selection(|sel, _| *sel = previous);
                 edit.commit();
             }),
-            cmd("select.feather", "Feather Selection", None, |ctx| {
+            cmd("select.feather", "Feather Selection",
+                "Soften the selection's edge by a two-pixel blur, so the next edit fades out across it.", None, |ctx| {
                 let mut edit = ctx.doc.begin_edit("Feather");
                 edit.change_selection(|sel, _| sel.feather(2.0));
                 edit.commit();
             }),
-            cmd("select.grow", "Grow", None, |ctx| {
+            cmd("select.grow", "Grow",
+                "Extend the selection into touching pixels that resemble what is already selected, within the magic wand's tolerance.", None, |ctx| {
                 grow_selection(ctx, true);
             }),
-            cmd("select.similar", "Similar", None, |ctx| {
+            cmd("select.similar", "Similar",
+                "Select every pixel in the layer resembling the selection, touching it or not, within the magic wand's tolerance.", None, |ctx| {
                 grow_selection(ctx, false);
             }),
-            cmd("select.save", "Save Selection", None, |ctx| {
+            cmd("select.save", "Save Selection",
+                "Stash the current selection in the document as a named alpha channel.", None, |ctx| {
                 if ctx.doc.selection.is_empty() {
                     ctx.refuse("Select something first");
                     return;
@@ -701,7 +726,8 @@ impl CommandPlugin for CoreCommandsPlugin {
                 ctx.doc.saved_selections.push((format!("Alpha {n}"), sel));
                 ctx.doc.mark_dirty();
             }),
-            cmd("select.load", "Load Selection", None, |ctx| {
+            cmd("select.load", "Load Selection",
+                "Restore the most recently saved selection.", None, |ctx| {
                 // Loads the most recently saved one; the dialog picks by
                 // name once there is a channels panel to name them in.
                 let Some((_, sel)) = ctx.doc.saved_selections.last().cloned() else {
@@ -712,15 +738,18 @@ impl CommandPlugin for CoreCommandsPlugin {
                 edit.commit();
             }),
             // --- Layer ordering ---
-            cmd("layer.raise", "Bring Forward", Some("cmd-]"), |ctx| {
+            cmd("layer.raise", "Bring Forward",
+                "Move the active layer one place up its group's stack.", Some("cmd-]"), |ctx| {
                 move_layer_by(ctx, 1);
             }),
-            cmd("layer.lower", "Send Backward", Some("cmd-["), |ctx| {
+            cmd("layer.lower", "Send Backward",
+                "Move the active layer one place down its group's stack.", Some("cmd-["), |ctx| {
                 move_layer_by(ctx, -1);
             }),
             cmd(
                 "layer.to_front",
                 "Bring to Front",
+                "Move the active layer to the top of its group.",
                 Some("cmd-shift-]"),
                 |ctx| {
                     move_layer_to_end(ctx, true);
@@ -729,6 +758,7 @@ impl CommandPlugin for CoreCommandsPlugin {
             cmd(
                 "layer.to_back",
                 "Send to Back",
+                "Move the active layer to the bottom of its group.",
                 Some("cmd-shift-["),
                 |ctx| {
                     move_layer_to_end(ctx, false);
@@ -737,6 +767,7 @@ impl CommandPlugin for CoreCommandsPlugin {
             cmd(
                 "layer.clipping_mask",
                 "Create/Release Clipping Mask",
+                "Clip the active layer to the one below it, or release it if it already is; a clipped layer shows only where its base has pixels.",
                 Some("cmd-alt-g"),
                 |ctx| {
                     let Some(id) = ctx.doc.active_layer else {
@@ -757,6 +788,7 @@ impl CommandPlugin for CoreCommandsPlugin {
             cmd(
                 "layer.cut_to_new",
                 "Layer via Cut",
+                "Move the selected pixels out of the active layer and onto a new layer above it.",
                 Some("cmd-shift-j"),
                 |ctx| {
                     let Some(clip) = copy_pixels(ctx.doc, false) else {
@@ -778,7 +810,8 @@ impl CommandPlugin for CoreCommandsPlugin {
                     ctx.doc.active_layer = Some(id);
                 },
             ),
-            cmd("layer.add_mask", "Add Layer Mask", None, |ctx| {
+            cmd("layer.add_mask", "Add Layer Mask",
+                "Add a layer mask to the active layer, revealing only the selection when there is one.", None, |ctx| {
                 let Some(id) = ctx.doc.active_layer else {
                     return;
                 };
@@ -807,11 +840,14 @@ impl CommandPlugin for CoreCommandsPlugin {
                 edit.set_mask(id, Some(mask));
                 edit.commit();
             }),
-            cmd("layer.flatten", "Flatten Image", None, flatten_image),
-            cmd("layer.merge_down", "Merge Down", Some("cmd-e"), merge_down),
+            cmd("layer.flatten", "Flatten Image",
+                "Composite everything visible into one opaque Background layer, discarding hidden layers.", None, flatten_image),
+            cmd("layer.merge_down", "Merge Down",
+                "Composite the active layer into the layer beneath it.", Some("cmd-e"), merge_down),
             cmd(
                 "layer.merge_visible",
                 "Merge Visible",
+                "Composite every visible layer into one, leaving hidden layers alone.",
                 Some("cmd-shift-e"),
                 merge_visible,
             ),

--- a/plugins/tools-basic/src/lib.rs
+++ b/plugins/tools-basic/src/lib.rs
@@ -108,6 +108,10 @@ impl ToolPlugin for MoveTool {
     fn name(&self) -> &'static str {
         "Move"
     }
+    fn description(&self) -> &'static str {
+        "Drag the active layer's contents to a new position. With Auto-Select on, \
+         the press picks whichever layer -- or whole group -- is under the pointer first."
+    }
     fn icon(&self) -> &'static str {
         "move"
     }
@@ -304,6 +308,10 @@ impl ToolPlugin for EyedropperTool {
     fn name(&self) -> &'static str {
         "Eyedropper"
     }
+    fn description(&self) -> &'static str {
+        "Sample the colour under the pointer into the foreground swatch, or into the \
+         background swatch when alt is held. Dragging keeps sampling."
+    }
     fn icon(&self) -> &'static str {
         "eyedropper"
     }
@@ -357,7 +365,7 @@ impl ToolPlugin for EyedropperTool {
 
 /// Viewport tools — no-ops at the document level (see module docs).
 macro_rules! viewport_tool {
-    ($ty:ident, $id:literal, $name:literal, $icon:literal, $key:literal) => {
+    ($ty:ident, $id:literal, $name:literal, $desc:literal, $icon:literal, $key:literal) => {
         pub struct $ty;
 
         impl ToolPlugin for $ty {
@@ -366,6 +374,9 @@ macro_rules! viewport_tool {
             }
             fn name(&self) -> &'static str {
                 $name
+            }
+            fn description(&self) -> &'static str {
+                $desc
             }
             fn icon(&self) -> &'static str {
                 $icon
@@ -380,8 +391,24 @@ macro_rules! viewport_tool {
     };
 }
 
-viewport_tool!(HandTool, "hand", "Hand", "hand", "h");
-viewport_tool!(ZoomTool, "zoom", "Zoom", "zoom", "z");
+viewport_tool!(
+    HandTool,
+    "hand",
+    "Hand",
+    "Pans the view. The viewport belongs to the window, so headless this tool does nothing \
+     to the document.",
+    "hand",
+    "h"
+);
+viewport_tool!(
+    ZoomTool,
+    "zoom",
+    "Zoom",
+    "Zooms the view. The viewport belongs to the window, so headless this tool does nothing \
+     to the document.",
+    "zoom",
+    "z"
+);
 
 pub struct BasicToolsPlugin;
 

--- a/plugins/tools-doc/src/lib.rs
+++ b/plugins/tools-doc/src/lib.rs
@@ -152,6 +152,22 @@ impl ToolPlugin for RectTool {
             RectKind::Frame => "Frame",
         }
     }
+    fn description(&self) -> &'static str {
+        match self.kind {
+            RectKind::Artboard => {
+                "Drag out an artboard: a named region of the canvas that exports on its own. \
+                 Dragging inside an existing one moves it."
+            }
+            RectKind::Slice => {
+                "Drag out an export slice, a named rectangle of the canvas exported as its \
+                 own image. Dragging inside an existing one moves it."
+            }
+            RectKind::Frame => {
+                "Drag out a frame: a rectangular (or elliptical) layer that masks whatever \
+                 is placed into it."
+            }
+        }
+    }
     fn icon(&self) -> &'static str {
         match self.kind {
             RectKind::Artboard => "artboard",
@@ -371,6 +387,18 @@ impl ToolPlugin for PointTool {
         match self.kind {
             PointKind::Note => "Note",
             PointKind::Count => "Count",
+        }
+    }
+    fn description(&self) -> &'static str {
+        match self.kind {
+            PointKind::Note => {
+                "Click empty canvas to pin a note there, stamped with the author and colour \
+                 in the editor state; click an existing pin to select it for the Notes panel."
+            }
+            PointKind::Count => {
+                "Click to drop numbered count markers on the canvas, and click an existing \
+                 one to remove it."
+            }
         }
     }
     fn icon(&self) -> &'static str {

--- a/plugins/tools-paint/src/lib.rs
+++ b/plugins/tools-paint/src/lib.rs
@@ -737,6 +737,45 @@ impl ToolPlugin for PaintTool {
         }
     }
 
+    fn description(&self) -> &'static str {
+        match self.mode {
+            PaintMode::Brush => {
+                "Paint a soft-edged stroke in the foreground colour, sized by the editor's \
+                 brush size, hardness and opacity."
+            }
+            PaintMode::Pencil => {
+                "Paint a hard-edged, unantialiased stroke in the foreground colour."
+            }
+            PaintMode::Eraser => "Erase along the stroke, taking the layer back to transparency.",
+            PaintMode::Clone => {
+                "Clone Stamp: alt-click to set the source point, then paint pixels copied \
+                 from it at that offset."
+            }
+            PaintMode::Dodge => "Lighten the pixels the stroke passes over.",
+            PaintMode::Burn => "Darken the pixels the stroke passes over.",
+            PaintMode::Sponge => "Saturate, or desaturate, the pixels the stroke passes over.",
+            PaintMode::Blur => "Blur the pixels the stroke passes over.",
+            PaintMode::Sharpen => "Sharpen the pixels the stroke passes over.",
+            PaintMode::Smudge => "Drag colour along the stroke, as if pushing wet paint.",
+            PaintMode::Heal => {
+                "Healing Brush: alt-click to set the source, then paint; the source's texture \
+                 is blended into the destination's own colour and lighting."
+            }
+            PaintMode::SpotHeal => {
+                "Spot Healing Brush: paint over a blemish and it is replaced with texture \
+                 taken from around it -- no source point to set."
+            }
+            PaintMode::HistoryBrush => {
+                "Paint pixels back out of the document's history snapshot, undoing later \
+                 work stroke by stroke."
+            }
+            PaintMode::BackgroundEraser => {
+                "Erase the colour sampled under the brush's centre and leave unlike pixels \
+                 alone, for lifting a subject off its background."
+            }
+        }
+    }
+
     fn icon(&self) -> &'static str {
         match self.mode {
             PaintMode::Brush => "brush",
@@ -943,6 +982,19 @@ impl ToolPlugin for GradientTool {
         match self.kind {
             GradientKind::Linear => "Gradient",
             GradientKind::Radial => "Radial Gradient",
+        }
+    }
+    fn description(&self) -> &'static str {
+        match self.kind {
+            GradientKind::Linear => {
+                "Drag to fill the layer -- through the selection when there is one -- with a \
+                 linear gradient running from the foreground colour to the background colour \
+                 along the drag."
+            }
+            GradientKind::Radial => {
+                "Drag from the centre outwards to fill with a radial gradient between the \
+                 foreground and background colours."
+            }
         }
     }
     fn icon(&self) -> &'static str {
@@ -1166,6 +1218,10 @@ impl ToolPlugin for BucketTool {
     }
     fn name(&self) -> &'static str {
         "Paint Bucket"
+    }
+    fn description(&self) -> &'static str {
+        "Click to flood the connected area of similar colour under the pointer with the \
+         foreground colour, within the tool's tolerance."
     }
     fn icon(&self) -> &'static str {
         "bucket"

--- a/plugins/tools-retouch/src/lib.rs
+++ b/plugins/tools-retouch/src/lib.rs
@@ -125,6 +125,11 @@ impl ToolPlugin for PatchTool {
     fn name(&self) -> &'static str {
         "Patch"
     }
+    fn description(&self) -> &'static str {
+        "Drag an outline around a flaw, then drag that selection onto clean pixels: the \
+         texture there is fitted into the flaw. Patch mode chooses which end of the pair \
+         you drag."
+    }
     fn icon(&self) -> &'static str {
         "patch"
     }
@@ -302,6 +307,10 @@ impl ToolPlugin for ContentAwareMoveTool {
     fn name(&self) -> &'static str {
         "Content-Aware Move"
     }
+    fn description(&self) -> &'static str {
+        "Drag a selected object elsewhere and the hole it leaves is filled in from its \
+         surroundings. In Extend mode the object is stretched instead of moved."
+    }
     fn icon(&self) -> &'static str {
         "content-move"
     }
@@ -454,6 +463,9 @@ impl ToolPlugin for RedEyeTool {
     fn name(&self) -> &'static str {
         "Red Eye"
     }
+    fn description(&self) -> &'static str {
+        "Click a pupil to drain the flash red out of it."
+    }
     fn icon(&self) -> &'static str {
         "red-eye"
     }
@@ -599,6 +611,10 @@ impl ToolPlugin for MagicEraserTool {
     }
     fn name(&self) -> &'static str {
         "Magic Eraser"
+    }
+    fn description(&self) -> &'static str {
+        "Click to erase the area of similar colour under the pointer, within the tool's \
+         tolerance -- contiguous with the click, or everywhere in the layer."
     }
     fn icon(&self) -> &'static str {
         "eraser-magic"

--- a/plugins/tools-select/src/lib.rs
+++ b/plugins/tools-select/src/lib.rs
@@ -212,6 +212,20 @@ impl ToolPlugin for MarqueeTool {
         }
     }
 
+    fn description(&self) -> &'static str {
+        match self.shape {
+            MarqueeShape::Rect => {
+                "Drag out a rectangular selection. Shift at the start of the drag adds to \
+                 the selection, alt subtracts, both intersect; shift during the drag squares \
+                 it off. A click with no drag deselects."
+            }
+            MarqueeShape::Ellipse => {
+                "Drag out an elliptical selection, with the same shift/alt combining as the \
+                 rectangular marquee."
+            }
+        }
+    }
+
     fn icon(&self) -> &'static str {
         match self.shape {
             MarqueeShape::Rect => "marquee-rect",
@@ -451,6 +465,22 @@ impl ToolPlugin for LassoTool {
             LassoKind::Magnetic => "Magnetic Lasso",
         }
     }
+    fn description(&self) -> &'static str {
+        match self.kind {
+            LassoKind::Free => {
+                "Drag a freehand outline; the selection closes across the ends when the drag \
+                 finishes. Shift adds, alt subtracts."
+            }
+            LassoKind::Polygonal => {
+                "Click corner after corner to build a straight-edged selection, and click \
+                 near the first point to close it."
+            }
+            LassoKind::Magnetic => {
+                "Trace roughly along an edge and the outline snaps to the strongest contrast \
+                 near the path."
+            }
+        }
+    }
     fn icon(&self) -> &'static str {
         match self.kind {
             LassoKind::Free => "lasso",
@@ -672,6 +702,10 @@ impl ToolPlugin for WandTool {
     fn name(&self) -> &'static str {
         "Magic Wand"
     }
+    fn description(&self) -> &'static str {
+        "Click to select the connected area of similar colour under the pointer, within \
+         the tolerance option -- the same tolerance Grow, Similar and Color Range read."
+    }
     fn icon(&self) -> &'static str {
         "wand"
     }
@@ -820,6 +854,10 @@ impl ToolPlugin for QuickSelectTool {
     }
     fn name(&self) -> &'static str {
         "Quick Selection"
+    }
+    fn description(&self) -> &'static str {
+        "Paint over a region and the selection grows through the similar pixels the brush \
+         passes over."
     }
     fn icon(&self) -> &'static str {
         "quick-select"
@@ -1134,6 +1172,9 @@ impl ToolPlugin for ObjectSelectTool {
     }
     fn name(&self) -> &'static str {
         "Object Selection"
+    }
+    fn description(&self) -> &'static str {
+        "Drag a box around an object and the selection snaps to the object found inside it."
     }
     fn icon(&self) -> &'static str {
         "object-select"

--- a/plugins/tools-transform/src/lib.rs
+++ b/plugins/tools-transform/src/lib.rs
@@ -338,6 +338,22 @@ impl ToolPlugin for TransformTool {
             TransformMode::Selection => "Transform Selection",
         }
     }
+
+    fn description(&self) -> &'static str {
+        match self.mode {
+            TransformMode::Layer => {
+                "Free Transform. Activating it opens a transform box around the active \
+                 layer: drag a corner to scale, drag outside one to rotate, drag an edge to \
+                 skew. Nothing is written until it is committed (Enter), and cancelling \
+                 (Escape) puts the layer back."
+            }
+            TransformMode::Selection => {
+                "Transform Selection: the same box, moving the selection outline rather than \
+                 the pixels inside it. Commit or cancel to finish."
+            }
+        }
+    }
+
     fn icon(&self) -> &'static str {
         "transform"
     }
@@ -638,6 +654,10 @@ impl ToolPlugin for CropTool {
     }
     fn name(&self) -> &'static str {
         "Crop"
+    }
+    fn description(&self) -> &'static str {
+        "Drag out the area to keep and adjust its handles; committing (Enter) trims the \
+         document to it, cancelling (Escape) leaves it alone."
     }
     fn icon(&self) -> &'static str {
         "crop"

--- a/plugins/tools-type/src/lib.rs
+++ b/plugins/tools-type/src/lib.rs
@@ -300,6 +300,11 @@ impl ToolPlugin for TypeTool {
     fn name(&self) -> &'static str {
         "Type"
     }
+    fn description(&self) -> &'static str {
+        "Click to start a text layer there, or click an existing one to edit it. While it \
+         is open the tool takes raw keys (send characters as key input), and committing \
+         renders the layer and closes the edit."
+    }
     fn icon(&self) -> &'static str {
         "type"
     }

--- a/plugins/tools-vector/src/lib.rs
+++ b/plugins/tools-vector/src/lib.rs
@@ -441,6 +441,21 @@ impl ToolPlugin for ShapeTool {
         }
     }
 
+    fn description(&self) -> &'static str {
+        match self.kind {
+            ShapeKind::Rectangle => {
+                "Drag out a rectangle shape layer in the foreground colour; it stays vector \
+                 and re-rasterizes when resized."
+            }
+            ShapeKind::Ellipse => "Drag out an ellipse shape layer in the foreground colour.",
+            ShapeKind::Line => "Drag out a straight line shape layer in the foreground colour.",
+            ShapeKind::Polygon => {
+                "Drag out a regular polygon shape layer in the foreground colour, with the \
+                 number of sides from the options."
+            }
+        }
+    }
+
     fn icon(&self) -> &'static str {
         match self.kind {
             ShapeKind::Rectangle => "shape-rect",
@@ -636,6 +651,10 @@ impl ToolPlugin for PenTool {
     }
     fn name(&self) -> &'static str {
         "Pen"
+    }
+    fn description(&self) -> &'static str {
+        "Build a path: click for a corner point, drag to pull curve handles out of it, and \
+         click the first point to close. Commit turns the path into a shape layer."
     }
     fn icon(&self) -> &'static str {
         "pen"

--- a/plugins/tools-vector/src/paths.rs
+++ b/plugins/tools-vector/src/paths.rs
@@ -164,6 +164,14 @@ impl ToolPlugin for PathSelectTool {
             ArrowKind::Direct => "Direct Selection",
         }
     }
+    fn description(&self) -> &'static str {
+        match self.kind {
+            ArrowKind::Path => "Click a path to select it, and drag to move the whole path.",
+            ArrowKind::Direct => {
+                "Drag an individual anchor point or its handles to reshape the path around it."
+            }
+        }
+    }
     fn icon(&self) -> &'static str {
         match self.kind {
             ArrowKind::Path => "path-select",
@@ -366,6 +374,13 @@ impl ToolPlugin for FreeformPenTool {
             "Curvature Pen"
         } else {
             "Freeform Pen"
+        }
+    }
+    fn description(&self) -> &'static str {
+        if self.curvature {
+            "Click a series of points and the path is curved smoothly through them."
+        } else {
+            "Drag a freehand line and it is fitted to a path, as loosely as the Fit option says."
         }
     }
     fn icon(&self) -> &'static str {
@@ -587,6 +602,9 @@ impl ToolPlugin for CustomShapeTool {
     }
     fn name(&self) -> &'static str {
         "Custom Shape"
+    }
+    fn description(&self) -> &'static str {
+        "Drag out one of the built-in preset shapes, picked with the Shape option."
     }
     fn icon(&self) -> &'static str {
         "shape-custom"

--- a/plugins/tools-warp/src/liquify.rs
+++ b/plugins/tools-warp/src/liquify.rs
@@ -260,6 +260,10 @@ impl ToolPlugin for LiquifyTool {
     fn name(&self) -> &'static str {
         "Liquify"
     }
+    fn description(&self) -> &'static str {
+        "Push, twirl, pucker or bloat pixels under a large brush -- the mode option picks \
+         which. The warp accumulates in a mesh and is applied to the layer on commit."
+    }
     fn icon(&self) -> &'static str {
         "liquify"
     }

--- a/plugins/tools-warp/src/perspective.rs
+++ b/plugins/tools-warp/src/perspective.rs
@@ -250,6 +250,10 @@ impl ToolPlugin for VanishingPointTool {
     fn name(&self) -> &'static str {
         "Vanishing Point"
     }
+    fn description(&self) -> &'static str {
+        "Drag out a plane over something with perspective in it, then switch the mode to \
+         Clone and paint: the copied pixels follow the plane, shrinking with distance."
+    }
     fn icon(&self) -> &'static str {
         "vanishing-point"
     }

--- a/plugins/tools-warp/src/puppet.rs
+++ b/plugins/tools-warp/src/puppet.rs
@@ -252,6 +252,10 @@ impl ToolPlugin for PuppetWarpTool {
     fn name(&self) -> &'static str {
         "Puppet Warp"
     }
+    fn description(&self) -> &'static str {
+        "Click to pin the layer at a few points, then drag one: the mesh bends around the \
+         pins, stiffly or loosely as the Stiffness option says. Commit applies it."
+    }
     fn icon(&self) -> &'static str {
         "puppet"
     }


### PR DESCRIPTION
## What

`tools/list` no longer advertises five generic invokers plus a `describe` call to find out what they can be pointed at. Every installed feature is published as its own MCP tool, with its own typed, documented parameters, built from the same plugin registry the app assembles its menus from.

| prefix | count | what |
|---|---|---|
| `filter_*` | 134 | one per filter; params carry label, range, default, unit, and dropdowns as string enums |
| `tool_*` | 55 | one per canvas tool; the call activates it **and** applies any options-bar values passed with it |
| `cmd_*` | 34 | one per menu command |
| `adjust_*` | 18 | sliders as numbers, checkboxes as booleans, plus a `params` escape hatch for curve points / gradient stops / per-range tables |
| builtins | 13 | sessions, `get_state`, `tool_stroke`/`tool_input`, layer props, `render`, `save`/`export`, `photoshop_plugins` |

Sample of what a client now sees without a second call:

```
filter_gaussian_blur
  Gaussian Blur — Filter ▸ Blur. Runs on the active raster layer, feathered
  through the selection when there is one, as one undoable edit.
    radius   number [0..100]   "Radius. 0..100 px (default 4)"

cmd_select_similar
  Similar — Select every pixel in the layer resembling the selection, touching
  it or not, within the magic wand's tolerance. Menu command "select.similar".
```

## Structures extended

- `Command` gained a `description` — a menu title ("Grow", "Similar") says nothing to a caller that cannot see the menu around it. All 34 core commands got one written.
- `ToolPlugin` gained a defaulted `description()`, implemented for all 55 tools (per-mode text for the 14 paint modes, 3 lassos, 4 shapes…). Defaulted so plugins built outside this repo still compile.
- Filters and adjustments needed no new fields: `FilterParam` and `Params::param_specs()` already carry ranges and defaults, and adjustment flags are read/written through the serialized form, so an adjustment that grows a checkbox is published without further work.

## Removed

`describe`, `select_tool`, `set_tool_options`, `run_command`, `apply_filter`, `apply_adjustment`. Nothing `describe` reported is lost: codec extensions are in the `create_session`/`save` descriptions, blend modes are an enum on `set_layer_props`, and the Photoshop diagnostics survive as the `photoshop_plugins` tool (the plug-ins that loaded are filters now; what is left to report is the ones that did not).

## Notes for review

- **254 tools is a large list** (~250 KB of JSON per connection). That is inherent to publishing everything, and it is called out in `docs/mcp.md` rather than silently capped. The biggest single contributor is `tool_type`'s `type-family` enum, which is every installed font.
- `filter_add_noise`'s `monochrome` publishes as `number [0..1]` rather than a boolean, faithfully: `FilterParam` has no toggle kind, so inferring one would be guesswork. Worth a follow-up if we want it typed.

## Verification

- `cargo build --workspace --all-targets` — clean
- `cargo test --workspace` — passes, including 9 new tests (name uniqueness and validity, every published name dispatches, filter params published, choices reaching filters as indices, tool select+configure in one call, adjustment flags and sliders together, collision numbering)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- Exercised end to end over real stdio JSON-RPC: session → tool select with options → stroke → filter with a named choice → adjustment with a flag → undo → error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)