### PR TITLE
fix: the HEIC download dialog looping in a signed macOS build

### DIFF
--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -88,10 +88,14 @@ configured, so renewing the certificate means replacing two secrets and
 nothing else.
 
 Signing runs under the hardened runtime, which notarization requires. That
-in turn requires the JIT entitlement in
-[`packaging/macos/entitlements.plist`](../packaging/macos/entitlements.plist):
-the plugin host compiles every plugin with Cranelift at load time, and
-without that entitlement a notarized build dies as soon as it loads one.
+in turn requires both entitlements in
+[`packaging/macos/entitlements.plist`](../packaging/macos/entitlements.plist).
+The JIT one: the plugin host compiles every plugin with Cranelift at load
+time, and without it a notarized build dies as soon as it loads one. And
+library validation off: HEIC import dlopen's libheif — Homebrew's, or the
+decode-only build the app offers to download — and the hardened runtime
+otherwise refuses to load any library not signed by this Team ID, which no
+copy of libheif is.
 
 Windows builds are not signed — there is no certificate for them yet, so
 the installer triggers SmartScreen on first download.

--- a/packaging/macos/entitlements.plist
+++ b/packaging/macos/entitlements.plist
@@ -8,5 +8,15 @@
          notarized Schist launches and then dies the moment it loads a
          plugin, which is to say immediately. -->
     <key>com.apple.security.cs.allow-jit</key><true/>
+
+    <!-- HEIC import dlopen's libheif: either Homebrew's or the
+         decode-only build the app offers to download. Neither is signed
+         by this Team ID, and the hardened runtime's library validation
+         rejects any library that is not, so without this a signed build
+         cannot load either one -- HEIC fails, the download dialog
+         offers the fix, and the fix cannot load either. Only affects
+         libraries this process dlopen's by name; .8bf plug-ins are
+         hosted in a separate helper process. -->
+    <key>com.apple.security.cs.disable-library-validation</key><true/>
 </dict>
 </plist>

--- a/plugins/codecs-common/src/heif.rs
+++ b/plugins/codecs-common/src/heif.rs
@@ -148,17 +148,48 @@ pub fn is_missing_library_error(err: &anyhow::Error) -> bool {
     format!("{err:#}").contains(NOT_AVAILABLE)
 }
 
+/// True when the failure is "this machine cannot decode HEIC" — no
+/// libheif at all, or one with no HEVC decoder — rather than a broken
+/// file. Tests skip on this; the app asks the further question of
+/// whether a download would fix it.
+pub fn no_decoder_available(err: &anyhow::Error) -> bool {
+    is_missing_library_error(err) || format!("{err:#}").contains(NO_DECODER)
+}
+
 /// True when this machine cannot decode HEIC today but installing the
 /// managed library would fix it: either no libheif loaded at all, or
 /// the loaded (system) build has no HEVC decoder — stock Ubuntu ships
 /// libheif with only AV1 plugins — and the managed build, which always
-/// carries one, is not the library in use.
+/// carries one, is neither in use nor already installed.
 pub fn download_would_help(err: &anyhow::Error) -> bool {
-    if is_missing_library_error(err) {
-        return true;
+    if !no_decoder_available(err) {
+        return false;
     }
-    let from_managed = LOADED.lock().unwrap().is_some_and(|(_, managed)| managed);
-    !from_managed && format!("{err:#}").contains(NO_DECODER)
+    // The managed build is loaded and still could not do it: there is
+    // nothing left to fetch.
+    if LOADED.lock().unwrap().is_some_and(|(_, managed)| managed) {
+        return false;
+    }
+    // Nor is there when the pinned build is already on disk and simply
+    // did not load — dlopen refused it (a signature policy, a missing
+    // dependency, the wrong architecture), and downloading the same
+    // bytes over the top would only offer the dialog again, forever.
+    !managed_installed()
+}
+
+/// Whether the pinned managed library is already on disk, byte for
+/// byte. A mismatch counts as not installed: that is an older pinned
+/// version, which a download does replace.
+pub fn managed_installed() -> bool {
+    managed_library().is_some_and(|managed| installed_matches(&managed.library))
+}
+
+/// Whether `file` is already in the managed directory with exactly the
+/// pinned contents.
+pub(crate) fn installed_matches(file: &RemoteFile) -> bool {
+    use sha2::Digest as _;
+    std::fs::read(managed_dir().join(file.name))
+        .is_ok_and(|bytes| format!("{:x}", sha2::Sha256::digest(&bytes)) == file.sha256)
 }
 
 /// One file the app may download: URL pinned to a release tag, contents
@@ -326,12 +357,16 @@ fn libheif() -> anyhow::Result<&'static LibHeif> {
     }
     candidates.extend(LIBRARY_CANDIDATES.iter().map(|name| (name.into(), false)));
 
-    let mut last_err = String::new();
+    // Every candidate's failure, not just the last: the one that
+    // matters is usually the managed library's, and it is first in the
+    // list. Reporting only the last leaves a downloaded library that
+    // dlopen refused looking like it was never there.
+    let mut errors = Vec::new();
     for (name, from_managed) in &candidates {
         let lib = match unsafe { libloading::Library::new(name) } {
             Ok(lib) => lib,
             Err(err) => {
-                last_err = err.to_string();
+                errors.push(format!("{}: {err}", name.to_string_lossy()));
                 continue;
             }
         };
@@ -346,12 +381,13 @@ fn libheif() -> anyhow::Result<&'static LibHeif> {
                 *loaded = Some((lib, *from_managed));
                 return Ok(lib);
             }
-            Err(err) => last_err = err,
+            Err(err) => errors.push(format!("{}: {err}", name.to_string_lossy())),
         }
     }
     Err(anyhow::anyhow!(
-        "{NOT_AVAILABLE} ({last_err}). Opening HEIC needs the libheif library \
-         (Linux: install libheif1; macOS: brew install libheif)"
+        "{NOT_AVAILABLE} ({}). Opening HEIC needs the libheif library \
+         (Linux: install libheif1; macOS: brew install libheif)",
+        errors.join("; ")
     ))
 }
 

--- a/plugins/codecs-common/src/lib.rs
+++ b/plugins/codecs-common/src/lib.rs
@@ -598,7 +598,7 @@ mod tests {
         };
         assert!(HeifCodec.probe(&bytes), "{name} should probe as HEIF");
         match HeifCodec.import(&bytes) {
-            Err(err) if heif::download_would_help(&err) => {
+            Err(err) if heif::no_decoder_available(&err) => {
                 eprintln!("skipping: {err:#}");
                 None
             }
@@ -623,12 +623,25 @@ mod tests {
             "nothing written on mismatch"
         );
 
+        assert!(
+            !heif::installed_matches(&file),
+            "nothing installed before the good write"
+        );
+
         let path = heif::install(&file, b"payload").unwrap();
         assert_eq!(std::fs::read(&path).unwrap(), b"payload");
         assert!(
             !path.with_extension("part").exists(),
             "temp file renamed away"
         );
+        // What stops the download dialog looping: with the pinned bytes
+        // on disk, a second download has nothing to add. Bytes that are
+        // merely *present* do not count -- an older pinned version is
+        // exactly what a download replaces.
+        assert!(heif::installed_matches(&file), "pinned bytes recognised");
+        std::fs::write(&path, b"an older pinned build").unwrap();
+        assert!(!heif::installed_matches(&file), "stale build is not it");
+
         std::env::remove_var("SCHIST_LIBHEIF_DIR");
         let _ = std::fs::remove_dir_all(dir);
     }


### PR DESCRIPTION
`codesign --options runtime` turns on library validation, and a process under it may only dlopen libraries signed by its own Team ID. No copy of libheif is: not Homebrew's, and not the decode-only build the app downloads, which is ad-hoc signed on arm64 and unsigned on x86_64. So in a signed build every candidate is refused, the retry after the install fails exactly like the first attempt did, and the consent dialog opens again -- and again. Unsigned dev builds do not enforce validation, which is why this only appeared once bundled.

The entitlement is the fix. The rest is so that a library that will not load can never again present itself as one that is missing:

`download_would_help` now says no once the pinned bytes are already on disk. Fetching the same five megabytes over the top cannot change the mind of a loader that has already refused them, so the failure falls through to the status line instead of back into the dialog. Bytes that merely exist do not count -- a hash that does not match the pin is an older managed build, which a download does replace.

And what reaches that status line is now worth reading: `libheif()` kept only the last candidate's error, so the managed library's rejection was overwritten by the system library's "image not found" and the signature policy never surfaced. Every candidate reports.

The test-skip predicate keeps the old meaning under its own name, `no_decoder_available`: a machine with no decoder should skip the fixtures whether or not a download would do anything about it.