### PR TITLE
perf: take the login shell's PATH off the launch path

### DIFF
--- a/crates/app/src/ai/claude.rs
+++ b/crates/app/src/ai/claude.rs
@@ -6,7 +6,7 @@
 //! requests to [`PanelServer`], which queues them for the UI thread and
 //! awaits the reply — no socket, no bridge, no second process.
 
-use super::{AgentEvent, AiShared, CmdSender, ConvCmd, Conversation, SYSTEM_PROMPT};
+use super::{path, AgentEvent, AiShared, Backend, CmdSender, ConvCmd, Conversation, SYSTEM_PROMPT};
 use claude_agent_sdk_rs::types::mcp::McpSdkServerConfig;
 use claude_agent_sdk_rs::{
     ClaudeAgentOptions, ClaudeClient, ClaudeError, McpServerConfig, McpServers, Message,
@@ -96,6 +96,12 @@ fn options(shared: &AiShared, resume: Option<String>) -> ClaudeAgentOptions {
         cwd: std::env::var_os("HOME")
             .or_else(|| std::env::var_os("USERPROFILE"))
             .map(std::path::PathBuf::from),
+        // Found on the login shell's PATH rather than launchd's, which is
+        // all a Finder launch inherits; `env` hands that same PATH to
+        // whatever the CLI spawns in turn. `None` lets the SDK run its
+        // own search and say its own thing when it comes up empty.
+        cli_path: Backend::Claude.locate(),
+        env: path::child_env(),
         ..Default::default()
     }
 }

--- a/crates/app/src/ai/codex.rs
+++ b/crates/app/src/ai/codex.rs
@@ -9,7 +9,7 @@
 //! process (the pid is shared with [`Conversation`]); the thread id
 //! survives and the next conversation resumes it.
 
-use super::{AgentEvent, AiShared, CmdSender, ConvCmd, Conversation, SYSTEM_PROMPT};
+use super::{path, AgentEvent, AiShared, Backend, CmdSender, ConvCmd, Conversation, SYSTEM_PROMPT};
 use anyhow::{Context as _, Result};
 use codex_codes::cli::AppServerBuilder;
 use codex_codes::client_sync::SyncClient;
@@ -67,9 +67,16 @@ fn run(
     resume: Option<String>,
 ) -> Result<()> {
     let exe = std::env::current_exe().context("locating the schist binary")?;
+    // The CLI is located on the login shell's PATH, not launchd's — the
+    // builder's own `which` would only see what a Finder launch inherits
+    // — and that PATH is passed on to the app-server's own children.
+    let mut builder = AppServerBuilder::new().env("PATH", path::resolved());
+    if let Some(codex) = Backend::Codex.locate() {
+        builder = builder.command(codex);
+    }
     // The bridge command and its token, as codex config: the value side of
     // each `-c` is TOML.
-    let mut builder = AppServerBuilder::new()
+    builder = builder
         .config_override(
             "mcp_servers.schist.command",
             toml_string(&exe.display().to_string()),

--- a/crates/app/src/ai/mod.rs
+++ b/crates/app/src/ai/mod.rs
@@ -16,72 +16,7 @@ pub mod claude;
 pub mod codex;
 pub mod endpoint;
 pub mod models;
-
-/// Adopt the login shell's PATH when launched from Finder or a desktop
-/// environment.
-///
-/// A GUI launch inherits launchd's (or the desktop session's) minimal
-/// PATH, never the user's shell configuration, so a `claude` or `codex`
-/// living in ~/.local/bin, /opt/homebrew/bin or an npm prefix looks
-/// missing to [`Backend::available`] — and to the SDKs' own spawns —
-/// while working fine from a terminal. Asking the user's shell for its
-/// PATH once at startup makes the panel see the same commands the
-/// terminal does.
-///
-/// Must run early in `main`, before other threads could be reading the
-/// environment: it calls `std::env::set_var`.
-#[cfg(unix)]
-pub fn adopt_login_shell_path() {
-    // A terminal launch already carries the user's PATH; don't spend a
-    // shell startup on it.
-    if std::env::var_os("TERM").is_some() {
-        return;
-    }
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
-    // Interactive + login so both the profile and the rc file
-    // contribute — installers append PATH edits to either. Those files
-    // may print banners, so the value is fenced with markers; and the
-    // inner printf runs under `sh` because fish would expand its own
-    // "$PATH" as a space-joined list, while the exported environment is
-    // colon-joined for every shell.
-    const MARK: &str = "__SCHIST_PATH__";
-    const PRINTER: &str = "sh -c 'printf \"__SCHIST_PATH__%s__SCHIST_PATH__\" \"$PATH\"'";
-    let (tx, rx) = std::sync::mpsc::channel();
-    let spawned = std::thread::Builder::new()
-        .name("shell-path".into())
-        .spawn({
-            let shell = shell.clone();
-            move || {
-                let out = std::process::Command::new(shell)
-                    .args(["-l", "-i", "-c", PRINTER])
-                    .stdin(std::process::Stdio::null())
-                    .output();
-                let _ = tx.send(out);
-            }
-        });
-    if spawned.is_err() {
-        return;
-    }
-    // A shell rc that hangs must not hang the app: give it a few seconds
-    // and launch with the plain PATH otherwise. (On timeout the probe
-    // thread is abandoned; it exits whenever the shell does.)
-    let out = match rx.recv_timeout(std::time::Duration::from_secs(5)) {
-        Ok(Ok(out)) => out,
-        Ok(Err(e)) => {
-            log::warn!("asking {shell} for PATH failed: {e}");
-            return;
-        }
-        Err(_) => {
-            log::warn!("asking {shell} for PATH timed out; installed CLIs may look missing");
-            return;
-        }
-    };
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    match stdout.split(MARK).nth(1) {
-        Some(path) if !path.is_empty() => std::env::set_var("PATH", path),
-        _ => log::warn!("{shell} printed no PATH; installed CLIs may look missing"),
-    }
-}
+pub mod path;
 
 /// Which agent harness a conversation runs on.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -106,15 +41,20 @@ impl Backend {
         }
     }
 
-    /// Whether the CLI is installed, by the same lookup the SDKs use.
+    /// Whether the CLI is installed, as far as the login-shell PATH
+    /// probe has got. Never waits for it — this is what the picker
+    /// paints, and a GUI launch's answer can be a stale "missing" until
+    /// the probe lands (see `Workspace::watch_agent_path`).
     pub fn available(self) -> bool {
-        let path = std::env::var_os("PATH").unwrap_or_default();
-        std::env::split_paths(&path).any(|dir| {
-            let file = dir.join(self.binary());
-            #[cfg(windows)]
-            let file = file.with_extension("exe");
-            file.is_file()
-        })
+        path::lookup(self.binary(), &path::current()).is_some()
+    }
+
+    /// Where the CLI is, waiting for the login-shell PATH if the probe is
+    /// still out. For worker threads about to spawn one: handing the SDKs
+    /// an absolute path also spares them their own PATH search, which
+    /// costs a `claude --version` spawn of its own.
+    pub fn locate(self) -> Option<std::path::PathBuf> {
+        path::lookup(self.binary(), &path::resolved())
     }
 
     /// The preference-file spelling.

--- a/crates/app/src/ai/models.rs
+++ b/crates/app/src/ai/models.rs
@@ -9,7 +9,7 @@
 //! failure the static fallback catalog is reported instead, so the
 //! picker is never empty.
 
-use super::{AgentEvent, AiShared, Backend, ModelEntry};
+use super::{path, AgentEvent, AiShared, Backend, ModelEntry};
 use anyhow::{anyhow, Context as _, Result};
 
 pub fn fetch(backend: Backend, shared: AiShared) {
@@ -42,6 +42,10 @@ fn probe(backend: Backend) -> Result<Vec<ModelEntry>> {
 /// Connect the Agent SDK client just long enough to read the server info
 /// its initialize handshake carries, then hang up.
 fn claude_models() -> Result<Vec<ModelEntry>> {
+    // Before the runtime: resolving the CLI waits on the login-shell PATH
+    // probe, and that wait does not belong inside an async block.
+    let cli_path = Backend::Claude.locate();
+    let env = path::child_env();
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?;
@@ -51,6 +55,10 @@ fn claude_models() -> Result<Vec<ModelEntry>> {
                 .or_else(|| std::env::var_os("USERPROFILE"))
                 .map(std::path::PathBuf::from),
             skip_version_check: true,
+            // Same spawn settings the conversation uses: see
+            // `claude::options`.
+            cli_path,
+            env,
             ..Default::default()
         };
         let mut client = claude_agent_sdk_rs::ClaudeClient::new(options);
@@ -108,7 +116,10 @@ fn claude_models() -> Result<Vec<ModelEntry>> {
 
 /// One `model/list` round trip on a throwaway app-server.
 fn codex_models() -> Result<Vec<ModelEntry>> {
-    let mut builder = codex_codes::AppServerBuilder::new();
+    let mut builder = codex_codes::AppServerBuilder::new().env("PATH", path::resolved());
+    if let Some(codex) = Backend::Codex.locate() {
+        builder = builder.command(codex);
+    }
     if let Some(home) = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE")) {
         builder = builder.working_directory(std::path::PathBuf::from(home));
     }

--- a/crates/app/src/ai/path.rs
+++ b/crates/app/src/ai/path.rs
@@ -1,0 +1,209 @@
+//! The PATH the agent CLIs are looked up on.
+//!
+//! A GUI launch inherits launchd's (or the desktop session's) minimal
+//! PATH, never the user's shell configuration, so a `claude` or `codex`
+//! living in ~/.local/bin, /opt/homebrew/bin or an npm prefix looks
+//! missing while working fine from a terminal. The fix is to ask the
+//! user's login shell what its PATH is — but that is a whole shell
+//! startup, rc files and all, and on a real dotfile setup it costs the
+//! better part of a second. Nothing about opening a window should wait
+//! for it, so the shell is asked on a thread and the answer collected
+//! whenever it turns up: by the picker when it repaints ([`current`]),
+//! and by a worker thread that is actually about to spawn a CLI
+//! ([`resolved`], the only caller that waits).
+//!
+//! The answer is deliberately *not* published with `set_var`. By the time
+//! it lands the app is many threads deep in GPUI, and editing the process
+//! environment underneath them is unsound; it is handed to each spawn
+//! explicitly instead — an absolute path for the CLI itself, a `PATH`
+//! override for the children it goes on to spawn.
+
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
+use std::sync::{Condvar, Mutex, OnceLock};
+
+/// How long the shell gets to answer before the app gives up on it.
+const SHELL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// The longest [`resolved`] will wait — the shell's own budget plus a
+/// margin, so a probe that was never started (or a thread that died
+/// between spawning and publishing) cannot wedge a worker forever.
+const WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
+
+#[derive(Default)]
+struct Probe {
+    /// `None` while the shell is still being asked; `Some(None)` once it
+    /// has been asked and had nothing to add.
+    answer: Mutex<Option<Option<OsString>>>,
+    answered: Condvar,
+}
+
+fn probe() -> &'static Probe {
+    static PROBE: OnceLock<Probe> = OnceLock::new();
+    PROBE.get_or_init(Probe::default)
+}
+
+fn publish(path: Option<OsString>) {
+    let probe = probe();
+    if let Ok(mut slot) = probe.answer.lock() {
+        *slot = Some(path);
+    }
+    probe.answered.notify_all();
+}
+
+/// Whatever PATH this process was launched with.
+fn inherited() -> OsString {
+    std::env::var_os("PATH").unwrap_or_default()
+}
+
+/// Start asking the login shell for its PATH. Returns immediately; call
+/// it once, early in `main`.
+pub fn start() {
+    #[cfg(unix)]
+    {
+        // A terminal launch already carries the user's PATH; don't spend
+        // a shell startup on it.
+        if std::env::var_os("TERM").is_none() {
+            let spawned = std::thread::Builder::new()
+                .name("shell-path".into())
+                .spawn(|| publish(ask_login_shell()));
+            if spawned.is_ok() {
+                return;
+            }
+        }
+    }
+    publish(None);
+}
+
+/// Ask the user's login shell what its PATH is. `None` when it could not
+/// be asked, took too long, or said nothing useful.
+#[cfg(unix)]
+fn ask_login_shell() -> Option<OsString> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/sh".into());
+    // Interactive + login so both the profile and the rc file
+    // contribute — installers append PATH edits to either. Those files
+    // may print banners, so the value is fenced with markers; and the
+    // inner printf runs under `sh` because fish would expand its own
+    // "$PATH" as a space-joined list, while the exported environment is
+    // colon-joined for every shell.
+    const MARK: &str = "__SCHIST_PATH__";
+    const PRINTER: &str = "sh -c 'printf \"__SCHIST_PATH__%s__SCHIST_PATH__\" \"$PATH\"'";
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::Builder::new()
+        .name("shell-path-run".into())
+        .spawn({
+            let shell = shell.clone();
+            move || {
+                let out = std::process::Command::new(shell)
+                    .args(["-l", "-i", "-c", PRINTER])
+                    .stdin(std::process::Stdio::null())
+                    .output();
+                let _ = tx.send(out);
+            }
+        })
+        .ok()?;
+    // A shell rc that hangs must not hold an agent up for ever: give it a
+    // few seconds and settle for the plain PATH otherwise. (On timeout
+    // the probe thread is abandoned; it exits whenever the shell does.)
+    let out = match rx.recv_timeout(SHELL_TIMEOUT) {
+        Ok(Ok(out)) => out,
+        Ok(Err(e)) => {
+            log::warn!("asking {shell} for PATH failed: {e}");
+            return None;
+        }
+        Err(_) => {
+            log::warn!("asking {shell} for PATH timed out; installed CLIs may look missing");
+            return None;
+        }
+    };
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    match stdout.split(MARK).nth(1) {
+        Some(path) if !path.is_empty() => Some(OsString::from(path)),
+        _ => {
+            log::warn!("{shell} printed no PATH; installed CLIs may look missing");
+            None
+        }
+    }
+}
+
+/// Whether the probe has answered. False means [`current`] is still the
+/// launch PATH and may yet improve.
+pub fn ready() -> bool {
+    probe().answer.lock().map(|s| s.is_some()).unwrap_or(true)
+}
+
+/// The PATH to look agent CLIs up on, as far as it is known *now*: the
+/// login shell's once the probe has answered, this process's own until
+/// then. Never blocks — this is the one the UI thread asks.
+pub fn current() -> OsString {
+    match probe().answer.lock() {
+        Ok(slot) => match slot.as_ref() {
+            Some(Some(path)) => path.clone(),
+            _ => inherited(),
+        },
+        Err(_) => inherited(),
+    }
+}
+
+/// The same, but waits for the probe to answer (it gives up on its own,
+/// so the wait is bounded). For worker threads about to spawn a CLI —
+/// never for the UI thread.
+pub fn resolved() -> OsString {
+    let probe = probe();
+    let Ok(slot) = probe.answer.lock() else {
+        return inherited();
+    };
+    let waited = probe
+        .answered
+        .wait_timeout_while(slot, WAIT_TIMEOUT, |slot| slot.is_none());
+    match waited {
+        Ok((slot, _)) => match slot.as_ref() {
+            Some(Some(path)) => path.clone(),
+            _ => inherited(),
+        },
+        Err(_) => inherited(),
+    }
+}
+
+/// The environment an agent CLI is spawned with, on top of the app's own:
+/// the PATH it was found on, so the children *it* spawns see what a
+/// terminal would.
+pub fn child_env() -> std::collections::HashMap<String, String> {
+    std::collections::HashMap::from([(
+        "PATH".to_string(),
+        resolved().to_string_lossy().into_owned(),
+    )])
+}
+
+/// Where `binary` lives on `path`, by the same lookup a shell does.
+pub fn lookup(binary: &str, path: &OsStr) -> Option<PathBuf> {
+    std::env::split_paths(path).find_map(|dir| {
+        let file = dir.join(binary);
+        #[cfg(windows)]
+        let file = file.with_extension("exe");
+        file.is_file().then_some(file)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::lookup;
+
+    #[test]
+    fn a_binary_is_found_on_the_path_it_is_given() {
+        let dir = std::env::temp_dir().join(format!("schist-path-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let bin = dir.join(if cfg!(windows) { "agent.exe" } else { "agent" });
+        std::fs::write(&bin, b"").unwrap();
+        let path = std::env::join_paths([std::path::Path::new("/nowhere"), dir.as_path()]).unwrap();
+        assert_eq!(lookup("agent", &path), Some(bin));
+        // Not on the path at all, and a directory is not a command.
+        assert_eq!(lookup("missing", &path), None);
+        let only_dirs = std::env::join_paths([dir.parent().unwrap()]).unwrap();
+        assert_eq!(
+            lookup(dir.file_name().unwrap().to_str().unwrap(), &only_dirs),
+            None
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/app/src/main.rs
+++ b/crates/app/src/main.rs
@@ -210,11 +210,11 @@ fn main() {
         }
     }
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
-    // A Finder/desktop launch gets launchd's bare PATH; take the login
-    // shell's instead so the AI panel finds the same CLIs the terminal
-    // does. Before anything spawns threads — this edits the environment.
-    #[cfg(unix)]
-    ai::adopt_login_shell_path();
+    // A Finder/desktop launch gets launchd's bare PATH, not the one the
+    // AI panel's CLIs live on. Start asking the login shell for its PATH
+    // now and collect the answer later: it is a shell startup, and the
+    // window must not wait on it.
+    ai::path::start();
     // Before anything else: a system with no Vulkan driver cannot open a
     // window, and saying so plainly beats the panic that follows from
     // deep inside GPUI's renderer.

--- a/crates/app/src/workspace/ai.rs
+++ b/crates/app/src/workspace/ai.rs
@@ -58,6 +58,40 @@ impl Workspace {
         }
     }
 
+    /// Pick up the login-shell PATH once its probe answers.
+    ///
+    /// Asking the shell costs a shell startup, so it runs on a thread
+    /// while the window opens (see [`crate::ai::path`]) — which means the
+    /// availability this workspace was built with can say the CLIs are
+    /// missing when they are merely off launchd's PATH. Poll for the
+    /// answer and redo it. The probe gives up on its own, so the loop
+    /// always ends.
+    pub fn watch_agent_path(&mut self, cx: &mut Context<Self>) {
+        if ai::path::ready() {
+            return;
+        }
+        cx.spawn(async move |this, cx| {
+            while !ai::path::ready() {
+                cx.background_executor()
+                    .timer(std::time::Duration::from_millis(100))
+                    .await;
+            }
+            this.update(cx, |ws, cx| {
+                let found = (Backend::Claude.available(), Backend::Codex.available());
+                if found == ws.ai.available {
+                    return;
+                }
+                ws.ai.available = found;
+                if ws.view.ai_panel {
+                    ws.ensure_ai_models(cx);
+                }
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
     /// The fetched (or fallback) catalog for a harness.
     pub fn ai_models_for(&self, backend: Backend) -> Vec<ModelEntry> {
         let cached = match backend {

--- a/crates/app/src/workspace/mod.rs
+++ b/crates/app/src/workspace/mod.rs
@@ -1031,6 +1031,7 @@ impl Workspace {
         if ws.view.ai_panel {
             ws.ensure_ai_models(cx);
         }
+        ws.watch_agent_path(cx);
         ws.rebuild_tool_groups();
         ws.sync_note_defaults();
         // A launch-time update check, when the preference allows one and


### PR DESCRIPTION
Asking the login shell for its PATH is a whole shell startup — 0.75s on a real dotfile setup — and every Finder launch since #84 has waited out that shell before the window was created, because the answer was published with `set_var` and that is only sound before other threads exist.

The probe moves to its own thread and stops touching the process environment. Its answer is published through a mutex/condvar and handed to each spawn explicitly: `path::current()` never waits and is what `Backend::available` and the picker read, `path::resolved()` waits (five seconds for the shell, six for a caller) and is only ever called from a worker thread about to spawn a CLI. Both SDKs are given an absolute `cli_path`/`command` plus a PATH override for the children they spawn in turn, so nothing depends on the app's own environment any more — which also spares the Claude SDK its discovery pass, a `claude --version` spawn on every connect.

Availability computed while the probe is still out can say a CLI is missing when it is merely off launchd's PATH, so the workspace watches for the answer and redoes it, refreshing the model catalogs if the panel is open.


Claude-Session: https://claude.ai/code/session_012FgdQwG9FfmLWtpRvC7VWP