### PR TITLE
Fix the blade-atlas zoom crash and the memory growth while painting

### DIFF
--- a/crates/app/src/panels/menu_bar.rs
+++ b/crates/app/src/panels/menu_bar.rs
@@ -31,8 +31,14 @@ pub(crate) fn run_app_item(
         AppItem::Save => ws.save_current(window, cx),
         AppItem::SaveAs => crate::keymap::save_file_dialog(ws, window, cx),
         AppItem::Quit => ws.request_quit(cx),
-        AppItem::ZoomIn => ws.zoom_by(1.25, None),
-        AppItem::ZoomOut => ws.zoom_by(0.8, None),
+        AppItem::ZoomIn => {
+            ws.zoom_by(1.25, None);
+            ws.view_gesture_event(cx);
+        }
+        AppItem::ZoomOut => {
+            ws.zoom_by(0.8, None);
+            ws.view_gesture_event(cx);
+        }
         AppItem::ZoomFit => ws.fit_to_view(),
         AppItem::ZoomActual => {
             ws.zoom = 1.0;

--- a/crates/app/src/panels/navigator.rs
+++ b/crates/app/src/panels/navigator.rs
@@ -42,10 +42,13 @@ pub fn navigator(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoEl
                     "nav-zoom",
                     zoom_ratio,
                     150.0,
-                    |ws, r, _cx| {
+                    |ws, r, cx| {
                         // Log scale: 0.8% .. 3200%.
                         let zoom = 2f32.powf(r * 12.0 - 7.0);
                         ws.set_zoom(zoom);
+                        // The slider fires per mouse-move; damp the rebuilds
+                        // like wheel zoom.
+                        ws.view_gesture_event(cx);
                     },
                     cx,
                 ))

--- a/crates/app/src/workspace/chrome.rs
+++ b/crates/app/src/workspace/chrome.rs
@@ -38,6 +38,14 @@ impl Workspace {
         self.retired_images.push(image);
     }
 
+    /// Drop the cached viewport image, retiring it so its atlas slot is
+    /// freed after the next paint rather than leaked.
+    pub(super) fn invalidate_viewport_image(&mut self) {
+        if let Some((_, old)) = self.viewport_image.take() {
+            self.retired_images.push(old);
+        }
+    }
+
     pub fn box_position(&self, id: &'static str, window_pos: Point<Pixels>) -> Option<(f32, f32)> {
         let b = self.slider_bounds.get(id)?;
         let (w, h) = (f32::from(b.size.width), f32::from(b.size.height));
@@ -199,11 +207,23 @@ impl Workspace {
         let buffer = image::RgbaImage::from_raw(w as u32, h as u32, bgra)?;
         let img = Arc::new(RenderImage::new(smallvec![image::Frame::new(buffer)]));
         let rev = doc.revision;
-        self.thumbs.insert(id, (rev, img.clone()));
+        if let Some((_, old)) = self.thumbs.insert(id, (rev, img.clone())) {
+            self.retire_image(old);
+        }
         // Drop cache entries for layers that no longer exist.
         if self.thumbs.len() > 64 {
             if let Some(doc) = self.doc.as_ref() {
-                self.thumbs.retain(|lid, _| doc.tree.find(*lid).is_some());
+                let dead: Vec<_> = self
+                    .thumbs
+                    .keys()
+                    .copied()
+                    .filter(|lid| doc.tree.find(*lid).is_none())
+                    .collect();
+                for lid in dead {
+                    if let Some((_, old)) = self.thumbs.remove(&lid) {
+                        self.retired_images.push(old);
+                    }
+                }
             }
         }
         Some(img)
@@ -290,7 +310,9 @@ impl Workspace {
         }
         let buffer = image::RgbaImage::from_raw(w, h, bgra)?;
         let img = Arc::new(RenderImage::new(smallvec![image::Frame::new(buffer)]));
-        self.nav_thumb = Some((revision, img.clone()));
+        if let Some((_, old)) = self.nav_thumb.replace((revision, img.clone())) {
+            self.retire_image(old);
+        }
         Some(img)
     }
 

--- a/crates/app/src/workspace/colormgmt.rs
+++ b/crates/app/src/workspace/colormgmt.rs
@@ -16,9 +16,14 @@ impl Workspace {
         self.proof_transform = self.color.proof_transform(icc.as_deref()).map(Arc::new);
         self.cache.invalidate_all();
         self.display_tiles.clear();
-        self.viewport_image = None;
+        self.invalidate_viewport_image();
+        if let Some(old) = self.preview.image.take() {
+            self.retired_images.push(old);
+        }
         self.preview = Preview::default();
-        self.thumbs.clear();
+        for (_, (_, old)) in self.thumbs.drain() {
+            self.retired_images.push(old);
+        }
         self.color_epoch += 1;
     }
 

--- a/crates/app/src/workspace/commands.rs
+++ b/crates/app/src/workspace/commands.rs
@@ -34,7 +34,16 @@ impl Workspace {
                 for coord in TileCoord::covering(rect) {
                     self.display_tiles.remove(&coord);
                 }
-                self.preview.dirty.push(*rect);
+                // The preview only drains this list when it is the active
+                // render path (far zoom-out), so at working zooms a long
+                // stroke would grow it forever. Past a threshold, collapse
+                // to "rebuild everything on next refresh".
+                if self.preview.dirty.len() >= 256 {
+                    self.preview.dirty.clear();
+                    self.preview.valid = false;
+                } else {
+                    self.preview.dirty.push(*rect);
+                }
             }
         }
         cx.notify();

--- a/crates/app/src/workspace/compose.rs
+++ b/crates/app/src/workspace/compose.rs
@@ -97,7 +97,9 @@ impl Workspace {
             let s = (key.surround & 0xFF) as u8;
             let buffer = image::RgbaImage::from_raw(1, 1, vec![s, s, s, 255])?;
             let img = Arc::new(RenderImage::new(smallvec![image::Frame::new(buffer)]));
-            self.viewport_image = Some((key, img.clone()));
+            if let Some((_, old)) = self.viewport_image.replace((key, img.clone())) {
+                self.retired_images.push(old);
+            }
             return Some(img);
         }
 
@@ -311,7 +313,9 @@ impl Workspace {
         }
         let buffer = image::RgbaImage::from_raw(w, h, self.preview.buf.clone())?;
         let img = Arc::new(RenderImage::new(smallvec![image::Frame::new(buffer)]));
-        self.preview.image = Some(img.clone());
+        if let Some(old) = self.preview.image.replace(img.clone()) {
+            self.retired_images.push(old);
+        }
         Some(img)
     }
 }

--- a/crates/app/src/workspace/docs.rs
+++ b/crates/app/src/workspace/docs.rs
@@ -198,10 +198,15 @@ impl Workspace {
         self.cache.invalidate_all();
         self.display_tiles.clear();
         self.prefetch_queue.clear();
-        self.viewport_image = None;
+        self.invalidate_viewport_image();
+        if let Some(old) = self.preview.image.take() {
+            self.retired_images.push(old);
+        }
         self.preview = Preview::default();
         self.selection_outline = None;
-        self.nav_thumb = None;
+        if let Some((_, old)) = self.nav_thumb.take() {
+            self.retired_images.push(old);
+        }
         self.filter_preview = None;
         self.dragging_guide = None;
     }

--- a/crates/app/src/workspace/input.rs
+++ b/crates/app/src/workspace/input.rs
@@ -55,6 +55,7 @@ impl Workspace {
         if self.editor.active_tool == "zoom" {
             let factor = if ev.modifiers.alt { 1.0 / 1.5 } else { 1.5 };
             self.zoom_by(factor, Some(local));
+            self.view_gesture_event(cx);
             cx.notify();
             return;
         }

--- a/crates/app/src/workspace/render.rs
+++ b/crates/app/src/workspace/render.rs
@@ -13,6 +13,9 @@ impl Workspace {
             self.fit_to_view();
         }
         let mut job = PaintJob::default();
+        // Taken before the no-document return so replaced images still get
+        // their atlas slots released while no document is open.
+        job.retired.extend(std::mem::take(&mut self.retired_images));
         let Some(doc) = self.doc.as_ref() else {
             return job;
         };
@@ -131,7 +134,7 @@ impl Workspace {
             job.tiles.push((bounds, img));
         }
 
-        job.retired = std::mem::take(&mut self.retired_images);
+        job.retired.extend(std::mem::take(&mut self.retired_images));
 
         // Document border. An axis-aligned rectangle cannot follow a
         // rotated view, so when the view is turned it is drawn as a path
@@ -673,10 +676,15 @@ impl Render for Workspace {
             }))
             .on_action(cx.listener(|ws, _: &ZoomIn, _w, cx| {
                 ws.zoom_by(1.25, None);
+                // Damp like wheel zoom: a burst of key presses stretches the
+                // previous image and rebuilds once settled, instead of
+                // rebuilding a window-sized atlas image per press.
+                ws.view_gesture_event(cx);
                 cx.notify();
             }))
             .on_action(cx.listener(|ws, _: &ZoomOut, _w, cx| {
                 ws.zoom_by(0.8, None);
+                ws.view_gesture_event(cx);
                 cx.notify();
             }))
             .on_action(cx.listener(|ws, _: &ZoomFit, _w, cx| {

--- a/crates/app/src/workspace/viewport.rs
+++ b/crates/app/src/workspace/viewport.rs
@@ -51,7 +51,7 @@ impl Workspace {
     /// a settle timer; the timer only ends the gesture if no further event
     /// has bumped the sequence, so a stream of wheel ticks costs one
     /// full-quality rebuild at the end rather than one per tick.
-    pub(super) fn view_gesture_event(&mut self, cx: &mut Context<Self>) {
+    pub(crate) fn view_gesture_event(&mut self, cx: &mut Context<Self>) {
         self.view_gesture_active = true;
         self.view_gesture_seq += 1;
         let seq = self.view_gesture_seq;
@@ -106,7 +106,7 @@ impl Workspace {
     /// Turn the view by `delta` radians.
     pub fn rotate_view(&mut self, delta: f32, cx: &mut Context<Self>) {
         self.rotation = (self.rotation + delta).rem_euclid(std::f32::consts::TAU);
-        self.viewport_image = None;
+        self.invalidate_viewport_image();
         self.status = format!("Rotate View {:.0}\u{b0}", self.rotation.to_degrees()).into();
         cx.notify();
     }
@@ -114,7 +114,7 @@ impl Workspace {
     /// Put the view back upright.
     pub fn reset_view_rotation(&mut self, cx: &mut Context<Self>) {
         self.rotation = 0.0;
-        self.viewport_image = None;
+        self.invalidate_viewport_image();
         self.status = "View reset".into();
         cx.notify();
     }

--- a/crates/core/src/history.rs
+++ b/crates/core/src/history.rs
@@ -140,10 +140,33 @@ pub enum EditOp {
     },
 }
 
+impl EditOp {
+    /// Rough heap bytes this op keeps alive, for the history byte budget.
+    /// Only the bulky pixel payloads are counted, and shared `Arc`s are
+    /// counted at full size, so this overestimates what evicting the op
+    /// actually frees — the safe direction for a cap.
+    fn retained_bytes(&self) -> usize {
+        let tile = |t: &Option<Arc<TileBuf>>| t.as_ref().map_or(0, |t| t.byte_len());
+        match self {
+            EditOp::TileWrite { before, after, .. } => tile(before) + tile(after),
+            EditOp::MaskTileWrite { before, after, .. } => {
+                (before.is_some() as usize + after.is_some() as usize) * TILE_PIXELS
+            }
+            _ => 0,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Edit {
     pub name: String,
     pub ops: Vec<EditOp>,
+}
+
+impl Edit {
+    fn retained_bytes(&self) -> usize {
+        self.ops.iter().map(EditOp::retained_bytes).sum()
+    }
 }
 
 /// Linear undo history. `undo_stack.last()` is the most recent edit.
@@ -153,6 +176,11 @@ pub struct History {
     redo_stack: Vec<Edit>,
     /// Cap on retained edits; oldest are dropped past this.
     pub limit: usize,
+    /// Cap on retained pixel bytes across the undo stack; oldest edits are
+    /// dropped past this. One large stroke can hold tens of megabytes of
+    /// tiles, so an edit-count cap alone lets a painting session retain
+    /// gigabytes. The newest edit always stays, however large.
+    pub byte_limit: usize,
     /// How deep the undo stack was when the document was last saved, so
     /// undoing back to that point can clear the dirty flag again. `None`
     /// once that edit has aged out past `limit`, since we can no longer
@@ -166,6 +194,7 @@ impl History {
             undo_stack: Vec::new(),
             redo_stack: Vec::new(),
             limit: 200,
+            byte_limit: 1 << 30,
             saved_depth: Some(0),
         }
     }
@@ -182,8 +211,19 @@ impl History {
         }
         self.redo_stack.clear();
         self.undo_stack.push(edit);
+        let mut excess = 0;
         if self.undo_stack.len() > self.limit {
-            let excess = self.undo_stack.len() - self.limit;
+            excess = self.undo_stack.len() - self.limit;
+        }
+        let mut retained: usize = self.undo_stack[excess..]
+            .iter()
+            .map(Edit::retained_bytes)
+            .sum();
+        while retained > self.byte_limit && excess + 1 < self.undo_stack.len() {
+            retained -= self.undo_stack[excess].retained_bytes();
+            excess += 1;
+        }
+        if excess > 0 {
             self.undo_stack.drain(0..excess);
             // Dropping the oldest edits shifts every depth down; a save
             // point that falls off the bottom is gone for good.

--- a/crates/core/src/tile.rs
+++ b/crates/core/src/tile.rs
@@ -80,6 +80,15 @@ impl TileBuf {
         }
     }
 
+    /// Heap bytes held by the pixel data.
+    pub fn byte_len(&self) -> usize {
+        match self {
+            TileBuf::U8(b) => b.len(),
+            TileBuf::U16(b) => b.len() * 2,
+            TileBuf::F32(b) => b.len() * 4,
+        }
+    }
+
     #[inline]
     pub fn get(&self, ix: usize) -> Rgba {
         let i = ix * 4;


### PR DESCRIPTION
## Summary

A user crash report showed the app panicking at `blade_atlas.rs:229` (`Option::unwrap()` on `None`) after a burst of atlas-texture churn during zooming. This PR fixes the crash in the gpui fork and removes the schist-side churn and leaks that fed it, which were also the main cause of memory growth while painting brush strokes.

### gpui fork (fix landed as [`6a7092a`](https://github.com/IAmJSD/gpui/commit/6a7092a2f20e083fc0089ecd9f0533d5ee7a6f77); `main` already pins [`73c9da6`](https://github.com/IAmJSD/gpui/commit/73c9da683944ce7f4f2fdde767cded8aaf783276), which contains it, so this PR no longer touches Cargo.toml)

An image too big for the shared 1024² atlas page gets a dedicated texture, queued for init/upload and drained at the next frame flush. Removing the image in between destroyed the texture slot, and the flush panicked indexing the empty `Option`. Removal now cancels the dead texture's pending work and returns the tile's rectangle to the allocator (shared atlases never reclaimed space before), and both flush paths skip freed slots — mirroring upstream zed's wgpu atlas.

### schist

- **Zoom damping everywhere**: `ZoomIn`/`ZoomOut` actions, the zoom tool, the menu bar and the navigator slider now arm the existing 120 ms view-gesture settle like wheel/pinch zoom, so rapid zoom stretches the previous image and rebuilds once instead of creating/destroying a window-sized (~8 MB) texture per step.
- **Retire replaced images**: dropping an `Arc<RenderImage>` never frees its atlas slot. Every site that silently dropped one now routes through `retire_image` → `drop_image`: the layer/navigator thumbnails (rebuilt on **every brush dab** — the primary painting-memory leak), the far-zoom preview, the empty-viewport branch, and viewport invalidation on rotate-view, colour-transform rebuilds and per-document cache resets.
- **Undo byte budget**: history kept up to 200 edits with no size cap; one stroke can retain ~50 MB of before/after tiles. A 1 GiB budget now evicts oldest edits (the newest always survives).
- **`preview.dirty` cap**: the list is only drained at far zoom; it now collapses to a full-rebuild flag past 256 rects instead of growing per dab forever.

## Testing

- gpui fork: `cargo check`, `cargo fmt -- --check`, pinch + wayland unit tests, `cargo check --target x86_64-pc-windows-gnu` all clean.
- schist: `make build` clean; **856 workspace tests pass, 0 failures**.
- Headless repro (Xvfb + lavapipe, the known rapid-`ctrl+minus` crash recipe): 26 rapid zoom keys → zero atlas rebuilds, no crash (previously one texture create/destroy per press, then the panic); 24 settled zooms → 12 create/destroy cycles through the fixed removal path, no crash; 15 brush strokes → remaining growth is bounded undo retention only.

## Follow-ups (not in this PR)

- An in-place atlas-update API in the gpui fork so the per-frame viewport rebuild while painting re-uploads pixels into the existing tile instead of create/destroy.
- Byte-budget/LRU for `TileCache`/`display_tiles`.
- Paint-tool allocation churn: sparse/u8 `Stroke.coverage` and borrowing `Ink` instead of cloning a `TileMap` per tile per dab.
- Blade still destroys textures with no GPU fence; a deferred-destruction queue would close the (theoretical) stale-sprite hazard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
