### PR TITLE
feat: camera raw import — clean-room pure-Rust decoder with a LibRaw fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6246,6 +6246,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "schist-codec-raw"
+version = "0.10.0"
+dependencies = [
+ "image",
+ "log",
+ "miniz_oxide",
+ "rayon",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "schist-codecs-common"
 version = "0.10.0"
 dependencies = [
@@ -6256,6 +6267,7 @@ dependencies = [
  "log",
  "moxcms",
  "schist-codec-affinity",
+ "schist-codec-raw",
  "schist-color",
  "schist-colormgmt",
  "schist-compositor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/color",
     "crates/codec-psd",
     "crates/codec-affinity",
+    "crates/codec-raw",
     "crates/vector",
     "crates/text-engine",
     "crates/adjustments",
@@ -58,6 +59,7 @@ schist-fx = { path = "crates/fx" }
 schist-color = { path = "crates/color" }
 schist-codec-psd = { path = "crates/codec-psd" }
 schist-codec-affinity = { path = "crates/codec-affinity" }
+schist-codec-raw = { path = "crates/codec-raw" }
 schist-vector = { path = "crates/vector" }
 schist-layer-fx = { path = "crates/layer-fx" }
 schist-neural = { path = "crates/neural" }

--- a/README.md
+++ b/README.md
@@ -71,15 +71,19 @@ channels. Every block Schist doesn't understand is preserved
 byte-for-byte, so a round trip never loses work. **Smart objects** keep
 their source pixels, so transforming one repeatedly costs no more quality
 than transforming it once. Also PNG, JPEG, WebP and TIFF, plus HEIC/HEIF import (iPhone photos)
-and camera raw import: NEF, ARW, CR2, CR3, DNG, RAF, ORF, RW2, PEF and
-everything else LibRaw reads, developed with the camera's white balance
-to 16-bit sRGB. HEIC decodes through libheif loaded at runtime: the
-system's copy if installed, otherwise Schist offers to download a
-hash-pinned, decode-only build (with its LGPL license texts) from
-[libheif-prebuilt](https://github.com/IAmJSD/libheif-prebuilt) — nothing
-links at build time and the build stays pure Rust. Raws go through the
-system's LibRaw the same way (`brew install libraw`, or the distro's
-package). Affinity files
+and camera raw import: NEF, ARW, CR2, DNG, RAF, ORF, RW2, PEF, SRW and the
+rest, developed with the camera's white balance to 16-bit sRGB. Raws
+decode through Schist's own clean-room `schist-codec-raw` crate (pure
+Rust, written from the public specifications and verified sample for
+sample against LibRaw across some 250 camera files), which covers most
+bodies; what it declines — Canon CR3 pixels, Fuji's compressed RAF, a
+few odd codecs, and cameras with no colour matrix in its table yet —
+falls back to the system's LibRaw, loaded at runtime (`brew install
+libraw`, or the distro's package). HEIC decodes through libheif the
+same way: the system's copy if installed, otherwise Schist offers to
+download a hash-pinned, decode-only build (with its LGPL license texts)
+from [libheif-prebuilt](https://github.com/IAmJSD/libheif-prebuilt) —
+nothing links at build time and the build stays pure Rust. Affinity files
 (`.af`/`.afphoto`/`.afdesign`/`.afpub` — Affinity 1, 2 and the unified Canva-era format) open through a
 natively reverse-engineered reader
 ([docs/affinity-format.md](docs/affinity-format.md)): pixel layers,

--- a/README.md
+++ b/README.md
@@ -70,12 +70,16 @@ all 27 blend modes, adjustment layers, layer effects, vector shapes,
 channels. Every block Schist doesn't understand is preserved
 byte-for-byte, so a round trip never loses work. **Smart objects** keep
 their source pixels, so transforming one repeatedly costs no more quality
-than transforming it once. Also PNG, JPEG, WebP and TIFF, plus HEIC/HEIF import (iPhone photos).
-HEIC decodes through libheif loaded at runtime: the system's copy if
-installed, otherwise Schist offers to download a hash-pinned,
-decode-only build (with its LGPL license texts) from
+than transforming it once. Also PNG, JPEG, WebP and TIFF, plus HEIC/HEIF import (iPhone photos)
+and camera raw import: NEF, ARW, CR2, CR3, DNG, RAF, ORF, RW2, PEF and
+everything else LibRaw reads, developed with the camera's white balance
+to 16-bit sRGB. HEIC decodes through libheif loaded at runtime: the
+system's copy if installed, otherwise Schist offers to download a
+hash-pinned, decode-only build (with its LGPL license texts) from
 [libheif-prebuilt](https://github.com/IAmJSD/libheif-prebuilt) — nothing
-links at build time and the build stays pure Rust. Affinity files
+links at build time and the build stays pure Rust. Raws go through the
+system's LibRaw the same way (`brew install libraw`, or the distro's
+package). Affinity files
 (`.af`/`.afphoto`/`.afdesign`/`.afpub` — Affinity 1, 2 and the unified Canva-era format) open through a
 natively reverse-engineered reader
 ([docs/affinity-format.md](docs/affinity-format.md)): pixel layers,

--- a/crates/app/src/workspace/library_ops.rs
+++ b/crates/app/src/workspace/library_ops.rs
@@ -384,6 +384,14 @@ const LOSSY_EXTS: &[&str] = &["jpg", "jpeg", "jpe", "jfif", "heic", "heif", "avi
 /// has to land as a PNG: nothing here encodes HEIC.
 const LOSSY_WRITABLE: &[&str] = &["jpg", "jpeg", "jpe", "jfif"];
 
+/// A camera raw: the opposite case from lossy. The capture is worth
+/// more than any rendering of it and nothing here writes one, so an
+/// unedited raw is archived as it is, and only an edit becomes a PNG.
+fn is_raw(ext: &str) -> bool {
+    use schist_plugin_api::CodecPlugin as _;
+    schist_codecs_common::RawCodec.extensions().contains(&ext)
+}
+
 /// How a photo goes into an archive: which file it comes from, whether
 /// those bytes can go in untouched, and the extension the entry ends
 /// up with.
@@ -397,8 +405,8 @@ struct ZipPlan {
 /// Work out that plan. An edited photo contributes its edit — the
 /// point of the archive is the picture you see in the gallery — and
 /// the entry keeps a lossy photo's own format (re-encoded from the
-/// edit when there is one, byte-for-byte when there is not), while
-/// everything else becomes a PNG.
+/// edit when there is one, byte-for-byte when there is not), an
+/// unedited raw goes in untouched, and everything else becomes a PNG.
 fn zip_plan(path: &Path) -> ZipPlan {
     let ext = path
         .extension()
@@ -416,10 +424,11 @@ fn zip_plan(path: &Path) -> ZipPlan {
                 ext: if keep { ext } else { "png".into() },
             }
         }
-        // Unedited: a lossy photo (or a PNG) is already exactly what
-        // the archive wants, so its bytes go in as they are —
-        // re-encoding a JPEG would only lose a second generation.
-        None if lossy || ext == "png" => ZipPlan {
+        // Unedited: a lossy photo (or a PNG, or a raw) is already
+        // exactly what the archive wants, so its bytes go in as they
+        // are — re-encoding a JPEG would only lose a second generation,
+        // and a raw developed to PNG would lose the raw.
+        None if lossy || ext == "png" || is_raw(&ext) => ZipPlan {
             source: path.to_path_buf(),
             verbatim: true,
             ext,
@@ -819,10 +828,13 @@ mod tests {
             "plain.tif",
             "shot.HEIC",
             "edited.jpg",
+            "capture.NEF",
+            "developed.nef",
         ] {
             std::fs::write(dir.join(name), b"x").unwrap();
         }
         std::fs::write(dir.join(".schist/edited.jpg.psd"), b"edit").unwrap();
+        std::fs::write(dir.join(".schist/developed.nef.psd"), b"edit").unwrap();
         let plan = |name: &str| zip_plan(&dir.join(name));
 
         // Unedited and lossy: its own bytes, its own format. Nothing is
@@ -864,6 +876,25 @@ mod tests {
                 source: dir.join(".schist/edited.jpg.psd"),
                 verbatim: false,
                 ext: "jpg".into()
+            }
+        );
+        // A raw is the capture: untouched, it goes in as it is rather
+        // than as a development of itself; edited, the edit is a PNG,
+        // since nothing writes a raw.
+        assert_eq!(
+            plan("capture.NEF"),
+            ZipPlan {
+                source: dir.join("capture.NEF"),
+                verbatim: true,
+                ext: "nef".into()
+            }
+        );
+        assert_eq!(
+            plan("developed.nef"),
+            ZipPlan {
+                source: dir.join(".schist/developed.nef.psd"),
+                verbatim: false,
+                ext: "png".into()
             }
         );
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/app/src/workspace/library_view.rs
+++ b/crates/app/src/workspace/library_view.rs
@@ -1103,7 +1103,8 @@ fn grid(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElement {
                         None if scanning => "Scanning folders\u{2026}",
                         None => {
                             "No photos found in the watched folders. Images Schist can open \
-                         (PNG, JPEG, WebP, TIFF, HEIC, PSD, Affinity) appear here; \
+                         (PNG, JPEG, WebP, TIFF, HEIC, camera raws, PSD, Affinity) \
+                         appear here; \
                          sub-folders are scanned six levels deep."
                         }
                     },

--- a/crates/codec-raw/Cargo.toml
+++ b/crates/codec-raw/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "schist-codec-raw"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Camera raw decoding and development in pure Rust: DNG and the vendor formats, sensor data to linear sRGB"
+
+# Deliberately standalone: no schist crates, so it builds in seconds and
+# could be published on its own. The plugin in codecs-common adapts its
+# output to a Document.
+[dependencies]
+# DNG's deflate-compressed (and float) tiles.
+miniz_oxide.workspace = true
+# Lossy DNG tiles are baseline JPEG; nothing else here goes through
+# `image`.
+image.workspace = true
+rayon.workspace = true
+thiserror.workspace = true
+log.workspace = true
+
+[dev-dependencies]

--- a/crates/codec-raw/README.md
+++ b/crates/codec-raw/README.md
@@ -1,0 +1,51 @@
+# schist-codec-raw
+
+Camera raw files, decoded and developed in pure Rust, written clean-room
+from the public DNG, TIFF/EP, EXIF and ITU T.81 specifications, published
+format descriptions, and observation of real files against LibRaw's
+`unprocessed_raw` output. Nothing in it derives from dcraw, LibRaw,
+rawspeed, rawler or any other copyleft decoder.
+
+`decode` reads a file into a `RawImage` (the sensor frame, its filter
+array, levels, white balance, colour matrix, crop, orientation and the
+camera's embedded JPEG); `develop` turns that into linear sRGB. `probe`
+names the container without decoding, `preview` finds the JPEG cheaply,
+`orientation` reads the tag cheaply.
+
+## Coverage
+
+"Exact" means every sample of the decoded frame matched LibRaw's unpacked
+frame on the files listed, drawn from the raw.pixls.us sample set.
+
+| container | status |
+| --- | --- |
+| DNG (incl. ProRAW, Pixel, Leica, Pentax, Ricoh, Sigma, DJI, Hasselblad) | exact on 26; uncompressed, lossless JPEG, deflate, lossy JPEG, float; GoPro VC-5 and JPEG XL unsupported |
+| Sony ARW / SR2 / SRF | exact on 24, every generation incl. ARW 1.0 and ARW 4 lossless |
+| Nikon NEF / NRW | exact on 36 (20 bodies); Z 8/9 High Efficiency unsupported |
+| Canon CR2 | exact on 14; sRAW/mRAW unsupported |
+| Canon CRW | uncompressed only; the compressed Huffman sets are not publicly documented |
+| Canon CR3 | container, metadata and previews exact; the CRX pixel codec is not decoded |
+| Fujifilm RAF | exact on 9 uncompressed bodies (X-Trans and Bayer); compressed RAF refused |
+| Olympus / OM ORF | exact on 12, four sensor layouts |
+| Panasonic RW2 / Leica RWL | exact on 29; RawFormat 8 (GH6, G9 II) unsupported |
+| Pentax PEF | exact on 10 |
+| Samsung SRW | exact on 15; the NX1/NX500 codec unsupported |
+| Minolta MRW, Kodak DCR/KDC, Epson ERF, Mamiya MEF | exact on 15 bodies; Kodak DC50 unsupported; Epson's as-shot balance is not found in the file |
+| Hasselblad 3FR / FFF | exact on 7 |
+| Phase One IIQ | exact on 5 ("IIQ L" and raw); "IIQ S" unsupported |
+| Leaf MOS | exact on 3 |
+| Sigma X3F | metadata and preview only |
+
+Colour needs a matrix. DNG carries its own; the other formats look one
+up in `cameras.rs` (189 bodies, each entry naming its source). A camera
+with no entry develops in camera RGB, and the Schist plugin prefers
+LibRaw for those.
+
+## Verifying
+
+`SCHIST_RAW_CORPUS=<dir> cargo test --release -p schist-codec-raw` runs
+every module's corpus test over a directory of raws with LibRaw oracle
+sidecars beside them (`<file>.tiff` from `unprocessed_raw -T`,
+`<file>.identify.txt` from `raw-identify -v -w`, `<file>.json` from
+`exiftool -G -a -u -j`). `cargo run --release -p schist-codec-raw
+--example rawinfo -- <file>` prints what `decode` makes of a file.

--- a/crates/codec-raw/examples/rawinfo.rs
+++ b/crates/codec-raw/examples/rawinfo.rs
@@ -1,0 +1,66 @@
+//! Print what `decode` makes of a file, without developing it:
+//! `rawinfo <file>...`. The quickest way to compare a decoder's
+//! metadata against `raw-identify -v -w`.
+
+fn main() {
+    for path in std::env::args().skip(1) {
+        let bytes = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("{path}: {e}");
+                continue;
+            }
+        };
+        println!("{path}: probe {:?}", schist_codec_raw::probe(&bytes));
+        let started = std::time::Instant::now();
+        match schist_codec_raw::decode(&bytes) {
+            Ok(raw) => {
+                println!(
+                    "  {} / {} (table: {} / {}), decoded in {:.2?}",
+                    raw.make,
+                    raw.model,
+                    raw.clean_make,
+                    raw.clean_model,
+                    started.elapsed()
+                );
+                println!(
+                    "  frame {}x{} cpp {} cfa {:?}",
+                    raw.width, raw.height, raw.cpp, raw.cfa
+                );
+                println!(
+                    "  black {:?} white {} wb {:?} orientation {:?}",
+                    raw.black_levels, raw.white_level, raw.wb_coeffs, raw.orientation
+                );
+                println!("  crop {:?}", raw.crop);
+                println!("  matrix {:?}", raw.color_matrix);
+                println!(
+                    "  preview {} bytes, {:?}",
+                    raw.preview.as_ref().map_or(0, |p| p.len()),
+                    raw.metadata
+                );
+                // `RAWINFO_COLUMNS=n`: the mean of each of the last n
+                // columns over the middle rows, for looking at masked
+                // borders.
+                if let Ok(n) = std::env::var("RAWINFO_COLUMNS") {
+                    let n: usize = n.parse().unwrap_or(0);
+                    let (w, h) = (raw.width, raw.height);
+                    for c in w.saturating_sub(n)..w {
+                        let (mut sum, mut squares, mut count) = (0f64, 0f64, 0f64);
+                        for r in (h / 4..h * 3 / 4).step_by(2) {
+                            let v = raw.data.get(r * w + c) as f64;
+                            sum += v;
+                            squares += v * v;
+                            count += 1.0;
+                        }
+                        let mean = sum / count;
+                        println!(
+                            "  column {c}: {mean:.0} sd {:.1}",
+                            (squares / count - mean * mean).max(0.0).sqrt()
+                        );
+                    }
+                }
+            }
+            Err(e) => println!("  error: {e}"),
+        }
+    }
+}

--- a/crates/codec-raw/src/bits.rs
+++ b/crates/codec-raw/src/bits.rs
@@ -1,0 +1,806 @@
+//! Bit readers and Huffman tables, the ground every compressed raw is
+//! decoded on.
+//!
+//! Four pumps, differing in which end of each byte comes first, the
+//! width of the unit they refill from, and whether JPEG's `0xFF 0x00`
+//! stuffing is stripped. All are infallible past the end of input:
+//! they return zero bits rather than fail, and decoders bound their
+//! loops by the pixel count, so a truncated file yields a partly black
+//! frame instead of a panic.
+//!
+//! Every pump keeps a 64-bit accumulator so a `peek` of up to 32 bits
+//! is always satisfiable from at most one refill, and refills in
+//! multi-byte gulps rather than a bit or a byte at a time: this is the
+//! innermost loop of every decoder in the crate.
+
+/// A mask of the low `n` bits, `n` up to 32 (`1 << 32` is why the
+/// intermediate is 64-bit).
+#[inline(always)]
+fn mask(n: u32) -> u32 {
+    ((1u64 << n) - 1) as u32
+}
+
+/// True if any byte of `word` is `0xFF`. The usual "zero byte in a
+/// word" bit trick applied to the complement; used to decide whether a
+/// JPEG refill can take the whole word at once or has to walk it
+/// looking for stuffing.
+#[inline(always)]
+fn has_ff(word: u64) -> bool {
+    let x = !word;
+    (x.wrapping_sub(0x0101_0101_0101_0101) & !x & 0x8080_8080_8080_8080) != 0
+}
+
+/// Most-significant-bit-first reader (lossless JPEG without stuffing,
+/// Nikon, Pentax, Olympus, Kodak, Hasselblad).
+pub struct BitPumpMsb<'a> {
+    bytes: &'a [u8],
+    /// Next byte to feed the accumulator.
+    pos: usize,
+    /// The live bits, right-aligned: the next bit out is bit
+    /// `nbits - 1`. Bits above `nbits` are spent and ignored.
+    cache: u64,
+    nbits: u32,
+    consumed: usize,
+}
+
+/// Least-significant-bit-first reader (Sony ARW, Panasonic's inner
+/// stream, Canon sRAW tables). Bytes still arrive in stream order;
+/// within a byte the low bit comes first, and a multi-bit value's
+/// first-read bit is its low bit.
+pub struct BitPumpLsb<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+    /// The live bits, left-aligned at bit 0: the next bit out is bit 0.
+    cache: u64,
+    nbits: u32,
+    consumed: usize,
+}
+
+/// MSB-first with JPEG marker stuffing: a `0xFF` followed by `0x00`
+/// yields one `0xFF` byte, and a `0xFF` followed by anything else is a
+/// marker that ends the stream (further reads give zeros).
+pub struct BitPumpJpeg<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+    cache: u64,
+    nbits: u32,
+    consumed: usize,
+    /// Set once a marker has been met; `pos` then rests on its `0xFF`
+    /// and no further byte is ever taken from `bytes`.
+    marker: bool,
+}
+
+/// MSB-first over 32-bit little-endian words (each word's bytes
+/// reversed before reading; Olympus/Panasonic-era Sony and some Kodak
+/// use it). A trailing group shorter than four bytes is padded with
+/// zeros, exactly as a reader that loads a `u32` from a zeroed buffer
+/// would see it.
+pub struct BitPumpMsb32<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+    cache: u64,
+    nbits: u32,
+    consumed: usize,
+}
+
+/// The operations every pump offers.
+pub trait BitPump {
+    /// The next `n` bits (0..=32) without consuming them.
+    fn peek(&mut self, n: u32) -> u32;
+    /// Drop `n` bits (0..=32).
+    fn consume(&mut self, n: u32);
+    /// Read `n` bits (0..=32).
+    fn get(&mut self, n: u32) -> u32 {
+        let v = self.peek(n);
+        self.consume(n);
+        v
+    }
+    /// Bits consumed so far.
+    fn position(&self) -> usize;
+}
+
+/// `peek`/`consume`/`position` for the pumps whose accumulator is
+/// right-aligned MSB-first; each supplies its own `fill`.
+macro_rules! msb_pump {
+    ($ty:ident) => {
+        impl BitPump for $ty<'_> {
+            #[inline(always)]
+            fn peek(&mut self, n: u32) -> u32 {
+                debug_assert!(n <= 32);
+                if self.nbits < n {
+                    self.fill(n);
+                }
+                ((self.cache >> (self.nbits - n)) as u32) & mask(n)
+            }
+            #[inline(always)]
+            fn consume(&mut self, n: u32) {
+                debug_assert!(n <= 32);
+                if self.nbits < n {
+                    self.fill(n);
+                }
+                self.nbits -= n;
+                self.consumed += n as usize;
+            }
+            #[inline(always)]
+            fn position(&self) -> usize {
+                self.consumed
+            }
+        }
+    };
+}
+
+impl<'a> BitPumpMsb<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
+        BitPumpMsb {
+            bytes,
+            pos: 0,
+            cache: 0,
+            nbits: 0,
+            consumed: 0,
+        }
+    }
+
+    /// Top the accumulator up to at least `n` (<= 32) live bits. With
+    /// eight bytes in hand this is one shifted OR; at the end of the
+    /// input it feeds zeros for ever.
+    #[inline]
+    fn fill(&mut self, n: u32) {
+        // `need` is capped at 7 so the shifts below are never 64.
+        // Because `fill` only runs with `nbits < n <= 32`, need is at
+        // least 4, so one gulp always satisfies the request.
+        if self.pos + 8 <= self.bytes.len() {
+            let word = u64::from_be_bytes(self.bytes[self.pos..self.pos + 8].try_into().unwrap());
+            let need = (63 - self.nbits) / 8;
+            self.cache = (self.cache << (need * 8)) | (word >> (64 - need * 8));
+            self.pos += need as usize;
+            self.nbits += need * 8;
+            return;
+        }
+        while self.nbits < n {
+            let b = self.bytes.get(self.pos).copied().unwrap_or(0);
+            self.pos += 1;
+            self.cache = (self.cache << 8) | b as u64;
+            self.nbits += 8;
+        }
+    }
+}
+msb_pump!(BitPumpMsb);
+
+impl<'a> BitPumpLsb<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
+        BitPumpLsb {
+            bytes,
+            pos: 0,
+            cache: 0,
+            nbits: 0,
+            consumed: 0,
+        }
+    }
+
+    #[inline]
+    fn fill(&mut self, n: u32) {
+        if self.pos + 8 <= self.bytes.len() {
+            let word = u64::from_le_bytes(self.bytes[self.pos..self.pos + 8].try_into().unwrap());
+            let need = (63 - self.nbits) / 8;
+            self.cache |= (word & (mask32(need * 8))) << self.nbits;
+            self.pos += need as usize;
+            self.nbits += need * 8;
+            return;
+        }
+        while self.nbits < n {
+            let b = self.bytes.get(self.pos).copied().unwrap_or(0);
+            self.pos += 1;
+            self.cache |= (b as u64) << self.nbits;
+            self.nbits += 8;
+        }
+    }
+}
+
+/// Low-`n`-bits mask as a `u64`, `n` up to 63.
+#[inline(always)]
+fn mask32(n: u32) -> u64 {
+    (1u64 << n) - 1
+}
+
+impl BitPump for BitPumpLsb<'_> {
+    #[inline(always)]
+    fn peek(&mut self, n: u32) -> u32 {
+        debug_assert!(n <= 32);
+        if self.nbits < n {
+            self.fill(n);
+        }
+        (self.cache as u32) & mask(n)
+    }
+    #[inline(always)]
+    fn consume(&mut self, n: u32) {
+        debug_assert!(n <= 32);
+        if self.nbits < n {
+            self.fill(n);
+        }
+        self.cache >>= n;
+        self.nbits -= n;
+        self.consumed += n as usize;
+    }
+    #[inline(always)]
+    fn position(&self) -> usize {
+        self.consumed
+    }
+}
+
+impl<'a> BitPumpJpeg<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
+        BitPumpJpeg {
+            bytes,
+            pos: 0,
+            cache: 0,
+            nbits: 0,
+            consumed: 0,
+            marker: false,
+        }
+    }
+
+    /// The offset of the next byte the pump would take from its input.
+    /// Once [`BitPumpJpeg::at_marker`] is true this is the offset of
+    /// that marker's `0xFF`, which is how a decoder finds an `RSTn` to
+    /// restart after. Note bits already in the accumulator sit *before*
+    /// this offset: it is a bound on how far the entropy data was read,
+    /// not the exact position of the last consumed bit.
+    #[inline]
+    pub fn byte_pos(&self) -> usize {
+        self.pos
+    }
+
+    /// Whether a marker (anything but `FF 00`) has been met, so all
+    /// further bits are zeros.
+    #[inline]
+    pub fn at_marker(&self) -> bool {
+        self.marker
+    }
+
+    #[inline]
+    fn fill(&mut self, n: u32) {
+        // The common case: eight bytes in hand with no 0xFF among
+        // them, so the stuffing rules cannot apply and the word goes
+        // in whole.
+        if !self.marker && self.pos + 8 <= self.bytes.len() {
+            let word = u64::from_be_bytes(self.bytes[self.pos..self.pos + 8].try_into().unwrap());
+            if !has_ff(word) {
+                let need = (63 - self.nbits) / 8;
+                self.cache = (self.cache << (need * 8)) | (word >> (64 - need * 8));
+                self.pos += need as usize;
+                self.nbits += need * 8;
+                return;
+            }
+        }
+        while self.nbits < n {
+            let b = self.next_byte();
+            self.cache = (self.cache << 8) | b as u64;
+            self.nbits += 8;
+        }
+    }
+
+    /// One byte of entropy-coded data: `FF 00` collapses to `FF`, and
+    /// any other `FF xx` is a marker, which stops the stream where it
+    /// stands (leaving `pos` on the `FF`) and yields zeros from then
+    /// on. A trailing lone `FF` at the very end counts as a marker
+    /// too: there is no second byte to make it a stuffed one.
+    #[inline]
+    fn next_byte(&mut self) -> u8 {
+        if self.marker {
+            return 0;
+        }
+        let Some(&b) = self.bytes.get(self.pos) else {
+            self.marker = true;
+            return 0;
+        };
+        if b != 0xFF {
+            self.pos += 1;
+            return b;
+        }
+        match self.bytes.get(self.pos + 1) {
+            Some(0) => {
+                self.pos += 2;
+                0xFF
+            }
+            _ => {
+                self.marker = true;
+                0
+            }
+        }
+    }
+}
+msb_pump!(BitPumpJpeg);
+
+impl<'a> BitPumpMsb32<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
+        BitPumpMsb32 {
+            bytes,
+            pos: 0,
+            cache: 0,
+            nbits: 0,
+            consumed: 0,
+        }
+    }
+
+    #[inline]
+    fn fill(&mut self, n: u32) {
+        // A whole 32-bit word at a time, its bytes in little-endian
+        // order, consumed from the top down. `nbits` is under 32 here
+        // (fill runs only when `nbits < n <= 32`), so one word is
+        // always enough and the accumulator cannot overflow 64 bits.
+        while self.nbits < n {
+            let word = match self.bytes.get(self.pos..self.pos + 4) {
+                Some(w) => u32::from_le_bytes(w.try_into().unwrap()),
+                // Past the end, or a tail shorter than a word: pad
+                // with zeros.
+                None => {
+                    let b = |i: usize| self.bytes.get(self.pos + i).copied().unwrap_or(0) as u32;
+                    b(0) | (b(1) << 8) | (b(2) << 16) | (b(3) << 24)
+                }
+            };
+            self.pos += 4;
+            self.cache = (self.cache << 32) | word as u64;
+            self.nbits += 32;
+        }
+    }
+}
+msb_pump!(BitPumpMsb32);
+
+/// How many bits of a code the flat lookup covers. Twelve is 4096
+/// entries: small enough to build per tile without hurting, long
+/// enough that the slow path is rare in camera-written tables.
+const LOOKUP_BITS: u32 = 12;
+
+/// A Huffman table in JPEG's form: sixteen counts of codes of each
+/// length, then the symbols in code order. Symbols are "difference
+/// lengths" in the lossless-JPEG family, so [`HuffTable::decode_diff`]
+/// reads the length then the sign-extended value bits in one go.
+#[derive(Debug, Clone)]
+pub struct HuffTable {
+    /// Indexed by the next [`LOOKUP_BITS`] bits: `len << 16 | symbol`,
+    /// or 0 when the code is longer than the lookup and the canonical
+    /// walk below has to finish the job.
+    lookup: Vec<u32>,
+    /// Canonical decoding, per code length 1..=16: the first code of
+    /// that length, the last one, and where its symbols start in
+    /// `symbols`. `max_code` is -1 for a length with no codes.
+    min_code: [i32; 17],
+    max_code: [i32; 17],
+    val_ptr: [i32; 17],
+    symbols: Vec<u8>,
+}
+
+impl HuffTable {
+    /// From DHT-style `bits[1..=16]` (index 0 unused or the 16 counts
+    /// from index 0 — accept a 16- or 17-long slice) and the symbols.
+    pub fn new(bits: &[u8], symbols: &[u8]) -> Result<HuffTable, crate::Error> {
+        // The DHT segment carries sixteen counts; callers that keep
+        // JPEG's one-based indexing hand us seventeen with a dead
+        // first entry.
+        // Both slices are exactly sixteen long here, so the
+        // conversion cannot fail; the length check is the match arm.
+        let counts: [u8; 16] = match bits.len() {
+            16 => bits[..16].try_into().expect("sixteen counts"),
+            17 => bits[1..17].try_into().expect("sixteen counts"),
+            n => {
+                return Err(crate::Error::Corrupt(format!(
+                    "huffman table has {n} code-length counts, want 16 or 17"
+                )))
+            }
+        };
+        let total: usize = counts.iter().map(|c| *c as usize).sum();
+        if total == 0 {
+            return Err(crate::Error::Corrupt(
+                "huffman table defines no codes".into(),
+            ));
+        }
+        if total > symbols.len() {
+            return Err(crate::Error::Corrupt(format!(
+                "huffman table promises {total} symbols but carries {}",
+                symbols.len()
+            )));
+        }
+        let symbols = symbols[..total].to_vec();
+
+        let mut min_code = [0i32; 17];
+        let mut max_code = [-1i32; 17];
+        let mut val_ptr = [0i32; 17];
+        let mut lookup = vec![0u32; 1 << LOOKUP_BITS];
+
+        let mut code: i32 = 0;
+        let mut index: usize = 0;
+        for len in 1..=16u32 {
+            let n = counts[len as usize - 1] as usize;
+            val_ptr[len as usize] = index as i32;
+            min_code[len as usize] = code;
+            if n > 0 {
+                // Every code of this length must fit inside it: an
+                // over-subscribed table is a corrupt one, and left
+                // unchecked it would alias entries in the lookup.
+                if code as i64 + n as i64 > (1i64 << len) {
+                    return Err(crate::Error::Corrupt(format!(
+                        "huffman table over-subscribed at code length {len}"
+                    )));
+                }
+                for k in 0..n {
+                    let symbol = symbols[index + k] as u32;
+                    if len <= LOOKUP_BITS {
+                        // One entry per continuation of the code:
+                        // codes shorter than the lookup width claim a
+                        // whole run of indices.
+                        let shift = LOOKUP_BITS - len;
+                        let base = ((code + k as i32) as usize) << shift;
+                        for slot in &mut lookup[base..base + (1 << shift)] {
+                            *slot = (len << 16) | symbol;
+                        }
+                    }
+                }
+                max_code[len as usize] = code + n as i32 - 1;
+                index += n;
+                code += n as i32;
+            }
+            code <<= 1;
+        }
+
+        Ok(HuffTable {
+            lookup,
+            min_code,
+            max_code,
+            val_ptr,
+            symbols,
+        })
+    }
+
+    /// The next symbol.
+    #[inline]
+    pub fn decode(&self, pump: &mut impl BitPump) -> u16 {
+        let entry = self.lookup[pump.peek(LOOKUP_BITS) as usize];
+        if entry != 0 {
+            pump.consume(entry >> 16);
+            return (entry & 0xFFFF) as u16;
+        }
+        self.decode_long(pump)
+    }
+
+    /// Codes longer than the lookup, walked a bit at a time in the
+    /// canonical way. Rare enough that it need not be fast.
+    #[cold]
+    fn decode_long(&self, pump: &mut impl BitPump) -> u16 {
+        let mut code: i32 = 0;
+        for len in 1..=16usize {
+            code = (code << 1) | pump.get(1) as i32;
+            if code <= self.max_code[len] {
+                let index = self.val_ptr[len] + (code - self.min_code[len]);
+                return self.symbols.get(index as usize).copied().unwrap_or(0) as u16;
+            }
+        }
+        // No code matched in sixteen bits: the stream is garbage (or
+        // we have run off the end into the zero fill). Sixteen bits
+        // have been consumed, so a decoder's loop still terminates.
+        0
+    }
+
+    /// Lossless-JPEG difference: decode the length symbol `l`, then
+    /// read `l` bits and sign-extend them JPEG-style (a leading 0 bit
+    /// means negative: value - (1 << l) + 1). Symbol 16 with no bits
+    /// yields 32768 in JPEG; the read-sixteen-bits variant some writers use is the caller's
+    /// — see [`HuffTable::decode_diff_ext`].
+    #[inline]
+    pub fn decode_diff(&self, pump: &mut impl BitPump) -> i32 {
+        self.diff(pump, false)
+    }
+
+    /// As [`HuffTable::decode_diff`], but symbol 16 reads sixteen
+    /// extra bits instead of standing for 32768 on its own. Some DNG
+    /// and Hasselblad writers encode the widest difference that way,
+    /// and a reader has to be told which convention a file follows.
+    #[inline]
+    pub fn decode_diff_ext(&self, pump: &mut impl BitPump) -> i32 {
+        self.diff(pump, true)
+    }
+
+    #[inline(always)]
+    fn diff(&self, pump: &mut impl BitPump, ext: bool) -> i32 {
+        let l = self.decode(pump) as u32;
+        if l == 0 {
+            return 0;
+        }
+        if l == 16 && !ext {
+            // T.81's lossless convention: category 16 holds the single
+            // difference -32768, which is 32768 modulo 65536, and no
+            // extra bits follow.
+            return 32768;
+        }
+        if l > 16 {
+            // A symbol outside 0..=16 cannot be a difference length;
+            // treat it as no difference rather than shifting wildly.
+            return 0;
+        }
+        let v = pump.get(l) as i32;
+        // A leading zero bit marks the negative half of the category.
+        if v < 1 << (l - 1) {
+            v - (1 << l) + 1
+        } else {
+            v
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // 0b1010_1100, 0b0011_0101
+    const AB: &[u8] = &[0xAC, 0x35];
+
+    #[test]
+    fn msb_reads_from_the_top_of_each_byte() {
+        let mut p = BitPumpMsb::new(AB);
+        assert_eq!(p.get(1), 1);
+        assert_eq!(p.get(3), 0b010);
+        assert_eq!(p.get(4), 0b1100);
+        assert_eq!(p.get(8), 0x35);
+        assert_eq!(p.position(), 16);
+        // Past the end: zeros for ever, no panic.
+        assert_eq!(p.get(32), 0);
+        assert_eq!(p.get(32), 0);
+        assert_eq!(p.position(), 80);
+    }
+
+    #[test]
+    fn msb_peek_does_not_consume() {
+        let mut p = BitPumpMsb::new(AB);
+        assert_eq!(p.peek(16), 0xAC35);
+        assert_eq!(p.peek(16), 0xAC35);
+        assert_eq!(p.position(), 0);
+        assert_eq!(p.peek(0), 0);
+        p.consume(16);
+        assert_eq!(p.position(), 16);
+    }
+
+    #[test]
+    fn msb_spans_thirty_two_bits() {
+        let bytes = [0x12, 0x34, 0x56, 0x78, 0x9A];
+        let mut p = BitPumpMsb::new(&bytes);
+        assert_eq!(p.get(4), 1);
+        assert_eq!(p.get(32), 0x2345_6789);
+        assert_eq!(p.get(4), 0xA);
+        assert_eq!(p.position(), 40);
+    }
+
+    #[test]
+    fn msb_long_input_uses_the_word_path() {
+        let bytes: Vec<u8> = (0..64u8).collect();
+        let mut p = BitPumpMsb::new(&bytes);
+        for want in 0..64u32 {
+            assert_eq!(p.get(8), want);
+        }
+        assert_eq!(p.position(), 512);
+    }
+
+    #[test]
+    fn lsb_reads_from_the_bottom_of_each_byte() {
+        let mut p = BitPumpLsb::new(AB);
+        // 0xAC = 1010_1100: low bits first are 0,0,1,1,0,1,0,1.
+        assert_eq!(p.get(1), 0);
+        assert_eq!(p.get(3), 0b110);
+        assert_eq!(p.get(4), 0b1010);
+        // The second byte's low bit is next; a wider read puts the
+        // earlier bits at the bottom.
+        assert_eq!(p.get(8), 0x35);
+        assert_eq!(p.position(), 16);
+        assert_eq!(p.get(32), 0);
+    }
+
+    #[test]
+    fn lsb_spans_bytes_low_end_first() {
+        let bytes = [0x21, 0x43];
+        let mut p = BitPumpLsb::new(&bytes);
+        assert_eq!(p.get(16), 0x4321);
+    }
+
+    #[test]
+    fn lsb_long_input_uses_the_word_path() {
+        let bytes: Vec<u8> = (0..64u8).collect();
+        let mut p = BitPumpLsb::new(&bytes);
+        for want in 0..64u32 {
+            assert_eq!(p.get(8), want);
+        }
+        assert_eq!(p.position(), 512);
+    }
+
+    #[test]
+    fn jpeg_unstuffs_ff_zero() {
+        let bytes = [0xFF, 0x00, 0x12, 0xFF, 0x00, 0x34];
+        let mut p = BitPumpJpeg::new(&bytes);
+        assert_eq!(p.get(8), 0xFF);
+        assert_eq!(p.get(8), 0x12);
+        assert_eq!(p.get(8), 0xFF);
+        assert_eq!(p.get(8), 0x34);
+        assert!(!p.at_marker());
+        assert_eq!(p.get(8), 0);
+        assert!(p.at_marker());
+    }
+
+    #[test]
+    fn jpeg_stops_at_a_marker() {
+        // Three real bytes, then RST0.
+        let bytes = [0x11, 0x22, 0x33, 0xFF, 0xD0, 0x44, 0x55];
+        let mut p = BitPumpJpeg::new(&bytes);
+        assert_eq!(p.get(24), 0x0011_2233);
+        assert_eq!(p.get(16), 0);
+        assert!(p.at_marker());
+        assert_eq!(p.byte_pos(), 3);
+        // Data after the marker is never reached by this pump.
+        assert_eq!(p.get(32), 0);
+        assert_eq!(p.position(), 72);
+    }
+
+    #[test]
+    fn jpeg_marker_hidden_behind_a_long_run() {
+        // Longer than the eight-byte fast path, so the word gulp has
+        // to notice the 0xFF and fall back.
+        let mut bytes = vec![0x5A; 20];
+        bytes.push(0xFF);
+        bytes.push(0xD9);
+        bytes.extend_from_slice(&[0x77; 8]);
+        let mut p = BitPumpJpeg::new(&bytes);
+        for _ in 0..20 {
+            assert_eq!(p.get(8), 0x5A);
+        }
+        assert_eq!(p.get(8), 0);
+        assert!(p.at_marker());
+        assert_eq!(p.byte_pos(), 20);
+    }
+
+    #[test]
+    fn jpeg_lone_trailing_ff_is_a_marker() {
+        let bytes = [0x01, 0xFF];
+        let mut p = BitPumpJpeg::new(&bytes);
+        assert_eq!(p.get(8), 0x01);
+        assert_eq!(p.get(8), 0x00);
+        assert!(p.at_marker());
+    }
+
+    #[test]
+    fn msb32_reverses_each_word() {
+        let bytes = [0x01, 0x02, 0x03, 0x04, 0xAA, 0xBB, 0xCC, 0xDD];
+        let mut p = BitPumpMsb32::new(&bytes);
+        assert_eq!(p.get(32), 0x0403_0201);
+        assert_eq!(p.get(32), 0xDDCC_BBAA);
+        assert_eq!(p.get(8), 0);
+        assert_eq!(p.position(), 72);
+    }
+
+    #[test]
+    fn msb32_pads_a_short_tail() {
+        let bytes = [0x01, 0x02, 0x03, 0x04, 0xAA, 0xBB];
+        let mut p = BitPumpMsb32::new(&bytes);
+        assert_eq!(p.get(32), 0x0403_0201);
+        // The tail is padded to a word with zeros, so the top half of
+        // the word is zero and the two bytes come last.
+        assert_eq!(p.get(32), 0x0000_BBAA);
+        assert_eq!(p.get(16), 0);
+    }
+
+    #[test]
+    fn msb32_bit_order_within_a_word() {
+        let bytes = [0x00, 0x00, 0x00, 0x81];
+        let mut p = BitPumpMsb32::new(&bytes);
+        assert_eq!(p.get(1), 1);
+        assert_eq!(p.get(7), 1);
+        assert_eq!(p.get(24), 0);
+    }
+
+    /// A table where the codes are 0, 10, 110, 1110, 11110: symbols
+    /// 0..=4 in canonical order.
+    fn unary_table() -> HuffTable {
+        HuffTable::new(
+            &[1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 1, 2, 3, 4],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn huffman_decodes_canonical_codes() {
+        let t = unary_table();
+        // 0 10 110 1110 11110 -> 0,1,2,3,4, then zero fill decodes 0s.
+        let bits = [0b0101_1011, 0b1011_1100];
+        let mut p = BitPumpMsb::new(&bits);
+        assert_eq!(t.decode(&mut p), 0);
+        assert_eq!(t.decode(&mut p), 1);
+        assert_eq!(t.decode(&mut p), 2);
+        assert_eq!(t.decode(&mut p), 3);
+        assert_eq!(t.decode(&mut p), 4);
+        assert_eq!(p.position(), 15);
+    }
+
+    #[test]
+    fn huffman_accepts_the_seventeen_entry_form() {
+        let a = HuffTable::new(
+            &[1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 1, 2, 3, 4],
+        )
+        .unwrap();
+        let b = HuffTable::new(
+            &[9, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            &[0, 1, 2, 3, 4],
+        )
+        .unwrap();
+        let mut pa = BitPumpMsb::new(&[0b0101_1011]);
+        let mut pb = BitPumpMsb::new(&[0b0101_1011]);
+        assert_eq!(a.decode(&mut pa), b.decode(&mut pb));
+        assert_eq!(a.decode(&mut pa), b.decode(&mut pb));
+    }
+
+    #[test]
+    fn huffman_rejects_broken_tables() {
+        // More symbols promised than supplied.
+        assert!(HuffTable::new(&[2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], &[7]).is_err());
+        // Three codes of length one cannot exist.
+        assert!(HuffTable::new(
+            &[3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            &[1, 2, 3]
+        )
+        .is_err());
+        // Wrong count length.
+        assert!(HuffTable::new(&[1, 0, 0], &[1]).is_err());
+    }
+
+    #[test]
+    fn huffman_handles_codes_longer_than_the_lookup() {
+        // One code of every length 1..=15 plus two of 16: a complete
+        // code that forces the slow path for the long ones.
+        let mut counts = [1u8; 16];
+        counts[15] = 2;
+        let symbols: Vec<u8> = (0..17u8).collect();
+        let t = HuffTable::new(&counts, &symbols).unwrap();
+        // Symbol 15's code is fifteen 1s followed by a 0; symbol 16 is
+        // sixteen 1s.
+        let bits = [0xFF, 0xFE, 0xFF, 0xFF];
+        let mut p = BitPumpMsb::new(&bits);
+        assert_eq!(t.decode(&mut p), 15);
+        assert_eq!(p.position(), 16);
+        assert_eq!(t.decode(&mut p), 16);
+        assert_eq!(p.position(), 32);
+    }
+
+    #[test]
+    fn huffman_diff_sign_extends() {
+        let t = unary_table();
+        // Symbol 3 (code 1110) then three bits.
+        for (value, want) in [
+            (0b111u32, 7),
+            (0b100, 4),
+            (0b011, -4),
+            (0b000, -7),
+            (0b001, -6),
+        ] {
+            let byte = [((0b1110u32 << 4) | (value << 1)) as u8];
+            let mut p = BitPumpMsb::new(&byte);
+            assert_eq!(t.decode_diff(&mut p), want, "value {value:03b}");
+        }
+        // Symbol 0 is a zero difference and reads no extra bits.
+        let mut p = BitPumpMsb::new(&[0]);
+        assert_eq!(t.decode_diff(&mut p), 0);
+        assert_eq!(p.position(), 1);
+    }
+
+    #[test]
+    fn huffman_diff_sixteen_is_special() {
+        let mut counts = [0u8; 16];
+        counts[0] = 1;
+        let t = HuffTable::new(&counts, &[16]).unwrap();
+        // The lone code is a single 0 bit.
+        let mut p = BitPumpMsb::new(&[0x0F, 0xFF]);
+        assert_eq!(t.decode_diff(&mut p), 32768);
+        assert_eq!(p.position(), 1);
+        let mut p = BitPumpMsb::new(&[0x0F, 0xFF]);
+        // The extension convention reads sixteen bits instead: the
+        // fifteen bits left in the input plus one zero from the fill,
+        // 0b0001_1111_1111_1110, whose leading zero makes it negative.
+        assert_eq!(t.decode_diff_ext(&mut p), 0x1FFE - (1 << 16) + 1);
+        assert_eq!(p.position(), 17);
+    }
+}

--- a/crates/codec-raw/src/bmff.rs
+++ b/crates/codec-raw/src/bmff.rs
@@ -1,0 +1,642 @@
+//! ISO base media file format boxes, for Canon CR3.
+//!
+//! Just the box tree: sizes (32-bit and the 64-bit `largesize` form),
+//! fourccs, and `uuid` boxes; containers (`moov`, `trak`, `mdia`,
+//! `minf`, `stbl`, Canon's `uuid` with the CRAW id) are descended.
+//! Nothing here knows what any box means.
+
+use crate::Result;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Box_ {
+    pub kind: [u8; 4],
+    /// The 16-byte type of a `uuid` box.
+    pub uuid: Option<[u8; 16]>,
+    /// Absolute range of the payload (after the header).
+    pub data: std::ops::Range<usize>,
+    pub children: Vec<Box_>,
+}
+
+impl Box_ {
+    /// First child with this fourcc.
+    pub fn child(&self, kind: &[u8; 4]) -> Option<&Box_> {
+        self.children.iter().find(|b| &b.kind == kind)
+    }
+    /// Every descendant with this fourcc, depth-first.
+    pub fn find_all(&self, kind: &[u8; 4]) -> Vec<&Box_> {
+        let mut out = Vec::new();
+        for c in &self.children {
+            if &c.kind == kind {
+                out.push(c);
+            }
+            out.extend(c.find_all(kind));
+        }
+        out
+    }
+}
+
+/// Canon's own uuid boxes: the CRAW one inside `moov` (metadata: CNCV,
+/// CCTP, CTBO, the CMT1..CMT4 TIFF blocks and the THMB thumbnail) and
+/// the preview one at the top level (PRVW).
+pub const UUID_CANON_CRAW: [u8; 16] = [
+    0x85, 0xc0, 0xb6, 0x87, 0x82, 0x0f, 0x11, 0xe0, 0x81, 0x11, 0xf4, 0xce, 0x46, 0x2b, 0x6a, 0x48,
+];
+pub const UUID_CANON_PREVIEW: [u8; 16] = [
+    0xea, 0xf4, 0x2b, 0x5e, 0x1c, 0x98, 0x4b, 0x88, 0xb9, 0xfb, 0xb7, 0xdc, 0x40, 0x6e, 0x4d, 0x16,
+];
+
+/// Depth and count caps: a CR3 nests six levels
+/// (moov/trak/mdia/minf/stbl/stsd/CRAW/CMP1) and holds a few dozen
+/// boxes, so anything past these is a file trying to make us work.
+const MAX_DEPTH: usize = 10;
+const MAX_BOXES: usize = 4096;
+
+/// Boxes whose payload is a plain sequence of child boxes.
+fn is_container(kind: &[u8; 4]) -> bool {
+    matches!(
+        kind,
+        b"moov" | b"trak" | b"mdia" | b"minf" | b"stbl" | b"dinf" | b"edts" | b"udta"
+    )
+}
+
+/// Where a sample entry's child boxes begin, counted from its payload
+/// (that is, after the 8-byte box header). A VisualSampleEntry's fixed
+/// part is 78 bytes; Canon's CRAW adds four more before its CMP1 /
+/// CDI1 / JPEG children, which is where 82 comes from; 86 is the same
+/// with one more 4-byte field, an offset seen in the wild rather than
+/// derived from a spec. The candidates are tried in turn and only
+/// accepted if the boxes from there tile the rest of the entry
+/// exactly, so a sample entry of some other shape stays a leaf rather
+/// than sprouting nonsense.
+const SAMPLE_ENTRY_CHILDREN: [usize; 3] = [82, 78, 86];
+
+/// Leading bytes to skip inside a `uuid` payload before its child
+/// boxes. Canon's preview uuid starts with eight bytes of its own
+/// before the PRVW box; the CRAW uuid starts with boxes straight away.
+const UUID_CHILDREN: [usize; 2] = [0, 8];
+
+/// Parse the top-level boxes of a file, descending known containers.
+pub fn parse(bytes: &[u8]) -> Result<Vec<Box_>> {
+    let mut budget = MAX_BOXES;
+    // The top level is parsed leniently: a file truncated mid-`mdat`
+    // still yields the `moov` in front of it, which is where everything
+    // this crate wants lives.
+    let (boxes, _) = boxes_in(bytes, 0, bytes.len(), 0, &mut budget, false);
+    if boxes.is_empty() {
+        return Err(crate::Error::Corrupt("no ISO-BMFF boxes".into()));
+    }
+    Ok(boxes)
+}
+
+/// Parse the boxes filling `start..end`, returning them and the
+/// position after the last one parsed. `sample_entries` marks the
+/// children of an `stsd`, which are boxes with a fixed header before
+/// their own children rather than plain containers.
+fn boxes_in(
+    bytes: &[u8],
+    start: usize,
+    end: usize,
+    depth: usize,
+    budget: &mut usize,
+    sample_entries: bool,
+) -> (Vec<Box_>, usize) {
+    let mut out = Vec::new();
+    let mut at = start;
+    if depth > MAX_DEPTH || end > bytes.len() {
+        return (out, at);
+    }
+    while at + 8 <= end && *budget > 0 {
+        *budget -= 1;
+        let size =
+            u32::from_be_bytes([bytes[at], bytes[at + 1], bytes[at + 2], bytes[at + 3]]) as u64;
+        let mut kind = [0u8; 4];
+        kind.copy_from_slice(&bytes[at + 4..at + 8]);
+        let mut header = 8usize;
+        // size == 1 puts the real size in a 64-bit field after the
+        // fourcc (mdat in a large CR3 uses it); size == 0 means the box
+        // runs to the end of the enclosing range.
+        let size = if size == 1 {
+            if at + 16 > end {
+                break;
+            }
+            header = 16;
+            let mut b = [0u8; 8];
+            b.copy_from_slice(&bytes[at + 8..at + 16]);
+            u64::from_be_bytes(b)
+        } else if size == 0 {
+            (end - at) as u64
+        } else {
+            size
+        };
+        let uuid = if &kind == b"uuid" {
+            if at + header + 16 > end {
+                break;
+            }
+            let mut id = [0u8; 16];
+            id.copy_from_slice(&bytes[at + header..at + header + 16]);
+            header += 16;
+            Some(id)
+        } else {
+            None
+        };
+        let Ok(size) = usize::try_from(size) else {
+            break;
+        };
+        // A box shorter than its own header, or one running past the
+        // end of its parent, is where a truncated or garbage file stops
+        // making sense: keep what came before it.
+        if size < header {
+            break;
+        }
+        let Some(box_end) = at.checked_add(size) else {
+            break;
+        };
+        if box_end > end {
+            break;
+        }
+        let data = at + header..box_end;
+        let children = if sample_entries {
+            sample_entry_children(bytes, &data, depth, budget)
+        } else {
+            children_of(bytes, &kind, uuid.is_some(), &data, depth, budget)
+        };
+        out.push(Box_ {
+            kind,
+            uuid,
+            data,
+            children,
+        });
+        at = box_end;
+    }
+    (out, at)
+}
+
+/// The children of one box, by fourcc.
+fn children_of(
+    bytes: &[u8],
+    kind: &[u8; 4],
+    is_uuid: bool,
+    data: &std::ops::Range<usize>,
+    depth: usize,
+    budget: &mut usize,
+) -> Vec<Box_> {
+    if is_uuid {
+        // A uuid box may hold anything at all — Canon puts an XMP
+        // packet in one — so its children only count if they tile the
+        // payload exactly.
+        for skip in UUID_CHILDREN {
+            if let Some(children) = exact(
+                bytes,
+                data.start.saturating_add(skip),
+                data.end,
+                depth,
+                budget,
+                false,
+            ) {
+                return children;
+            }
+        }
+        return Vec::new();
+    }
+    if is_container(kind) {
+        return boxes_in(bytes, data.start, data.end, depth + 1, budget, false).0;
+    }
+    if kind == b"stsd" {
+        // stsd is a full box: version+flags then an entry count, and
+        // only then the sample entries.
+        let start = data.start.saturating_add(8);
+        if start <= data.end {
+            return boxes_in(bytes, start, data.end, depth + 1, budget, true).0;
+        }
+    }
+    Vec::new()
+}
+
+/// A sample entry (CRAW, CTMD, ...) carries fixed fields before any
+/// child boxes; find where they end by trying the known lengths and
+/// keeping the first that parses to exactly the end of the entry.
+fn sample_entry_children(
+    bytes: &[u8],
+    data: &std::ops::Range<usize>,
+    depth: usize,
+    budget: &mut usize,
+) -> Vec<Box_> {
+    for skip in SAMPLE_ENTRY_CHILDREN {
+        let start = data.start.saturating_add(skip);
+        if start >= data.end {
+            continue;
+        }
+        if let Some(children) = exact(bytes, start, data.end, depth, budget, false) {
+            return children;
+        }
+    }
+    Vec::new()
+}
+
+/// Boxes that tile `start..end` exactly, or `None`: the test that says
+/// "this really was a sequence of boxes and not something else".
+fn exact(
+    bytes: &[u8],
+    start: usize,
+    end: usize,
+    depth: usize,
+    budget: &mut usize,
+    sample_entries: bool,
+) -> Option<Vec<Box_>> {
+    if start >= end {
+        return None;
+    }
+    let mut probe = *budget;
+    let (boxes, consumed) = boxes_in(bytes, start, end, depth + 1, &mut probe, sample_entries);
+    if boxes.is_empty()
+        || consumed != end
+        || !boxes
+            .iter()
+            .all(|b| b.kind.iter().all(|c| c.is_ascii_graphic()))
+    {
+        return None;
+    }
+    *budget = probe;
+    Some(boxes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------------------------------------------------------------
+    // Hand-built boxes.
+    // ---------------------------------------------------------------
+
+    /// A box with a 32-bit size.
+    fn small(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+        let mut out = ((payload.len() + 8) as u32).to_be_bytes().to_vec();
+        out.extend_from_slice(kind);
+        out.extend_from_slice(payload);
+        out
+    }
+    /// A box in the `size == 1` form, with a 64-bit largesize.
+    fn large(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+        let mut out = 1u32.to_be_bytes().to_vec();
+        out.extend_from_slice(kind);
+        out.extend_from_slice(&((payload.len() + 16) as u64).to_be_bytes());
+        out.extend_from_slice(payload);
+        out
+    }
+    /// A `uuid` box: the fourcc, then the 16-byte type, then payload.
+    fn uuid(id: &[u8; 16], payload: &[u8]) -> Vec<u8> {
+        let mut body = id.to_vec();
+        body.extend_from_slice(payload);
+        small(b"uuid", &body)
+    }
+    /// A box whose size field is zero: it runs to the end of the file.
+    fn to_end(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+        let mut out = 0u32.to_be_bytes().to_vec();
+        out.extend_from_slice(kind);
+        out.extend_from_slice(payload);
+        out
+    }
+
+    /// Every box in a tree, self included, depth-first.
+    fn flatten(boxes: &[Box_]) -> Vec<&Box_> {
+        let mut out = Vec::new();
+        for b in boxes {
+            out.push(b);
+            out.extend(flatten(&b.children));
+        }
+        out
+    }
+
+    fn kinds(boxes: &[Box_]) -> Vec<String> {
+        boxes
+            .iter()
+            .map(|b| String::from_utf8_lossy(&b.kind).to_string())
+            .collect()
+    }
+
+    #[test]
+    fn top_level_boxes() {
+        let mut file = small(b"ftyp", b"crx isom");
+        file.extend(small(b"mdat", &[0u8; 32]));
+        let boxes = parse(&file).unwrap();
+        assert_eq!(kinds(&boxes), ["ftyp", "mdat"]);
+        assert_eq!(boxes[0].data, 8..16);
+        assert_eq!(boxes[1].data.len(), 32);
+        // mdat is not a container: its payload is pixels, not boxes.
+        assert!(boxes[1].children.is_empty());
+    }
+
+    #[test]
+    fn largesize_and_run_to_end_forms() {
+        let mut file = large(b"mdat", &[7u8; 40]);
+        file.extend(to_end(b"free", &[0u8; 9]));
+        let boxes = parse(&file).unwrap();
+        assert_eq!(kinds(&boxes), ["mdat", "free"]);
+        assert_eq!(boxes[0].data.len(), 40);
+        assert_eq!(boxes[1].data.len(), 9);
+    }
+
+    #[test]
+    fn containers_are_descended() {
+        let stbl = small(b"stbl", &small(b"stsz", &[0u8; 12]));
+        let minf = small(b"minf", &[small(b"vmhd", &[0u8; 8]), stbl].concat());
+        let mdia = small(b"mdia", &minf);
+        let trak = small(b"trak", &mdia);
+        let moov = small(b"moov", &trak);
+        let boxes = parse(&moov).unwrap();
+        let all = flatten(&boxes);
+        let names: Vec<_> = all
+            .iter()
+            .map(|b| String::from_utf8_lossy(&b.kind).to_string())
+            .collect();
+        assert_eq!(
+            names,
+            ["moov", "trak", "mdia", "minf", "vmhd", "stbl", "stsz"]
+        );
+        assert_eq!(boxes[0].find_all(b"stsz").len(), 1);
+        assert!(boxes[0].child(b"trak").is_some());
+        assert!(
+            boxes[0].child(b"stbl").is_none(),
+            "child() is not recursive"
+        );
+    }
+
+    #[test]
+    fn uuid_boxes_carry_their_type_and_children() {
+        // Canon's metadata uuid holds boxes directly.
+        let craw = uuid(
+            &UUID_CANON_CRAW,
+            &[
+                small(b"CNCV", b"CanonCR3_001"),
+                small(b"CMT1", b"II\x2a\x00"),
+            ]
+            .concat(),
+        );
+        // The preview uuid holds eight bytes of its own first.
+        let mut preview_payload = vec![0u8; 8];
+        preview_payload.extend(small(b"PRVW", &[0xff, 0xd8, 0xff, 0xdb]));
+        let preview = uuid(&UUID_CANON_PREVIEW, &preview_payload);
+        // And an XMP packet in a uuid is not boxes at all.
+        let xmp = uuid(
+            &[0xbe; 16],
+            b"\0Packet <x:xmpmeta xmlns:x='adobe:ns:meta/'>",
+        );
+        let file = [craw, preview, xmp].concat();
+
+        let boxes = parse(&file).unwrap();
+        assert_eq!(boxes.len(), 3);
+        assert_eq!(boxes[0].uuid, Some(UUID_CANON_CRAW));
+        assert_eq!(kinds(&boxes[0].children), ["CNCV", "CMT1"]);
+        assert_eq!(boxes[1].uuid, Some(UUID_CANON_PREVIEW));
+        assert_eq!(kinds(&boxes[1].children), ["PRVW"]);
+        assert_eq!(
+            boxes[2].children,
+            vec![],
+            "an opaque uuid payload stays opaque"
+        );
+    }
+
+    #[test]
+    fn stsd_sample_entries_and_their_children() {
+        // A CRAW sample entry: 8-byte box header, 82 bytes of fixed
+        // fields (SampleEntry + VisualSampleEntry + Canon's four), then
+        // child boxes.
+        let mut craw = vec![0u8; 82];
+        craw[24..26].copy_from_slice(&1618u16.to_be_bytes()); // width, for flavour
+        craw.extend(small(b"CMP1", &[0u8; 52]));
+        craw.extend(small(b"CDI1", &[0u8; 44]));
+        let mut stsd_payload = vec![0, 0, 0, 0, 0, 0, 0, 1]; // version+flags, entry count
+        stsd_payload.extend(small(b"CRAW", &craw));
+        let file = small(b"moov", &small(b"stbl", &small(b"stsd", &stsd_payload)));
+
+        let boxes = parse(&file).unwrap();
+        let stsd = boxes[0].find_all(b"stsd");
+        assert_eq!(stsd.len(), 1);
+        assert_eq!(kinds(&stsd[0].children), ["CRAW"]);
+        assert_eq!(kinds(&stsd[0].children[0].children), ["CMP1", "CDI1"]);
+        // The sample entry keeps its whole payload, fixed fields
+        // included, so a decoder can read the dimensions out of it.
+        assert_eq!(stsd[0].children[0].data.len(), 82 + 60 + 52);
+    }
+
+    #[test]
+    fn a_sample_entry_of_another_shape_stays_a_leaf() {
+        // CTMD has no child boxes; the bytes at offset 82 must not be
+        // mistaken for any.
+        let mut stsd_payload = vec![0, 0, 0, 0, 0, 0, 0, 1];
+        stsd_payload.extend(small(b"CTMD", &(0..100u8).collect::<Vec<_>>()));
+        let file = small(b"stbl", &small(b"stsd", &stsd_payload));
+        let boxes = parse(&file).unwrap();
+        let stsd = &boxes[0].children[0];
+        assert_eq!(kinds(&stsd.children), ["CTMD"]);
+        assert!(stsd.children[0].children.is_empty());
+    }
+
+    #[test]
+    fn garbage_and_truncation_are_errors_not_panics() {
+        let mut craw = vec![0u8; 82];
+        craw.extend(small(b"CMP1", &[0u8; 52]));
+        let mut stsd_payload = vec![0, 0, 0, 0, 0, 0, 0, 1];
+        stsd_payload.extend(small(b"CRAW", &craw));
+        let mut good = small(b"ftyp", b"crx isom");
+        good.extend(small(
+            b"moov",
+            &[
+                uuid(&UUID_CANON_CRAW, &small(b"CMT1", b"II\x2a\x00")),
+                small(b"stbl", &small(b"stsd", &stsd_payload)),
+            ]
+            .concat(),
+        ));
+        good.extend(large(b"mdat", &[0u8; 64]));
+
+        // Every prefix of a real-shaped file.
+        for cut in 0..good.len() {
+            let result = std::panic::catch_unwind(|| parse(&good[..cut]));
+            assert!(result.is_ok(), "panic on a {cut}-byte prefix");
+        }
+        // Sizes that lie: smaller than the header, bigger than the file.
+        for bad in [
+            vec![0, 0, 0, 3, b'm', b'o', b'o', b'v'],
+            vec![0, 0, 0, 7, b'm', b'o', b'o', b'v', 0],
+            vec![0xff, 0xff, 0xff, 0xff, b'm', b'd', b'a', b't'],
+            vec![
+                0, 0, 0, 1, b'm', b'd', b'a', b't', 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            ],
+            // A uuid box that ends inside its own 16-byte type.
+            vec![0, 0, 0, 12, b'u', b'u', b'i', b'd', 1, 2, 3, 4],
+        ] {
+            let result = std::panic::catch_unwind(|| parse(&bad));
+            assert!(result.is_ok(), "panic on {bad:02x?}");
+            assert!(result.unwrap().is_err(), "{bad:02x?} should not parse");
+        }
+        // Boxes nested past the depth cap: bounded work, no stack blow.
+        let mut deep = small(b"moov", b"");
+        for _ in 0..200 {
+            deep = small(b"moov", &deep);
+        }
+        assert!(std::panic::catch_unwind(|| parse(&deep)).is_ok());
+    }
+
+    // ---------------------------------------------------------------
+    // Corpus: real CR3 files.
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn corpus_cr3_files_have_the_boxes_a_decoder_needs() {
+        let Some(root) = crate::tiff::tests::corpus() else {
+            return;
+        };
+        let mut checked = 0;
+        let mut problems: Vec<String> = Vec::new();
+        for path in crate::tiff::tests::samples(&root) {
+            let is_cr3 = path
+                .extension()
+                .map(|e| e.to_string_lossy().to_ascii_uppercase() == "CR3")
+                .unwrap_or(false);
+            if !is_cr3 {
+                continue;
+            }
+            let Ok(bytes) = std::fs::read(&path) else {
+                continue;
+            };
+            let name = path
+                .strip_prefix(&root)
+                .unwrap_or(&path)
+                .display()
+                .to_string();
+            let boxes = match parse(&bytes) {
+                Ok(boxes) => boxes,
+                Err(e) => {
+                    problems.push(format!("{name}: {e}"));
+                    continue;
+                }
+            };
+            checked += 1;
+            let all = flatten(&boxes);
+            // Collected, not asserted one at a time: one run should
+            // report everything wrong with the corpus at once.
+            fn want(problems: &mut Vec<String>, name: &str, cond: bool, what: &str) {
+                if !cond {
+                    problems.push(format!("{name}: no {what}"));
+                }
+            }
+            want(
+                &mut problems,
+                &name,
+                boxes.iter().any(|b| &b.kind == b"ftyp"),
+                "top-level ftyp",
+            );
+            want(
+                &mut problems,
+                &name,
+                boxes.iter().any(|b| &b.kind == b"moov"),
+                "top-level moov",
+            );
+            want(
+                &mut problems,
+                &name,
+                boxes.iter().any(|b| &b.kind == b"mdat"),
+                "top-level mdat",
+            );
+            let craw = all.iter().find(|b| b.uuid == Some(UUID_CANON_CRAW));
+            match craw {
+                None => problems.push(format!("{name}: no Canon CRAW uuid box")),
+                Some(craw) => {
+                    for tag in [b"CNCV", b"CMT1", b"CMT2", b"CMT3", b"CMT4", b"THMB"] {
+                        if craw.child(tag).is_none() {
+                            problems.push(format!(
+                                "{name}: CRAW uuid has no {}",
+                                String::from_utf8_lossy(tag)
+                            ));
+                        }
+                    }
+                    // CMT1..CMT4 are whole little TIFFs (IFD0, Exif,
+                    // GPS and the maker's own), which is where the CR3
+                    // decoder reads its metadata.
+                    if let Some(cmt1) = craw.child(b"CMT1") {
+                        match crate::tiff::Tiff::parse_embedded(&bytes, cmt1.data.start) {
+                            Ok(tiff) => {
+                                let (make, _) = tiff.make_model();
+                                if !make.to_ascii_uppercase().starts_with("CANON") {
+                                    problems.push(format!("{name}: CMT1 Make is {make:?}"));
+                                }
+                            }
+                            Err(e) => problems.push(format!("{name}: CMT1 is not a TIFF: {e}")),
+                        }
+                    }
+                    // THMB is a full box. In version 0 (every body up
+                    // to the EOS R generation) it is width, height,
+                    // size and two unknown bytes, then a JFIF stream:
+                    // 16 bytes of payload before the JPEG. Version 1,
+                    // on the R8 and its contemporaries, is a different
+                    // shape holding an HEVC-coded thumbnail (a CISZ
+                    // box and an hvcC record), and there is no JPEG in
+                    // it at all — a CR3 decoder wanting a preview
+                    // should take PRVW there.
+                    if let Some(thmb) = craw.child(b"THMB") {
+                        let payload = bytes
+                            .get(thmb.data.start..thmb.data.end)
+                            .unwrap_or_default();
+                        match payload.first() {
+                            Some(0) => {
+                                if !matches!(payload.get(16..18), Some([0xff, 0xd8])) {
+                                    problems.push(format!("{name}: THMB v0 holds no JPEG"));
+                                }
+                            }
+                            Some(version) => {
+                                eprintln!(
+                                    "{name}: THMB version {version} (no JPEG; HEVC thumbnail)"
+                                );
+                                if !payload.windows(4).take(32).any(|w| w == *b"CISZ") {
+                                    problems.push(format!(
+                                        "{name}: THMB v{version} is not the HEVC shape either"
+                                    ));
+                                }
+                            }
+                            None => problems.push(format!("{name}: empty THMB")),
+                        }
+                    }
+                }
+            }
+            let preview = all.iter().find(|b| b.uuid == Some(UUID_CANON_PREVIEW));
+            match preview {
+                None => problems.push(format!("{name}: no Canon preview uuid box")),
+                Some(preview) => want(
+                    &mut problems,
+                    &name,
+                    preview.child(b"PRVW").is_some(),
+                    "PRVW in the preview uuid",
+                ),
+            }
+            // The raw track's sample entry and its CMP1 (the CRX
+            // codec's parameters) must be reachable.
+            want(
+                &mut problems,
+                &name,
+                !all.iter()
+                    .any(|b| &b.kind == b"stsd" && b.children.is_empty()),
+                "children under every stsd",
+            );
+            let craw_entries: Vec<_> = all.iter().filter(|b| &b.kind == b"CRAW").collect();
+            want(
+                &mut problems,
+                &name,
+                !craw_entries.is_empty(),
+                "CRAW sample entry",
+            );
+            want(
+                &mut problems,
+                &name,
+                craw_entries.iter().any(|b| b.child(b"CMP1").is_some()),
+                "CMP1 inside a CRAW sample entry",
+            );
+        }
+        assert!(
+            problems.is_empty(),
+            "{} problems:\n{}",
+            problems.len(),
+            problems.join("\n")
+        );
+        eprintln!("corpus: {checked} CR3 files parsed");
+    }
+}

--- a/crates/codec-raw/src/cameras.rs
+++ b/crates/codec-raw/src/cameras.rs
@@ -1,0 +1,3854 @@
+//! The camera table: what a vendor raw does not say about itself.
+//!
+//! DNG files carry their colour matrix; every other format relies on a
+//! table keyed by make and model. Black and white levels are here only
+//! for cameras whose files do not record them.
+//!
+//! Provenance matters. Each entry names where its numbers came from in
+//! a comment: the ColorMatrix of a DNG that Adobe's converter or the
+//! camera itself wrote for that model is the canonical public source.
+//! Nothing is to be copied from dcraw, LibRaw or rawspeed's tables.
+//!
+//! # What goes in the table
+//!
+//! Only the D65 matrix. A DNG carries up to two calibrations, one per
+//! illuminant, and the developer is meant to interpolate between them
+//! by colour temperature; this crate's [`Camera::color_matrix`] is the
+//! single XYZ(D65)→camera matrix the [`crate::develop`] step wants, so
+//! an entry is made only when a *D65* calibration is known. Cameras
+//! whose only published matrix is for another illuminant (D50 on the
+//! Leica SL and the GoPro GPRs, for instance) are left out rather than
+//! entered under the wrong white point.
+//!
+//! Each entry's `// source:` comment says which of three provenances
+//! it has, strongest first:
+//!
+//! * `ColorMatrix2 (D65) of <file>` — read straight out of a real DNG
+//!   for that model: the camera's own, or one Adobe's converter (or
+//!   Lightroom) wrote. Exact, and re-checkable by anyone with the file.
+//! * `Adobe DNG Converter ColorMatrix2, D65 ... cross-checked` —
+//!   Adobe's published calibration for the model, agreeing with the
+//!   camera's own white-balance presets (see below). The comment
+//!   carries the numbers so the check can be repeated.
+//! * `... NOT individually verified` — the same source, for bodies
+//!   whose raws publish nothing a matrix can be checked against. These
+//!   are the ones to replace first.
+//!
+//! One provenance is deliberately *not* used. Several DNGs on
+//! raw.pixls.us were written by CHDK, the third-party Canon firmware,
+//! and carry a colour matrix for a compact that has no other public
+//! calibration. CHDK is GPL, and where it got those numbers is not
+//! documented in the file, so taking them could launder a copyleft
+//! table into this one. Its files are read for their sensor layout and
+//! ignored for colour.
+//!
+//! Two makes are conspicuously absent and it is worth saying why.
+//! Samsung's NX bodies publish their own camera-to-sRGB correction
+//! matrix and a white balance for each of two calibration
+//! illuminants, which is in principle enough to rebuild the DNG
+//! matrix (`M = diag(w) . CCM^-1 . S`, the correction matrix alone
+//! leaving `w` free because its rows sum to one). Derived that way the
+//! red axis lands within about 1% of the published Adobe value, but
+//! the blue comes out near 1.0 on half the bodies and around 1.4 on
+//! the rest, which no sensor does — the blue slot of that tag is not
+//! what it looks like on the older models — so the whole block is left
+//! out rather than half-trusted. Phase One and Leaf carry a
+//! white-balanced correction matrix whose rows sum to one, which fixes
+//! the colours but not the neutral, so it cannot be turned into a
+//! ColorMatrix either.
+//!
+//! # How a matrix is cross-checked
+//!
+//! A colour matrix fixes the camera's response to a neutral: applying
+//! it to the XYZ of D65 white gives the raw R:G:B a grey card produces
+//! under D65, and the reciprocal of that is the white balance the
+//! camera would apply at 6504 K. Most cameras record their own
+//! white-balance presets with the colour temperature each was made for
+//! — Canon's `WB_RGGBLevelsDaylight`/`Cloudy`/`Shade` alongside
+//! `ColorTempDaylight` and friends, Pentax's whole 16-point
+//! `KelvinWB_*` curve, Sony's `WB_RGBLevels6000K`/`8500K`, Olympus's
+//! `WB_RBLevels*K` — so interpolating those to 6504 K in mireds
+//! measures the same quantity independently of any matrix.
+//!
+//! On the four cameras here that have both a real D65 matrix in a DNG
+//! and a preset curve, the two agree to 1–3% (Pentax K-5, Ricoh GR
+//! IIIx), which is what sets the tolerance; entries that disagreed by
+//! more than 8% were dropped rather than massaged, and the ones that
+//! were dropped are named in this crate's notes. The check only pins
+//! the neutral axis — two of nine degrees of freedom — so passing it
+//! is necessary, not sufficient.
+//!
+//! Two entries fail their own check and are kept anyway, flagged in
+//! their comments: the Pentax K10D's and 645D's in-camera matrices
+//! disagree with those cameras' own Kelvin curves. They are what the
+//! bodies' DNGs carry, so using them keeps PEF and DNG rendering alike.
+//! Where a body has both an in-camera matrix and a recalled Adobe one,
+//! the check picks between them rather than a rule of thumb: a
+//! manufacturer's own numbers are not automatically the better ones,
+//! as those two show.
+//!
+//! One more guard, because the neutral axis is only two of the nine
+//! numbers: no two cameras may carry byte-identical matrices unless
+//! one of them is read from a file, or the pair is a declared rebadge
+//! or shared sensor. Two unrelated cameras agreeing to the last digit
+//! is not a coincidence, it is a recollection filed under the wrong
+//! body — that is how the Panasonic DMC-GH4 entry was caught wearing
+//! the DJI FC6310's matrix, and how the D7200 was caught wearing the
+//! D7100's.
+//!
+//! # Black and white levels
+//!
+//! Nearly every entry leaves both `None`, deliberately. The formats
+//! this crate decodes either record the levels (DNG, ORF, RW2, PEF,
+//! SRW, ARW, NEF) or let the decoder derive them: black from the
+//! masked border columns the sensor frame keeps, white from the sample
+//! bit depth. A per-model saturation value is exactly the sort of
+//! number that only exists inside the copyleft tables this crate may
+//! not read, and measuring it from sample frames does not work — of
+//! the Canon frames here only one is clipped at all, and it clips at
+//! the full 14-bit 16383 the bit depth already implies. A white level
+//! guessed too low clips highlights to a coloured smear, so guessing is
+//! worse than the decoder's default.
+
+use std::cmp::Ordering;
+
+/// One camera's calibration.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Camera {
+    pub make: &'static str,
+    pub model: &'static str,
+    /// XYZ (D65) to camera RGB, rows R/G/B — the DNG ColorMatrix
+    /// convention, as floats (a DNG stores them ×10000).
+    pub color_matrix: [[f32; 3]; 3],
+    pub black_level: Option<u16>,
+    pub white_level: Option<u16>,
+}
+
+// ---------------------------------------------------------------- names
+
+/// Vendor make strings, canonicalised. The left-hand side is what is
+/// left of the file's Make after whitespace collapsing and the
+/// corporate-suffix strip below, uppercased; the right-hand side is the
+/// spelling this crate uses everywhere.
+///
+/// `OM Digital Solutions` — the company Olympus's camera division was
+/// sold to in 2021 — is given its own make, `OM System`, because that
+/// is the brand on the bodies and the string the files carry, and
+/// because folding it into `Olympus` would make `clean_make` disagree
+/// with the camera. [`lookup`] treats the two as one namespace so an
+/// entry filed under either is found from either, which is what
+/// matters for a body like the E-M1 Mark III that shipped under one
+/// name and gained firmware under the other.
+const MAKE_ALIASES: &[(&str, &str)] = &[
+    ("AGFAPHOTO", "AgfaPhoto"),
+    ("APPLE", "Apple"),
+    ("ASAHI", "Pentax"),
+    ("BLACKMAGIC", "Blackmagic"),
+    ("BLACKMAGIC DESIGN", "Blackmagic"),
+    ("CANON", "Canon"),
+    ("CASIO", "Casio"),
+    ("CONTAX", "Contax"),
+    ("DJI", "DJI"),
+    ("EASTMAN KODAK", "Kodak"),
+    ("EPSON", "Epson"),
+    ("FOVEON", "Sigma"),
+    ("FUJI", "Fujifilm"),
+    ("FUJIFILM", "Fujifilm"),
+    ("FUJI PHOTO FILM", "Fujifilm"),
+    ("GOOGLE", "Google"),
+    ("GOPRO", "GoPro"),
+    ("HASSELBLAD", "Hasselblad"),
+    ("HUAWEI", "Huawei"),
+    // Imacon's backs became Hasselblad's; their files say Hasselblad.
+    ("IMACON", "Hasselblad"),
+    ("KODAK", "Kodak"),
+    ("KONICA", "Minolta"),
+    ("KONICA MINOLTA", "Minolta"),
+    ("LEAF", "Leaf"),
+    ("LEICA", "Leica"),
+    ("LG", "LG"),
+    ("LG ELECTRONICS", "LG"),
+    ("MAMIYA", "Mamiya"),
+    ("MAMIYA-OP", "Mamiya"),
+    ("MATSUSHITA ELECTRIC INDUSTRIAL", "Panasonic"),
+    ("MINOLTA", "Minolta"),
+    ("MOTOROLA", "Motorola"),
+    ("NIKON", "Nikon"),
+    ("NOKIA", "Nokia"),
+    ("OLYMPUS", "Olympus"),
+    ("OMDS", "OM System"),
+    ("OM DIGITAL SOLUTIONS", "OM System"),
+    ("OM SYSTEM", "OM System"),
+    ("ONEPLUS", "OnePlus"),
+    ("PANASONIC", "Panasonic"),
+    ("PENTAX", "Pentax"),
+    ("PHASEONE", "Phase One"),
+    ("PHASE ONE", "Phase One"),
+    ("RICOH", "Ricoh"),
+    ("SAMSUNG", "Samsung"),
+    ("SEIKO EPSON", "Epson"),
+    ("SIGMA", "Sigma"),
+    ("SINAR", "Sinar"),
+    ("SONY", "Sony"),
+    ("XIAOMI", "Xiaomi"),
+    ("ZEISS", "Zeiss"),
+];
+
+/// Trailing tokens that say what kind of company the vendor is rather
+/// than which vendor it is. Compared after dropping `.` and `,` from
+/// the token and uppercasing it, so `CO.,LTD` and `Co., Ltd.` both
+/// reduce to tokens in here. Stripped from the end repeatedly, never
+/// far enough to leave the make empty: `RICOH IMAGING COMPANY, LTD.`
+/// loses `LTD`, `COMPANY` and `IMAGING` and stops at `RICOH`.
+const COMPANY_SUFFIXES: &[&str] = &[
+    "A/S",
+    "AB",
+    "AG",
+    "CAMERA",
+    "CAMERAS",
+    "CO",
+    "COLTD",
+    "COMPANY",
+    "CORP",
+    "CORPORATION",
+    "GMBH",
+    "IMAGING",
+    "INC",
+    "INCORPORATED",
+    "KG",
+    "LIMITED",
+    "LLC",
+    "LTD",
+    "NV",
+    "OPTICAL",
+    "PLC",
+    "SA",
+];
+
+/// Leading model tokens each make repeats out of its own name. Keyed by
+/// the canonical make. Multi-word prefixes are matched token by token,
+/// so a model that merely starts with the same letters (`OM-3` under
+/// `OM System`) is untouched.
+const MODEL_PREFIXES: &[(&str, &[&str])] = &[
+    ("Canon", &["CANON"]),
+    ("DJI", &["DJI"]),
+    ("Epson", &["EPSON", "SEIKO EPSON"]),
+    ("Fujifilm", &["FUJIFILM", "FUJI"]),
+    ("GoPro", &["GOPRO"]),
+    ("Google", &["GOOGLE"]),
+    ("Hasselblad", &["HASSELBLAD"]),
+    ("Kodak", &["KODAK", "EASTMAN KODAK"]),
+    ("Leaf", &["LEAF"]),
+    ("Leica", &["LEICA"]),
+    ("Mamiya", &["MAMIYA"]),
+    ("Minolta", &["MINOLTA", "KONICA MINOLTA"]),
+    ("Nikon", &["NIKON"]),
+    (
+        "OM System",
+        &["OM SYSTEM", "OM DIGITAL SOLUTIONS", "OM DIGITAL"],
+    ),
+    ("Olympus", &["OLYMPUS"]),
+    ("Panasonic", &["PANASONIC"]),
+    ("Pentax", &["PENTAX"]),
+    ("Phase One", &["PHASE ONE", "PHASEONE"]),
+    ("Ricoh", &["RICOH"]),
+    ("Samsung", &["SAMSUNG"]),
+    ("Sigma", &["SIGMA"]),
+    ("Sony", &["SONY"]),
+];
+
+/// Cut a vendor string at its first NUL — TIFF ASCII fields are
+/// NUL-terminated and vendors pad them — then collapse every run of
+/// whitespace to one space and trim the ends.
+fn collapse(s: &str) -> String {
+    let s = match s.find('\0') {
+        Some(end) => &s[..end],
+        None => s,
+    };
+    let mut out = String::with_capacity(s.len());
+    for word in s.split_whitespace() {
+        if !out.is_empty() {
+            out.push(' ');
+        }
+        out.push_str(word);
+    }
+    out
+}
+
+/// A token's comparison key: uppercase, without the `.` and `,` that
+/// vendors sprinkle through their legal names.
+fn token_key(token: &str) -> String {
+    token
+        .chars()
+        .filter(|c| *c != '.' && *c != ',')
+        .flat_map(char::to_uppercase)
+        .collect()
+}
+
+/// Drop trailing corporate-form tokens, keeping at least one.
+fn strip_company_suffixes(make: &str) -> String {
+    let mut tokens: Vec<&str> = make.split(' ').filter(|t| !t.is_empty()).collect();
+    while tokens.len() > 1 {
+        let last = token_key(tokens[tokens.len() - 1]);
+        if COMPANY_SUFFIXES.contains(&last.as_str()) {
+            tokens.pop();
+        } else {
+            break;
+        }
+    }
+    // A lone token can still end in the punctuation the suffixes carried.
+    tokens.join(" ").trim_end_matches([',', '.']).to_string()
+}
+
+/// The canonical spelling of a make, or `None` if this crate has never
+/// heard of it.
+fn canonical_make(stripped: &str) -> Option<&'static str> {
+    let key: String = stripped.to_uppercase();
+    MAKE_ALIASES
+        .iter()
+        .find(|(alias, _)| *alias == key)
+        .map(|(_, canonical)| *canonical)
+}
+
+/// Whether `model`'s leading tokens are exactly `prefix`'s.
+fn starts_with_tokens(model: &[&str], prefix: &str) -> Option<usize> {
+    let wanted: Vec<&str> = prefix.split(' ').collect();
+    if model.len() <= wanted.len() {
+        // Never strip a model down to nothing: a file whose Model is
+        // just the make ("DJI"/"DJI") keeps its model.
+        return None;
+    }
+    wanted
+        .iter()
+        .zip(model)
+        .all(|(w, m)| token_key(m) == *w)
+        .then_some(wanted.len())
+}
+
+/// Canonical make and model for table lookup: the vendor's long-form
+/// make collapsed ("NIKON CORPORATION" → "Nikon", "OLYMPUS IMAGING
+/// CORP." → "Olympus", "SONY" → "Sony"...), the make stripped from
+/// the front of the model where vendors repeat it ("NIKON D3300" →
+/// "D3300", "Canon EOS 450D" → "EOS 450D"), whitespace collapsed.
+///
+/// The rules, in order, all of them case-insensitive and none of them
+/// depending on anything but the two strings:
+///
+/// 1. Both strings are cut at their first NUL and have runs of
+///    whitespace collapsed to single spaces.
+/// 2. Trailing corporate-form tokens come off the make
+///    (`COMPANY_SUFFIXES`), then it goes through `MAKE_ALIASES`. A
+///    make this crate does not know keeps its own spelling, minus the
+///    suffixes and any trailing comma or full stop, because there is
+///    nothing to canonicalise it to.
+/// 3. An empty make is guessed from the front of the model, so the
+///    CIFF and other headerless containers that carry only
+///    "Canon PowerShot A620" still land under `Canon`.
+/// 4. Ricoh bought Pentax and ships both under one Make string:
+///    `RICOH IMAGING COMPANY, LTD.` with a model starting `PENTAX` is
+///    a Pentax body, anything else from that make is a Ricoh.
+/// 5. Vendor quirks in the model: Leaf packs a serial and a back type
+///    into it (`Leaf Aptus 75(LI400146   )/Large Format`) and
+///    Hasselblad a shutter mode (`CFV 100C/Electronic Shutter`), so
+///    those two makes' models are cut at the first `(` and `/`.
+///    Kodak's end in `Digital Camera`/`Zoom Camera`, which comes off.
+/// 6. Leading tokens repeating the make come off the model
+///    (`MODEL_PREFIXES`), repeatedly, never leaving it empty.
+///
+/// What it deliberately does *not* do is rename models. `E-M1MarkII`
+/// does not become `E-M1 Mark II`, `E8800` does not become
+/// `COOLPIX 8800`, `MAXXUM 7D` does not become `DYNAX 7D`: every such
+/// mapping is a fact about a particular camera rather than a rule, the
+/// table is keyed on the string the file actually carries, and a
+/// regional twin like the EOS 1300D/Rebel T6/Kiss X80 gets one table
+/// entry per name it ships under.
+pub fn normalize(make: &str, model: &str) -> (String, String) {
+    let make = collapse(make);
+    let mut model = collapse(model);
+
+    let stripped = strip_company_suffixes(&make);
+    let mut clean_make = match canonical_make(&stripped) {
+        Some(canonical) => canonical.to_string(),
+        None => stripped,
+    };
+
+    // A make-less file: the model usually still leads with the brand.
+    if clean_make.is_empty() {
+        let tokens: Vec<&str> = model.split(' ').filter(|t| !t.is_empty()).collect();
+        for take in (1..=tokens.len().min(3)).rev() {
+            if let Some(canonical) = canonical_make(&tokens[..take].join(" ")) {
+                clean_make = canonical.to_string();
+                break;
+            }
+        }
+    }
+
+    // Pentax bodies still say PENTAX in the model under Ricoh's make.
+    if clean_make == "Ricoh" && starts_with_tokens(&split(&model), "PENTAX").is_some() {
+        clean_make = "Pentax".to_string();
+    } else if clean_make == "Pentax" && starts_with_tokens(&split(&model), "RICOH").is_some() {
+        clean_make = "Ricoh".to_string();
+    }
+
+    match clean_make.as_str() {
+        "Leaf" => {
+            model = model.split(['(', '/']).next().unwrap_or(&model).to_string();
+        }
+        "Hasselblad" => {
+            model = model.split('/').next().unwrap_or(&model).to_string();
+        }
+        "Kodak" => {
+            for tail in [" Digital Camera", " Zoom Camera"] {
+                if model.len() > tail.len() && model.to_uppercase().ends_with(&tail.to_uppercase())
+                {
+                    model.truncate(model.len() - tail.len());
+                }
+            }
+        }
+        _ => {}
+    }
+    let mut model = collapse(&model);
+
+    if let Some((_, prefixes)) = MODEL_PREFIXES.iter().find(|(m, _)| *m == clean_make) {
+        loop {
+            let tokens = split(&model);
+            // Longest prefix first, so "KONICA MINOLTA" wins over "MINOLTA".
+            let hit = prefixes
+                .iter()
+                .filter_map(|p| starts_with_tokens(&tokens, p))
+                .max();
+            match hit {
+                Some(n) => model = tokens[n..].join(" "),
+                None => break,
+            }
+        }
+    }
+
+    (clean_make, model)
+}
+
+fn split(s: &str) -> Vec<&str> {
+    s.split(' ').filter(|t| !t.is_empty()).collect()
+}
+
+// --------------------------------------------------------------- lookup
+
+/// ASCII-case-insensitive ordering, the key [`CAMERAS`] is sorted by.
+fn ci_cmp(a: &str, b: &str) -> Ordering {
+    let mut left = a.bytes().map(|b| b.to_ascii_lowercase());
+    let mut right = b.bytes().map(|b| b.to_ascii_lowercase());
+    loop {
+        match (left.next(), right.next()) {
+            (None, None) => return Ordering::Equal,
+            (None, Some(_)) => return Ordering::Less,
+            (Some(_), None) => return Ordering::Greater,
+            (Some(x), Some(y)) if x == y => continue,
+            (Some(x), Some(y)) => return x.cmp(&y),
+        }
+    }
+}
+
+fn find(make: &str, model: &str) -> Option<&'static Camera> {
+    CAMERAS
+        .binary_search_by(|c| ci_cmp(c.make, make).then_with(|| ci_cmp(c.model, model)))
+        .ok()
+        .map(|i| &CAMERAS[i])
+}
+
+/// Look a camera up by normalised make and model.
+///
+/// Both are compared case-insensitively, so a decoder that hands over
+/// what the file said (`dp2 Quattro` where the table says
+/// `DP2 Quattro`) still finds its camera. Olympus and OM System share
+/// one namespace; see [`MAKE_ALIASES`].
+pub fn lookup(clean_make: &str, clean_model: &str) -> Option<&'static Camera> {
+    if let Some(camera) = find(clean_make, clean_model) {
+        return Some(camera);
+    }
+    let sibling = if clean_make.eq_ignore_ascii_case("Olympus") {
+        "OM System"
+    } else if clean_make.eq_ignore_ascii_case("OM System") {
+        "Olympus"
+    } else {
+        return None;
+    };
+    find(sibling, clean_model)
+}
+
+/// Every camera in the table.
+pub fn all() -> &'static [Camera] {
+    CAMERAS
+}
+
+// ----------------------------------------------------------- the table
+
+/// Every camera this crate has calibration for, sorted by (make,
+/// model) under [`ci_cmp`] so [`find`] can binary search it.
+// These are measured sensor coefficients; that one of them lands on
+// pi/6 to four places is a coincidence, not a constant.
+#[allow(clippy::approx_constant)]
+static CAMERAS: &[Camera] = &[
+    // source: ColorMatrix2 (D65) of IMG_1361.DNG, a real DNG for this body
+    // (raw.pixls.us). Exact, not recalled.
+    Camera {
+        make: "Apple",
+        model: "iPhone 12 Pro",
+        color_matrix: [
+            [0.914543, -0.322228, -0.126225],
+            [-0.428868, 1.309541, 0.094676],
+            [-0.106292, 0.235045, 0.430733],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of iPhone_6s_Plus-IMG_0853.DNG, a real
+    // DNG for this body (raw.pixls.us). Exact, not recalled.
+    Camera {
+        make: "Apple",
+        model: "iPhone 6s Plus",
+        color_matrix: [
+            [0.709328, -0.227577, -0.021302],
+            [-0.605197, 1.248974, 0.30108],
+            [-0.112681, 0.131703, 0.58865],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware ProCamera 10.2. Exact, not recalled.
+    Camera {
+        make: "Apple",
+        model: "iPhone 7 Plus",
+        color_matrix: [
+            [0.704868, -0.221958, -0.06626],
+            [-0.463425, 1.218776, 0.2053],
+            [-0.087825, 0.130628, 0.543115],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of
+    // iPhone_8-RAW_2018_11_07_14_43_14_820_noflash.dng, a real DNG for
+    // this body (raw.pixls.us). Exact, not recalled.
+    Camera {
+        make: "Apple",
+        model: "iPhone 8",
+        color_matrix: [
+            [0.829948, -0.273887, -0.097103],
+            [-0.572908, 1.363504, 0.170901],
+            [-0.086339, 0.136364, 0.536422],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of
+    // iPhone_SE-A4973FFB-9CBD-4ED8-805D-E30F4AE08A95.dng, a real DNG for
+    // this body (raw.pixls.us). Exact, not recalled. The 2016 SE
+    // (iPhone8,4) shares the 6s Plus's calibration to the last digit;
+    // Apple ships one profile for the sensor, not one per body.
+    Camera {
+        make: "Apple",
+        model: "iPhone SE",
+        color_matrix: [
+            [0.709328, -0.227577, -0.021302],
+            [-0.605197, 1.248974, 0.30108],
+            [-0.112681, 0.131703, 0.58865],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware ProCamera 12.4. Exact, not recalled.
+    Camera {
+        make: "Apple",
+        model: "iPhone XS",
+        color_matrix: [
+            [0.736833, -0.217277, -0.087254],
+            [-0.460324, 1.224908, 0.197411],
+            [-0.082088, 0.136331, 0.473013],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-1000d: at 6504 K
+    // they want R 2.41 B 1.32, this matrix implies R 2.57 B 1.29
+    // (+7%/-3%).
+    Camera {
+        make: "Canon",
+        model: "EOS 1000D",
+        color_matrix: [
+            [0.6771, -0.1139, -0.0977],
+            [-0.7818, 1.5123, 0.2928],
+            [-0.1244, 0.1437, 0.7533],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-100d: at 6504 K they
+    // want R 2.26 B 1.36, this matrix implies R 2.42 B 1.36 (+7%/+0%).
+    // This is the EOS 650D under the name its own files use; the check
+    // above is on a EOS 100D sample, not the EOS 650D's.
+    Camera {
+        make: "Canon",
+        model: "EOS 100D",
+        color_matrix: [
+            [0.6602, -0.0841, -0.0939],
+            [-0.4472, 1.2458, 0.2247],
+            [-0.0975, 0.2039, 0.6148],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Canon",
+        model: "EOS 10D",
+        color_matrix: [
+            [0.8197, -0.2, -0.1118],
+            [-0.6714, 1.4335, 0.2592],
+            [-0.2536, 0.3178, 0.8266],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-200d: at 6504 K they
+    // want R 1.99 B 1.48, this matrix implies R 2.08 B 1.43 (+5%/-4%).
+    Camera {
+        make: "Canon",
+        model: "EOS 200D",
+        color_matrix: [
+            [0.7377, -0.0742, -0.0998],
+            [-0.4676, 1.241, 0.2578],
+            [-0.1279, 0.2597, 0.567],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in EOS_20D-IMG_3893.CR2: at
+    // 6504 K they want R 2.18 B 1.31, this matrix implies R 2.26 B 1.27
+    // (+4%/-3%).
+    Camera {
+        make: "Canon",
+        model: "EOS 20D",
+        color_matrix: [
+            [0.6599, -0.0537, -0.0891],
+            [-0.8071, 1.5783, 0.2424],
+            [-0.1983, 0.2234, 0.7462],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-30d: at 6504 K they
+    // want R 2.29 B 1.32, this matrix implies R 2.36 B 1.35 (+3%/+2%).
+    Camera {
+        make: "Canon",
+        model: "EOS 30D",
+        color_matrix: [
+            [0.6257, -0.0303, -0.1],
+            [-0.788, 1.5621, 0.2396],
+            [-0.1714, 0.1904, 0.7046],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in EOS_350D-IMG_1707.CR2: at
+    // 6504 K they want R 2.50 B 1.27, this matrix implies R 2.69 B 1.27
+    // (+8%/+0%).
+    Camera {
+        make: "Canon",
+        model: "EOS 350D DIGITAL",
+        color_matrix: [
+            [0.6018, -0.0617, -0.0965],
+            [-0.8645, 1.5881, 0.2975],
+            [-0.153, 0.1719, 0.7642],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-400d: at 6504 K they
+    // want R 2.58 B 1.27, this matrix implies R 2.63 B 1.25 (+2%/-1%).
+    Camera {
+        make: "Canon",
+        model: "EOS 400D DIGITAL",
+        color_matrix: [
+            [0.7054, -0.1501, -0.099],
+            [-0.8156, 1.5544, 0.2812],
+            [-0.1278, 0.1414, 0.7796],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in EOS_40D-_MG_0153.CR2: at
+    // 6504 K they want R 2.46 B 1.28, this matrix implies R 2.63 B 1.25
+    // (+7%/-2%).
+    Camera {
+        make: "Canon",
+        model: "EOS 40D",
+        color_matrix: [
+            [0.6071, -0.0747, -0.0856],
+            [-0.7653, 1.5365, 0.2441],
+            [-0.2025, 0.2553, 0.7315],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in _MG_7191.CR2: at 6504 K
+    // they want R 2.42 B 1.22, this matrix implies R 2.49 B 1.22
+    // (+3%/-0%).
+    Camera {
+        make: "Canon",
+        model: "EOS 450D",
+        color_matrix: [
+            [0.5784, -0.0262, -0.0821],
+            [-0.7539, 1.5064, 0.2672],
+            [-0.1982, 0.2681, 0.7427],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-500d: at 6504 K they
+    // want R 2.29 B 1.27, this matrix implies R 2.38 B 1.26 (+4%/-1%).
+    Camera {
+        make: "Canon",
+        model: "EOS 500D",
+        color_matrix: [
+            [0.4763, 0.0712, -0.0646],
+            [-0.6821, 1.4399, 0.264],
+            [-0.1921, 0.3276, 0.6561],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in EOS_50D-IMG_9516.CR2: at
+    // 6504 K they want R 2.28 B 1.20, this matrix implies R 2.33 B 1.19
+    // (+2%/-1%).
+    Camera {
+        make: "Canon",
+        model: "EOS 50D",
+        color_matrix: [
+            [0.492, 0.0616, -0.0593],
+            [-0.6493, 1.3964, 0.2784],
+            [-0.1774, 0.3178, 0.7005],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in EOS_550D-IMG_4047.CR2: at
+    // 6504 K they want R 2.38 B 1.36, this matrix implies R 2.38 B 1.39
+    // (+0%/+2%).
+    Camera {
+        make: "Canon",
+        model: "EOS 550D",
+        color_matrix: [
+            [0.6941, -0.1164, -0.0857],
+            [-0.3825, 1.1597, 0.2534],
+            [-0.0416, 0.154, 0.6039],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-5d2: at 6504 K they
+    // want R 2.49 B 1.43, this matrix implies R 2.57 B 1.39 (+3%/-3%).
+    Camera {
+        make: "Canon",
+        model: "EOS 5D Mark II",
+        color_matrix: [
+            [0.4716, 0.0603, -0.083],
+            [-0.7798, 1.5474, 0.248],
+            [-0.1496, 0.1937, 0.6651],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written by MLVFS. Exact, not recalled. Its own white-balance presets
+    // want R 2.23 B 1.40 at 6504 K against this matrix's R 2.25 B 1.42
+    // (+1%/+2%).
+    Camera {
+        make: "Canon",
+        model: "EOS 5D Mark III",
+        color_matrix: [
+            [0.6722, -0.0635, -0.0963],
+            [-0.4287, 1.246, 0.2028],
+            [-0.0908, 0.2162, 0.5668],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-5d4: at 6504 K they
+    // want R 2.18 B 1.29, this matrix implies R 2.22 B 1.26 (+2%/-2%).
+    Camera {
+        make: "Canon",
+        model: "EOS 5D Mark IV",
+        color_matrix: [
+            [0.6446, -0.0366, -0.0864],
+            [-0.4436, 1.2204, 0.2513],
+            [-0.0952, 0.2496, 0.6348],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-5dsr: at 6504 K they
+    // want R 2.50 B 1.51, this matrix implies R 2.48 B 1.51 (-1%/+0%).
+    Camera {
+        make: "Canon",
+        model: "EOS 5DS R",
+        color_matrix: [
+            [0.625, -0.0711, -0.0808],
+            [-0.5153, 1.2794, 0.2636],
+            [-0.1249, 0.2198, 0.561],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-600d: at 6504 K they
+    // want R 2.37 B 1.38, this matrix implies R 2.50 B 1.40 (+5%/+2%).
+    Camera {
+        make: "Canon",
+        model: "EOS 600D",
+        color_matrix: [
+            [0.6461, -0.0907, -0.0882],
+            [-0.43, 1.2184, 0.2378],
+            [-0.0819, 0.1944, 0.5931],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written by MLV App. Exact, not recalled. Its own white-balance
+    // presets want R 2.40 B 1.35 at 6504 K against this matrix's R 2.43 B
+    // 1.35 (+1%/-0%). Also a digit-for-digit match with the recalled
+    // value.
+    Camera {
+        make: "Canon",
+        model: "EOS 60D",
+        color_matrix: [
+            [0.6719, -0.0994, -0.0925],
+            [-0.4408, 1.2426, 0.2211],
+            [-0.0887, 0.2129, 0.6051],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-650d: at 6504 K they
+    // want R 2.30 B 1.44, this matrix implies R 2.42 B 1.36 (+5%/-5%).
+    Camera {
+        make: "Canon",
+        model: "EOS 650D",
+        color_matrix: [
+            [0.6602, -0.0841, -0.0939],
+            [-0.4472, 1.2458, 0.2247],
+            [-0.0975, 0.2039, 0.6148],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-6d: at 6504 K they
+    // want R 2.14 B 1.48, this matrix implies R 2.22 B 1.42 (+4%/-4%).
+    Camera {
+        make: "Canon",
+        model: "EOS 6D",
+        color_matrix: [
+            [0.7034, -0.0804, -0.1014],
+            [-0.442, 1.2564, 0.2058],
+            [-0.0851, 0.1994, 0.5758],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-6d2: at 6504 K they
+    // want R 2.35 B 1.45, this matrix implies R 2.36 B 1.44 (+0%/-1%).
+    Camera {
+        make: "Canon",
+        model: "EOS 6D Mark II",
+        color_matrix: [
+            [0.6875, -0.097, -0.0932],
+            [-0.4691, 1.2459, 0.2501],
+            [-0.0874, 0.1953, 0.5809],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-700d: at 6504 K they
+    // want R 2.24 B 1.31, this matrix implies R 2.42 B 1.36 (+8%/+4%).
+    // This is the EOS 650D under the name its own files use; the check
+    // above is on a EOS 700D sample, not the EOS 650D's.
+    Camera {
+        make: "Canon",
+        model: "EOS 700D",
+        color_matrix: [
+            [0.6602, -0.0841, -0.0939],
+            [-0.4472, 1.2458, 0.2247],
+            [-0.0975, 0.2039, 0.6148],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-750d: at 6504 K they
+    // want R 2.39 B 1.49, this matrix implies R 2.50 B 1.48 (+5%/-1%).
+    Camera {
+        make: "Canon",
+        model: "EOS 750D",
+        color_matrix: [
+            [0.6362, -0.0823, -0.0847],
+            [-0.4426, 1.2109, 0.2616],
+            [-0.0743, 0.1857, 0.5635],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-7d: at 6504 K they
+    // want R 2.38 B 1.31, this matrix implies R 2.33 B 1.34 (-2%/+3%).
+    Camera {
+        make: "Canon",
+        model: "EOS 7D",
+        color_matrix: [
+            [0.6844, -0.0996, -0.0856],
+            [-0.3876, 1.1761, 0.2396],
+            [-0.0593, 0.1772, 0.6198],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written by Adobe Photoshop Lightroom Classic 13.0.1 (Windows).
+    // Exact, not recalled. Its own white-balance presets want R 2.16 B
+    // 1.47 at 6504 K against this matrix's R 2.26 B 1.42 (+4%/-4%). Also a
+    // digit-for-digit match with the recalled value.
+    Camera {
+        make: "Canon",
+        model: "EOS 7D Mark II",
+        color_matrix: [
+            [0.7268, -0.1082, -0.0969],
+            [-0.4186, 1.1839, 0.2663],
+            [-0.0825, 0.2029, 0.5839],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-800d: at 6504 K they
+    // want R 2.07 B 1.46, this matrix implies R 2.08 B 1.43 (+1%/-2%).
+    // This is the EOS 200D under the name its own files use; the check
+    // above is on a EOS 800D sample, not the EOS 200D's.
+    Camera {
+        make: "Canon",
+        model: "EOS 800D",
+        color_matrix: [
+            [0.7377, -0.0742, -0.0998],
+            [-0.4676, 1.241, 0.2578],
+            [-0.1279, 0.2597, 0.567],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-80d: at 6504 K they
+    // want R 2.02 B 1.52, this matrix implies R 1.99 B 1.50 (-1%/-2%).
+    Camera {
+        make: "Canon",
+        model: "EOS 80D",
+        color_matrix: [
+            [0.7457, -0.0671, -0.0937],
+            [-0.4849, 1.2495, 0.2643],
+            [-0.1213, 0.2354, 0.5492],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in EOS_90D-RAW-ISO-100.CR3:
+    // at 6504 K they want R 1.98 B 1.37, this matrix implies R 1.94 B 1.39
+    // (-2%/+1%).
+    Camera {
+        make: "Canon",
+        model: "EOS 90D",
+        color_matrix: [
+            [1.1498, -0.3759, -0.1516],
+            [-0.5073, 1.2954, 0.2349],
+            [-0.0892, 0.1867, 0.6118],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Canon",
+        model: "EOS D60",
+        color_matrix: [
+            [0.6188, -0.1341, -0.089],
+            [-0.7168, 1.5481, 0.1699],
+            [-0.1717, 0.2151, 0.7043],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: the EOS 1000D entry above. Same sensor and colour filter
+    // array, sold under this name; Adobe calibrates the pair together.
+    // Nothing in a EOS DIGITAL REBEL XS file was used to check it.
+    Camera {
+        make: "Canon",
+        model: "EOS DIGITAL REBEL XS",
+        color_matrix: [
+            [0.6771, -0.1139, -0.0977],
+            [-0.7818, 1.5123, 0.2928],
+            [-0.1244, 0.1437, 0.7533],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-xsi: at 6504 K they
+    // want R 2.44 B 1.26, this matrix implies R 2.49 B 1.22 (+2%/-3%).
+    // This is the EOS 450D under the name its own files use; the check
+    // above is on a EOS DIGITAL REBEL XSi sample, not the EOS 450D's.
+    Camera {
+        make: "Canon",
+        model: "EOS DIGITAL REBEL XSi",
+        color_matrix: [
+            [0.5784, -0.0262, -0.0821],
+            [-0.7539, 1.5064, 0.2672],
+            [-0.1982, 0.2681, 0.7427],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-kissx4: at 6504 K
+    // they want R 2.42 B 1.35, this matrix implies R 2.38 B 1.39
+    // (-2%/+3%). This is the EOS 550D under the name its own files use;
+    // the check above is on a EOS Kiss X4 sample, not the EOS 550D's.
+    Camera {
+        make: "Canon",
+        model: "EOS Kiss X4",
+        color_matrix: [
+            [0.6941, -0.1164, -0.0857],
+            [-0.3825, 1.1597, 0.2534],
+            [-0.0416, 0.154, 0.6039],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. This is the EOS 200D
+    // under the name its own files carry; the matrix was cross-checked on
+    // a EOS 200D sample (canon-200d), not on one of these.
+    Camera {
+        make: "Canon",
+        model: "EOS Kiss X9",
+        color_matrix: [
+            [0.7377, -0.0742, -0.0998],
+            [-0.4676, 1.241, 0.2578],
+            [-0.1279, 0.2597, 0.567],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in EOS_M2-m2_test_02.cr2: at
+    // 6504 K they want R 2.21 B 1.43, this matrix implies R 2.29 B 1.32
+    // (+4%/-7%).
+    Camera {
+        make: "Canon",
+        model: "EOS M2",
+        color_matrix: [
+            [0.64, -0.048, -0.0888],
+            [-0.5294, 1.3416, 0.2047],
+            [-0.1116, 0.2511, 0.6032],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-r6: at 6504 K they
+    // want R 2.06 B 1.39, this matrix implies R 2.12 B 1.35 (+3%/-3%).
+    Camera {
+        make: "Canon",
+        model: "EOS R6",
+        color_matrix: [
+            [0.8293, -0.1611, -0.1132],
+            [-0.4759, 1.2711, 0.2275],
+            [-0.1013, 0.2415, 0.5915],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. This is the EOS 100D
+    // under the name its own files carry; the matrix was cross-checked on
+    // a EOS 100D sample (canon-100d), not on one of these.
+    Camera {
+        make: "Canon",
+        model: "EOS Rebel SL1",
+        color_matrix: [
+            [0.6602, -0.0841, -0.0939],
+            [-0.4472, 1.2458, 0.2247],
+            [-0.0975, 0.2039, 0.6148],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. This is the EOS 200D
+    // under the name its own files carry; the matrix was cross-checked on
+    // a EOS 200D sample (canon-200d), not on one of these.
+    Camera {
+        make: "Canon",
+        model: "EOS Rebel SL2",
+        color_matrix: [
+            [0.7377, -0.0742, -0.0998],
+            [-0.4676, 1.241, 0.2578],
+            [-0.1279, 0.2597, 0.567],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-t1i: at 6504 K they
+    // want R 2.26 B 1.23, this matrix implies R 2.38 B 1.26 (+5%/+2%).
+    // This is the EOS 500D under the name its own files use; the check
+    // above is on a EOS REBEL T1i sample, not the EOS 500D's.
+    Camera {
+        make: "Canon",
+        model: "EOS REBEL T1i",
+        color_matrix: [
+            [0.4763, 0.0712, -0.0646],
+            [-0.6821, 1.4399, 0.264],
+            [-0.1921, 0.3276, 0.6561],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-t2i: at 6504 K they
+    // want R 2.43 B 1.37, this matrix implies R 2.38 B 1.39 (-2%/+2%).
+    // This is the EOS 550D under the name its own files use; the check
+    // above is on a EOS REBEL T2i sample, not the EOS 550D's.
+    Camera {
+        make: "Canon",
+        model: "EOS REBEL T2i",
+        color_matrix: [
+            [0.6941, -0.1164, -0.0857],
+            [-0.3825, 1.1597, 0.2534],
+            [-0.0416, 0.154, 0.6039],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-t3i: at 6504 K they
+    // want R 2.37 B 1.35, this matrix implies R 2.50 B 1.40 (+6%/+4%).
+    // This is the EOS 600D under the name its own files use; the check
+    // above is on a EOS REBEL T3i sample, not the EOS 600D's.
+    Camera {
+        make: "Canon",
+        model: "EOS REBEL T3i",
+        color_matrix: [
+            [0.6461, -0.0907, -0.0882],
+            [-0.43, 1.2184, 0.2378],
+            [-0.0819, 0.1944, 0.5931],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-t4i: at 6504 K they
+    // want R 2.26 B 1.38, this matrix implies R 2.42 B 1.36 (+7%/-1%).
+    // This is the EOS 650D under the name its own files use; the check
+    // above is on a EOS REBEL T4i sample, not the EOS 650D's.
+    Camera {
+        make: "Canon",
+        model: "EOS REBEL T4i",
+        color_matrix: [
+            [0.6602, -0.0841, -0.0939],
+            [-0.4472, 1.2458, 0.2247],
+            [-0.0975, 0.2039, 0.6148],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. This is the EOS 750D
+    // under the name its own files carry; the matrix was cross-checked on
+    // a EOS 750D sample (canon-750d), not on one of these.
+    Camera {
+        make: "Canon",
+        model: "EOS Rebel T6i",
+        color_matrix: [
+            [0.6362, -0.0823, -0.0847],
+            [-0.4426, 1.2109, 0.2616],
+            [-0.0743, 0.1857, 0.5635],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. This is the EOS 800D
+    // under the name its own files carry; the matrix was cross-checked on
+    // a EOS 800D sample (canon-800d), not on one of these.
+    Camera {
+        make: "Canon",
+        model: "EOS REBEL T7i",
+        color_matrix: [
+            [0.7377, -0.0742, -0.0998],
+            [-0.4676, 1.241, 0.2578],
+            [-0.1279, 0.2597, 0.567],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in
+    // EOS-1D_Mark_II_N-RY5Q8391.CR2: at 6504 K they want R 2.32 B 1.14,
+    // this matrix implies R 2.40 B 1.21 (+4%/+6%).
+    Camera {
+        make: "Canon",
+        model: "EOS-1D Mark II N",
+        color_matrix: [
+            [0.6612, -0.0841, -0.0889],
+            [-0.8188, 1.5606, 0.2686],
+            [-0.193, 0.257, 0.7472],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in canon-1d4: at 6504 K they
+    // want R 2.28 B 1.40, this matrix implies R 2.31 B 1.41 (+1%/+1%).
+    Camera {
+        make: "Canon",
+        model: "EOS-1D Mark IV",
+        color_matrix: [
+            [0.6014, -0.022, -0.0795],
+            [-0.4109, 1.2014, 0.2361],
+            [-0.0561, 0.1824, 0.5787],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written by Topaz Photo AI 1.3.4. Exact, not recalled. Also a
+    // digit-for-digit match with the recalled value.
+    Camera {
+        make: "Canon",
+        model: "EOS-1D X",
+        color_matrix: [
+            [0.6847, -0.0614, -0.1014],
+            [-0.4669, 1.2737, 0.2139],
+            [-0.1197, 0.2488, 0.6846],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in
+    // EOS-1Ds_Mark_III-RAW_CANON_1DSM3.CR2: at 6504 K they want R 2.34 B
+    // 1.29, this matrix implies R 2.47 B 1.29 (+5%/-1%).
+    Camera {
+        make: "Canon",
+        model: "EOS-1Ds Mark III",
+        color_matrix: [
+            [0.5859, -0.0211, -0.093],
+            [-0.8255, 1.6017, 0.2353],
+            [-0.1732, 0.1887, 0.7448],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in
+    // PowerShot_G11-IMG_3310.CR2: at 6504 K they want R 1.79 B 1.94, this
+    // matrix implies R 1.89 B 1.88 (+6%/-3%).
+    Camera {
+        make: "Canon",
+        model: "PowerShot G11",
+        color_matrix: [
+            [1.2177, -0.4817, -0.1069],
+            [-0.1612, 0.9864, 0.2049],
+            [-0.0098, 0.085, 0.4471],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of FC6310-DJI_0220.DNG, a real DNG for
+    // this body (raw.pixls.us). Exact, not recalled. FC6310 is the camera
+    // in the Phantom 4 Pro; the model field carries the gimbal's part
+    // number, not a marketing name.
+    Camera {
+        make: "DJI",
+        model: "FC6310",
+        color_matrix: [
+            [0.7122, -0.2108, -0.0512],
+            [-0.3155, 1.1201, 0.2231],
+            [-0.0541, 0.1423, 0.5045],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of DJI_Osmo_Action-DJI_0254.DNG, a real
+    // DNG for this body (raw.pixls.us). Exact, not recalled.
+    Camera {
+        make: "DJI",
+        model: "Osmo Action",
+        color_matrix: [
+            [0.8257, -0.2417, -0.1016],
+            [-0.4478, 1.3209, 0.1344],
+            [-0.064, 0.1694, 0.5385],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Epson",
+        model: "R-D1",
+        color_matrix: [
+            [0.6827, -0.1878, -0.0732],
+            [-0.8429, 1.6012, 0.2564],
+            [-0.1701, 0.1804, 0.669],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: the R-D1 entry above. Same sensor and colour filter array,
+    // sold under this name; Adobe calibrates the pair together. Nothing in
+    // a R-D1x file was used to check it.
+    Camera {
+        make: "Epson",
+        model: "R-D1x",
+        color_matrix: [
+            [0.6827, -0.1878, -0.0732],
+            [-0.8429, 1.6012, 0.2564],
+            [-0.1701, 0.1804, 0.669],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // its one named daylight preset in
+    // GFX100S-Fujifilm-GFX100S-14bits-compress-4_3.RAF: at 6504 K they
+    // want R 1.93 B 1.64, this matrix implies R 2.01 B 1.45 (+4%/-12%). A
+    // single preset carried to 6504 K, so this is a coarser check than
+    // most here.
+    Camera {
+        make: "Fujifilm",
+        model: "GFX100S",
+        color_matrix: [
+            [1.6212, -0.8423, -0.1583],
+            [-0.4336, 1.2583, 0.1937],
+            [-0.0195, 0.0726, 0.6199],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // its one named daylight preset in X-A5-DSCF0617.RAF: at 6504 K they
+    // want R 2.17 B 1.62, this matrix implies R 2.04 B 1.57 (-6%/-3%). A
+    // single preset carried to 6504 K, so this is a coarser check than
+    // most here.
+    Camera {
+        make: "Fujifilm",
+        model: "X-A5",
+        color_matrix: [
+            [1.1673, -0.476, -0.1041],
+            [-0.3988, 1.2058, 0.2166],
+            [-0.0771, 0.1417, 0.5569],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // its one named daylight preset in X-E2S-_DSF0540.RAF: at 6504 K they
+    // want R 2.14 B 1.32, this matrix implies R 2.30 B 1.33 (+8%/+1%). A
+    // single preset carried to 6504 K, so this is a coarser check than
+    // most here. This is the X-T1 under the name its own files use; the
+    // check above is on a X-E2S sample, not the X-T1's.
+    Camera {
+        make: "Fujifilm",
+        model: "X-E2S",
+        color_matrix: [
+            [0.8458, -0.2451, -0.0855],
+            [-0.4597, 1.2447, 0.2407],
+            [-0.1475, 0.2482, 0.6413],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // its one named daylight preset in X-Pro3-_DSF2384.RAF: at 6504 K they
+    // want R 2.09 B 1.60, this matrix implies R 2.08 B 1.47 (-1%/-8%). A
+    // single preset carried to 6504 K, so this is a coarser check than
+    // most here. This is the X-T3 under the name its own files use; the
+    // check above is on a X-Pro3 sample, not the X-T3's.
+    Camera {
+        make: "Fujifilm",
+        model: "X-Pro3",
+        color_matrix: [
+            [1.3426, -0.6334, -0.1177],
+            [-0.4244, 1.2136, 0.2371],
+            [-0.058, 0.1303, 0.598],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // its one named daylight preset in 20171229_110916.RAF: at 6504 K they
+    // want R 2.19 B 1.40, this matrix implies R 2.30 B 1.33 (+5%/-5%). A
+    // single preset carried to 6504 K, so this is a coarser check than
+    // most here.
+    Camera {
+        make: "Fujifilm",
+        model: "X-T1",
+        color_matrix: [
+            [0.8458, -0.2451, -0.0855],
+            [-0.4597, 1.2447, 0.2407],
+            [-0.1475, 0.2482, 0.6413],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // its one named daylight preset in X-T10-DSCF8146.RAF: at 6504 K they
+    // want R 2.05 B 1.38, this matrix implies R 2.30 B 1.33 (+12%/-4%). A
+    // single preset carried to 6504 K, so this is a coarser check than
+    // most here. This is the X-T1 under the name its own files use; the
+    // check above is on a X-T10 sample, not the X-T1's.
+    Camera {
+        make: "Fujifilm",
+        model: "X-T10",
+        color_matrix: [
+            [0.8458, -0.2451, -0.0855],
+            [-0.4597, 1.2447, 0.2407],
+            [-0.1475, 0.2482, 0.6413],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // its one named daylight preset in fuji-xt2: at 6504 K they want R
+    // 2.11 B 1.62, this matrix implies R 2.29 B 1.61 (+9%/-0%). A single
+    // preset carried to 6504 K, so this is a coarser check than most here.
+    Camera {
+        make: "Fujifilm",
+        model: "X-T2",
+        color_matrix: [
+            [1.1434, -0.4948, -0.121],
+            [-0.3746, 1.2042, 0.1903],
+            [-0.0666, 0.1479, 0.5235],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // its one named daylight preset in X-T3-AFXT2720.RAF: at 6504 K they
+    // want R 2.05 B 1.60, this matrix implies R 2.08 B 1.47 (+1%/-8%). A
+    // single preset carried to 6504 K, so this is a coarser check than
+    // most here.
+    Camera {
+        make: "Fujifilm",
+        model: "X-T3",
+        color_matrix: [
+            [1.3426, -0.6334, -0.1177],
+            [-0.4244, 1.2136, 0.2371],
+            [-0.058, 0.1303, 0.598],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // its one named daylight preset in
+    // X100F-DSCF5760_x100f_lossless_compressed_raw_Temple.RAF: at 6504 K
+    // they want R 2.25 B 1.66, this matrix implies R 2.29 B 1.61
+    // (+2%/-3%). A single preset carried to 6504 K, so this is a coarser
+    // check than most here. This is the X-T2 under the name its own files
+    // use; the check above is on a X100F sample, not the X-T2's.
+    Camera {
+        make: "Fujifilm",
+        model: "X100F",
+        color_matrix: [
+            [1.1434, -0.4948, -0.121],
+            [-0.3746, 1.2042, 0.1903],
+            [-0.0666, 0.1479, 0.5235],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written by Adobe DNG Converter 10.3 (Windows). Exact, not recalled.
+    // Its own white-balance presets want R 2.18 B 1.29 at 6504 K against
+    // this matrix's R 2.27 B 1.31 (+4%/+2%).
+    Camera {
+        make: "Fujifilm",
+        model: "X100S",
+        color_matrix: [
+            [1.0592, -0.4262, -0.1008],
+            [-0.3514, 1.1355, 0.2465],
+            [-0.087, 0.2025, 0.6386],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of Pixel_2_XL-IMG_20180109_080629.dng, a
+    // real DNG for this body (raw.pixls.us). Exact, not recalled. This DNG
+    // puts D65 in the *first* illuminant slot, so the matrix here is its
+    // ColorMatrix1; the slot number means nothing, the illuminant tag
+    // does.
+    Camera {
+        make: "Google",
+        model: "Pixel 2 XL",
+        color_matrix: [
+            [0.796875, -0.164062, -0.125],
+            [-0.632812, 1.570312, 0.03125],
+            [-0.171875, 0.351562, 0.46875],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of Pixel_4a-PXL_20201121_100251397.dng, a
+    // real DNG for this body (raw.pixls.us). Exact, not recalled.
+    Camera {
+        make: "Google",
+        model: "Pixel 4a",
+        color_matrix: [
+            [1.0626, -0.4466, -0.1116],
+            [-0.4205, 1.2766, 0.1562],
+            [-0.0739, 0.2132, 0.5474],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of
+    // Pixel_8_Pro-PXL_20240415_103400204.RAW-02.ORIGINAL.dng, a real DNG
+    // for this body (raw.pixls.us). Exact, not recalled.
+    Camera {
+        make: "Google",
+        model: "Pixel 8 Pro",
+        color_matrix: [
+            [0.849, -0.2014, -0.1226],
+            [-0.585, 1.4801, 0.1018],
+            [-0.186, 0.3981, 0.4547],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of
+    // CFV_100CElectronic_Shutter-B0003499.3FR, a real DNG for this body
+    // (raw.pixls.us). Exact, not recalled. Same sensor and the same matrix
+    // as the X2D 100C above, to the last digit; Hasselblad ships one
+    // calibration for the 100-megapixel back.
+    Camera {
+        make: "Hasselblad",
+        model: "CFV 100C",
+        color_matrix: [
+            [0.595057, -0.146675, -0.03413],
+            [-0.51593, 1.263062, 0.282611],
+            [-0.103826, 0.167558, 0.615209],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of
+    // H5D-50c-20151114_CCSG_on_Hasselblad_H5D50c-0017.fff, a real DNG for
+    // this body (raw.pixls.us). Exact, not recalled. Illuminant untagged
+    // as on the other Hasselblads; its neutral agrees with the 6350 K
+    // AsShotNeutral in the same file to 9%.
+    Camera {
+        make: "Hasselblad",
+        model: "H5D-50c",
+        color_matrix: [
+            [0.493195, -0.083511, 0.014068],
+            [-0.487762, 1.186829, 0.343658],
+            [-0.113823, 0.196106, 0.706665],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of L1D-20c-DJI_0017.DNG, a real DNG for
+    // this body (raw.pixls.us). Exact, not recalled. The camera on DJI's
+    // Mavic 2 Pro, badged Hasselblad.
+    Camera {
+        make: "Hasselblad",
+        model: "L1D-20c",
+        color_matrix: [
+            [0.731, -0.2746, -0.0646],
+            [-0.2991, 1.0847, 0.2469],
+            [0.0163, 0.0585, 0.6324],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware 10.00.40.18. Exact, not recalled.
+    Camera {
+        make: "Hasselblad",
+        model: "L2D-20c",
+        color_matrix: [
+            [0.8575, -0.3219, -0.0868],
+            [-0.3351, 1.1451, 0.1593],
+            [0.0207, 0.0468, 0.4876],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of X2D_100C-B0000079.3FR, a real DNG for
+    // this body (raw.pixls.us). Exact, not recalled. 3FR and FFF carry one
+    // matrix and no CalibrationIlluminant tag. It is the daylight one: the
+    // neutral it implies, R 2.83 B 1.46, is within 9% of the AsShotNeutral
+    // the same files record for daylight frames, where a tungsten
+    // calibration would be out by a factor of two.
+    Camera {
+        make: "Hasselblad",
+        model: "X2D 100C",
+        color_matrix: [
+            [0.595057, -0.146675, -0.03413],
+            [-0.51593, 1.263062, 0.282611],
+            [-0.103826, 0.167558, 0.615209],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware 1.0. Exact, not recalled.
+    Camera {
+        make: "Leica",
+        model: "CL",
+        color_matrix: [
+            [0.697, -0.225, -0.079],
+            [-0.482, 1.239, 0.201],
+            [-0.149, 0.232, 0.476],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Leica",
+        model: "DIGILUX 2",
+        color_matrix: [
+            [1.134, -0.4069, -0.1275],
+            [-0.7555, 1.5266, 0.2448],
+            [-0.296, 0.3426, 0.7519],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware 2.0.2.5. Exact, not recalled.
+    Camera {
+        make: "Leica",
+        model: "M (Typ 240)",
+        color_matrix: [
+            [0.6653, -0.1486, -0.0611],
+            [-0.4221, 1.3303, 0.0929],
+            [-0.0881, 0.2416, 0.7226],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of M10-f5381888.dng, a real DNG for this
+    // body (raw.pixls.us). Exact, not recalled.
+    Camera {
+        make: "Leica",
+        model: "M10",
+        color_matrix: [
+            [0.805908, -0.27832, -0.060547],
+            [-0.529053, 1.44165, 0.055176],
+            [-0.093506, 0.300293, 0.636719],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware 2.014. Exact, not recalled.
+    Camera {
+        make: "Leica",
+        model: "M8 Digital Camera",
+        color_matrix: [
+            [0.7675, -0.2195, -0.0305],
+            [-0.586, 1.4118, 0.1857],
+            [-0.2425, 0.4007, 0.6578],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware 1.202. Exact, not recalled.
+    Camera {
+        make: "Leica",
+        model: "M9 Digital Camera",
+        color_matrix: [
+            [0.626, -0.1019, -0.047],
+            [-0.373, 1.145, 0.193],
+            [-0.1409, 0.295, 0.621],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of X2-L1021324.DNG, a real DNG for this
+    // body (raw.pixls.us). Exact, not recalled.
+    Camera {
+        make: "Leica",
+        model: "X2",
+        color_matrix: [
+            [0.7158, -0.1911, -0.0606],
+            [-0.3603, 1.0669, 0.253],
+            [-0.0659, 0.1236, 0.553],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: the 1 V1 entry above. Same sensor and colour filter array,
+    // sold under this name; Adobe calibrates the pair together. Nothing in
+    // a 1 AW1 file was used to check it.
+    Camera {
+        make: "Nikon",
+        model: "1 AW1",
+        color_matrix: [
+            [0.8994, -0.2667, -0.0865],
+            [-0.4594, 1.2324, 0.2552],
+            [-0.0699, 0.1786, 0.626],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "1 V1",
+        color_matrix: [
+            [0.8994, -0.2667, -0.0865],
+            [-0.4594, 1.2324, 0.2552],
+            [-0.0699, 0.1786, 0.626],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: the D7000 entry above. Same sensor and colour filter array,
+    // sold under this name; Adobe calibrates the pair together. Nothing in
+    // a COOLPIX A file was used to check it.
+    Camera {
+        make: "Nikon",
+        model: "COOLPIX A",
+        color_matrix: [
+            [0.8198, -0.2239, -0.0724],
+            [-0.4871, 1.2389, 0.2798],
+            [-0.1043, 0.205, 0.7181],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D100",
+        color_matrix: [
+            [0.5902, -0.0933, -0.0782],
+            [-0.8983, 1.6719, 0.2354],
+            [-0.1402, 0.1455, 0.6464],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D200",
+        color_matrix: [
+            [0.8367, -0.2248, -0.0763],
+            [-0.8758, 1.6447, 0.2422],
+            [-0.1527, 0.155, 0.8053],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D300",
+        color_matrix: [
+            [0.903, -0.1992, -0.0715],
+            [-0.8465, 1.6302, 0.2255],
+            [-0.2689, 0.3217, 0.8069],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: the D300 entry above. Same sensor and colour filter array,
+    // sold under this name; Adobe calibrates the pair together. Nothing in
+    // a D300S file was used to check it.
+    Camera {
+        make: "Nikon",
+        model: "D300S",
+        color_matrix: [
+            [0.903, -0.1992, -0.0715],
+            [-0.8465, 1.6302, 0.2255],
+            [-0.2689, 0.3217, 0.8069],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D3200",
+        color_matrix: [
+            [0.7013, -0.1408, -0.0635],
+            [-0.5268, 1.2902, 0.264],
+            [-0.147, 0.2801, 0.7379],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D3300",
+        color_matrix: [
+            [0.6988, -0.1384, -0.0714],
+            [-0.5631, 1.341, 0.2447],
+            [-0.1485, 0.2204, 0.7318],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D3500",
+        color_matrix: [
+            [0.8821, -0.2938, -0.0785],
+            [-0.4178, 1.2142, 0.2287],
+            [-0.0824, 0.1651, 0.686],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D3X",
+        color_matrix: [
+            [0.7171, -0.1986, -0.0648],
+            [-0.8085, 1.5555, 0.2718],
+            [-0.217, 0.2512, 0.7457],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D40",
+        color_matrix: [
+            [0.6992, -0.1668, -0.0806],
+            [-0.8138, 1.5748, 0.2543],
+            [-0.0874, 0.085, 0.7897],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D50",
+        color_matrix: [
+            [0.7732, -0.2422, -0.0789],
+            [-0.8238, 1.5884, 0.2498],
+            [-0.0859, 0.0783, 0.733],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: the D90 entry above. Same sensor and colour filter array,
+    // sold under this name; Adobe calibrates the pair together. Nothing in
+    // a D5000 file was used to check it.
+    Camera {
+        make: "Nikon",
+        model: "D5000",
+        color_matrix: [
+            [0.7309, -0.1403, -0.0519],
+            [-0.8474, 1.6008, 0.2622],
+            [-0.2434, 0.2826, 0.8064],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D60",
+        color_matrix: [
+            [0.8736, -0.2458, -0.0935],
+            [-0.9075, 1.6894, 0.2251],
+            [-0.1354, 0.1242, 0.8263],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D610",
+        color_matrix: [
+            [0.8178, -0.2245, -0.0609],
+            [-0.4857, 1.2394, 0.2776],
+            [-0.1207, 0.2086, 0.7298],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D70",
+        color_matrix: [
+            [0.7732, -0.2422, -0.0789],
+            [-0.8238, 1.5884, 0.2498],
+            [-0.0859, 0.0783, 0.733],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D700",
+        color_matrix: [
+            [0.8139, -0.2171, -0.0663],
+            [-0.8747, 1.6541, 0.2295],
+            [-0.1925, 0.2008, 0.8093],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D7000",
+        color_matrix: [
+            [0.8198, -0.2239, -0.0724],
+            [-0.4871, 1.2389, 0.2798],
+            [-0.1043, 0.205, 0.7181],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D7100",
+        color_matrix: [
+            [0.8322, -0.3112, -0.1047],
+            [-0.6367, 1.4342, 0.2179],
+            [-0.0988, 0.1638, 0.6394],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D750",
+        color_matrix: [
+            [0.902, -0.289, -0.0715],
+            [-0.4535, 1.2436, 0.2348],
+            [-0.0934, 0.1919, 0.7086],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written by Adobe Photoshop Lightroom 3.4. Exact, not recalled. This
+    // one settles the provenance of the recalled numbers: the matrix Adobe
+    // wrote here is digit for digit the one written down for the D80
+    // before the file was found.
+    Camera {
+        make: "Nikon",
+        model: "D80",
+        color_matrix: [
+            [0.8629, -0.241, -0.0883],
+            [-0.9055, 1.694, 0.2171],
+            [-0.149, 0.1363, 0.852],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D800E",
+        color_matrix: [
+            [0.7866, -0.2108, -0.0555],
+            [-0.4869, 1.2483, 0.2681],
+            [-0.1176, 0.2069, 0.7501],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D810",
+        color_matrix: [
+            [0.9369, -0.3195, -0.0791],
+            [-0.4488, 1.243, 0.2301],
+            [-0.0893, 0.1796, 0.6872],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D850",
+        color_matrix: [
+            [1.0405, -0.3755, -0.127],
+            [-0.5461, 1.3787, 0.1793],
+            [-0.104, 0.2015, 0.6785],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "D90",
+        color_matrix: [
+            [0.7309, -0.1403, -0.0519],
+            [-0.8474, 1.6008, 0.2622],
+            [-0.2434, 0.2826, 0.8064],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "Z 30",
+        color_matrix: [
+            [1.0339, -0.3822, -0.089],
+            [-0.4183, 1.2023, 0.2436],
+            [-0.0671, 0.1638, 0.6444],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "Z 50",
+        color_matrix: [
+            [1.164, -0.4829, -0.1079],
+            [-0.5107, 1.3006, 0.2325],
+            [-0.0972, 0.1711, 0.738],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "Z 6",
+        color_matrix: [
+            [0.821, -0.2534, -0.0683],
+            [-0.5355, 1.3338, 0.2212],
+            [-0.1143, 0.1929, 0.6464],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Nikon",
+        model: "Z 7",
+        color_matrix: [
+            [1.3705, -0.6004, -0.14],
+            [-0.5464, 1.3568, 0.2062],
+            [-0.094, 0.1706, 0.7618],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in
+    // E-1-E_1__C106743_gredos.ORF: at 6504 K they want R 1.91 B 0.97, this
+    // matrix implies R 1.90 B 0.98 (-0%/+1%).
+    Camera {
+        make: "Olympus",
+        model: "E-1",
+        color_matrix: [
+            [1.1846, -0.4767, -0.0945],
+            [-0.7027, 1.5878, 0.1089],
+            [-0.2699, 0.4122, 0.8311],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in oly-e620: at 6504 K they
+    // want R 2.16 B 1.14, this matrix implies R 2.29 B 1.15 (+6%/+1%).
+    Camera {
+        make: "Olympus",
+        model: "E-620",
+        color_matrix: [
+            [0.8453, -0.2198, -0.1092],
+            [-0.7609, 1.5681, 0.2008],
+            [-0.1725, 0.2337, 0.7824],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in oly-em10m2: at 6504 K they
+    // want R 2.14 B 1.57, this matrix implies R 2.31 B 1.58 (+8%/+1%).
+    // This is the E-M5 under the name its own files use; the check above
+    // is on a E-M10MarkII sample, not the E-M5's.
+    Camera {
+        make: "Olympus",
+        model: "E-M10MarkII",
+        color_matrix: [
+            [0.838, -0.263, -0.0639],
+            [-0.2887, 1.0725, 0.2496],
+            [-0.0627, 0.1427, 0.5438],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in oly-em5: at 6504 K they
+    // want R 2.21 B 1.61, this matrix implies R 2.31 B 1.58 (+4%/-2%).
+    Camera {
+        make: "Olympus",
+        model: "E-M5",
+        color_matrix: [
+            [0.838, -0.263, -0.0639],
+            [-0.2887, 1.0725, 0.2496],
+            [-0.0627, 0.1427, 0.5438],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in oly-em5m2: at 6504 K they
+    // want R 2.13 B 1.53, this matrix implies R 2.15 B 1.54 (+1%/+0%).
+    Camera {
+        make: "Olympus",
+        model: "E-M5MarkII",
+        color_matrix: [
+            [0.9422, -0.3258, -0.0711],
+            [-0.2655, 1.0898, 0.2015],
+            [-0.0512, 0.1354, 0.5512],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in oly-ep5: at 6504 K they
+    // want R 2.17 B 1.54, this matrix implies R 2.31 B 1.58 (+6%/+3%).
+    // This is the E-M5 under the name its own files use; the check above
+    // is on a E-P5 sample, not the E-M5's.
+    Camera {
+        make: "Olympus",
+        model: "E-P5",
+        color_matrix: [
+            [0.838, -0.263, -0.0639],
+            [-0.2887, 1.0725, 0.2496],
+            [-0.0627, 0.1427, 0.5438],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in oly-epl5: at 6504 K they
+    // want R 2.17 B 1.58, this matrix implies R 2.31 B 1.58 (+6%/+0%).
+    // This is the E-M5 under the name its own files use; the check above
+    // is on a E-PL5 sample, not the E-M5's.
+    Camera {
+        make: "Olympus",
+        model: "E-PL5",
+        color_matrix: [
+            [0.838, -0.263, -0.0639],
+            [-0.2887, 1.0725, 0.2496],
+            [-0.0627, 0.1427, 0.5438],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in oly-epl7: at 6504 K they
+    // want R 2.34 B 1.57, this matrix implies R 2.19 B 1.56 (-6%/-1%).
+    Camera {
+        make: "Olympus",
+        model: "E-PL7",
+        color_matrix: [
+            [0.9197, -0.319, -0.0659],
+            [-0.2606, 1.083, 0.2039],
+            [-0.0458, 0.125, 0.5458],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in E-PL8-P9110021.ORF: at
+    // 6504 K they want R 2.09 B 1.52, this matrix implies R 2.19 B 1.56
+    // (+5%/+3%). This is the E-PL7 under the name its own files use; the
+    // check above is on a E-PL8 sample, not the E-PL7's.
+    Camera {
+        make: "Olympus",
+        model: "E-PL8",
+        color_matrix: [
+            [0.9197, -0.319, -0.0659],
+            [-0.2606, 1.083, 0.2039],
+            [-0.0458, 0.125, 0.5458],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in oly-penf: at 6504 K they
+    // want R 2.06 B 1.55, this matrix implies R 2.11 B 1.59 (+3%/+3%).
+    Camera {
+        make: "Olympus",
+        model: "PEN-F",
+        color_matrix: [
+            [0.9476, -0.3182, -0.0765],
+            [-0.2613, 1.0958, 0.1893],
+            [-0.0449, 0.1315, 0.5268],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in oly-xz1: at 6504 K they
+    // want R 2.23 B 1.63, this matrix implies R 2.08 B 1.52 (-6%/-7%).
+    Camera {
+        make: "Olympus",
+        model: "XZ-1",
+        color_matrix: [
+            [1.0901, -0.4095, -0.1074],
+            [-0.1141, 0.9208, 0.2293],
+            [-0.0062, 0.1417, 0.5158],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // its one named daylight preset in
+    // DMC-FZ300-RAW_PANASONIC_FZ300_1-1.RW2: at 6504 K they want R 2.23 B
+    // 1.80, this matrix implies R 2.43 B 1.67 (+9%/-7%). A single preset
+    // carried to 6504 K, so this is a coarser check than most here.
+    Camera {
+        make: "Panasonic",
+        model: "DMC-FZ300",
+        color_matrix: [
+            [0.8378, -0.2798, -0.0769],
+            [-0.3068, 1.141, 0.1877],
+            [-0.0538, 0.1792, 0.4623],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Panasonic",
+        model: "DMC-G5",
+        color_matrix: [
+            [0.7798, -0.2562, -0.074],
+            [-0.3894, 1.1972, 0.2234],
+            [-0.11, 0.2335, 0.6529],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // its one named daylight preset in DMC-G85-_1030981.RW2: at 6504 K
+    // they want R 2.46 B 1.46, this matrix implies R 2.71 B 1.49
+    // (+10%/+2%). A single preset carried to 6504 K, so this is a coarser
+    // check than most here.
+    Camera {
+        make: "Panasonic",
+        model: "DMC-G85",
+        color_matrix: [
+            [0.7524, -0.2518, -0.0671],
+            [-0.3343, 1.1651, 0.1937],
+            [-0.03, 0.1067, 0.5791],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Panasonic",
+        model: "DMC-GF1",
+        color_matrix: [
+            [0.7888, -0.291, -0.0795],
+            [-0.4055, 1.2074, 0.2214],
+            [-0.1042, 0.2134, 0.5947],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Panasonic",
+        model: "DMC-GH2",
+        color_matrix: [
+            [0.778, -0.241, -0.0806],
+            [-0.3913, 1.1724, 0.2484],
+            [-0.1018, 0.239, 0.5298],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Panasonic",
+        model: "DMC-GH3",
+        color_matrix: [
+            [0.6559, -0.1752, -0.0491],
+            [-0.3672, 1.1407, 0.2586],
+            [-0.0962, 0.1875, 0.513],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Panasonic",
+        model: "DMC-GX1",
+        color_matrix: [
+            [0.6763, -0.1919, -0.0863],
+            [-0.3868, 1.1515, 0.2685],
+            [-0.1216, 0.2387, 0.5879],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. NOT individually
+    // verified: this body's raws record only the white balance the shot
+    // was taken at, no preset curve, so there is nothing in a sample to
+    // check a matrix against. Every camera for which a converted DNG could
+    // be found (the D80, the EOS-1D X, the EOS 7D Mark II and the EOS 60D)
+    // reproduced the recalled value exactly, which is why these are here
+    // at all; replace any of them the moment a converted DNG for the body
+    // turns up.
+    Camera {
+        make: "Panasonic",
+        model: "DMC-GX7",
+        color_matrix: [
+            [0.761, -0.278, -0.0576],
+            [-0.4614, 1.2195, 0.2733],
+            [-0.1375, 0.2393, 0.649],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written by Adobe DNG Converter 10.3 (Windows). Exact, not recalled.
+    Camera {
+        make: "Panasonic",
+        model: "DMC-LX1",
+        color_matrix: [
+            [1.0704, -0.4187, -0.123],
+            [-0.8314, 1.5952, 0.2501],
+            [-0.092, 0.0945, 0.8927],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in ist_DL-IMGP0370.PEF: at
+    // 6504 K they want R 1.72 B 0.87, this matrix implies R 1.73 B 0.84
+    // (+1%/-3%).
+    Camera {
+        make: "Pentax",
+        model: "*ist DL",
+        color_matrix: [
+            [1.0829, -0.2838, -0.1115],
+            [-0.8339, 1.5817, 0.2696],
+            [-0.0837, 0.068, 1.1939],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in pentax-istds: at 6504 K
+    // they want R 1.72 B 0.94, this matrix implies R 1.74 B 0.88
+    // (+1%/-6%).
+    Camera {
+        make: "Pentax",
+        model: "*ist DS",
+        color_matrix: [
+            [1.0371, -0.2333, -0.1206],
+            [-0.8688, 1.6231, 0.2602],
+            [-0.123, 0.1116, 1.1282],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of 645D-645D2839.DNG, a real DNG for this
+    // body (raw.pixls.us). Exact, not recalled. Pentax's own matrix, and
+    // its blue row does not agree with the camera's Kelvin white-balance
+    // curve (it implies B 1.25 at 6504 K where the camera says 1.05). Kept
+    // because it is what the same body's DNGs carry, so PEF and DNG at
+    // least render alike; worth replacing with Adobe's if it turns up.
+    Camera {
+        make: "Pentax",
+        model: "645D",
+        color_matrix: [
+            [0.981354, -0.271622, -0.143921],
+            [-0.504913, 1.390701, 0.116577],
+            [-0.183014, 0.383621, 0.570557],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware PENTAX 645Z Ver. 1.00. Exact, not
+    // recalled. Its own white-balance presets want R 2.32 B 1.25 at 6504 K
+    // against this matrix's R 2.22 B 1.31 (-4%/+5%).
+    Camera {
+        make: "Pentax",
+        model: "645Z",
+        color_matrix: [
+            [0.955109, -0.301178, -0.123489],
+            [-0.368484, 1.213333, 0.172089],
+            [-0.101929, 0.188721, 0.654434],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware K-01 Ver 1.05. Exact, not recalled.
+    Camera {
+        make: "Pentax",
+        model: "K-01",
+        color_matrix: [
+            [0.841812, -0.254395, -0.112732],
+            [-0.399536, 1.230118, 0.188065],
+            [-0.097733, 0.17131, 0.651276],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware PENTAX K-1 Ver. 1.40. Exact, not
+    // recalled. Its own white-balance presets want R 2.39 B 1.32 at 6504 K
+    // against this matrix's R 2.48 B 1.36 (+4%/+3%).
+    Camera {
+        make: "Pentax",
+        model: "K-1",
+        color_matrix: [
+            [0.882736, -0.282928, -0.123825],
+            [-0.361176, 1.220398, 0.154984],
+            [-0.089706, 0.168762, 0.62912],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware PENTAX K-1 Mark II Ver. 1.02. Exact, not
+    // recalled.
+    Camera {
+        make: "Pentax",
+        model: "K-1 Mark II",
+        color_matrix: [
+            [0.906296, -0.290482, -0.127121],
+            [-0.361176, 1.220398, 0.154984],
+            [-0.089996, 0.169296, 0.631119],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware PENTAX K-3 Ver. 1.30. Exact, not
+    // recalled. Its own white-balance presets want R 2.52 B 1.26 at 6504 K
+    // against this matrix's R 2.43 B 1.26 (-4%/+0%).
+    Camera {
+        make: "Pentax",
+        model: "K-3",
+        color_matrix: [
+            [0.865585, -0.261581, -0.115921],
+            [-0.399536, 1.230118, 0.188065],
+            [-0.103821, 0.182037, 0.692062],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware PENTAX K-3 II Ver. 1.10. Exact, not
+    // recalled. Its own white-balance presets want R 2.51 B 1.25 at 6504 K
+    // against this matrix's R 2.44 B 1.26 (-3%/+1%).
+    Camera {
+        make: "Pentax",
+        model: "K-3 II",
+        color_matrix: [
+            [0.861725, -0.260406, -0.115402],
+            [-0.399536, 1.230118, 0.188065],
+            [-0.103516, 0.181519, 0.690094],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware PENTAX K-3 Mark III Ver. 1.01. Exact,
+    // not recalled. Its own white-balance presets want R 2.74 B 1.40 at
+    // 6504 K against this matrix's R 2.59 B 1.51 (-5%/+8%).
+    Camera {
+        make: "Pentax",
+        model: "K-3 Mark III",
+        color_matrix: [
+            [0.702194, -0.162216, -0.088959],
+            [-0.461395, 1.272781, 0.206543],
+            [-0.063995, 0.142883, 0.568558],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware K-30 Ver 1.06. Exact, not recalled.
+    Camera {
+        make: "Pentax",
+        model: "K-30",
+        color_matrix: [
+            [0.93634, -0.282959, -0.125397],
+            [-0.399536, 1.230118, 0.188065],
+            [-0.103073, 0.180664, 0.686844],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of _MAR0543.DNG, a real DNG for this body
+    // (raw.pixls.us). Exact, not recalled. Agrees with the camera's own
+    // Kelvin curve to 1%.
+    Camera {
+        make: "Pentax",
+        model: "K-5",
+        color_matrix: [
+            [0.862534, -0.260666, -0.115509],
+            [-0.399536, 1.230118, 0.188065],
+            [-0.098206, 0.172134, 0.654419],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware K-5 II Ver 1.07. Exact, not recalled.
+    Camera {
+        make: "Pentax",
+        model: "K-5 II",
+        color_matrix: [
+            [0.843491, -0.254898, -0.112961],
+            [-0.399536, 1.230118, 0.188065],
+            [-0.098892, 0.173355, 0.659073],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of K-50-IMGP1385.DNG, a real DNG for this
+    // body (raw.pixls.us). Exact, not recalled.
+    Camera {
+        make: "Pentax",
+        model: "K-50",
+        color_matrix: [
+            [0.922821, -0.278885, -0.123581],
+            [-0.399536, 1.230118, 0.188065],
+            [-0.099533, 0.174469, 0.663315],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware K-500 Ver. 1.02. Exact, not recalled.
+    Camera {
+        make: "Pentax",
+        model: "K-500",
+        color_matrix: [
+            [0.898972, -0.271667, -0.120392],
+            [-0.399536, 1.230118, 0.188065],
+            [-0.09903, 0.173599, 0.659973],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65, preferred over the
+    // in-camera DNG's own matrix for this body because it is the one that
+    // agrees with the camera's white-balance curve. Its own white-balance
+    // presets want R 2.07 B 0.99 at 6504 K against this matrix's R 2.11 B
+    // 1.04 (+2%/+5%).
+    Camera {
+        make: "Pentax",
+        model: "K-7",
+        color_matrix: [
+            [0.9142, -0.2947, -0.0678],
+            [-0.8648, 1.6967, 0.1663],
+            [-0.2224, 0.2898, 0.8615],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware PENTAX K-70 Ver. 1.10. Exact, not
+    // recalled. Its own white-balance presets want R 2.41 B 1.36 at 6504 K
+    // against this matrix's R 2.50 B 1.39 (+4%/+2%).
+    Camera {
+        make: "Pentax",
+        model: "K-70",
+        color_matrix: [
+            [0.799911, -0.204788, -0.125626],
+            [-0.435867, 1.295334, 0.151459],
+            [-0.109055, 0.195511, 0.604355],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware PENTAX K-S1 Ver. 1.20. Exact, not
+    // recalled.
+    Camera {
+        make: "Pentax",
+        model: "K-S1",
+        color_matrix: [
+            [0.81636, -0.256592, -0.116196],
+            [-0.388229, 1.234985, 0.16893],
+            [-0.085358, 0.151001, 0.638519],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware PENTAX K-S2 Ver. 1.20. Exact, not
+    // recalled. Its own white-balance presets want R 2.60 B 1.33 at 6504 K
+    // against this matrix's R 2.70 B 1.37 (+4%/+3%).
+    Camera {
+        make: "Pentax",
+        model: "K-S2",
+        color_matrix: [
+            [0.80867, -0.254181, -0.115097],
+            [-0.388229, 1.234985, 0.16893],
+            [-0.085663, 0.15155, 0.640808],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware K-x Ver 1.03. Exact, not recalled. Its
+    // own white-balance presets want R 1.93 B 1.12 at 6504 K against this
+    // matrix's R 1.99 B 1.22 (+3%/+9%).
+    Camera {
+        make: "Pentax",
+        model: "K-x",
+        color_matrix: [
+            [1.044144, -0.332535, -0.114777],
+            [-0.557129, 1.35994, 0.21489],
+            [-0.120621, 0.175415, 0.744888],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of K10D-IMGP5398.DNG, a real DNG for this
+    // body (raw.pixls.us). Exact, not recalled. As with the 645D this is
+    // Pentax's own matrix and its red row is well off the camera's Kelvin
+    // curve (1.33 against 1.83 at 6504 K). Kept for the same reason: the
+    // K10D's own DNGs render with exactly this.
+    Camera {
+        make: "Pentax",
+        model: "K10D",
+        color_matrix: [
+            [1.098602, -0.257263, -0.03801],
+            [-0.568558, 1.259155, 0.250153],
+            [-0.067535, 0.060776, 0.977936],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware K200D Ver 1.01. Exact, not recalled. Its
+    // own white-balance presets want R 1.83 B 1.09 at 6504 K against this
+    // matrix's R 1.89 B 1.20 (+4%/+9%).
+    Camera {
+        make: "Pentax",
+        model: "K200D",
+        color_matrix: [
+            [1.034805, -0.337326, -0.108109],
+            [-0.482162, 1.220963, 0.217987],
+            [-0.026398, 0.035126, 0.758392],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware K20D Ver 1.04. Exact, not recalled. Its
+    // own white-balance presets want R 1.66 B 1.10 at 6504 K against this
+    // matrix's R 1.75 B 1.10 (+5%/+1%).
+    Camera {
+        make: "Pentax",
+        model: "K20D",
+        color_matrix: [
+            [1.138107, -0.346939, -0.148712],
+            [-0.4767, 1.345383, 0.098969],
+            [-0.145813, 0.31279, 0.67128],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: the K-70 entry above. Same sensor and colour filter array,
+    // sold under this name; Adobe calibrates the pair together. Nothing in
+    // a KF file was used to check it.
+    Camera {
+        make: "Pentax",
+        model: "KF",
+        color_matrix: [
+            [0.799911, -0.204788, -0.125626],
+            [-0.435867, 1.295334, 0.151459],
+            [-0.109055, 0.195511, 0.604355],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware PENTAX KP Ver. 1.00. Exact, not
+    // recalled.
+    Camera {
+        make: "Pentax",
+        model: "KP",
+        color_matrix: [
+            [0.765549, -0.211395, -0.137329],
+            [-0.484177, 1.355545, 0.134949],
+            [-0.152664, 0.239807, 0.569351],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of GR-R0003611.DNG, a real DNG for this
+    // body (raw.pixls.us). Exact, not recalled.
+    Camera {
+        make: "Ricoh",
+        model: "GR",
+        color_matrix: [
+            [0.5329, -0.1459, -0.039],
+            [-0.5407, 1.293, 0.2768],
+            [-0.1119, 0.1772, 0.6046],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of GR_II-R0000443.DNG, a real DNG for
+    // this body (raw.pixls.us). Exact, not recalled.
+    Camera {
+        make: "Ricoh",
+        model: "GR II",
+        color_matrix: [
+            [0.493271, -0.088852, -0.045059],
+            [-0.497665, 1.280502, 0.241669],
+            [-0.064835, 0.149033, 0.621185],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware RICOH GR III Ver. 1.00. Exact, not
+    // recalled.
+    Camera {
+        make: "Ricoh",
+        model: "GR III",
+        color_matrix: [
+            [0.613297, -0.141678, -0.077698],
+            [-0.461395, 1.272781, 0.206543],
+            [-0.066528, 0.14856, 0.591125],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of GR_IIIx-R0001005.DNG, a real DNG for
+    // this body (raw.pixls.us). Exact, not recalled. Agrees with the
+    // camera's Kelvin curve to 3%.
+    Camera {
+        make: "Ricoh",
+        model: "GR IIIx",
+        color_matrix: [
+            [0.61145, -0.141251, -0.077469],
+            [-0.461395, 1.272781, 0.206543],
+            [-0.066269, 0.147949, 0.58873],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware S918BXXS3AWF7. Exact, not recalled.
+    Camera {
+        make: "Samsung",
+        model: "Galaxy S23 Ultra",
+        color_matrix: [
+            [0.716797, -0.140625, -0.116211],
+            [-0.575195, 1.451172, 0.086914],
+            [-0.166016, 0.337891, 0.472656],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware GX10 Ver 1.30. Exact, not recalled.
+    Camera {
+        make: "Samsung",
+        model: "GX10",
+        color_matrix: [
+            [1.098602, -0.257263, -0.03801],
+            [-0.568558, 1.259155, 0.250153],
+            [-0.067535, 0.060776, 0.977936],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware GX20 Ver 1.01. Exact, not recalled.
+    Camera {
+        make: "Samsung",
+        model: "GX20",
+        color_matrix: [
+            [2.771667, -1.740295, -0.577927],
+            [-0.845032, 1.977798, 0.037689],
+            [0.045914, -0.197754, 1.122131],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware G950FXXU2CRED. Exact, not recalled.
+    Camera {
+        make: "Samsung",
+        model: "SM-G950F",
+        color_matrix: [
+            [0.674805, -0.088867, -0.112305],
+            [-0.503906, 1.40625, 0.067383],
+            [-0.219727, 0.495117, 0.483398],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of SM-G955F-20180202_091722.dng, a real
+    // DNG for this body (raw.pixls.us). Exact, not recalled. Galaxy S8+.
+    // D65 is in the first illuminant slot here.
+    Camera {
+        make: "Samsung",
+        model: "SM-G955F",
+        color_matrix: [
+            [0.674805, -0.088867, -0.112305],
+            [-0.503906, 1.40625, 0.067383],
+            [-0.219727, 0.495117, 0.483398],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware G960FXXU7CSJ1. Exact, not recalled.
+    Camera {
+        make: "Samsung",
+        model: "SM-G960F",
+        color_matrix: [
+            [0.645508, -0.060547, -0.107422],
+            [-0.550781, 1.442383, 0.075195],
+            [-0.179688, 0.43457, 0.483398],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware G973FXXS3ASJG. Exact, not recalled.
+    Camera {
+        make: "Samsung",
+        model: "SM-G973F",
+        color_matrix: [
+            [0.786133, -0.15918, -0.142578],
+            [-0.609375, 1.542969, 0.033203],
+            [-0.256836, 0.513672, 0.442383],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of Galaxy_S22_Ultra-20230531_111518.dng,
+    // a real DNG for this body (raw.pixls.us). Exact, not recalled. Galaxy
+    // S22. D65 is in the first illuminant slot here.
+    Camera {
+        make: "Samsung",
+        model: "SM-S901U",
+        color_matrix: [
+            [0.780273, -0.217773, -0.113281],
+            [-0.535156, 1.402344, 0.097656],
+            [-0.149414, 0.3125, 0.458984],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of
+    // fp-A002_647_20240229_000001_4k_12bit.DNG, a real DNG for this body
+    // (raw.pixls.us). Exact, not recalled.
+    Camera {
+        make: "Sigma",
+        model: "fp",
+        color_matrix: [
+            [0.8252, -0.2044, -0.1744],
+            [-0.4961, 1.1648, 0.0631],
+            [-0.1156, 0.1607, 0.3607],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: ColorMatrix2 (D65) of a DNG for this body from raw.pixls.us,
+    // written in-camera, firmware SIGMA fp L Ver.3.00.0.V88. Exact, not
+    // recalled.
+    Camera {
+        make: "Sigma",
+        model: "fp L",
+        color_matrix: [
+            [0.8326, -0.2062, -0.1759],
+            [-0.4961, 1.1648, 0.0631],
+            [-0.1116, 0.1551, 0.3483],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in sony-rx100m3: at 6504 K
+    // they want R 2.77 B 1.58, this matrix implies R 2.96 B 1.68
+    // (+7%/+6%).
+    Camera {
+        make: "Sony",
+        model: "DSC-RX100M3",
+        color_matrix: [
+            [0.6596, -0.2079, -0.0562],
+            [-0.4782, 1.3016, 0.1933],
+            [-0.097, 0.1581, 0.5181],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in
+    // DSLR-A450-20170423_113243_A450_07665.ARW: at 6504 K they want R 2.68
+    // B 1.32, this matrix implies R 2.71 B 1.24 (+1%/-7%).
+    Camera {
+        make: "Sony",
+        model: "DSLR-A450",
+        color_matrix: [
+            [0.495, -0.058, -0.0103],
+            [-0.5228, 1.2542, 0.3029],
+            [-0.0709, 0.1435, 0.7371],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in ILCA-99M2-BR_00086.ARW: at
+    // 6504 K they want R 2.72 B 1.46, this matrix implies R 2.76 B 1.45
+    // (+1%/-1%).
+    Camera {
+        make: "Sony",
+        model: "ILCA-99M2",
+        color_matrix: [
+            [0.666, -0.1918, -0.0471],
+            [-0.4613, 1.2243, 0.2657],
+            [-0.028, 0.1285, 0.5897],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in
+    // ILCE-1-A1_full_compressed.ARW: at 6504 K they want R 2.69 B 1.41,
+    // this matrix implies R 2.60 B 1.34 (-3%/-5%).
+    Camera {
+        make: "Sony",
+        model: "ILCE-1",
+        color_matrix: [
+            [0.8161, -0.2947, -0.0739],
+            [-0.4811, 1.3045, 0.1793],
+            [-0.0518, 0.1615, 0.6106],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in sony-a6300: at 6504 K they
+    // want R 2.93 B 1.58, this matrix implies R 3.02 B 1.50 (+3%/-5%).
+    Camera {
+        make: "Sony",
+        model: "ILCE-6300",
+        color_matrix: [
+            [0.5973, -0.1695, -0.0419],
+            [-0.3826, 1.1797, 0.2293],
+            [-0.0639, 0.1398, 0.5789],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in sony-a7: at 6504 K they
+    // want R 2.57 B 1.28, this matrix implies R 2.76 B 1.24 (+7%/-4%).
+    Camera {
+        make: "Sony",
+        model: "ILCE-7",
+        color_matrix: [
+            [0.5271, -0.0712, -0.0347],
+            [-0.6153, 1.3653, 0.2763],
+            [-0.1601, 0.2366, 0.7242],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in sony-a7m2: at 6504 K they
+    // want R 2.68 B 1.34, this matrix implies R 2.76 B 1.24 (+3%/-7%).
+    // This is the ILCE-7 under the name its own files use; the check above
+    // is on a ILCE-7M2 sample, not the ILCE-7's.
+    Camera {
+        make: "Sony",
+        model: "ILCE-7M2",
+        color_matrix: [
+            [0.5271, -0.0712, -0.0347],
+            [-0.6153, 1.3653, 0.2763],
+            [-0.1601, 0.2366, 0.7242],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in sony-a7m3: at 6504 K they
+    // want R 2.56 B 1.44, this matrix implies R 2.67 B 1.35 (+4%/-6%).
+    Camera {
+        make: "Sony",
+        model: "ILCE-7M3",
+        color_matrix: [
+            [0.7374, -0.2389, -0.0551],
+            [-0.5435, 1.3162, 0.2519],
+            [-0.1006, 0.1795, 0.6552],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in
+    // ILCE-7M4-ILCE-7M4_DSC06674_FullFrame-LossLess-Compressed-Large.ARW:
+    // at 6504 K they want R 2.62 B 1.45, this matrix implies R 2.63 B 1.39
+    // (+0%/-5%).
+    Camera {
+        make: "Sony",
+        model: "ILCE-7M4",
+        color_matrix: [
+            [0.746, -0.2365, -0.0588],
+            [-0.5687, 1.3442, 0.2474],
+            [-0.0624, 0.1156, 0.6584],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in
+    // ILCE-7RM2-12-bit-compressed.ARW: at 6504 K they want R 2.59 B 1.44,
+    // this matrix implies R 2.77 B 1.36 (+7%/-6%).
+    Camera {
+        make: "Sony",
+        model: "ILCE-7RM2",
+        color_matrix: [
+            [0.6629, -0.19, -0.0483],
+            [-0.4618, 1.2349, 0.255],
+            [-0.0622, 0.1381, 0.6514],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in sony-a7rm3: at 6504 K they
+    // want R 2.73 B 1.44, this matrix implies R 2.74 B 1.37 (+0%/-5%).
+    Camera {
+        make: "Sony",
+        model: "ILCE-7RM3",
+        color_matrix: [
+            [0.664, -0.1847, -0.0503],
+            [-0.5238, 1.301, 0.2474],
+            [-0.0993, 0.1673, 0.6527],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in
+    // ILCE-7RM5-7RM5-LosslessCompressedLarge.ARW: at 6504 K they want R
+    // 2.72 B 1.53, this matrix implies R 2.66 B 1.45 (-2%/-5%).
+    Camera {
+        make: "Sony",
+        model: "ILCE-7RM5",
+        color_matrix: [
+            [0.82, -0.2976, -0.0719],
+            [-0.4296, 1.2053, 0.2532],
+            [-0.0429, 0.1178, 0.6083],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in NEX-5N-DSC02519.ARW: at
+    // 6504 K they want R 2.77 B 1.34, this matrix implies R 2.90 B 1.35
+    // (+5%/+1%).
+    Camera {
+        make: "Sony",
+        model: "NEX-5N",
+        color_matrix: [
+            [0.5991, -0.1456, -0.0455],
+            [-0.4764, 1.2135, 0.298],
+            [-0.0707, 0.1425, 0.6701],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in sony-nex6: at 6504 K they
+    // want R 2.97 B 1.31, this matrix implies R 2.90 B 1.35 (-2%/+3%).
+    // This is the NEX-5N under the name its own files use; the check above
+    // is on a NEX-6 sample, not the NEX-5N's.
+    Camera {
+        make: "Sony",
+        model: "NEX-6",
+        color_matrix: [
+            [0.5991, -0.1456, -0.0455],
+            [-0.4764, 1.2135, 0.298],
+            [-0.0707, 0.1425, 0.6701],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in sony-nex7: at 6504 K they
+    // want R 2.90 B 1.31, this matrix implies R 2.99 B 1.25 (+3%/-5%).
+    Camera {
+        make: "Sony",
+        model: "NEX-7",
+        color_matrix: [
+            [0.5491, -0.1192, -0.0363],
+            [-0.4951, 1.2342, 0.2948],
+            [-0.0911, 0.1722, 0.7192],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+    // source: Adobe DNG Converter ColorMatrix2, D65. Cross-checked against
+    // the camera's own white-balance presets in SLT-A55-DSC06309.ARW: at
+    // 6504 K they want R 2.76 B 1.32, this matrix implies R 2.93 B 1.33
+    // (+6%/+1%).
+    Camera {
+        make: "Sony",
+        model: "SLT-A55V",
+        color_matrix: [
+            [0.5932, -0.1492, -0.0411],
+            [-0.4813, 1.2285, 0.2856],
+            [-0.0741, 0.1524, 0.6739],
+        ],
+        black_level: None,
+        white_level: None,
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// XYZ of a perfect white under D65, the illuminant every matrix
+    /// in the table is calibrated for.
+    const WHITE_D65: [f32; 3] = [0.95047, 1.0, 1.08883];
+
+    // ------------------------------------------------------- normalising
+
+    /// Make and model strings taken verbatim from the sample corpus
+    /// (`exiftool -Make -Model`), with what `normalize` must make of
+    /// them. Where the file has an oracle `.identify.txt` beside it,
+    /// these agree with its "Normalized Make/Model" line.
+    const CASES: &[(&str, &str, &str, &str)] = &[
+        // The eleven top-level samples, whose raw-identify output names
+        // the same pairs.
+        ("NIKON CORPORATION", "NIKON D3300", "Nikon", "D3300"),
+        ("SONY", "ILCE-6000", "Sony", "ILCE-6000"),
+        ("Canon", "Canon EOS 450D", "Canon", "EOS 450D"),
+        ("Apple", "iPhone 12 Pro", "Apple", "iPhone 12 Pro"),
+        ("PENTAX", "PENTAX K-5", "Pentax", "K-5"),
+        ("Google", "Pixel 4a", "Google", "Pixel 4a"),
+        ("FUJIFILM", "X-T1", "Fujifilm", "X-T1"),
+        ("OLYMPUS IMAGING CORP.", "E-M10", "Olympus", "E-M10"),
+        ("Panasonic", "DMC-GX7", "Panasonic", "DMC-GX7"),
+        ("Canon", "Canon EOS R", "Canon", "EOS R"),
+        // Every other make string the corpus contains.
+        ("NIKON", "E8800", "Nikon", "E8800"),
+        ("Nikon", "Nikon COOLSCAN V ED", "Nikon", "COOLSCAN V ED"),
+        ("NIKON CORPORATION", "NIKON 1 AW1", "Nikon", "1 AW1"),
+        ("NIKON CORPORATION", "NIKON Z 30", "Nikon", "Z 30"),
+        (
+            "Canon",
+            "Canon PowerShot A570 IS",
+            "Canon",
+            "PowerShot A570 IS",
+        ),
+        (
+            "Canon",
+            "Canon EOS-1Ds Mark III",
+            "Canon",
+            "EOS-1Ds Mark III",
+        ),
+        ("Canon", "Canon EOS Rebel T6", "Canon", "EOS Rebel T6"),
+        ("SONY", "SLT-A55V", "Sony", "SLT-A55V"),
+        ("SONY", "DSC-RX100M7", "Sony", "DSC-RX100M7"),
+        ("FUJIFILM", "FinePix S9600", "Fujifilm", "FinePix S9600"),
+        ("FUJIFILM", "DBP for GX680", "Fujifilm", "DBP for GX680"),
+        ("OLYMPUS CORPORATION", "E-M1MarkII", "Olympus", "E-M1MarkII"),
+        ("OLYMPUS OPTICAL CO.,LTD", "C5050Z", "Olympus", "C5050Z"),
+        // OM Digital Solutions keeps the brand on the body, and a model
+        // starting "OM-" must not lose its first token to it.
+        ("OM Digital Solutions", "OM-3", "OM System", "OM-3"),
+        (
+            "OM Digital Solutions",
+            "OM-5MarkII",
+            "OM System",
+            "OM-5MarkII",
+        ),
+        ("OM SYSTEM", "OM SYSTEM OM-1", "OM System", "OM-1"),
+        ("Panasonic", "DC-S1R", "Panasonic", "DC-S1R"),
+        ("LEICA", "D-LUX 5", "Leica", "D-LUX 5"),
+        ("LEICA", "C (Typ 112)", "Leica", "C (Typ 112)"),
+        (
+            "LEICA CAMERA AG",
+            "LEICA SL (Typ 601)",
+            "Leica",
+            "SL (Typ 601)",
+        ),
+        ("Leica Camera AG", "LEICA M10", "Leica", "M10"),
+        ("PENTAX Corporation", "PENTAX *ist DL", "Pentax", "*ist DL"),
+        // Ricoh's make covers both brands; the model says which.
+        (
+            "RICOH IMAGING COMPANY, LTD.",
+            "PENTAX K-3 Mark III",
+            "Pentax",
+            "K-3 Mark III",
+        ),
+        ("RICOH IMAGING COMPANY, LTD.", "PENTAX KF", "Pentax", "KF"),
+        ("RICOH IMAGING COMPANY, LTD.", "GR II", "Ricoh", "GR II"),
+        (
+            "RICOH IMAGING COMPANY, LTD.",
+            "RICOH GR IIIx",
+            "Ricoh",
+            "GR IIIx",
+        ),
+        ("SAMSUNG", "NX2000", "Samsung", "NX2000"),
+        ("samsung", "SM-G955F", "Samsung", "SM-G955F"),
+        (
+            "KONICA MINOLTA",
+            "ALPHA-7 DIGITAL",
+            "Minolta",
+            "ALPHA-7 DIGITAL",
+        ),
+        ("KONICA MINOLTA", "MAXXUM 7D", "Minolta", "MAXXUM 7D"),
+        ("Minolta Co., Ltd.", "DiMAGE 7i", "Minolta", "DiMAGE 7i"),
+        (
+            "EASTMAN KODAK COMPANY",
+            "KODAK EasyShare Z981 Digital Camera",
+            "Kodak",
+            "EasyShare Z981",
+        ),
+        (
+            "Eastman Kodak Company",
+            "Kodak Digital Science DC50 Zoom Camera",
+            "Kodak",
+            "Digital Science DC50",
+        ),
+        ("Kodak", "DCS Pro SLR/c", "Kodak", "DCS Pro SLR/c"),
+        ("SEIKO EPSON CORP.", "R-D1x", "Epson", "R-D1x"),
+        ("Mamiya-OP Co.,Ltd.", "MAMIYA ZD", "Mamiya", "ZD"),
+        ("Phase One A/S", "IQ140", "Phase One", "IQ140"),
+        ("Phase One A/S", "iXU180", "Phase One", "iXU180"),
+        // Hasselblad packs the shutter mode into the model, Leaf a
+        // serial number and the back's format.
+        (
+            "Hasselblad",
+            "Hasselblad X2D 100C",
+            "Hasselblad",
+            "X2D 100C",
+        ),
+        ("Hasselblad", "X2D 100C", "Hasselblad", "X2D 100C"),
+        (
+            "Hasselblad",
+            "CFV 100C/Electronic Shutter",
+            "Hasselblad",
+            "CFV 100C",
+        ),
+        ("Hasselblad", "Hasselblad H5D-50c", "Hasselblad", "H5D-50c"),
+        (
+            "Leaf",
+            "Leaf Aptus 75(LI400146   )/Large Format",
+            "Leaf",
+            "Aptus 75",
+        ),
+        (
+            "Leaf",
+            "Leaf AFi-II 12(LI600083   )/Leaf AFi",
+            "Leaf",
+            "AFi-II 12",
+        ),
+        ("SIGMA", "SIGMA DP2 Merrill", "Sigma", "DP2 Merrill"),
+        ("SIGMA", "SIGMA dp0 Quattro", "Sigma", "dp0 Quattro"),
+        ("DJI", "DJI Osmo Action", "DJI", "Osmo Action"),
+        ("DJI", "FC6310", "DJI", "FC6310"),
+        ("GoPro", "HERO8 Black", "GoPro", "HERO8 Black"),
+    ];
+
+    #[test]
+    fn normalises_the_corpus_strings() {
+        for (make, model, want_make, want_model) in CASES {
+            let got = normalize(make, model);
+            assert_eq!(
+                (got.0.as_str(), got.1.as_str()),
+                (*want_make, *want_model),
+                "normalize({make:?}, {model:?})"
+            );
+        }
+    }
+
+    #[test]
+    fn normalises_ragged_strings() {
+        // TIFF ASCII fields are NUL-terminated and vendors pad them.
+        assert_eq!(
+            normalize("NIKON CORPORATION\0\0", "NIKON  D3300 \0junk"),
+            ("Nikon".into(), "D3300".into())
+        );
+        // Whitespace of every kind collapses.
+        assert_eq!(
+            normalize("  Canon\t", "\nCanon   EOS\t 5D  Mark  II "),
+            ("Canon".into(), "EOS 5D Mark II".into())
+        );
+        // A make this crate has never heard of keeps its own spelling,
+        // minus the corporate form.
+        assert_eq!(
+            normalize("Acme Imaging Corp.", "Widget 1"),
+            ("Acme".into(), "Widget 1".into())
+        );
+        // Nothing at all is not an error.
+        assert_eq!(normalize("", ""), (String::new(), String::new()));
+        // A make-less file is rescued from the model, which is how the
+        // CIFF samples carry their camera.
+        assert_eq!(
+            normalize("", "Canon PowerShot A620"),
+            ("Canon".into(), "PowerShot A620".into())
+        );
+        // The model is never stripped away to nothing, however much it
+        // repeats the make.
+        assert_eq!(normalize("DJI", "DJI"), ("DJI".into(), "DJI".into()));
+        assert_eq!(
+            normalize("Nikon", "NIKON"),
+            ("Nikon".into(), "NIKON".into())
+        );
+    }
+
+    #[test]
+    fn normalising_is_idempotent() {
+        // A decoder that hands back its own clean strings must get them
+        // unchanged, or `apply_camera_table` would key on a moving target.
+        for (make, model, _, _) in CASES {
+            let once = normalize(make, model);
+            let twice = normalize(&once.0, &once.1);
+            assert_eq!(
+                once, twice,
+                "normalize is not idempotent on {make:?}/{model:?}"
+            );
+        }
+    }
+
+    // ------------------------------------------------------------- table
+
+    #[test]
+    fn table_is_sorted_and_unique() {
+        for pair in CAMERAS.windows(2) {
+            let (a, b) = (&pair[0], &pair[1]);
+            let order = ci_cmp(a.make, b.make).then_with(|| ci_cmp(a.model, b.model));
+            assert_eq!(
+                order,
+                Ordering::Less,
+                "table out of order (or duplicated) at {}/{} before {}/{}",
+                a.make,
+                a.model,
+                b.make,
+                b.model
+            );
+        }
+    }
+
+    /// The table is keyed on what [`normalize`] produces, not on what
+    /// a file happens to say: an entry whose key does not survive
+    /// normalising could never be found.
+    #[test]
+    fn table_keys_are_normalised() {
+        for camera in CAMERAS {
+            let (make, model) = normalize(camera.make, camera.model);
+            assert_eq!(
+                (make.as_str(), model.as_str()),
+                (camera.make, camera.model),
+                "table key {}/{} is not what normalize would produce",
+                camera.make,
+                camera.model
+            );
+        }
+    }
+
+    #[test]
+    fn every_entry_is_findable() {
+        for camera in CAMERAS {
+            assert_eq!(lookup(camera.make, camera.model), Some(camera));
+            // Case-insensitively too: decoders pass on what the file
+            // said, and vendors are not consistent about case.
+            assert_eq!(
+                lookup(&camera.make.to_uppercase(), &camera.model.to_lowercase()),
+                Some(camera)
+            );
+        }
+        assert_eq!(lookup("Nikon", "no such camera"), None);
+        assert_eq!(lookup("No Such Make", "D3300"), None);
+    }
+
+    #[test]
+    fn olympus_and_om_system_share_a_namespace() {
+        // Whichever make an entry is filed under, both names find it:
+        // bodies from the handover shipped under one and took firmware
+        // under the other.
+        for camera in CAMERAS
+            .iter()
+            .filter(|c| c.make == "Olympus" || c.make == "OM System")
+        {
+            assert!(
+                lookup("Olympus", camera.model).is_some(),
+                "{}",
+                camera.model
+            );
+            assert!(
+                lookup("OM System", camera.model).is_some(),
+                "{}",
+                camera.model
+            );
+        }
+    }
+
+    #[test]
+    fn matrices_are_plausible() {
+        for camera in CAMERAS {
+            let m = camera.color_matrix;
+            let name = format!("{}/{}", camera.make, camera.model);
+            assert!(
+                m.iter().flatten().all(|v| v.is_finite()),
+                "{name}: matrix is not finite"
+            );
+
+            // Invertible, and not so nearly singular that developing
+            // would blow noise up: every real camera matrix sits near
+            // 0.05..1.0 in determinant.
+            let det = m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+                - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+                + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]);
+            assert!(
+                det.abs() > 0.01 && det.abs() < 10.0,
+                "{name}: determinant {det} is not that of a camera matrix"
+            );
+
+            // Each sensor channel responds most to its own part of the
+            // spectrum, so a row's largest term is positive and sits on
+            // the diagonal or next to it (blue channels on phones often
+            // peak one column over, at green).
+            for (i, row) in m.iter().enumerate() {
+                let peak = (0..3)
+                    .max_by(|a, b| row[*a].abs().total_cmp(&row[*b].abs()))
+                    .unwrap();
+                assert!(
+                    row[peak] > 0.0 && peak.abs_diff(i) <= 1,
+                    "{name}: row {i} peaks at column {peak} ({row:?})"
+                );
+            }
+
+            // A neutral must stay neutral-ish: white under D65 has to
+            // give three positive raw responses, or white balance would
+            // divide by a negative number.
+            let response = mul(&m, &WHITE_D65);
+            assert!(
+                response.iter().all(|v| *v > 0.0),
+                "{name}: D65 white gives {response:?}"
+            );
+            // And no channel may be wildly out of proportion: the
+            // implied white-balance multipliers of every camera ever
+            // built land well inside 1..8.
+            let (r, g, b) = (response[0], response[1], response[2]);
+            for mult in [g / r, g / b] {
+                assert!(
+                    (0.2..8.0).contains(&mult),
+                    "{name}: implied white balance {:?} is not a camera's",
+                    [g / r, g / b]
+                );
+            }
+        }
+    }
+
+    fn mul(m: &[[f32; 3]; 3], v: &[f32; 3]) -> [f32; 3] {
+        std::array::from_fn(|i| (0..3).map(|j| m[i][j] * v[j]).sum())
+    }
+
+    // ------------------------------------------------------------ corpus
+
+    /// Pull a JSON string value out of `exiftool -j` output without a
+    /// JSON parser (this crate has no serde). Good enough for the flat
+    /// `"Group:Tag": "value"` shape exiftool writes.
+    fn json_string(text: &str, key: &str) -> Option<String> {
+        let at = text.find(&format!("\"{key}\""))? + key.len() + 2;
+        let rest = text[at..].trim_start();
+        let rest = rest.strip_prefix(':')?.trim_start();
+        let mut chars = rest.strip_prefix('"')?.chars();
+        let mut out = String::new();
+        loop {
+            match chars.next()? {
+                '"' => return Some(out),
+                '\\' => match chars.next()? {
+                    'n' => out.push('\n'),
+                    'u' => {
+                        let hex: String = (0..4).filter_map(|_| chars.next()).collect();
+                        let code = u32::from_str_radix(&hex, 16).ok()?;
+                        out.push(char::from_u32(code)?);
+                    }
+                    other => out.push(other),
+                },
+                other => out.push(other),
+            }
+        }
+    }
+
+    fn walk(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().is_some_and(|e| {
+                let e = e.to_string_lossy().to_ascii_lowercase();
+                !matches!(e.as_str(), "json" | "txt" | "tiff" | "tif")
+            }) {
+                out.push(path);
+            }
+        }
+    }
+
+    /// Every camera in the sample corpus should be in the table.
+    ///
+    /// Opt-in (`SCHIST_RAW_CORPUS=/tmp/rawsamples`) because it needs the
+    /// samples and their `exiftool -j` siblings. It is a report, not a
+    /// gate: it prints the cameras still to be calibrated and passes,
+    /// because the corpus grows faster than anyone can measure matrices
+    /// and a permanently red test teaches people to ignore it. Run it
+    /// with `--nocapture` to read the list, and set `SCHIST_RAW_STRICT`
+    /// as well to make an uncalibrated camera an actual failure.
+    #[test]
+    fn corpus_cameras_are_in_the_table() {
+        let Ok(root) = std::env::var("SCHIST_RAW_CORPUS") else {
+            return;
+        };
+        let mut files = Vec::new();
+        walk(std::path::Path::new(&root), &mut files);
+
+        let mut misses: Vec<String> = Vec::new();
+        let mut hits = 0;
+        for file in files {
+            let sidecar = std::path::PathBuf::from(format!("{}.json", file.display()));
+            let Ok(text) = std::fs::read_to_string(&sidecar) else {
+                continue;
+            };
+            let get = |tag: &str| {
+                json_string(&text, &format!("IFD0:{tag}"))
+                    .or_else(|| json_string(&text, &format!("EXIF:{tag}")))
+                    .or_else(|| json_string(&text, &format!("MakerNotes:{tag}")))
+            };
+            let (Some(make), Some(model)) = (get("Make"), get("Model")) else {
+                continue;
+            };
+            if make.trim().is_empty() && model.trim().is_empty() {
+                continue;
+            }
+            let (clean_make, clean_model) = normalize(&make, &model);
+            if lookup(&clean_make, &clean_model).is_some() {
+                hits += 1;
+            } else {
+                let miss = format!("{clean_make} / {clean_model}   ({make} / {model})");
+                if !misses.contains(&miss) {
+                    misses.push(miss);
+                }
+            }
+        }
+        misses.sort();
+        if misses.is_empty() {
+            println!("corpus: all {hits} samples' cameras are in the table");
+            return;
+        }
+        let report = format!(
+            "{} corpus samples matched; {} cameras have no table entry:\n  {}",
+            hits,
+            misses.len(),
+            misses.join("\n  ")
+        );
+        println!("{report}");
+        assert!(std::env::var_os("SCHIST_RAW_STRICT").is_none(), "{report}");
+    }
+}

--- a/crates/codec-raw/src/demosaic.rs
+++ b/crates/codec-raw/src/demosaic.rs
@@ -1,0 +1,986 @@
+//! Colour filter array interpolation.
+//!
+//! Input is one plane of normalised, white-balanced samples (black
+//! subtracted, white at 1.0) with the CFA that describes it; output is
+//! three floats a pixel.
+//!
+//! Because the plane arrives white balanced, a neutral subject gives
+//! *equal* numbers under every filter colour. That is what makes the
+//! mosaic itself usable as a luminance signal: neighbouring samples of
+//! different colours can be compared directly, so gradients measured
+//! across the mosaic mean something, and the colour-difference planes
+//! (R-G, B-G) really are the slowly varying signals every demosaic
+//! algorithm assumes they are. Demosaicing before white balance would
+//! break both assumptions.
+//!
+//! Three families live here:
+//!
+//! * Bayer, [`Quality::Fast`]: bilinear.
+//! * Bayer, [`Quality::Best`]: the Hamilton-Adams gradient-corrected
+//!   method (Adams & Hamilton, *Adaptive colour plane interpolation*,
+//!   1997), written from the published description: green is
+//!   interpolated along whichever of the horizontal and vertical
+//!   directions has the smaller second-order gradient, with a Laplacian
+//!   correction from the centre pixel's own colour; red and blue then
+//!   follow from the colour-difference planes, choosing the quieter
+//!   diagonal.
+//! * Everything else (X-Trans and arbitrary `Pattern`s): a generic
+//!   per-colour interpolation. `Fast` is an inverse-square-distance
+//!   weighted average of each colour over a 5x5 window. `Best` is a
+//!   gradient-weighted, three-pass version of the same idea: a green
+//!   lowpass to steer the weights with, then green everywhere from
+//!   the colour-difference model, then red and blue as green plus an
+//!   interpolated colour difference. It is directional in the sense
+//!   that matters — a neighbour across an edge barely counts — while
+//!   staying agnostic about where the pattern puts its colours,
+//!   which is what lets one routine serve X-Trans and whatever a
+//!   vendor invents next.
+//!
+//! No part of this is derived from another decoder's source: the
+//! algorithms come from their published descriptions and the code is
+//! this crate's own.
+
+use crate::{Cfa, CfaColor, Error, Result};
+use rayon::prelude::*;
+
+/// How much work to spend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Quality {
+    /// Bilinear: previews, and the fallback for any pattern.
+    Fast,
+    /// The best available for the pattern: an adaptive homogeneity or
+    /// gradient-directed method for Bayer, a directional method for
+    /// X-Trans.
+    #[default]
+    Best,
+}
+
+/// Internal colour codes: the index of the output channel a sample
+/// belongs to. A second green is just green — the develop stage has
+/// already balanced it against the first.
+const RED: u8 = 0;
+const GRN: u8 = 1;
+const BLU: u8 = 2;
+
+/// How far the working plane is extended past the frame. Every
+/// algorithm here reaches at most two pixels, and the widening search
+/// for a missing colour at most six.
+const PAD: usize = 6;
+
+/// Inverse-square-distance weights over a 5x5 window, indexed
+/// `(dy + 2) * 5 + (dx + 2)`. The centre is never used (it is the
+/// pixel's own sample), so its weight is zero.
+#[rustfmt::skip]
+const SPATIAL: [f32; 25] = [
+    0.125, 0.2, 0.25, 0.2, 0.125,
+    0.2,   0.5, 1.0,  0.5, 0.2,
+    0.25,  1.0, 0.0,  1.0, 0.25,
+    0.2,   0.5, 1.0,  0.5, 0.2,
+    0.125, 0.2, 0.25, 0.2, 0.125,
+];
+
+/// How much of the centre's own detail the generic `Best` model
+/// carries across to the other colours.
+///
+/// The colour-difference model says green equals the centre's sample
+/// plus the local mean of green minus the local mean of the centre's
+/// colour. Taken literally (a factor of one) it over-sharpens, and
+/// badly: the centre's colour is sampled every second pixel at best,
+/// so `centre - mean` is a second difference over twice the distance
+/// the green mean spans, and the correction comes out roughly twice
+/// the detail green actually has. Fitting the two transfer functions
+/// over the frequencies a filter array can carry puts the factor
+/// between 0.4 and 0.6 — the same reason Hamilton-Adams weights its
+/// own Laplacian term by a half.
+const CORRECTION: f32 = 0.5;
+
+/// Strength of the edge-sensing term in the generic `Best` weights.
+/// Samples are nominally 0..1, so a difference of an eighth of full
+/// scale roughly halves a neighbour's weight.
+const RANGE: f32 = 8.0;
+
+/// Interpolate `data` (`width * height`, one sample a pixel) under
+/// `cfa` into RGB (`width * height * 3`). Any `Cfa` variant: Bayer and
+/// X-Trans get their proper algorithms, `Pattern` gets a generic
+/// per-colour interpolation (CMYG sensors are converted to RGB by the
+/// develop matrix, so they come out as four "colours" here — see
+/// `develop`).
+pub fn demosaic(
+    data: &[f32],
+    width: usize,
+    height: usize,
+    cfa: &Cfa,
+    quality: Quality,
+) -> Result<Vec<f32>> {
+    if data.len() != width * height {
+        return Err(Error::Corrupt(format!(
+            "demosaic: {} samples for a {}x{} plane",
+            data.len(),
+            width,
+            height
+        )));
+    }
+    if width == 0 || height == 0 {
+        return Ok(Vec::new());
+    }
+    if matches!(cfa, Cfa::None) {
+        return Err(Error::Unsupported(
+            "demosaic: Cfa::None is three samples a pixel already".into(),
+        ));
+    }
+    let mosaic = Mosaic::build(data, width, height, cfa)?;
+    // A Bayer array that is not actually Bayer (a vendor's odd
+    // four-colour layout squeezed into the variant) falls through to
+    // the generic path rather than being interpolated as if the
+    // neighbours were the colours the algorithm expects.
+    let bayer = matches!(cfa, Cfa::Bayer(_)) && mosaic.is_true_bayer();
+    Ok(match (bayer, quality) {
+        (true, Quality::Fast) => bayer_bilinear(&mosaic, width, height),
+        (true, Quality::Best) => bayer_hamilton_adams(&mosaic, width, height),
+        (false, Quality::Fast) => generic_weighted(&mosaic, width, height),
+        (false, Quality::Best) => generic_directional(&mosaic, width, height),
+    })
+}
+
+/// The sample plane extended by [`PAD`] pixels on every side, with a
+/// colour code for every position.
+///
+/// The border is filled by copying from one CFA period further in
+/// (`x - PAD` becomes `x - PAD + period` when it falls off the left,
+/// and so on). Plain mirroring would be wrong for anything but a 2x2
+/// array: moving by a whole period is the only extension that keeps
+/// every padded position under the same filter colour it would have
+/// had if the sensor went on for ever, which is what lets the
+/// algorithms run unbranched right up to the frame edge.
+struct Mosaic {
+    plane: Vec<f32>,
+    codes: Vec<u8>,
+    pw: usize,
+    ph: usize,
+}
+
+impl Mosaic {
+    #[inline(always)]
+    fn at(&self, x: usize, y: usize) -> f32 {
+        self.plane[y * self.pw + x]
+    }
+
+    #[inline(always)]
+    fn code(&self, x: usize, y: usize) -> u8 {
+        self.codes[y * self.pw + x]
+    }
+
+    fn build(data: &[f32], width: usize, height: usize, cfa: &Cfa) -> Result<Mosaic> {
+        let (cw, ch) = match cfa {
+            Cfa::None => return Err(Error::Unsupported("demosaic: no filter array".into())),
+            Cfa::Bayer(_) => (2, 2),
+            Cfa::XTrans(_) => (6, 6),
+            Cfa::Pattern {
+                width: pw,
+                height: ph,
+                colors,
+            } => {
+                if *pw == 0 || *ph == 0 || colors.len() < pw * ph {
+                    return Err(Error::Corrupt(format!(
+                        "demosaic: {}x{} filter pattern with {} colours",
+                        pw,
+                        ph,
+                        colors.len()
+                    )));
+                }
+                (*pw, *ph)
+            }
+        };
+        // One period of colour codes, laid out for *padded*
+        // coordinates: padded x corresponds to sensor x - PAD, so the
+        // period is rotated by PAD (mod the period).
+        let mut period = vec![0u8; cw * ch];
+        for py in 0..ch {
+            for px in 0..cw {
+                let ox = (px + cw * (PAD / cw + 1) - PAD) % cw;
+                let oy = (py + ch * (PAD / ch + 1) - PAD) % ch;
+                let color = cfa
+                    .color_at(ox, oy)
+                    .ok_or_else(|| Error::Corrupt("demosaic: filter pattern is short".into()))?;
+                period[py * cw + px] = code_of(color)?;
+            }
+        }
+        let (pw, ph) = (width + 2 * PAD, height + 2 * PAD);
+        let mut plane = vec![0f32; pw * ph];
+        plane.par_chunks_mut(pw).enumerate().for_each(|(py, row)| {
+            let sy = wrap(py as isize - PAD as isize, height, ch);
+            let src = &data[sy * width..sy * width + width];
+            row[PAD..PAD + width].copy_from_slice(src);
+            for px in 0..PAD {
+                row[px] = src[wrap(px as isize - PAD as isize, width, cw)];
+            }
+            for px in PAD + width..pw {
+                row[px] = src[wrap(px as isize - PAD as isize, width, cw)];
+            }
+        });
+        let mut codes = vec![0u8; pw * ph];
+        codes.par_chunks_mut(pw).enumerate().for_each(|(py, row)| {
+            let base = (py % ch) * cw;
+            let mut i = 0;
+            for c in row.iter_mut() {
+                *c = period[base + i];
+                i += 1;
+                if i == cw {
+                    i = 0;
+                }
+            }
+        });
+        Ok(Mosaic {
+            plane,
+            codes,
+            pw,
+            ph,
+        })
+    }
+
+    /// Whether the 2x2 array really is a Bayer one: one red, one blue
+    /// and two greens on a diagonal. The Hamilton-Adams code assumes
+    /// exactly that.
+    fn is_true_bayer(&self) -> bool {
+        let c = [
+            self.code(0, 0),
+            self.code(1, 0),
+            self.code(0, 1),
+            self.code(1, 1),
+        ];
+        let greens = c.iter().filter(|v| **v == GRN).count();
+        let diagonal = (c[0] == GRN && c[3] == GRN) || (c[1] == GRN && c[2] == GRN);
+        greens == 2
+            && diagonal
+            && c.iter().filter(|v| **v == RED).count() == 1
+            && c.iter().filter(|v| **v == BLU).count() == 1
+    }
+}
+
+fn code_of(color: CfaColor) -> Result<u8> {
+    match color {
+        CfaColor::Red => Ok(RED),
+        // A separately balanced second green is plain green by the
+        // time it reaches here: develop has already applied its own
+        // multiplier.
+        CfaColor::Green | CfaColor::Green2 => Ok(GRN),
+        CfaColor::Blue => Ok(BLU),
+        // CMYG and four-colour (emerald) arrays need a 4x3 sensor-to-
+        // XYZ matrix rather than the 3x3 the rest of this crate
+        // carries, so there is nothing sensible to interpolate them
+        // into yet.
+        other => Err(Error::Unsupported(format!(
+            "demosaic: {other:?} filter array (CMYG and four-colour sensors)"
+        ))),
+    }
+}
+
+/// Fold `i` into `0..n` by whole CFA periods, so the filter colour of
+/// the result is the filter colour `i` would have had. Falls back to
+/// clamping for frames narrower than one period, which no real sensor
+/// is.
+#[inline]
+fn wrap(i: isize, n: usize, period: usize) -> usize {
+    let (n, p) = (n as isize, period.max(1) as isize);
+    let mut i = i;
+    while i < 0 {
+        i += p;
+    }
+    while i >= n {
+        i -= p;
+    }
+    i.clamp(0, n - 1) as usize
+}
+
+/// Bilinear: the missing green at a red or blue site is the average of
+/// its four green neighbours, the missing opposite colour the average
+/// of the four diagonals, and at a green site each of red and blue
+/// comes from the two neighbours that carry it (one axis each).
+fn bayer_bilinear(m: &Mosaic, width: usize, height: usize) -> Vec<f32> {
+    let mut out = vec![0f32; width * height * 3];
+    out.par_chunks_mut(width * 3)
+        .enumerate()
+        .for_each(|(y, row)| {
+            let py = y + PAD;
+            for x in 0..width {
+                let px = x + PAD;
+                let v = m.at(px, py);
+                let (n, s) = (m.at(px, py - 1), m.at(px, py + 1));
+                let (w, e) = (m.at(px - 1, py), m.at(px + 1, py));
+                let o = &mut row[x * 3..x * 3 + 3];
+                match m.code(px, py) {
+                    GRN => {
+                        let horizontal = (w + e) * 0.5;
+                        let vertical = (n + s) * 0.5;
+                        let (r, b) = if m.code(px - 1, py) == RED {
+                            (horizontal, vertical)
+                        } else {
+                            (vertical, horizontal)
+                        };
+                        o[0] = r;
+                        o[1] = v;
+                        o[2] = b;
+                    }
+                    code => {
+                        let g = (n + s + w + e) * 0.25;
+                        let d = (m.at(px - 1, py - 1)
+                            + m.at(px + 1, py - 1)
+                            + m.at(px - 1, py + 1)
+                            + m.at(px + 1, py + 1))
+                            * 0.25;
+                        if code == RED {
+                            o[0] = v;
+                            o[1] = g;
+                            o[2] = d;
+                        } else {
+                            o[0] = d;
+                            o[1] = g;
+                            o[2] = v;
+                        }
+                    }
+                }
+            }
+        });
+    out
+}
+
+/// Hamilton-Adams pass one: green over the whole padded plane.
+///
+/// At a red or blue site the two candidate estimates are the average
+/// of the two green neighbours along an axis plus a quarter of the
+/// second derivative of the *centre's own* colour along the same axis
+/// (`2c - c_-2 - c_+2`). That correction is what carries detail finer
+/// than the green sampling grid across from the red/blue grid. The
+/// direction is chosen by the smaller of the two classifiers
+/// `|g_- - g_+| + |2c - c_-2 - c_+2|`, i.e. interpolate along the edge,
+/// never across it; a tie averages both.
+///
+/// Only the interior of the padded plane is filled: that covers the
+/// two-pixel margin the second pass reads around any real pixel.
+fn bayer_green(m: &Mosaic) -> Vec<f32> {
+    let mut green = vec![0f32; m.pw * m.ph];
+    green
+        .par_chunks_mut(m.pw)
+        .enumerate()
+        .for_each(|(py, row)| {
+            if py < 2 || py + 2 >= m.ph {
+                return;
+            }
+            for (px, out) in row.iter_mut().enumerate().take(m.pw - 2).skip(2) {
+                let v = m.at(px, py);
+                if m.code(px, py) == GRN {
+                    *out = v;
+                    continue;
+                }
+                let (w, e) = (m.at(px - 1, py), m.at(px + 1, py));
+                let (n, s) = (m.at(px, py - 1), m.at(px, py + 1));
+                let lh = 2.0 * v - m.at(px - 2, py) - m.at(px + 2, py);
+                let lv = 2.0 * v - m.at(px, py - 2) - m.at(px, py + 2);
+                let dh = (w - e).abs() + lh.abs();
+                let dv = (n - s).abs() + lv.abs();
+                let gh = 0.5 * (w + e) + 0.25 * lh;
+                let gv = 0.5 * (n + s) + 0.25 * lv;
+                *out = if dh < dv {
+                    gh
+                } else if dv < dh {
+                    gv
+                } else {
+                    0.5 * (gh + gv)
+                };
+            }
+        });
+    green
+}
+
+/// Hamilton-Adams pass two: red and blue from the colour differences.
+///
+/// With green known everywhere, `R - G` and `B - G` are smooth enough
+/// to interpolate linearly. At a green site the missing colour has two
+/// neighbours on one axis; at a red site blue (and vice versa) has
+/// four diagonal ones, and the quieter diagonal — the one whose two
+/// colour differences agree — is used alone.
+fn bayer_hamilton_adams(m: &Mosaic, width: usize, height: usize) -> Vec<f32> {
+    let green = bayer_green(m);
+    let mut out = vec![0f32; width * height * 3];
+    out.par_chunks_mut(width * 3)
+        .enumerate()
+        .for_each(|(y, row)| {
+            let py = y + PAD;
+            let diff = |x: usize, y: usize| m.at(x, y) - green[y * m.pw + x];
+            for x in 0..width {
+                let px = x + PAD;
+                let v = m.at(px, py);
+                let g = green[py * m.pw + px];
+                let o = &mut row[x * 3..x * 3 + 3];
+                match m.code(px, py) {
+                    GRN => {
+                        let horizontal = 0.5 * (diff(px - 1, py) + diff(px + 1, py));
+                        let vertical = 0.5 * (diff(px, py - 1) + diff(px, py + 1));
+                        let (r, b) = if m.code(px - 1, py) == RED {
+                            (horizontal, vertical)
+                        } else {
+                            (vertical, horizontal)
+                        };
+                        o[0] = g + r;
+                        o[1] = v;
+                        o[2] = g + b;
+                    }
+                    code => {
+                        let nw = diff(px - 1, py - 1);
+                        let ne = diff(px + 1, py - 1);
+                        let sw = diff(px - 1, py + 1);
+                        let se = diff(px + 1, py + 1);
+                        let down = (nw - se).abs();
+                        let up = (ne - sw).abs();
+                        let other = g + if down < up {
+                            0.5 * (nw + se)
+                        } else if up < down {
+                            0.5 * (ne + sw)
+                        } else {
+                            0.25 * (nw + ne + sw + se)
+                        };
+                        if code == RED {
+                            o[0] = v;
+                            o[1] = g;
+                            o[2] = other;
+                        } else {
+                            o[0] = other;
+                            o[1] = g;
+                            o[2] = v;
+                        }
+                    }
+                }
+            }
+        });
+    out
+}
+
+/// The last resort when a colour is missing from the 5x5 window (a
+/// pathological pattern, never a real sensor): widen ring by ring.
+fn wide_average(m: &Mosaic, px: usize, py: usize, want: u8) -> Option<f32> {
+    for r in 3..=PAD as isize {
+        let mut sum = 0.0;
+        let mut weight = 0.0;
+        for dy in -r..=r {
+            for dx in -r..=r {
+                if dx.abs() != r && dy.abs() != r {
+                    continue;
+                }
+                let (qx, qy) = ((px as isize + dx) as usize, (py as isize + dy) as usize);
+                if m.code(qx, qy) == want {
+                    let w = 1.0 / (dx * dx + dy * dy) as f32;
+                    sum += w * m.at(qx, qy);
+                    weight += w;
+                }
+            }
+        }
+        if weight > 0.0 {
+            return Some(sum / weight);
+        }
+    }
+    None
+}
+
+/// The generic `Fast` path: every missing colour is the inverse-square
+/// distance weighted average of that colour over a 5x5 window. It
+/// makes no assumption at all about the layout, so it works for
+/// X-Trans and for any `Cfa::Pattern`; it is simply soft, since each
+/// channel is reconstructed only from its own sparse samples.
+fn generic_weighted(m: &Mosaic, width: usize, height: usize) -> Vec<f32> {
+    let mut out = vec![0f32; width * height * 3];
+    out.par_chunks_mut(width * 3)
+        .enumerate()
+        .for_each(|(y, row)| {
+            let py = y + PAD;
+            for x in 0..width {
+                let px = x + PAD;
+                let own = m.code(px, py);
+                let mut sum = [0f32; 3];
+                let mut weight = [0f32; 3];
+                for dy in -2isize..=2 {
+                    let qy = (py as isize + dy) as usize;
+                    for dx in -2isize..=2 {
+                        if dx == 0 && dy == 0 {
+                            continue;
+                        }
+                        let qx = (px as isize + dx) as usize;
+                        let k = m.code(qx, qy) as usize;
+                        let w = SPATIAL[(dy + 2) as usize * 5 + (dx + 2) as usize];
+                        sum[k] += w * m.at(qx, qy);
+                        weight[k] += w;
+                    }
+                }
+                let o = &mut row[x * 3..x * 3 + 3];
+                for k in 0..3 {
+                    o[k] = if k as u8 == own {
+                        m.at(px, py)
+                    } else if weight[k] > 0.0 {
+                        sum[k] / weight[k]
+                    } else {
+                        wide_average(m, px, py, k as u8).unwrap_or_else(|| m.at(px, py))
+                    };
+                }
+            }
+        });
+    out
+}
+
+/// A dense but blurry green: the distance-weighted mean of the green
+/// samples in a 5x5 window, at *every* position.
+///
+/// This exists only as a guide for the edge-sensing weights below. The
+/// obvious thing — weighting a neighbour by how far its sample is from
+/// the centre's — is wrong across a filter array, because two samples
+/// of different colours differ by the subject's colour as well as by
+/// any edge between them. On a smooth gradient that turns into a
+/// systematic bias: the greens on the side whose values happen to sit
+/// nearer the centre's colour get the larger weights, and the mean
+/// comes out shifted. Comparing two green estimates instead compares
+/// like with like, so the weights stay symmetric where the image is
+/// smooth and only really change at edges.
+fn green_lowpass(m: &Mosaic) -> Vec<f32> {
+    let mut out = vec![0f32; m.pw * m.ph];
+    out.par_chunks_mut(m.pw).enumerate().for_each(|(py, row)| {
+        if py < 2 || py + 2 >= m.ph {
+            return;
+        }
+        for (px, out) in row.iter_mut().enumerate().take(m.pw - 2).skip(2) {
+            let mut sum = 0f32;
+            let mut weight = 0f32;
+            for dy in -2isize..=2 {
+                let qy = (py as isize + dy) as usize;
+                for dx in -2isize..=2 {
+                    let qx = (px as isize + dx) as usize;
+                    if (dx == 0 && dy == 0) || m.code(qx, qy) != GRN {
+                        continue;
+                    }
+                    let w = SPATIAL[(dy + 2) as usize * 5 + (dx + 2) as usize];
+                    sum += w * m.at(qx, qy);
+                    weight += w;
+                }
+            }
+            *out = if weight > 0.0 {
+                sum / weight
+            } else {
+                m.at(px, py)
+            };
+        }
+    });
+    out
+}
+
+/// Generic `Best`, pass one: green over the padded plane.
+///
+/// The model is the standard one — colour differences vary slowly — but
+/// applied without any assumption about where the colours sit. At a
+/// non-green site, green is the centre's own sample plus the local
+/// mean of green minus the local mean of the centre's colour (the
+/// centre itself excluded, so the sample's own detail survives instead
+/// of being averaged away). On a smooth gradient both means come out
+/// at the centre's position, so the estimate reduces to "the same
+/// colour difference as the neighbourhood", which is exact.
+///
+/// The weights are edge sensing: a neighbour counts less the further
+/// the *green lowpass* at its position is from the centre's, which on
+/// a white-balanced mosaic means "less across an edge" and nothing at
+/// all on smooth ground.
+fn generic_green(m: &Mosaic, guide: &[f32]) -> Vec<f32> {
+    let mut green = vec![0f32; m.pw * m.ph];
+    green
+        .par_chunks_mut(m.pw)
+        .enumerate()
+        .for_each(|(py, row)| {
+            if py < 4 || py + 4 >= m.ph {
+                return;
+            }
+            for (px, out) in row.iter_mut().enumerate().take(m.pw - 4).skip(4) {
+                let own = m.code(px, py);
+                let centre = m.at(px, py);
+                if own == GRN {
+                    *out = centre;
+                    continue;
+                }
+                let here = guide[py * m.pw + px];
+                let (mut sum_g, mut weight_g) = (0f32, 0f32);
+                let (mut sum_c, mut weight_c) = (0f32, 0f32);
+                for dy in -2isize..=2 {
+                    let qy = (py as isize + dy) as usize;
+                    for dx in -2isize..=2 {
+                        if dx == 0 && dy == 0 {
+                            continue;
+                        }
+                        let qx = (px as isize + dx) as usize;
+                        let k = m.code(qx, qy);
+                        if k != GRN && k != own {
+                            continue;
+                        }
+                        let w = SPATIAL[(dy + 2) as usize * 5 + (dx + 2) as usize]
+                            / (1.0 + RANGE * (guide[qy * m.pw + qx] - here).abs());
+                        if k == GRN {
+                            sum_g += w * m.at(qx, qy);
+                            weight_g += w;
+                        } else {
+                            sum_c += w * m.at(qx, qy);
+                            weight_c += w;
+                        }
+                    }
+                }
+                *out = if weight_g <= 0.0 {
+                    centre
+                } else if weight_c <= 0.0 {
+                    sum_g / weight_g
+                } else {
+                    sum_g / weight_g + CORRECTION * (centre - sum_c / weight_c)
+                };
+            }
+        });
+    green
+}
+
+/// Generic `Best`, pass two: red and blue as green plus an
+/// interpolated colour difference, with the edge-sensing weights now
+/// measured on the dense green plane.
+fn generic_directional(m: &Mosaic, width: usize, height: usize) -> Vec<f32> {
+    let green = generic_green(m, &green_lowpass(m));
+    let mut out = vec![0f32; width * height * 3];
+    out.par_chunks_mut(width * 3)
+        .enumerate()
+        .for_each(|(y, row)| {
+            let py = y + PAD;
+            for x in 0..width {
+                let px = x + PAD;
+                let own = m.code(px, py);
+                let centre = m.at(px, py);
+                let g = green[py * m.pw + px];
+                let mut sum = [0f32; 3];
+                let mut weight = [0f32; 3];
+                for dy in -2isize..=2 {
+                    let qy = (py as isize + dy) as usize;
+                    for dx in -2isize..=2 {
+                        if dx == 0 && dy == 0 {
+                            continue;
+                        }
+                        let qx = (px as isize + dx) as usize;
+                        let k = m.code(qx, qy) as usize;
+                        if k == GRN as usize {
+                            continue;
+                        }
+                        let qg = green[qy * m.pw + qx];
+                        let w = SPATIAL[(dy + 2) as usize * 5 + (dx + 2) as usize]
+                            / (1.0 + RANGE * (qg - g).abs());
+                        sum[k] += w * (m.at(qx, qy) - qg);
+                        weight[k] += w;
+                    }
+                }
+                let o = &mut row[x * 3..x * 3 + 3];
+                o[1] = g;
+                for k in [RED as usize, BLU as usize] {
+                    o[k] = if k as u8 == own {
+                        centre
+                    } else if weight[k] > 0.0 {
+                        g + sum[k] / weight[k]
+                    } else {
+                        wide_average(m, px, py, k as u8).unwrap_or(g)
+                    };
+                }
+            }
+        });
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A synthetic scene, built the way photographs are: one
+    /// luminance field carrying all the detail, modulated by a
+    /// chromaticity that varies slowly across the frame, plus a
+    /// couple of genuinely coloured patches.
+    ///
+    /// That correlation is not decoration. Every demosaic algorithm
+    /// worth the name works by assuming the colour *differences* are
+    /// the smooth part of the picture and the luminance carries the
+    /// detail, which is true of light through any real lens and any
+    /// real subject. A test image whose three channels moved
+    /// independently would punish exactly the assumption that makes
+    /// these algorithms good, and would measure nothing a sensor ever
+    /// sees.
+    ///
+    /// `detail` adds what separates the methods: hard edges at four
+    /// orientations, a fine near-Nyquist texture, and a zone plate
+    /// whose frequency climbs towards the corner.
+    fn scene(width: usize, height: usize, detail: bool) -> Vec<f32> {
+        let mut rgb = vec![0f32; width * height * 3];
+        for y in 0..height {
+            for x in 0..width {
+                let (fx, fy) = (x as f32 / width as f32, y as f32 / height as f32);
+                let mut l = 0.45 + 0.20 * fx - 0.10 * fy
+                    + 0.10 * (std::f32::consts::TAU * (fx + 0.5 * fy)).sin();
+                if detail {
+                    l += 0.05 * (x as f32 * 0.9).sin() * (y as f32 * 1.1).sin();
+                    if x < width / 2 && y < height / 2 {
+                        let (dx, dy) = (x as f32, y as f32);
+                        l = 0.5 + 0.32 * (0.006 * (dx * dx + dy * dy)).sin();
+                    }
+                    if (width / 2..width * 3 / 4).contains(&x)
+                        && (height / 8..height * 3 / 8).contains(&y)
+                    {
+                        l = 0.88;
+                    }
+                    if (x as f32) > 0.35 * width as f32 + 0.7 * y as f32 {
+                        l = 0.12;
+                    }
+                    if y > height * 7 / 8 {
+                        l = 0.75;
+                    }
+                }
+                // Slowly varying chromaticity, and — in the detailed
+                // scene — two patches where the colour itself changes.
+                // A demosaic has to survive those too, they are just
+                // rarer in photographs than luminance edges.
+                let (mut cr, mut cb) = (0.85 + 0.35 * fx, 1.15 - 0.35 * fy);
+                if detail {
+                    if (width / 8..width / 4).contains(&x)
+                        && (height / 2..height * 3 / 4).contains(&y)
+                    {
+                        cr = 1.6;
+                        cb = 0.4;
+                    }
+                    if (width / 3..width / 2).contains(&x)
+                        && (height * 5 / 8..height * 7 / 8).contains(&y)
+                    {
+                        cr = 0.4;
+                        cb = 1.7;
+                    }
+                }
+                let pixel = [
+                    (l * cr).clamp(0.0, 1.0),
+                    l.clamp(0.0, 1.0),
+                    (l * cb).clamp(0.0, 1.0),
+                ];
+                rgb[(y * width + x) * 3..(y * width + x) * 3 + 3].copy_from_slice(&pixel);
+            }
+        }
+        rgb
+    }
+
+    /// Sample a full-colour image through a filter array.
+    fn mosaic(rgb: &[f32], width: usize, height: usize, cfa: &Cfa) -> Vec<f32> {
+        (0..width * height)
+            .map(|i| {
+                let color = cfa.color_at(i % width, i / width).expect("test pattern");
+                rgb[i * 3 + code_of(color).expect("test colour") as usize]
+            })
+            .collect()
+    }
+
+    /// Peak signal to noise over the interior, ignoring `margin`
+    /// pixels of frame edge (every algorithm is degraded there and the
+    /// numbers would say more about the border policy than the
+    /// interpolation).
+    fn psnr(truth: &[f32], test: &[f32], width: usize, height: usize, margin: usize) -> f32 {
+        let mut sum = 0f64;
+        let mut n = 0u64;
+        for y in margin..height - margin {
+            for x in margin..width - margin {
+                for c in 0..3 {
+                    let d = (truth[(y * width + x) * 3 + c] - test[(y * width + x) * 3 + c]) as f64;
+                    sum += d * d;
+                    n += 1;
+                }
+            }
+        }
+        (10.0 * (1.0 / (sum / n as f64)).log10()) as f32
+    }
+
+    /// The Fujifilm X-Trans array, taken from the 36-byte CFA table in
+    /// the header of a real X-T10 RAF (metadata tag 0x131, 0 = red,
+    /// 1 = green, 2 = blue): twenty greens, eight each of red and
+    /// blue, with the 2x2 green blocks that give the array its name.
+    fn xtrans() -> Cfa {
+        #[rustfmt::skip]
+        const CODES: [[u8; 6]; 6] = [
+            [2, 1, 1, 0, 1, 1],
+            [0, 1, 1, 2, 1, 1],
+            [1, 2, 0, 1, 0, 2],
+            [0, 1, 1, 2, 1, 1],
+            [2, 1, 1, 0, 1, 1],
+            [1, 0, 2, 1, 2, 0],
+        ];
+        Cfa::XTrans(std::array::from_fn(|y| {
+            std::array::from_fn(|x| match CODES[y][x] {
+                0 => CfaColor::Red,
+                1 => CfaColor::Green,
+                _ => CfaColor::Blue,
+            })
+        }))
+    }
+
+    fn report(name: &str, cfa: &Cfa, edges: bool) -> (f32, f32) {
+        let (w, h) = (192, 160);
+        let truth = scene(w, h, edges);
+        let plane = mosaic(&truth, w, h, cfa);
+        let fast = demosaic(&plane, w, h, cfa, Quality::Fast).expect("fast");
+        let best = demosaic(&plane, w, h, cfa, Quality::Best).expect("best");
+        let (a, b) = (psnr(&truth, &fast, w, h, 6), psnr(&truth, &best, w, h, 6));
+        println!("{name}: fast {a:.2} dB, best {b:.2} dB");
+        (a, b)
+    }
+
+    #[test]
+    fn bayer_smooth_scene() {
+        for (name, cfa) in [
+            ("RGGB", Cfa::RGGB),
+            ("BGGR", Cfa::BGGR),
+            ("GRBG", Cfa::GRBG),
+            ("GBRG", Cfa::GBRG),
+        ] {
+            let (fast, best) = report(name, &cfa, false);
+            assert!(fast > 80.0, "{name} bilinear on a smooth scene: {fast} dB");
+            assert!(
+                best > 88.0,
+                "{name} Hamilton-Adams on a smooth scene: {best} dB"
+            );
+            assert!(
+                best > fast,
+                "{name}: best {best} dB is no better than fast {fast} dB"
+            );
+        }
+    }
+
+    #[test]
+    fn bayer_edges() {
+        for (name, cfa) in [
+            ("RGGB", Cfa::RGGB),
+            ("BGGR", Cfa::BGGR),
+            ("GRBG", Cfa::GRBG),
+            ("GBRG", Cfa::GBRG),
+        ] {
+            let (fast, best) = report(name, &cfa, true);
+            assert!(fast > 25.0, "{name} bilinear on edges: {fast} dB");
+            // The whole point of a directional method: several
+            // decibels of it, exactly where bilinear smears across
+            // the edge instead of along it.
+            assert!(
+                best > fast + 4.0,
+                "{name}: best {best} dB over fast {fast} dB"
+            );
+        }
+    }
+
+    #[test]
+    fn xtrans_scene() {
+        let (fast, best) = report("x-trans smooth", &xtrans(), false);
+        assert!(fast > 60.0, "x-trans weighted on a smooth scene: {fast} dB");
+        assert!(
+            best > fast + 5.0,
+            "x-trans: best {best} dB is no better than fast {fast} dB"
+        );
+        let (fast, best) = report("x-trans edges", &xtrans(), true);
+        assert!(fast > 22.0, "x-trans weighted on edges: {fast} dB");
+        assert!(
+            best > fast + 5.0,
+            "x-trans edges: best {best} dB is no better than fast {fast} dB"
+        );
+    }
+
+    /// An RGB `Cfa::Pattern` goes down the generic path and must still
+    /// reconstruct the scene; here the very same 2x2 array as
+    /// `Cfa::RGGB`, so the two paths are directly comparable.
+    #[test]
+    fn generic_pattern() {
+        let cfa = Cfa::Pattern {
+            width: 2,
+            height: 2,
+            colors: vec![
+                CfaColor::Red,
+                CfaColor::Green,
+                CfaColor::Green,
+                CfaColor::Blue,
+            ],
+        };
+        let (fast, best) = report("pattern RGGB", &cfa, false);
+        assert!(fast > 80.0, "generic weighted: {fast} dB");
+        assert!(
+            best > fast + 5.0,
+            "generic: best {best} dB is no better than fast {fast} dB"
+        );
+    }
+
+    /// A Bayer array that is not one — the four phases the algorithm
+    /// knows are the only ones it may assume — falls back to the
+    /// generic path instead of interpolating nonsense.
+    #[test]
+    fn odd_bayer_falls_back() {
+        let cfa = Cfa::Bayer([
+            CfaColor::Red,
+            CfaColor::Green,
+            CfaColor::Blue,
+            CfaColor::Green,
+        ]);
+        let (w, h) = (32, 32);
+        let plane = vec![0.5f32; w * h];
+        let out = demosaic(&plane, w, h, &cfa, Quality::Best).expect("odd bayer");
+        assert!(out.iter().all(|v| (*v - 0.5).abs() < 1e-5));
+    }
+
+    /// A flat field must come out flat under every path: any
+    /// interpolation of a constant is that constant.
+    #[test]
+    fn flat_field_stays_flat() {
+        for cfa in [Cfa::RGGB, Cfa::GBRG, xtrans()] {
+            for quality in [Quality::Fast, Quality::Best] {
+                let (w, h) = (37, 41);
+                let plane = vec![0.25f32; w * h];
+                let out = demosaic(&plane, w, h, &cfa, quality).expect("flat");
+                let worst = out.iter().map(|v| (*v - 0.25).abs()).fold(0.0f32, f32::max);
+                assert!(worst < 1e-5, "{cfa:?} {quality:?} drifted by {worst}");
+            }
+        }
+    }
+
+    /// Sizes smaller than the working border, odd sizes, and single
+    /// rows: the padded plane is built by whole CFA periods, so none
+    /// of these may panic.
+    #[test]
+    fn small_frames_do_not_panic() {
+        for (w, h) in [(1, 1), (2, 2), (1, 9), (9, 1), (3, 5), (6, 6), (13, 7)] {
+            for cfa in [Cfa::RGGB, xtrans()] {
+                for quality in [Quality::Fast, Quality::Best] {
+                    let plane: Vec<f32> = (0..w * h).map(|i| (i % 17) as f32 / 17.0).collect();
+                    let out = demosaic(&plane, w, h, &cfa, quality).expect("small frame");
+                    assert_eq!(out.len(), w * h * 3);
+                    assert!(out.iter().all(|v| v.is_finite()));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_bad_input() {
+        assert!(matches!(
+            demosaic(&[0.0; 3], 2, 2, &Cfa::RGGB, Quality::Fast),
+            Err(crate::Error::Corrupt(_))
+        ));
+        assert!(matches!(
+            demosaic(&[0.0; 4], 2, 2, &Cfa::None, Quality::Fast),
+            Err(crate::Error::Unsupported(_))
+        ));
+        // CMYG: no 3x3 matrix can describe it, so it is refused rather
+        // than guessed at.
+        let cmyg = Cfa::Pattern {
+            width: 2,
+            height: 2,
+            colors: vec![
+                CfaColor::Cyan,
+                CfaColor::Magenta,
+                CfaColor::Yellow,
+                CfaColor::Green,
+            ],
+        };
+        assert!(matches!(
+            demosaic(&[0.0; 4], 2, 2, &cmyg, Quality::Fast),
+            Err(crate::Error::Unsupported(_))
+        ));
+    }
+}

--- a/crates/codec-raw/src/develop.rs
+++ b/crates/codec-raw/src/develop.rs
@@ -1,0 +1,968 @@
+//! From sensor data to linear sRGB.
+//!
+//! The classic pipeline: subtract the black level, scale so the white
+//! level is 1.0, apply the white balance multipliers, interpolate the
+//! CFA, convert camera colour to sRGB through the camera matrix (with
+//! the white balance folded in the way DNG describes, so a neutral
+//! stays neutral), clip, then crop and orient. Output is linear light;
+//! the caller applies a tone curve and encoding.
+
+use crate::demosaic::demosaic;
+use crate::{Cfa, CfaColor, Error, Orientation, RawData, RawImage, Rect, Result};
+use rayon::prelude::*;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DevelopOptions {
+    pub quality: crate::demosaic::Quality,
+    /// Multipliers to use instead of the file's as-shot ones.
+    pub white_balance: Option<[f32; 4]>,
+    /// Apply `raw.crop`. Off yields the whole frame, masked borders and
+    /// all — for tests against an oracle's uncropped output.
+    pub crop: bool,
+    /// Apply `raw.orientation`.
+    pub orient: bool,
+    /// Skip the matrix and return white-balanced camera RGB, for
+    /// cameras with no matrix (the caller decides what to do).
+    pub camera_rgb: bool,
+}
+
+impl Default for DevelopOptions {
+    fn default() -> Self {
+        DevelopOptions {
+            quality: Default::default(),
+            white_balance: None,
+            crop: true,
+            orient: true,
+            camera_rgb: false,
+        }
+    }
+}
+
+/// Linear sRGB, three floats a pixel, nominally 0..=1 (specular
+/// highlights and out-of-gamut colours may exceed it).
+#[derive(Debug, Clone, PartialEq)]
+pub struct Developed {
+    pub width: usize,
+    pub height: usize,
+    pub rgb: Vec<f32>,
+}
+
+pub fn develop(raw: &RawImage, options: &DevelopOptions) -> Result<Developed> {
+    // Everything below indexes `data` from the declared dimensions and
+    // the crop, so the invariants have to hold before any of it runs.
+    raw.validate()?;
+    // `validate` pairs one sample a pixel with a filter array and
+    // three with none, but says nothing about the counts in between;
+    // nothing here knows what a two- or four-sample frame would mean.
+    if raw.cpp != 1 && raw.cpp != 3 {
+        return Err(Error::Unsupported(format!(
+            "develop: {} samples a pixel",
+            raw.cpp
+        )));
+    }
+    let (width, height) = (raw.width, raw.height);
+    let multipliers = white_balance(raw, options);
+
+    // Steps (a) and (b): one pass turning sensor units into
+    // white-balanced 0..1 scene-linear numbers. `Levels` holds the
+    // per-CFA-position black and the combined 1/(white-black) and
+    // white balance factor, so this costs one subtract and one
+    // multiply a sample.
+    let mut rgb = if raw.cpp == 3 {
+        // Linear DNG, Foveon and Canon sRAW arrive with three samples
+        // a pixel: no interpolation, levels and multipliers per
+        // channel.
+        let levels = Levels::per_channel(raw, multipliers)?;
+        let mut rgb = vec![0f32; width * height * 3];
+        let stride = width * 3;
+        match &raw.data {
+            RawData::U16(v) => rgb.par_chunks_mut(stride).enumerate().for_each(|(y, row)| {
+                normalise_pixels(row, &v[y * stride..(y + 1) * stride], &levels)
+            }),
+            RawData::F32(v) => rgb.par_chunks_mut(stride).enumerate().for_each(|(y, row)| {
+                normalise_pixels(row, &v[y * stride..(y + 1) * stride], &levels)
+            }),
+        }
+        rgb
+    } else {
+        let levels = Levels::per_position(raw, multipliers)?;
+        let mut plane = vec![0f32; width * height];
+        match &raw.data {
+            RawData::U16(v) => plane
+                .par_chunks_mut(width)
+                .enumerate()
+                .for_each(|(y, row)| {
+                    normalise_row(row, &v[y * width..(y + 1) * width], &levels, y)
+                }),
+            RawData::F32(v) => plane
+                .par_chunks_mut(width)
+                .enumerate()
+                .for_each(|(y, row)| {
+                    normalise_row(row, &v[y * width..(y + 1) * width], &levels, y)
+                }),
+        }
+        // Step (c).
+        demosaic(&plane, width, height, &raw.cfa, options.quality)?
+    };
+
+    // Step (d): camera RGB to linear sRGB. No matrix (or the caller
+    // asked for camera RGB) leaves the numbers in the camera's own
+    // space, which is still white balanced and so still neutral-
+    // correct, just not colour-correct.
+    let matrix = if options.camera_rgb {
+        None
+    } else {
+        raw.color_matrix.as_ref().map(camera_to_srgb)
+    };
+
+    // Steps (e) and (f). The crop happens after the interpolation, so
+    // the CFA phase never has to be adjusted: the demosaic saw the
+    // whole frame with the pattern anchored where the decoder said it
+    // was, and what comes out is plain RGB that can be cut anywhere.
+    // It also means the crop's edge pixels have real neighbours
+    // instead of the frame's own extended border.
+    let crop = if options.crop {
+        raw.crop
+    } else {
+        Rect {
+            x: 0,
+            y: 0,
+            width,
+            height,
+        }
+    };
+    let (mut out_w, mut out_h) = (crop.width, crop.height);
+    if crop.x == 0 && crop.y == 0 && crop.width == width && crop.height == height {
+        rgb.par_chunks_mut(width * 3)
+            .for_each(|row| finish_row(row, matrix.as_ref()));
+    } else {
+        let mut cropped = vec![0f32; crop.width * crop.height * 3];
+        cropped
+            .par_chunks_mut(crop.width * 3)
+            .enumerate()
+            .for_each(|(y, row)| {
+                let start = ((y + crop.y) * width + crop.x) * 3;
+                row.copy_from_slice(&rgb[start..start + crop.width * 3]);
+                finish_row(row, matrix.as_ref());
+            });
+        rgb = cropped;
+    }
+
+    // Step (g).
+    if options.orient && raw.orientation != Orientation::Normal {
+        rgb = orient(&rgb, out_w, out_h, raw.orientation);
+        if raw.orientation.transposes() {
+            std::mem::swap(&mut out_w, &mut out_h);
+        }
+    }
+    Ok(Developed {
+        width: out_w,
+        height: out_h,
+        rgb,
+    })
+}
+
+/// Sensor units to white-balanced scene-linear, one CFA row.
+///
+/// `black` and `gain` repeat with the filter pattern, so the position
+/// index cycles along the row rather than costing a division a sample.
+#[inline]
+fn normalise_row<T: Copy + Into<f32>>(row: &mut [f32], src: &[T], levels: &Levels, y: usize) {
+    let base = (y % levels.height) * levels.width;
+    let mut i = 0;
+    for (out, sample) in row.iter_mut().zip(src.iter()) {
+        *out = ((*sample).into() - levels.black[base + i]) * levels.gain[base + i];
+        i += 1;
+        if i == levels.width {
+            i = 0;
+        }
+    }
+}
+
+/// The same for data that is already three samples a pixel, where the
+/// levels are per channel rather than per filter position.
+#[inline]
+fn normalise_pixels<T: Copy + Into<f32>>(row: &mut [f32], src: &[T], levels: &Levels) {
+    for (pixel, sample) in row
+        .as_chunks_mut::<3>()
+        .0
+        .iter_mut()
+        .zip(src.as_chunks::<3>().0)
+    {
+        for (c, out) in pixel.iter_mut().enumerate() {
+            *out = (sample[c].into() - levels.black[c]) * levels.gain[c];
+        }
+    }
+}
+
+/// Apply the colour matrix, then clip negatives. Values above 1 are
+/// left alone: they are real light (specular highlights, and colours
+/// outside sRGB's gamut after the matrix), and the caller's tone curve
+/// is what should decide their fate.
+#[inline]
+fn finish_row(row: &mut [f32], matrix: Option<&[[f32; 3]; 3]>) {
+    match matrix {
+        Some(m) => {
+            for pixel in row.as_chunks_mut::<3>().0 {
+                let (r, g, b) = (pixel[0], pixel[1], pixel[2]);
+                for (c, out) in pixel.iter_mut().enumerate() {
+                    // NaN loses to 0.0 here, which is what we want for
+                    // a sample that arrived broken.
+                    *out = (m[c][0] * r + m[c][1] * g + m[c][2] * b).max(0.0);
+                }
+            }
+        }
+        None => {
+            for v in row.iter_mut() {
+                *v = v.max(0.0);
+            }
+        }
+    }
+}
+
+/// The multipliers to use: the caller's override, else the file's
+/// as-shot ones, with anything unusable replaced by 1.0. A zero or
+/// missing second green means "the sensor has one green", so it takes
+/// the first green's multiplier.
+fn white_balance(raw: &RawImage, options: &DevelopOptions) -> [f32; 4] {
+    let source = options.white_balance.unwrap_or(raw.wb_coeffs);
+    let usable = |m: f32| m.is_finite() && m > 0.0;
+    let mut wb = [1.0f32; 4];
+    for (out, m) in wb.iter_mut().zip(source.iter()) {
+        if usable(*m) {
+            *out = *m;
+        }
+    }
+    if !usable(source[3]) {
+        wb[3] = wb[1];
+    }
+    // The contract puts green at exactly 1.0; a decoder that forgot
+    // would otherwise scale the whole picture.
+    if wb[1] != 1.0 {
+        let g = wb[1];
+        for m in wb.iter_mut() {
+            *m /= g;
+        }
+    }
+    wb
+}
+
+/// Black level and combined scale for every position of the CFA
+/// period (or, for three-sample data, for every channel).
+struct Levels {
+    width: usize,
+    height: usize,
+    black: Vec<f32>,
+    gain: Vec<f32>,
+}
+
+impl Levels {
+    fn per_channel(raw: &RawImage, wb: [f32; 4]) -> Result<Levels> {
+        let mut levels = Levels {
+            width: 1,
+            height: 1,
+            black: Vec::with_capacity(3),
+            gain: Vec::with_capacity(3),
+        };
+        for (black, multiplier) in raw.black_levels.iter().zip(wb.iter()).take(3) {
+            levels.black.push(*black);
+            levels
+                .gain
+                .push(scale(*black, raw.white_level)? * multiplier);
+        }
+        Ok(levels)
+    }
+
+    fn per_position(raw: &RawImage, wb: [f32; 4]) -> Result<Levels> {
+        // For Bayer the four black levels *are* the four positions of
+        // the 2x2 array, in the same row-major order, so they index
+        // directly. Sensors that need this are the ones whose green
+        // rows sit at different offsets.
+        //
+        // For X-Trans and arbitrary patterns there is no such
+        // correspondence — a 6x6 array has 36 positions — so a single
+        // level is used unless the file gave four genuinely different
+        // ones, in which case they can only have meant one per colour
+        // (R, G, B, second G).
+        let (pw, ph) = match &raw.cfa {
+            Cfa::None => {
+                return Err(Error::Corrupt(
+                    "develop: one sample a pixel with no filter array".into(),
+                ))
+            }
+            Cfa::Bayer(_) => (2, 2),
+            Cfa::XTrans(_) => (6, 6),
+            Cfa::Pattern { width, height, .. } => (*width, *height),
+        };
+        if pw == 0 || ph == 0 {
+            return Err(Error::Corrupt("develop: empty filter pattern".into()));
+        }
+        // A period is a handful of pixels; a pattern claiming millions
+        // is a forged header, and must not size an allocation.
+        let cells = pw
+            .checked_mul(ph)
+            .filter(|n| *n <= 4096)
+            .ok_or_else(|| Error::Corrupt(format!("develop: filter pattern of {pw}x{ph}")))?;
+        if let Cfa::Pattern { colors, .. } = &raw.cfa {
+            if colors.len() != cells {
+                return Err(Error::Corrupt(format!(
+                    "develop: pattern of {pw}x{ph} with {} colours",
+                    colors.len()
+                )));
+            }
+        }
+        let bayer = matches!(raw.cfa, Cfa::Bayer(_));
+        let uniform = raw.black_levels.iter().all(|b| *b == raw.black_levels[0]);
+        let mut levels = Levels {
+            width: pw,
+            height: ph,
+            black: vec![0.0; pw * ph],
+            gain: vec![0.0; pw * ph],
+        };
+        for y in 0..ph {
+            for x in 0..pw {
+                let color = raw
+                    .cfa
+                    .color_at(x, y)
+                    .ok_or_else(|| Error::Corrupt("develop: filter pattern is short".into()))?;
+                let channel = match color {
+                    CfaColor::Red => 0,
+                    CfaColor::Green => 1,
+                    CfaColor::Blue => 2,
+                    CfaColor::Green2 => 3,
+                    other => {
+                        return Err(Error::Unsupported(format!(
+                            "develop: {other:?} filter array (CMYG and four-colour sensors)"
+                        )))
+                    }
+                };
+                let black = if bayer {
+                    raw.black_levels[y * 2 + x]
+                } else if uniform {
+                    raw.black_levels[0]
+                } else {
+                    raw.black_levels[channel]
+                };
+                let multiplier = if channel == 3 { wb[3] } else { wb[channel] };
+                levels.black[y * pw + x] = black;
+                levels.gain[y * pw + x] = scale(black, raw.white_level)? * multiplier;
+            }
+        }
+        Ok(levels)
+    }
+}
+
+/// 1/(white - black) for one position. `validate` has already checked
+/// every recorded black level against white, but a pattern position
+/// can pick up a level `validate` never looked at, so check again.
+fn scale(black: f32, white: f32) -> Result<f32> {
+    let range = white - black;
+    // Written this way round on purpose: a NaN level has to fail, and
+    // `range <= 0.0` alone would let it through.
+    if range.is_nan() || range <= 0.0 {
+        return Err(Error::Corrupt(format!(
+            "develop: black {black} is not below white {white}"
+        )));
+    }
+    Ok(1.0 / range)
+}
+
+/// Rearrange `src` for `orientation`. Written as a gather over
+/// destination pixels — every thread only writes its own rows — and
+/// tiled, because the four transposing orientations otherwise walk a
+/// column of the source per destination row and miss the cache on
+/// every pixel.
+fn orient(src: &[f32], width: usize, height: usize, orientation: Orientation) -> Vec<f32> {
+    const TILE: usize = 32;
+    let (dw, dh) = if orientation.transposes() {
+        (height, width)
+    } else {
+        (width, height)
+    };
+    let mut out = vec![0f32; dw * dh * 3];
+    out.par_chunks_mut(dw * 3 * TILE)
+        .enumerate()
+        .for_each(|(band, rows)| {
+            let y0 = band * TILE;
+            for x0 in (0..dw).step_by(TILE) {
+                let x1 = (x0 + TILE).min(dw);
+                for (j, row) in rows.chunks_exact_mut(dw * 3).enumerate() {
+                    let dy = y0 + j;
+                    for dx in x0..x1 {
+                        // The eight EXIF orientations, as the inverse map
+                        // from the displayed pixel back to the stored one.
+                        // 5 and 7 are the two transposes; 6 and 8 the two
+                        // rotations.
+                        let (sx, sy) = match orientation {
+                            Orientation::Normal => (dx, dy),
+                            Orientation::MirrorHorizontal => (width - 1 - dx, dy),
+                            Orientation::Rotate180 => (width - 1 - dx, height - 1 - dy),
+                            Orientation::MirrorVertical => (dx, height - 1 - dy),
+                            Orientation::Transpose => (dy, dx),
+                            Orientation::Rotate90CW => (dy, height - 1 - dx),
+                            Orientation::Transverse => (width - 1 - dy, height - 1 - dx),
+                            Orientation::Rotate270CW => (width - 1 - dy, dx),
+                        };
+                        let s = (sy * width + sx) * 3;
+                        row[dx * 3..dx * 3 + 3].copy_from_slice(&src[s..s + 3]);
+                    }
+                }
+            }
+        });
+    out
+}
+
+/// The camera-to-linear-sRGB matrix for a raw, from its XYZ→camera
+/// matrix: invert, normalise each camera row so the matrix maps D65
+/// white to (1,1,1) in camera space (which is what makes the as-shot
+/// multipliers do their job), compose with XYZ→sRGB. Public so tests
+/// and the camera table can check it.
+///
+/// Why the normalisation: DNG's ColorMatrix takes XYZ to the camera's
+/// *unbalanced* space, where a white subject gives whatever three
+/// numbers the filters and the sensor happen to produce. The as-shot
+/// multipliers have already been applied by the time this matrix is
+/// used, so by then white *is* (1,1,1) in camera space. Dividing row
+/// `i` of M by `(M · XYZ_D65)[i]` builds exactly that convention into
+/// the matrix, and inverting it then gives a camera→XYZ that sends
+/// (1,1,1) to D65 white. Composing with XYZ→sRGB (also D65) therefore
+/// sends camera white to sRGB white, and every row of the result sums
+/// to one.
+pub fn camera_to_srgb(xyz_to_camera: &[[f32; 3]; 3]) -> [[f32; 3]; 3] {
+    /// CIE XYZ of the D65 white point, normalised to Y = 1.
+    const XYZ_D65: [f64; 3] = [0.9505, 1.0, 1.0890];
+    /// Linear sRGB primaries with a D65 white point, the standard
+    /// (IEC 61966-2-1) matrix.
+    #[rustfmt::skip]
+    const XYZ_TO_SRGB: [[f64; 3]; 3] = [
+        [ 3.2406, -1.5372, -0.4986],
+        [-0.9689,  1.8758,  0.0415],
+        [ 0.0557, -0.2040,  1.0570],
+    ];
+
+    let mut m = [[0f64; 3]; 3];
+    for i in 0..3 {
+        for j in 0..3 {
+            m[i][j] = xyz_to_camera[i][j] as f64;
+        }
+    }
+    for row in m.iter_mut() {
+        let white = row[0] * XYZ_D65[0] + row[1] * XYZ_D65[1] + row[2] * XYZ_D65[2];
+        if !(white.is_finite() && white.abs() > 1e-9) {
+            // A row that gives white no response is not a camera
+            // matrix; camera RGB is a better answer than NaNs.
+            log::warn!("raw: colour matrix {xyz_to_camera:?} has a dead row, leaving camera RGB");
+            return [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+        }
+        for v in row.iter_mut() {
+            *v /= white;
+        }
+    }
+    let Some(camera_to_xyz) = invert(&m) else {
+        // A singular matrix means the camera table or the file is
+        // wrong; camera RGB is a better answer than NaNs.
+        log::warn!("raw: colour matrix {xyz_to_camera:?} is singular, leaving camera RGB");
+        return [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+    };
+    let mut out = [[0f32; 3]; 3];
+    for i in 0..3 {
+        for j in 0..3 {
+            let mut sum = 0.0;
+            for k in 0..3 {
+                sum += XYZ_TO_SRGB[i][k] * camera_to_xyz[k][j];
+            }
+            out[i][j] = sum as f32;
+        }
+    }
+    out
+}
+
+/// 3x3 inverse by the adjugate, in double precision: camera matrices
+/// are near-singular often enough that the f32 determinant is not to
+/// be trusted.
+fn invert(m: &[[f64; 3]; 3]) -> Option<[[f64; 3]; 3]> {
+    let mut adj = [[0f64; 3]; 3];
+    // The indices are the point here: `adj[i][j]` is the *transposed*
+    // cofactor, built from rows j+1, j+2 and columns i+1, i+2, so
+    // iterating the destination by value would lose the relationship.
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..3 {
+        for j in 0..3 {
+            let (r0, r1) = ((j + 1) % 3, (j + 2) % 3);
+            let (c0, c1) = ((i + 1) % 3, (i + 2) % 3);
+            adj[i][j] = m[r0][c0] * m[r1][c1] - m[r0][c1] * m[r1][c0];
+        }
+    }
+    let det = m[0][0] * adj[0][0] + m[0][1] * adj[1][0] + m[0][2] * adj[2][0];
+    if !det.is_finite() || det.abs() < 1e-12 {
+        return None;
+    }
+    let mut out = [[0f64; 3]; 3];
+    for i in 0..3 {
+        for j in 0..3 {
+            out[i][j] = adj[i][j] / det;
+        }
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::demosaic::Quality;
+    use crate::Format;
+
+    /// A plausible XYZ→camera matrix of the shape DNG files carry:
+    /// not any particular camera's, just an invertible one with the
+    /// right sign pattern.
+    const CAMERA: [[f32; 3]; 3] = [
+        [0.6844, -0.0996, -0.0856],
+        [-0.3876, 1.1761, 0.2396],
+        [-0.0593, 0.1772, 0.6198],
+    ];
+
+    /// The sRGB primaries as an XYZ→RGB matrix, i.e. what a camera
+    /// whose filters were exactly sRGB's would record.
+    const SRGB: [[f32; 3]; 3] = [
+        [3.2406, -1.5372, -0.4986],
+        [-0.9689, 1.8758, 0.0415],
+        [0.0557, -0.2040, 1.0570],
+    ];
+
+    /// Mosaic a full-colour image (in normalised, white-balanced
+    /// units) back into sensor samples, inverting exactly what
+    /// `develop` will do: undo the multiplier, scale by the position's
+    /// own range, add its black level.
+    fn synthetic(
+        width: usize,
+        height: usize,
+        black: [f32; 4],
+        white: f32,
+        wb: [f32; 4],
+        pixel: impl Fn(usize, usize) -> [f32; 3],
+    ) -> RawImage {
+        let cfa = Cfa::RGGB;
+        let mut data = vec![0u16; width * height];
+        for y in 0..height {
+            for x in 0..width {
+                let (channel, multiplier) = match cfa.color_at(x, y).expect("bayer") {
+                    CfaColor::Red => (0, wb[0]),
+                    CfaColor::Green => (1, wb[1]),
+                    CfaColor::Blue => (2, wb[2]),
+                    CfaColor::Green2 => (1, wb[3]),
+                    other => panic!("{other:?}"),
+                };
+                let b = black[(y % 2) * 2 + x % 2];
+                let v = pixel(x, y)[channel] / multiplier * (white - b) + b;
+                data[y * width + x] = v.round().clamp(0.0, 65535.0) as u16;
+            }
+        }
+        let mut raw = RawImage::new(Format::Dng, width, height, 1, RawData::U16(data), cfa);
+        raw.black_levels = black;
+        raw.white_level = white;
+        raw.wb_coeffs = wb;
+        raw
+    }
+
+    fn close(a: &[f32], b: &[f32], tolerance: f32) {
+        assert_eq!(a.len(), b.len(), "lengths");
+        for (i, (x, y)) in a.iter().zip(b.iter()).enumerate() {
+            assert!((x - y).abs() <= tolerance, "sample {i}: {x} vs {y}");
+        }
+    }
+
+    /// A camera whose XYZ→RGB matrix *is* sRGB's needs no colour
+    /// conversion at all, so the derivation must give the identity.
+    #[test]
+    fn srgb_camera_is_the_identity() {
+        let m = camera_to_srgb(&SRGB);
+        for i in 0..3 {
+            for j in 0..3 {
+                let want = if i == j { 1.0 } else { 0.0 };
+                assert!((m[i][j] - want).abs() < 2e-3, "{m:?}");
+            }
+        }
+    }
+
+    /// The whole point of the row normalisation: white balanced camera
+    /// (1,1,1) has to land on sRGB (1,1,1), so a neutral subject stays
+    /// neutral. Equivalently, every row sums to one.
+    #[test]
+    fn white_is_preserved() {
+        for matrix in [
+            SRGB,
+            CAMERA,
+            [[1.0, 0.2, 0.1], [0.05, 0.9, 0.3], [0.2, 0.1, 1.4]],
+        ] {
+            let m = camera_to_srgb(&matrix);
+            for row in m {
+                let sum = row[0] + row[1] + row[2];
+                assert!((sum - 1.0).abs() < 1e-3, "row of {m:?} sums to {sum}");
+            }
+        }
+    }
+
+    /// A singular matrix cannot be inverted; camera RGB is the answer
+    /// rather than a plane of NaNs.
+    #[test]
+    fn singular_matrix_falls_back() {
+        let m = camera_to_srgb(&[[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]]);
+        assert_eq!(m, [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]);
+    }
+
+    /// Different black levels per Bayer position, a real white balance
+    /// and a real matrix: a subject that is neutral after balancing
+    /// has to develop to equal R, G and B.
+    #[test]
+    fn neutral_stays_neutral() {
+        let mut raw = synthetic(
+            24,
+            16,
+            [64.0, 68.0, 68.0, 72.0],
+            1024.0,
+            [2.0, 1.0, 1.5, 1.0],
+            |_, _| [0.5, 0.5, 0.5],
+        );
+        raw.color_matrix = Some(CAMERA);
+        let out = develop(&raw, &DevelopOptions::default()).expect("develop");
+        assert_eq!((out.width, out.height), (24, 16));
+        close(&out.rgb, &vec![0.5; 24 * 16 * 3], 3e-3);
+    }
+
+    /// A flat coloured patch interpolates exactly, so the developed
+    /// pixel is the matrix applied to the balanced camera triple and
+    /// nothing else.
+    #[test]
+    fn red_patch_goes_through_the_matrix() {
+        let camera = [0.8f32, 0.1, 0.1];
+        let mut raw = synthetic(20, 20, [0.0; 4], 4095.0, [1.7, 1.0, 1.9, 1.0], |_, _| {
+            camera
+        });
+        raw.color_matrix = Some(CAMERA);
+        let m = camera_to_srgb(&CAMERA);
+        let want: Vec<f32> = (0..3)
+            .map(|i| (m[i][0] * camera[0] + m[i][1] * camera[1] + m[i][2] * camera[2]).max(0.0))
+            .collect();
+        let out = develop(&raw, &DevelopOptions::default()).expect("develop");
+        for pixel in out.rgb.as_chunks::<3>().0 {
+            close(pixel, &want, 3e-3);
+        }
+        // And `camera_rgb` skips the matrix entirely.
+        let plain = develop(
+            &raw,
+            &DevelopOptions {
+                camera_rgb: true,
+                ..Default::default()
+            },
+        )
+        .expect("develop");
+        for pixel in plain.rgb.as_chunks::<3>().0 {
+            close(pixel, &camera, 3e-3);
+        }
+    }
+
+    /// The caller's multipliers replace the file's, and a zero second
+    /// green means "use the first".
+    #[test]
+    fn white_balance_override() {
+        let raw = synthetic(8, 8, [0.0; 4], 1023.0, [1.0, 1.0, 1.0, 1.0], |_, _| {
+            [0.25, 0.25, 0.25]
+        });
+        let out = develop(
+            &raw,
+            &DevelopOptions {
+                white_balance: Some([2.0, 1.0, 3.0, 0.0]),
+                camera_rgb: true,
+                ..Default::default()
+            },
+        )
+        .expect("develop");
+        for pixel in out.rgb.as_chunks::<3>().0 {
+            close(pixel, &[0.5, 0.25, 0.75], 3e-3);
+        }
+    }
+
+    /// Cropping after the interpolation means the cropped frame is
+    /// exactly the window of the uncropped one — no re-phasing of the
+    /// filter array, and no border artefacts pulled inside.
+    #[test]
+    fn crop_is_a_window_on_the_full_frame() {
+        let scene = |x: usize, y: usize| {
+            [
+                0.2 + 0.02 * (x % 7) as f32,
+                0.3 + 0.02 * (y % 5) as f32,
+                0.4 + 0.01 * ((x + y) % 11) as f32,
+            ]
+        };
+        let mut raw = synthetic(32, 24, [16.0; 4], 1023.0, [1.4, 1.0, 1.8, 1.0], scene);
+        raw.crop = Rect {
+            x: 3,
+            y: 5,
+            width: 20,
+            height: 14,
+        };
+        raw.color_matrix = Some(CAMERA);
+        let whole = develop(
+            &raw,
+            &DevelopOptions {
+                crop: false,
+                ..Default::default()
+            },
+        )
+        .expect("develop");
+        let cropped = develop(&raw, &DevelopOptions::default()).expect("develop");
+        assert_eq!((whole.width, whole.height), (32, 24));
+        assert_eq!((cropped.width, cropped.height), (20, 14));
+        for y in 0..14 {
+            let from = ((y + 5) * 32 + 3) * 3;
+            close(
+                &cropped.rgb[y * 20 * 3..(y + 1) * 20 * 3],
+                &whole.rgb[from..from + 20 * 3],
+                0.0,
+            );
+        }
+    }
+
+    /// Three samples a pixel: no interpolation, levels and
+    /// multipliers per channel. Values are `index / 10` so the eight
+    /// orientation cases below can be read off by eye.
+    fn linear_raw(orientation: Orientation) -> RawImage {
+        let (width, height) = (2, 3);
+        let data: Vec<u16> = (0..width * height)
+            .flat_map(|i| [i as u16 * 10; 3])
+            .collect();
+        let mut raw = RawImage::new(Format::Dng, width, height, 3, RawData::U16(data), Cfa::None);
+        raw.white_level = 100.0;
+        raw.orientation = orientation;
+        raw
+    }
+
+    #[test]
+    fn three_samples_a_pixel() {
+        let raw = linear_raw(Orientation::Normal);
+        let out = develop(&raw, &DevelopOptions::default()).expect("develop");
+        assert_eq!((out.width, out.height), (2, 3));
+        let want: Vec<f32> = (0..6).flat_map(|i| [i as f32 / 10.0; 3]).collect();
+        close(&out.rgb, &want, 1e-6);
+    }
+
+    /// All eight EXIF orientations against hand-written expectations.
+    /// The source is
+    ///
+    /// ```text
+    /// 0 1
+    /// 2 3
+    /// 4 5
+    /// ```
+    #[test]
+    fn every_orientation() {
+        #[rustfmt::skip]
+        let cases: [(Orientation, usize, usize, [usize; 6]); 8] = [
+            (Orientation::Normal,           2, 3, [0, 1, 2, 3, 4, 5]),
+            (Orientation::MirrorHorizontal, 2, 3, [1, 0, 3, 2, 5, 4]),
+            (Orientation::Rotate180,        2, 3, [5, 4, 3, 2, 1, 0]),
+            (Orientation::MirrorVertical,   2, 3, [4, 5, 2, 3, 0, 1]),
+            (Orientation::Transpose,        3, 2, [0, 2, 4, 1, 3, 5]),
+            (Orientation::Rotate90CW,       3, 2, [4, 2, 0, 5, 3, 1]),
+            (Orientation::Transverse,       3, 2, [5, 3, 1, 4, 2, 0]),
+            (Orientation::Rotate270CW,      3, 2, [1, 3, 5, 0, 2, 4]),
+        ];
+        for (orientation, width, height, want) in cases {
+            let raw = linear_raw(orientation);
+            let out = develop(&raw, &DevelopOptions::default()).expect("develop");
+            assert_eq!((out.width, out.height), (width, height), "{orientation:?}");
+            let expect: Vec<f32> = want.iter().flat_map(|i| [*i as f32 / 10.0; 3]).collect();
+            close(&out.rgb, &expect, 1e-6);
+            // Off by request, the stored orientation is left alone.
+            let stored = develop(
+                &raw,
+                &DevelopOptions {
+                    orient: false,
+                    ..Default::default()
+                },
+            )
+            .expect("develop");
+            assert_eq!((stored.width, stored.height), (2, 3), "{orientation:?}");
+        }
+    }
+
+    /// Orientation is applied to the *cropped* frame, and the crop is
+    /// in unrotated sensor coordinates.
+    #[test]
+    fn crop_then_orient() {
+        let mut raw = synthetic(16, 12, [0.0; 4], 1023.0, [1.0; 4], |_, _| [0.4, 0.4, 0.4]);
+        raw.crop = Rect {
+            x: 2,
+            y: 2,
+            width: 10,
+            height: 8,
+        };
+        raw.orientation = Orientation::Rotate90CW;
+        let out = develop(&raw, &DevelopOptions::default()).expect("develop");
+        assert_eq!((out.width, out.height), (8, 10));
+    }
+
+    /// Floating-point DNG data is already linear, and takes the same
+    /// levels as everything else.
+    #[test]
+    fn float_data() {
+        let (width, height) = (16, 16);
+        let data: Vec<f32> = (0..width * height)
+            .map(|i| 0.25 + (i % 4) as f32 * 0.05)
+            .collect();
+        let mut raw = RawImage::new(
+            Format::Dng,
+            width,
+            height,
+            1,
+            RawData::F32(data.clone()),
+            Cfa::RGGB,
+        );
+        raw.black_levels = [0.0; 4];
+        raw.white_level = 1.0;
+        let out = develop(
+            &raw,
+            &DevelopOptions {
+                camera_rgb: true,
+                quality: Quality::Fast,
+                ..Default::default()
+            },
+        )
+        .expect("develop");
+        // Every sample survives in its own colour channel, wherever
+        // the interpolation put the other two.
+        for y in 0..height {
+            for x in 0..width {
+                let channel = match raw.cfa.color_at(x, y).expect("bayer") {
+                    CfaColor::Red => 0,
+                    CfaColor::Blue => 2,
+                    _ => 1,
+                };
+                let got = out.rgb[(y * width + x) * 3 + channel];
+                assert!((got - data[y * width + x]).abs() < 1e-6, "{x},{y}: {got}");
+            }
+        }
+        // A float frame with a black level scales the same way.
+        let mut offset = raw.clone();
+        offset.data = RawData::F32(data.iter().map(|v| v * 0.5 + 0.25).collect());
+        offset.black_levels = [0.25; 4];
+        offset.white_level = 0.75;
+        let out = develop(
+            &offset,
+            &DevelopOptions {
+                camera_rgb: true,
+                quality: Quality::Fast,
+                ..Default::default()
+            },
+        )
+        .expect("develop");
+        for y in 0..height {
+            for x in 0..width {
+                let channel = match raw.cfa.color_at(x, y).expect("bayer") {
+                    CfaColor::Red => 0,
+                    CfaColor::Blue => 2,
+                    _ => 1,
+                };
+                let got = out.rgb[(y * width + x) * 3 + channel];
+                assert!((got - data[y * width + x]).abs() < 1e-5, "{x},{y}: {got}");
+            }
+        }
+    }
+
+    /// Negatives are clipped, values above one are not: they are real
+    /// light, and the caller's tone curve decides what to do with them.
+    #[test]
+    fn clips_below_zero_only() {
+        let mut raw = synthetic(8, 8, [0.0; 4], 100.0, [1.0; 4], |_, _| [1.5, 1.5, 1.5]);
+        raw.black_levels = [200.0; 4];
+        raw.white_level = 400.0;
+        let out = develop(
+            &raw,
+            &DevelopOptions {
+                camera_rgb: true,
+                ..Default::default()
+            },
+        )
+        .expect("develop");
+        assert!(out.rgb.iter().all(|v| *v == 0.0), "negatives should clip");
+
+        let raw = synthetic(8, 8, [0.0; 4], 1000.0, [1.0; 4], |_, _| [2.0, 2.0, 2.0]);
+        let out = develop(
+            &raw,
+            &DevelopOptions {
+                camera_rgb: true,
+                ..Default::default()
+            },
+        )
+        .expect("develop");
+        assert!(
+            out.rgb.iter().all(|v| *v > 1.5),
+            "highlights should survive"
+        );
+    }
+
+    /// Inconsistent images are refused before anything indexes them.
+    #[test]
+    fn rejects_bad_images() {
+        let mut raw = synthetic(8, 8, [0.0; 4], 1023.0, [1.0; 4], |_, _| [0.5; 3]);
+        raw.width = 9;
+        assert!(develop(&raw, &DevelopOptions::default()).is_err());
+    }
+
+    /// Sample counts the pipeline has no meaning for are refused
+    /// rather than half-read.
+    #[test]
+    fn rejects_odd_sample_counts() {
+        let mut raw = synthetic(8, 8, [0.0; 4], 1023.0, [1.0; 4], |_, _| [0.5; 3]);
+        raw.cpp = 4;
+        raw.data = RawData::U16(vec![100u16; 8 * 8 * 4]);
+        assert!(matches!(
+            develop(&raw, &DevelopOptions::default()),
+            Err(Error::Unsupported(_))
+        ));
+    }
+
+    /// Release-mode timing for a 24 megapixel Bayer frame, the size
+    /// this pipeline is meant to keep under a couple of seconds.
+    /// Ignored by default: `SCHIST_RAW_BENCH=1 cargo test --release -p
+    /// schist-codec-raw -- --ignored --nocapture`.
+    #[test]
+    #[ignore = "timing only; needs --release and SCHIST_RAW_BENCH"]
+    fn timing_24_megapixels() {
+        if std::env::var("SCHIST_RAW_BENCH").is_err() {
+            println!("set SCHIST_RAW_BENCH=1 to run the timing test");
+            return;
+        }
+        let (width, height) = (6000usize, 4000usize);
+        let data: Vec<u16> = (0..width * height)
+            .map(|i| (512 + (i * 2654435761usize) % 3000) as u16)
+            .collect();
+        let mut raw = RawImage::new(Format::Dng, width, height, 1, RawData::U16(data), Cfa::RGGB);
+        raw.black_levels = [512.0; 4];
+        raw.white_level = 4095.0;
+        raw.wb_coeffs = [2.1, 1.0, 1.5, 1.0];
+        raw.color_matrix = Some(CAMERA);
+        raw.crop = Rect {
+            x: 8,
+            y: 8,
+            width: width - 16,
+            height: height - 16,
+        };
+        for quality in [Quality::Fast, Quality::Best] {
+            let start = std::time::Instant::now();
+            let out = develop(
+                &raw,
+                &DevelopOptions {
+                    quality,
+                    ..Default::default()
+                },
+            )
+            .expect("develop");
+            println!(
+                "develop {width}x{height} {quality:?}: {:?}",
+                start.elapsed()
+            );
+            assert_eq!(out.rgb.len(), out.width * out.height * 3);
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/arw.rs
+++ b/crates/codec-raw/src/formats/arw.rs
@@ -1,0 +1,1627 @@
+//! Sony ARW, SR2 and SRF.
+//!
+//! Sony has shipped five different ways of storing a frame in what is
+//! otherwise an ordinary TIFF, and the container barely tells them
+//! apart: `Compression` is 1 or the private 32767 for four of them.
+//! What actually decides is how many bytes the strip holds per pixel:
+//!
+//! | bytes/pixel | variant                                        |
+//! |-------------|------------------------------------------------|
+//! | 1.0         | ARW 2.x "compressed": 16 pixels per 16 bytes    |
+//! | 1.5         | 12 bits packed two pixels to three bytes        |
+//! | 2.0         | one 16-bit word a pixel (12- or 14-bit data)    |
+//!
+//! plus `Compression` 7, which is Sony's "lossless compressed" (ARW
+//! 4.x): 512x512 tiles of plain lossless JPEG. The two oddities that
+//! predate all of that are the DSLR-A100's ARW 1.0, a column-major
+//! DPCM with a fixed Huffman table inherited from Minolta, and the
+//! DSC-F828's SRF, whose sensor data is encrypted with Sony's LFSR
+//! stream cipher.
+//!
+//! The metadata a developer needs — black level, as-shot white
+//! balance, the sensor's active area — is not in the TIFF either. It
+//! lives in an IFD that `DNGPrivateData` (0xC634) points at, whose
+//! 0x7200/0x7201/0x7221 triple gives the offset, length and key of a
+//! second IFD encrypted with the same LFSR. [`sr2_metadata`] decrypts
+//! and reads it.
+//!
+//! Clean-room: written from observation of the sample files against
+//! LibRaw's `unprocessed_raw` output, from ExifTool's published tag
+//! tables, and from the openly documented Sony LFSR. No copyleft
+//! decoder's source was consulted.
+
+use rayon::prelude::*;
+
+use crate::bits::{BitPump, BitPumpMsb};
+use crate::formats::common;
+use crate::tiff::{tags, Entry, Ifd, ImageLayout, Tiff};
+use crate::{Cfa, CfaColor, Error, Format, RawData, RawImage, Rect, Result};
+
+/// The Sony-private tags, in the two directories they live in.
+mod stags {
+    /// In the raw SubIFD: 0 uncompressed, 2 lossy, 4 lossless.
+    pub const RAW_FILE_TYPE: u16 = 0x7000;
+    /// Four 16-bit knee points defining the curve that expands an
+    /// ARW 2.x 11-bit sample to 14 bits.
+    pub const TONE_CURVE: u16 = 0x7010;
+    /// In the SR2Private IFD.
+    pub const SR2_SUBIFD_OFFSET: u16 = 0x7200;
+    pub const SR2_SUBIFD_LENGTH: u16 = 0x7201;
+    pub const SR2_SUBIFD_KEY: u16 = 0x7221;
+    /// In the decrypted SR2SubIFD.
+    pub const BLACK_LEVEL_2: u16 = 0x7300;
+    pub const WB_GRBG_LEVELS: u16 = 0x7303;
+    pub const BLACK_LEVEL: u16 = 0x7310;
+    pub const WB_RGGB_LEVELS: u16 = 0x7313;
+    /// left, top, right, bottom of the active area, in sensor pixels.
+    pub const CROP_RECT: u16 = 0x74C3;
+
+    pub const DNG_PRIVATE_DATA: u16 = 0xC634;
+    pub const DEFAULT_CROP_ORIGIN: u16 = 0xC61F;
+    pub const DEFAULT_CROP_SIZE: u16 = 0xC620;
+}
+
+/// Sony's private `Compression` value, used for both the block-packed
+/// "compressed" raw and for plainly packed or word-aligned data.
+const COMPRESSION_SONY: u32 = 32767;
+
+/// How the sensor data is stored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Variant {
+    /// ARW 2.x: 16 same-colour pixels per 16 bytes, through the tone
+    /// curve to 14 bits.
+    Blocks,
+    /// 12 bits a pixel, two pixels to three bytes, low bits first.
+    Packed12,
+    /// One 16-bit word a pixel. Which end comes first is decided from
+    /// the samples, not from a model list: ARW writes them
+    /// little-endian, the DSC-R1's SR2 and the DSC-F828's SRF
+    /// big-endian.
+    Words,
+    /// ARW 4.x lossless: 512x512 tiles of lossless JPEG.
+    LosslessTiles,
+}
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let tiff = Tiff::parse(bytes)?;
+    let (make, model) = tiff.make_model();
+
+    // The A100 is a rebadged Minolta and stores nothing the way any
+    // later Sony does: its "SubIFDs" tag is a bare data offset and its
+    // sizes come from an embedded MRW block, so it gets its own path.
+    if let Some(mrw) = minolta_block(&tiff) {
+        return decode_arw1(&tiff, &mrw, &make, &model);
+    }
+
+    let ifd = raw_ifd(&tiff)
+        .ok_or_else(|| Error::Unsupported("arw: no sensor IFD in this file".into()))?;
+    let layout = sony_layout(&tiff, ifd)?;
+    let (width, height) = (layout.width, layout.height);
+    if width == 0 || height == 0 || width > 1 << 16 || height > 1 << 16 {
+        return Err(Error::Corrupt(format!(
+            "arw: implausible frame {width}x{height}"
+        )));
+    }
+    let pixels = width * height;
+
+    let variant = variant_of(ifd, &layout)?;
+    let data = match variant {
+        Variant::LosslessTiles => decode_lossless_tiles(bytes, &layout)?,
+        Variant::Blocks => {
+            let curve = tone_curve(ifd)?;
+            decode_blocks(single_chunk(&tiff, &layout, pixels)?, width, height, &curve)?
+        }
+        Variant::Packed12 => decode_packed12(single_chunk(&tiff, &layout, pixels * 3 / 2)?, pixels),
+        Variant::Words => {
+            let chunk = single_chunk(&tiff, &layout, pixels * 2)?;
+            // SRF hides the sensor behind the LFSR; SR2 and ARW do
+            // not, and the byte order can only be judged once the
+            // samples are in the clear.
+            let plain = if tiff.root().has(stags::DNG_PRIVATE_DATA) {
+                std::borrow::Cow::Borrowed(chunk)
+            } else {
+                match srf_data_key(&tiff, bytes) {
+                    Some(key) => std::borrow::Cow::Owned(sony_decrypt(chunk, key)),
+                    // Decoding the ciphertext as samples would hand
+                    // back noise with no error.
+                    None => {
+                        return Err(Error::Unsupported(
+                            "SRF whose sensor-data key could not be found".into(),
+                        ))
+                    }
+                }
+            };
+            let little_endian = words_look_little_endian(&plain, tiff.little_endian());
+            decode_words(&plain, pixels, little_endian)
+        }
+    };
+    if data.len() != pixels {
+        return Err(Error::Corrupt(format!(
+            "arw: decoded {} samples for {width}x{height}",
+            data.len()
+        )));
+    }
+
+    let cfa = cfa_of(ifd, &make, &model);
+    let mut raw = RawImage::new(Format::Arw, width, height, 1, RawData::U16(data), cfa);
+    raw.set_camera(&make, &model);
+    raw.orientation = common::orientation(&tiff);
+    raw.preview = common::largest_jpeg(&tiff);
+    raw.metadata = common::metadata(&tiff);
+
+    // Everything below is 14-bit-scaled but the 12-bit packed frames,
+    // which LibRaw leaves at the sensor's own scale; the levels the
+    // camera records are always on the 14-bit one, so they shift too.
+    let shift = if variant == Variant::Packed12 { 2 } else { 0 };
+    raw.white_level = ((16383u32 >> shift) as f32).max(1.0);
+    let meta = sr2_metadata(&tiff, bytes);
+    if let Some(black) = meta.as_ref().and_then(|m| m.black) {
+        raw.black_levels = black.map(|b| (b >> shift) as f32);
+    }
+    if let Some(wb) = meta.as_ref().and_then(|m| m.wb) {
+        raw.wb_coeffs = wb;
+    }
+    raw.crop = crop_of(ifd, meta.as_ref(), width, height);
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    Ok(common::largest_jpeg(&Tiff::parse(bytes)?))
+}
+
+// ---------------------------------------------------------------- //
+// Picking the sensor IFD and working out how it is stored.
+// ---------------------------------------------------------------- //
+
+/// A four-byte value Sony writes as `BYTE[4]` where a LONG was meant.
+///
+/// `DNGPrivateData` (0xC634) is an offset and the SR2SubIFD key
+/// (0x7221) is a 32-bit number, but both are typed as undifferentiated
+/// bytes; read that way, `Entry::u32(0)` would hand back the first byte
+/// alone. Anything already typed as an integer is taken as it stands.
+fn long_of(entry: &Entry, little_endian: bool) -> Option<u32> {
+    match entry.bytes() {
+        Some(bytes) if bytes.len() >= 4 => {
+            let word: [u8; 4] = bytes[..4].try_into().ok()?;
+            Some(if little_endian {
+                u32::from_le_bytes(word)
+            } else {
+                u32::from_be_bytes(word)
+            })
+        }
+        _ => entry.u32(0),
+    }
+}
+
+/// The IFD holding sensor samples.
+///
+/// Every ARW and SR2 marks it with PhotometricInterpretation 32803
+/// (CFA). The DSC-F828's SRF marks nothing: its IFD0 claims to be an
+/// RGB image of three 14-bit samples, so the fallback takes the only
+/// directory deeper than eight bits that is not a JPEG.
+fn raw_ifd<'a>(tiff: &'a Tiff<'_>) -> Option<&'a Ifd> {
+    let cfa = tiff
+        .all()
+        .into_iter()
+        .find(|ifd| ifd.get(tags::PHOTOMETRIC).and_then(|e| e.u32(0)) == Some(32803));
+    cfa.or_else(|| {
+        tiff.all().into_iter().find(|ifd| {
+            let deep = ifd
+                .get(tags::BITS_PER_SAMPLE)
+                .and_then(|e| e.u32(0))
+                .unwrap_or(8)
+                > 8;
+            let compression = ifd
+                .get(tags::COMPRESSION)
+                .and_then(|e| e.u32(0))
+                .unwrap_or(1);
+            deep && !matches!(compression, 6 | 7)
+        })
+    })
+}
+
+/// Strips, tiles and byte counts, with SRF's missing `StripOffsets`
+/// filled in.
+///
+/// The F828 records `StripByteCounts` and `RowsPerStrip` but no
+/// offset at all: its sensor data is simply the tail of the file.
+fn sony_layout(tiff: &Tiff<'_>, ifd: &Ifd) -> Result<ImageLayout> {
+    // Only the missing-offset case is ours to patch up: a strip that
+    // runs off the end of a truncated file must still be an error.
+    if ifd.has(tags::STRIP_OFFSETS) || ifd.has(tags::TILE_OFFSETS) {
+        return ImageLayout::of(tiff, ifd);
+    }
+    let mut layout = ImageLayout {
+        width: ifd
+            .get(tags::IMAGE_WIDTH)
+            .and_then(|e| e.u32(0))
+            .ok_or_else(|| Error::Corrupt("arw: sensor IFD without ImageWidth".into()))?
+            as usize,
+        height: ifd
+            .get(tags::IMAGE_LENGTH)
+            .and_then(|e| e.u32(0))
+            .ok_or_else(|| Error::Corrupt("arw: sensor IFD without ImageLength".into()))?
+            as usize,
+        bits_per_sample: ifd
+            .get(tags::BITS_PER_SAMPLE)
+            .and_then(|e| e.u32(0))
+            .unwrap_or(8),
+        samples_per_pixel: 1,
+        compression: ifd
+            .get(tags::COMPRESSION)
+            .and_then(|e| e.u32(0))
+            .unwrap_or(1),
+        photometric: ifd
+            .get(tags::PHOTOMETRIC)
+            .and_then(|e| e.u32(0))
+            .unwrap_or(1),
+        chunks: Vec::new(),
+        tile: None,
+        rows_per_chunk: 0,
+    };
+    let len = ifd
+        .get(tags::STRIP_BYTE_COUNTS)
+        .and_then(|e| e.u64(0))
+        .and_then(|n| usize::try_from(n).ok())
+        .ok_or_else(|| {
+            Error::Corrupt("arw: sensor IFD with neither strip offsets nor byte counts".into())
+        })?;
+    let start = tiff
+        .bytes()
+        .len()
+        .checked_sub(len)
+        .ok_or_else(|| Error::Corrupt("arw: strip longer than the file".into()))?;
+    layout.rows_per_chunk = layout.height;
+    layout.chunks = vec![(start, len)];
+    Ok(layout)
+}
+
+/// Which of the five storage schemes this IFD uses.
+fn variant_of(ifd: &Ifd, layout: &ImageLayout) -> Result<Variant> {
+    if layout.compression == 7 || layout.tile.is_some() {
+        return Ok(Variant::LosslessTiles);
+    }
+    if !matches!(layout.compression, 1 | COMPRESSION_SONY) {
+        return Err(Error::Unsupported(format!(
+            "arw: compression {} is not a Sony raw scheme",
+            layout.compression
+        )));
+    }
+    let pixels = layout.width * layout.height;
+    let bytes: usize = layout.chunks.iter().map(|(_, len)| *len).sum();
+    // The strip is always exactly one of these three sizes; anything
+    // else is a variant nobody has shipped, or a truncated file.
+    if bytes == pixels {
+        return Ok(Variant::Blocks);
+    }
+    if bytes == pixels / 2 * 3 && pixels.is_multiple_of(2) {
+        return Ok(Variant::Packed12);
+    }
+    if bytes == pixels * 2 {
+        return Ok(Variant::Words);
+    }
+    Err(Error::Unsupported(format!(
+        "arw: {bytes} bytes for {}x{} pixels is no known Sony layout (compression {}, {} bits, raw type {:?})",
+        layout.width,
+        layout.height,
+        layout.compression,
+        layout.bits_per_sample,
+        ifd.get(stags::RAW_FILE_TYPE).and_then(|e| e.u32(0))
+    )))
+}
+
+/// Whether word-per-pixel data is little- or big-endian.
+///
+/// ARW writes native (little-endian) words; the DSC-R1's SR2 and the
+/// DSC-F828's SRF write big-endian ones inside a little-endian TIFF.
+/// Rather than keep a list of models, decide from the samples: no Sony
+/// sensor is deeper than fourteen bits, so the wrong byte order shows
+/// up at once as a flood of values with the top two bits set.
+fn words_look_little_endian(chunk: &[u8], default: bool) -> bool {
+    // Words from all over the frame, not one stretch of it: a flat
+    // band (a dark frame, a lens-cap shot) says nothing either way,
+    // and masked first rows read as near-zero whichever way round
+    // they are taken. A tie falls back to the container's own byte
+    // order rather than to a coin.
+    let words = chunk.as_chunks::<2>().0;
+    let step = (words.len() / (1 << 16)).max(1);
+    let (mut little_over, mut big_over) = (0usize, 0usize);
+    for word in words.iter().step_by(step) {
+        if u16::from_le_bytes(*word) > 0x3fff {
+            little_over += 1;
+        }
+        if u16::from_be_bytes(*word) > 0x3fff {
+            big_over += 1;
+        }
+    }
+    match little_over.cmp(&big_over) {
+        std::cmp::Ordering::Less => true,
+        std::cmp::Ordering::Greater => false,
+        std::cmp::Ordering::Equal => default,
+    }
+}
+
+/// The single strip of an untiled frame, checked against the size the
+/// variant needs.
+fn single_chunk<'a>(tiff: &Tiff<'a>, layout: &ImageLayout, want: usize) -> Result<&'a [u8]> {
+    let (start, len) = *layout
+        .chunks
+        .first()
+        .ok_or_else(|| Error::Corrupt("arw: sensor IFD with no strip".into()))?;
+    if layout.chunks.len() > 1 {
+        return Err(Error::Unsupported(
+            "arw: sensor data split over several strips".into(),
+        ));
+    }
+    if len < want {
+        return Err(Error::Corrupt(format!(
+            "arw: strip holds {len} bytes, needs {want}"
+        )));
+    }
+    tiff.bytes()
+        .get(start..start + want)
+        .ok_or_else(|| Error::Corrupt("arw: strip lies outside the file".into()))
+}
+
+// ---------------------------------------------------------------- //
+// ARW 2.x: sixteen pixels to sixteen bytes.
+// ---------------------------------------------------------------- //
+
+/// The 11-bit-to-14-bit expansion curve from tag 0x7010.
+///
+/// The tag holds four knee points. Divided by four they are indices
+/// into a 12-bit domain; the curve rises by 1 per step below the
+/// first, then by 2, 4, 8 and 16 in the segments between them, so the
+/// camera spends its precision where the eye does. Sony's stored
+/// values are the *inputs*: `[8000, 10400, 12900, 14100]` means knees
+/// at 2000, 2600, 3225 and 3525.
+fn tone_curve(ifd: &Ifd) -> Result<Vec<u16>> {
+    let entry = ifd.get(stags::TONE_CURVE).ok_or_else(|| {
+        Error::Unsupported("arw: compressed frame without a tone curve (tag 0x7010)".into())
+    })?;
+    let mut knees = [0usize; 6];
+    knees[5] = 4095;
+    for i in 0..4 {
+        let v = entry
+            .u32(i)
+            .ok_or_else(|| Error::Corrupt("arw: tone curve with fewer than four knees".into()))?;
+        knees[i + 1] = ((v >> 2) & 0xfff) as usize;
+    }
+    if knees.windows(2).any(|w| w[0] >= w[1]) {
+        return Err(Error::Unsupported(format!(
+            "arw: tone curve knees {:?} are not increasing",
+            &knees[1..5]
+        )));
+    }
+    let mut curve = vec![0u16; 4096];
+    for segment in 0..5 {
+        let step = 1u32 << segment;
+        for j in knees[segment] + 1..=knees[segment + 1] {
+            curve[j] = (curve[j - 1] as u32 + step).min(u16::MAX as u32) as u16;
+        }
+    }
+    Ok(curve)
+}
+
+/// One 16-byte block: the brightest and darkest of sixteen pixels,
+/// where they sit, and seven-bit deltas for the other fourteen.
+///
+/// The block is one 128-bit little-endian word. Bits 0..10 are the
+/// maximum, 11..21 the minimum (both 11 bits), 22..25 and 26..29 the
+/// indices of the pixel holding each, and the fourteen 7-bit deltas
+/// run from bit 30. A delta is scaled by `1 << shift`, the smallest
+/// shift that lets 127 steps span the block's range.
+#[inline]
+fn decode_block(block: u128, out: &mut [u16; 16]) {
+    let max = (block & 0x7ff) as u16;
+    let min = ((block >> 11) & 0x7ff) as u16;
+    let imax = ((block >> 22) & 0xf) as usize;
+    let imin = ((block >> 26) & 0xf) as usize;
+    let mut shift = 0u32;
+    while shift < 4 && (0x80u16 << shift) <= max.wrapping_sub(min) {
+        shift += 1;
+    }
+    let mut delta = 0;
+    for (i, pixel) in out.iter_mut().enumerate() {
+        *pixel = if i == imax {
+            max
+        } else if i == imin {
+            min
+        } else {
+            // A block naming the same slot for both extremes skips
+            // one pixel instead of two, which would ask for a
+            // fifteenth delta past the word's end; it is a broken
+            // block, and reading the last delta again keeps it inert.
+            let raw = ((block >> (30 + 7 * delta.min(13))) & 0x7f) as u16;
+            delta += 1;
+            (min + (raw << shift)).min(0x7ff)
+        };
+    }
+}
+
+/// A whole ARW 2.x frame.
+///
+/// The blocks are laid out along a row two colour streams at a time:
+/// the first sixteen bytes hold the sixteen even columns 0..30, the
+/// next sixteen the odd columns 1..31, then the next pair covers
+/// columns 32..63, and so on. One block therefore never mixes red
+/// with green, which is what makes a shared minimum and a 7-bit delta
+/// enough.
+fn decode_blocks(chunk: &[u8], width: usize, height: usize, curve: &[u16]) -> Result<Vec<u16>> {
+    if !width.is_multiple_of(32) {
+        return Err(Error::Unsupported(format!(
+            "arw: compressed frame {width} wide is not a whole number of 32-pixel block pairs"
+        )));
+    }
+    let mut out = vec![0u16; width * height];
+    out.par_chunks_mut(width)
+        .zip(chunk.par_chunks(width))
+        .for_each(|(row, source)| {
+            let mut pixels = [0u16; 16];
+            for (block_index, word) in source.as_chunks::<16>().0.iter().enumerate() {
+                decode_block(u128::from_le_bytes(*word), &mut pixels);
+                let first = (block_index / 2) * 32 + (block_index % 2);
+                for (i, pixel) in pixels.iter().enumerate() {
+                    // The 11-bit sample indexes the curve at twice its
+                    // value: the curve's domain is the 12-bit one the
+                    // knee points are expressed in.
+                    row[first + i * 2] = curve[(*pixel as usize) << 1];
+                }
+            }
+        });
+    Ok(out)
+}
+
+// ---------------------------------------------------------------- //
+// The plain layouts.
+// ---------------------------------------------------------------- //
+
+/// Two pixels to three bytes, each pixel's low eight bits first.
+fn decode_packed12(chunk: &[u8], pixels: usize) -> Vec<u16> {
+    let mut out = vec![0u16; pixels];
+    out.par_chunks_mut(2)
+        .zip(chunk.par_chunks_exact(3))
+        .for_each(|(pair, b)| {
+            pair[0] = (b[0] as u16) | ((b[1] as u16 & 0x0f) << 8);
+            if let Some(second) = pair.get_mut(1) {
+                *second = ((b[1] as u16) >> 4) | ((b[2] as u16) << 4);
+            }
+        });
+    out
+}
+
+/// One 16-bit word a pixel.
+fn decode_words(chunk: &[u8], pixels: usize, little_endian: bool) -> Vec<u16> {
+    let mut out = vec![0u16; pixels];
+    out.par_iter_mut()
+        .zip(chunk.par_chunks_exact(2))
+        .for_each(|(pixel, b)| {
+            *pixel = if little_endian {
+                u16::from_le_bytes([b[0], b[1]])
+            } else {
+                u16::from_be_bytes([b[0], b[1]])
+            };
+        });
+    out
+}
+
+// ---------------------------------------------------------------- //
+// ARW 4.x lossless: tiles of lossless JPEG.
+// ---------------------------------------------------------------- //
+
+/// A tiled frame of lossless-JPEG tiles.
+///
+/// Each 512x512 sensor tile is a complete SOF3 stream of four
+/// components at half the tile's dimensions: the four components are
+/// the four positions of one Bayer quad, so component `c` of JPEG
+/// pixel (x, y) is sensor pixel (2x + c%2, 2y + c/2). Frames are
+/// padded out to whole tiles — an 8672x5784 sensor becomes 8704x6144 —
+/// and the padding decodes with everything else.
+fn decode_lossless_tiles(bytes: &[u8], layout: &ImageLayout) -> Result<Vec<u16>> {
+    let (tile_width, tile_height) = layout
+        .tile
+        .filter(|(w, h)| *w > 0 && *h > 0)
+        .ok_or_else(|| Error::Unsupported("arw: lossless frame without tile dimensions".into()))?;
+    let across = layout.width.div_ceil(tile_width);
+    let down = layout.height.div_ceil(tile_height);
+    if across * down != layout.chunks.len() {
+        return Err(Error::Corrupt(format!(
+            "arw: {}x{} tiles of {tile_width}x{tile_height} but {} offsets",
+            across,
+            down,
+            layout.chunks.len()
+        )));
+    }
+    let width = layout.width;
+    let mut out = vec![0u16; width * layout.height];
+    // Tiles are independent streams; a row of them is a comfortable
+    // unit of work (204 tiles on an A1, 247 on an A7R V).
+    let rows: Vec<(usize, &mut [u16])> = out.chunks_mut(width * tile_height).enumerate().collect();
+    rows.into_par_iter().try_for_each(|(tile_row, band)| {
+        for tile_col in 0..across {
+            let (start, len) = layout.chunks[tile_row * across + tile_col];
+            let stream = bytes
+                .get(start..start + len)
+                .ok_or_else(|| Error::Corrupt("arw: tile lies outside the file".into()))?;
+            let jpeg = crate::ljpeg::decode(stream)?;
+            if jpeg.components != 4 {
+                return Err(Error::Unsupported(format!(
+                    "arw: lossless tile has {} components, expected four",
+                    jpeg.components
+                )));
+            }
+            if jpeg.width * 2 != tile_width || jpeg.height * 2 != tile_height {
+                return Err(Error::Corrupt(format!(
+                    "arw: lossless tile decodes {}x{} for a {tile_width}x{tile_height} tile",
+                    jpeg.width, jpeg.height
+                )));
+            }
+            let left = tile_col * tile_width;
+            for y in 0..jpeg.height {
+                for x in 0..jpeg.width {
+                    let quad = &jpeg.data[(y * jpeg.width + x) * 4..][..4];
+                    for (c, sample) in quad.iter().enumerate() {
+                        let row = y * 2 + c / 2;
+                        let col = left + x * 2 + c % 2;
+                        if row * width + col < band.len() && col < width {
+                            band[row * width + col] = *sample;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    })?;
+    Ok(out)
+}
+
+// ---------------------------------------------------------------- //
+// ARW 1.0: the DSLR-A100.
+// ---------------------------------------------------------------- //
+
+/// The A100's embedded Minolta block, when `DNGPrivateData` points at
+/// one. Later Sonys point the same tag at an SR2Private IFD instead.
+struct MinoltaBlock {
+    /// Full sensor extent, from the PRD block.
+    sensor: (usize, usize),
+    /// The area the camera calls the picture.
+    image: (usize, usize),
+    /// R, G1, G2, B white-balance levels from the WBG block.
+    wb: Option<[u16; 4]>,
+    /// Where the compressed sensor data starts.
+    data_offset: usize,
+}
+
+fn minolta_block(tiff: &Tiff<'_>) -> Option<MinoltaBlock> {
+    let bytes = tiff.bytes();
+    let little_endian = tiff.little_endian();
+    let start = tiff
+        .root()
+        .get(stags::DNG_PRIVATE_DATA)
+        .and_then(|e| long_of(e, little_endian))? as usize;
+    // MRM is Minolta's own signature; the A100 writes MRI. Both are
+    // followed by a length and then the same PRD/WBG sub-blocks.
+    let head = bytes.get(start..start + 8)?;
+    if !matches!(&head[..4], b"\0MRM" | b"\0MRI") {
+        return None;
+    }
+    let u16_at = |at: usize| -> Option<u16> {
+        let b: [u8; 2] = bytes.get(at..at + 2)?.try_into().ok()?;
+        Some(if little_endian {
+            u16::from_le_bytes(b)
+        } else {
+            u16::from_be_bytes(b)
+        })
+    };
+    // Minolta's own MRW numbers its blocks big-endian; the copy the
+    // A100 embeds follows the host TIFF instead, so the lengths are
+    // read in the file's order like everything else here.
+    let u32_at = |at: usize| -> Option<u32> {
+        let b: [u8; 4] = bytes.get(at..at + 4)?.try_into().ok()?;
+        Some(if little_endian {
+            u32::from_le_bytes(b)
+        } else {
+            u32::from_be_bytes(b)
+        })
+    };
+    let end = start + 8 + u32_at(start + 4)? as usize;
+    let mut at = start + 8;
+    let (mut sensor, mut image, mut wb) = (None, None, None);
+    while at + 8 <= end.min(bytes.len()) {
+        let tag: [u8; 4] = bytes.get(at..at + 4)?.try_into().ok()?;
+        let len = u32_at(at + 4)? as usize;
+        let body = at + 8;
+        match &tag {
+            // PRD: eight bytes of version, then the sensor and image
+            // dimensions as height/width pairs.
+            b"\0PRD" if len >= 16 => {
+                sensor = Some((u16_at(body + 10)? as usize, u16_at(body + 8)? as usize));
+                image = Some((u16_at(body + 14)? as usize, u16_at(body + 12)? as usize));
+            }
+            // WBG: four scale exponents, then four levels.
+            b"\0WBG" if len >= 12 => {
+                wb = Some([
+                    u16_at(body + 4)?,
+                    u16_at(body + 6)?,
+                    u16_at(body + 8)?,
+                    u16_at(body + 10)?,
+                ]);
+            }
+            _ => {}
+        }
+        at = body.checked_add(len)?;
+    }
+    // On the A100 the SubIFDs tag is not a directory pointer at all;
+    // it is where the Huffman stream begins.
+    let data_offset = tiff.root().get(tags::SUB_IFDS).and_then(|e| e.u32(0))? as usize;
+    Some(MinoltaBlock {
+        sensor: sensor?,
+        image: image?,
+        wb,
+        data_offset,
+    })
+}
+
+/// The eighteen codes of the A100's fixed Huffman table, as
+/// `(code length, difference bits)`. Codes are assigned in this order,
+/// longest first, each taking the next block of a flat 15-bit lookup —
+/// so the two 15-bit codes are 0 and 1, the 14-bit code is 1, and so
+/// on up to the two 2-bit codes 2 and 3. The lengths add to exactly
+/// one, so the table is complete.
+const ARW1_CODES: [(u32, u32); 18] = [
+    (15, 17),
+    (15, 16),
+    (14, 15),
+    (13, 14),
+    (12, 13),
+    (11, 12),
+    (10, 11),
+    (9, 10),
+    (8, 9),
+    (7, 8),
+    (6, 7),
+    (5, 6),
+    (4, 5),
+    (3, 4),
+    (3, 3),
+    (3, 0),
+    (2, 2),
+    (2, 1),
+];
+
+/// The flat 32768-entry lookup `ARW1_CODES` describes, as
+/// `(length, difference bits)` per 15-bit prefix.
+fn arw1_table() -> Vec<(u8, u8)> {
+    let mut table = Vec::with_capacity(1 << 15);
+    for (length, bits) in ARW1_CODES {
+        table.resize(
+            table.len() + (1usize << (15 - length)),
+            (length as u8, bits as u8),
+        );
+    }
+    table
+}
+
+/// The DSLR-A100's ARW 1.0 frame.
+///
+/// Unlike everything after it, this is scanned *down* columns, from
+/// the last to the first, and within a column the even rows come
+/// before the odd ones — so a difference is always taken against the
+/// pixel two rows up, under the same colour filter. The running sum
+/// is never reset, not even between columns.
+fn decode_arw1(tiff: &Tiff<'_>, mrw: &MinoltaBlock, make: &str, model: &str) -> Result<RawImage> {
+    let (sensor_width, sensor_height) = mrw.sensor;
+    // The stream carries one more column than the sensor block
+    // advertises, and the last row is decoded but never stored.
+    let width = sensor_width + 1;
+    let height = sensor_height;
+    if width * height > 1 << 28 {
+        return Err(Error::Corrupt("arw: implausible A100 frame".into()));
+    }
+    let stream = tiff
+        .bytes()
+        .get(mrw.data_offset..)
+        .ok_or_else(|| Error::Corrupt("arw: A100 data offset past the end of the file".into()))?;
+
+    let table = arw1_table();
+    let mut pump = BitPumpMsb::new(stream);
+    let mut out = vec![0u16; width * height];
+    let mut sum: i32 = 0;
+    let order: Vec<usize> = (0..height)
+        .step_by(2)
+        .chain((1..height).step_by(2))
+        .collect();
+    for col in (0..width).rev() {
+        for &row in &order {
+            let (length, bits) = table[pump.peek(15) as usize];
+            pump.consume(length as u32);
+            let mut diff = 0i32;
+            if bits > 0 {
+                let raw = pump.get(bits as u32) as i32;
+                // JPEG's difference extension: a value whose top bit
+                // is clear is the negative half of the range.
+                diff = if raw & (1 << (bits - 1)) != 0 {
+                    raw
+                } else {
+                    raw - ((1i32 << bits) - 1)
+                };
+            }
+            sum = sum.saturating_add(diff);
+            // The final row is padding the encoder emits and the
+            // camera never shows; leaving it zero is what LibRaw does.
+            if row + 1 < height {
+                out[row * width + col] = sum.clamp(0, 0xffff) as u16;
+            }
+        }
+    }
+
+    let mut raw = RawImage::new(Format::Arw, width, height, 1, RawData::U16(out), Cfa::GRBG);
+    raw.set_camera(make, model);
+    raw.orientation = common::orientation(tiff);
+    raw.preview = common::largest_jpeg(tiff);
+    raw.metadata = common::metadata(tiff);
+    // Twelve bits, and the A100 records no black level anywhere: the
+    // masked columns it does not ship would be the only evidence.
+    raw.white_level = 4095.0;
+    if let Some([r, g1, _g2, b]) = mrw.wb {
+        if g1 > 0 {
+            let g = g1 as f32;
+            raw.wb_coeffs = [r as f32 / g, 1.0, b as f32 / g, 1.0];
+        }
+    }
+    raw.crop = Rect {
+        x: 0,
+        y: 0,
+        width: mrw.image.0.min(width),
+        height: mrw.image.1.min(height),
+    };
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+// ---------------------------------------------------------------- //
+// The LFSR, and the metadata behind it.
+// ---------------------------------------------------------------- //
+
+/// Sony's stream cipher: a 127-word lagged-Fibonacci generator seeded
+/// from a 32-bit key, XORed over the data as big-endian words.
+///
+/// Four words come from iterating `key = key * 48828125 + 1`; the rest
+/// of the pad is `(pad[i-4] ^ pad[i-2]) << 1 | (pad[i-3] ^ pad[i-1]) >> 31`,
+/// and from then on each output word replaces `pad[p]` with
+/// `pad[p+1] ^ pad[p+65]`. Trailing bytes that do not fill a word are
+/// left alone, exactly as the camera leaves them.
+fn sony_decrypt(data: &[u8], key: u32) -> Vec<u8> {
+    let mut pad = [0u32; 128];
+    let mut k = key;
+    for slot in pad.iter_mut().take(4) {
+        k = k.wrapping_mul(48828125).wrapping_add(1);
+        *slot = k;
+    }
+    pad[3] = (pad[3] << 1) | ((pad[0] ^ pad[2]) >> 31);
+    for i in 4..127 {
+        pad[i] = ((pad[i - 4] ^ pad[i - 2]) << 1) | ((pad[i - 3] ^ pad[i - 1]) >> 31);
+    }
+    let mut out = data.to_vec();
+    let mut p = 127usize;
+    for word in out.as_chunks_mut::<4>().0 {
+        let v = pad[(p + 1) & 127] ^ pad[(p + 65) & 127];
+        pad[p & 127] = v;
+        p = p.wrapping_add(1);
+        *word = (u32::from_be_bytes(*word) ^ v).to_be_bytes();
+    }
+    out
+}
+
+/// What the encrypted SR2SubIFD gives us.
+#[derive(Debug, Default, Clone, PartialEq)]
+struct Sr2 {
+    /// Per CFA position, on the 14-bit scale.
+    black: Option<[u32; 4]>,
+    /// R, G, B, G2 multipliers with green at 1.0.
+    wb: Option<[f32; 4]>,
+    /// left, top, right, bottom of the active area.
+    crop: Option<[u32; 4]>,
+}
+
+/// Decrypt and read the SR2SubIFD.
+///
+/// `DNGPrivateData` holds a single LONG: the offset of a plain IFD
+/// (the "SR2Private" one) whose 0x7200/0x7201 give the position and
+/// length of a second, encrypted directory and whose 0x7221 is its
+/// key. The encrypted block is an ordinary IFD once decrypted, with
+/// offsets still measured from the start of the file — so it is
+/// parsed inside a buffer that puts it back where it came from.
+fn sr2_metadata(tiff: &Tiff<'_>, bytes: &[u8]) -> Option<Sr2> {
+    let little_endian = tiff.little_endian();
+    let private = tiff
+        .root()
+        .get(stags::DNG_PRIVATE_DATA)
+        .and_then(|e| long_of(e, little_endian))? as usize;
+    let outer = Tiff::parse_at(bytes, private, little_endian).ok()?;
+    let root = outer.root();
+    let offset = root.get(stags::SR2_SUBIFD_OFFSET).and_then(|e| e.u32(0))? as usize;
+    let length = root.get(stags::SR2_SUBIFD_LENGTH).and_then(|e| e.u32(0))? as usize;
+    let key = root
+        .get(stags::SR2_SUBIFD_KEY)
+        .and_then(|e| long_of(e, little_endian))?;
+    // A hostile file could name a gigabyte here; the real ones are
+    // under 64 KB and the block has to lie inside the file anyway.
+    if length == 0 || length > 1 << 22 {
+        return None;
+    }
+    let encrypted = bytes.get(offset..offset.checked_add(length)?)?;
+    let mut buffer = vec![0u8; offset];
+    buffer.extend_from_slice(&sony_decrypt(encrypted, key));
+
+    let inner = Tiff::parse_at(&buffer, offset, little_endian).ok()?;
+    let ifd = inner.root();
+    let quad = |tag: u16| -> Option<[u32; 4]> {
+        let entry = ifd.get(tag)?;
+        Some([entry.u32(0)?, entry.u32(1)?, entry.u32(2)?, entry.u32(3)?])
+    };
+    let mut sr2 = Sr2 {
+        black: quad(stags::BLACK_LEVEL).or_else(|| quad(stags::BLACK_LEVEL_2)),
+        wb: None,
+        crop: quad(stags::CROP_RECT),
+    };
+    // WB_RGGBLevels is R, G1, G2, B; the DSC-R1 writes WB_GRBGLevels
+    // instead, in the order its own filter array runs.
+    if let Some([r, g1, g2, b]) = quad(stags::WB_RGGB_LEVELS) {
+        sr2.wb = normalise_wb(r, g1, b, g2);
+    } else if let Some([g1, r, b, g2]) = quad(stags::WB_GRBG_LEVELS) {
+        sr2.wb = normalise_wb(r, g1, b, g2);
+    }
+    Some(sr2)
+}
+
+fn normalise_wb(r: u32, g: u32, b: u32, g2: u32) -> Option<[f32; 4]> {
+    if g == 0 || r == 0 || b == 0 {
+        return None;
+    }
+    let g = g as f32;
+    Some([
+        r as f32 / g,
+        1.0,
+        b as f32 / g,
+        (g2 as f32 / g).max(f32::MIN_POSITIVE),
+    ])
+}
+
+/// The key the DSC-F828's sensor data is encrypted with, or `None`
+/// when the file is an SR2 (which is stored in the clear).
+///
+/// SRF chains several IFDs after the maker note, each encrypted with a
+/// key held by the one before it. The first key is not reachable from
+/// the chain — it sits in an opaque block near the end of the file —
+/// so it is found by trying every aligned word between the maker note
+/// and the sensor data and keeping the one that turns the first
+/// encrypted directory into a well-formed two-entry IFD holding
+/// exactly the tags it should. That is self-checking, and cheaper than
+/// it sounds: the pad costs about 130 operations a candidate.
+fn srf_data_key(tiff: &Tiff<'_>, bytes: &[u8]) -> Option<u32> {
+    // Only SRF looks like this: no SR2Private, and a maker note whose
+    // own next-IFD pointer is the head of the encrypted chain.
+    if tiff.root().has(stags::DNG_PRIVATE_DATA) {
+        return None;
+    }
+    let maker = tiff.exif()?.get(tags::MAKER_NOTE)?;
+    let start = maker.offset;
+    // `count`, not the decoded bytes: the F828's maker note is most of
+    // a megabyte and the TIFF parser declines to hold values that big.
+    let count = maker.count;
+    let little_endian = tiff.little_endian();
+    let u16_at = |at: usize| -> Option<u16> {
+        let b: [u8; 2] = bytes.get(at..at + 2)?.try_into().ok()?;
+        Some(if little_endian {
+            u16::from_le_bytes(b)
+        } else {
+            u16::from_be_bytes(b)
+        })
+    };
+    let u32_at = |at: usize| -> Option<u32> {
+        let b: [u8; 4] = bytes.get(at..at + 4)?.try_into().ok()?;
+        Some(if little_endian {
+            u32::from_le_bytes(b)
+        } else {
+            u32::from_be_bytes(b)
+        })
+    };
+    // The maker note is itself an IFD; its next-IFD pointer is the
+    // first encrypted directory.
+    let entries = u16_at(start)? as usize;
+    if entries > 64 {
+        return None;
+    }
+    let chain = u32_at(start + 2 + entries * 12)? as usize;
+    let head = bytes.get(chain..chain + 32)?;
+    let end = start.checked_add(count)?.min(bytes.len());
+
+    for at in (start..end.saturating_sub(4)).step_by(4) {
+        let candidate = u32::from_be_bytes(bytes.get(at..at + 4)?.try_into().ok()?);
+        let plain = sony_decrypt(head, candidate);
+        // Two entries: tag 0 is the key of the next directory, tag 1
+        // is the key the sensor data itself is encrypted with. Both
+        // are single LONGs.
+        let field = |off: usize| -> u32 {
+            let b: [u8; 4] = plain[off..off + 4].try_into().expect("four bytes");
+            if little_endian {
+                u32::from_le_bytes(b)
+            } else {
+                u32::from_be_bytes(b)
+            }
+        };
+        let short = |off: usize| -> u16 {
+            let b: [u8; 2] = plain[off..off + 2].try_into().expect("two bytes");
+            if little_endian {
+                u16::from_le_bytes(b)
+            } else {
+                u16::from_be_bytes(b)
+            }
+        };
+        if short(0) == 2
+            && short(2) == 0
+            && short(4) == 4
+            && field(6) == 1
+            && short(14) == 1
+            && short(16) == 4
+            && field(18) == 1
+        {
+            return Some(field(22));
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------- //
+// Filter array and crop.
+// ---------------------------------------------------------------- //
+
+/// The filter array at the frame's own origin.
+///
+/// ARW and SR2 both carry a plain EXIF `CFAPattern`. The DSC-F828 does
+/// not: it is a four-colour RGBE sensor and the only description of
+/// its layout is the camera's.
+fn cfa_of(ifd: &Ifd, _make: &str, model: &str) -> Cfa {
+    if let Some(bytes) = ifd.get(tags::CFA_PATTERN).and_then(|e| e.bytes()) {
+        let dim = ifd
+            .get(tags::CFA_REPEAT_PATTERN_DIM)
+            .map(|e| e.u32s())
+            .unwrap_or_default();
+        let (w, h) = match dim.as_slice() {
+            [w, h] => (*w as usize, *h as usize),
+            _ => (2, 2),
+        };
+        if w == 2 && h == 2 && bytes.len() >= 4 {
+            let colors: Vec<CfaColor> = bytes[..4].iter().map(|c| cfa_color(*c)).collect();
+            return Cfa::Bayer([colors[0], colors[1], colors[2], colors[3]]);
+        }
+        if w > 0 && h > 0 && bytes.len() >= w * h && w * h <= 64 {
+            return Cfa::Pattern {
+                width: w,
+                height: h,
+                colors: bytes[..w * h].iter().map(|c| cfa_color(*c)).collect(),
+            };
+        }
+    }
+    if model.contains("F828") {
+        // Red, emerald / green, blue: the F828's four-colour array,
+        // which LibRaw prints as ERBG once its own five-column left
+        // margin is taken off.
+        return Cfa::Bayer([
+            CfaColor::Red,
+            CfaColor::Emerald,
+            CfaColor::Green,
+            CfaColor::Blue,
+        ]);
+    }
+    Cfa::RGGB
+}
+
+/// EXIF `CFAPattern` colour codes.
+fn cfa_color(code: u8) -> CfaColor {
+    match code {
+        0 => CfaColor::Red,
+        1 => CfaColor::Green,
+        2 => CfaColor::Blue,
+        3 => CfaColor::Cyan,
+        4 => CfaColor::Magenta,
+        5 => CfaColor::Yellow,
+        _ => CfaColor::Emerald,
+    }
+}
+
+/// The active area.
+///
+/// The decrypted SR2SubIFD's 0x74C3 gives it as left/top/right/bottom
+/// on every ARW and SR2 from the A700 on. Newer bodies also write the
+/// DNG `DefaultCropOrigin`/`DefaultCropSize` pair, which agrees with
+/// it. With neither — the DSC-F828 — the whole frame is shown.
+fn crop_of(ifd: &Ifd, meta: Option<&Sr2>, width: usize, height: usize) -> Rect {
+    let whole = Rect {
+        x: 0,
+        y: 0,
+        width,
+        height,
+    };
+    if let Some([left, top, right, bottom]) = meta.and_then(|m| m.crop) {
+        let (left, top, right, bottom) =
+            (left as usize, top as usize, right as usize, bottom as usize);
+        if right > left && bottom > top && right <= width && bottom <= height {
+            return Rect {
+                x: left,
+                y: top,
+                width: right - left,
+                height: bottom - top,
+            };
+        }
+    }
+    let origin = ifd
+        .get(stags::DEFAULT_CROP_ORIGIN)
+        .map(|e| e.u32s())
+        .unwrap_or_default();
+    let size = ifd
+        .get(stags::DEFAULT_CROP_SIZE)
+        .map(|e| e.u32s())
+        .unwrap_or_default();
+    if let ([x, y], [w, h]) = (&origin[..], &size[..]) {
+        let (x, y, w, h) = (*x as usize, *y as usize, *w as usize, *h as usize);
+        if w > 0 && h > 0 && x + w <= width && y + h <= height {
+            return Rect {
+                x,
+                y,
+                width: w,
+                height: h,
+            };
+        }
+    }
+    whole
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tiff::tests::{corpus, samples};
+    use crate::Orientation;
+    use std::path::{Path, PathBuf};
+
+    // ---------------------------------------------------------------
+    // The mechanics, on bytes built by hand.
+    // ---------------------------------------------------------------
+
+    /// The 128-bit little-endian block an ARW 2.x row is made of.
+    fn block(max: u16, min: u16, imax: usize, imin: usize, deltas: [u16; 14]) -> u128 {
+        let mut word =
+            (max as u128) | ((min as u128) << 11) | ((imax as u128) << 22) | ((imin as u128) << 26);
+        for (i, delta) in deltas.iter().enumerate() {
+            word |= (*delta as u128 & 0x7f) << (30 + 7 * i);
+        }
+        word
+    }
+
+    #[test]
+    fn block_places_its_extremes_and_scales_the_rest() {
+        let mut out = [0u16; 16];
+        // A range of 36 needs no shift: 127 steps already span it.
+        decode_block(
+            block(
+                338,
+                302,
+                7,
+                11,
+                [12, 24, 26, 32, 20, 28, 30, 10, 8, 6, 2, 14, 16, 2],
+            ),
+            &mut out,
+        );
+        assert_eq!(out[7], 338, "the maximum goes where imax says");
+        assert_eq!(out[11], 302, "and the minimum where imin says");
+        assert_eq!(out[0], 302 + 12);
+        assert_eq!(out[15], 302 + 2);
+
+        // 300 apart: 127 steps of one do not reach it, nor 127 of
+        // two, so the shift settles at two and each delta is worth
+        // four.
+        let mut out = [0u16; 16];
+        decode_block(block(400, 100, 0, 1, [1; 14]), &mut out);
+        assert_eq!(out[0], 400);
+        assert_eq!(out[1], 100);
+        assert_eq!(out[2], 104);
+    }
+
+    #[test]
+    fn block_deltas_cannot_escape_eleven_bits() {
+        let mut out = [0u16; 16];
+        // A near-full range takes the largest shift, and 127 << 3 on
+        // top of a high minimum would overflow the 11-bit domain.
+        decode_block(block(2047, 1500, 0, 1, [127; 14]), &mut out);
+        assert!(
+            out.iter().all(|v| *v <= 0x7ff),
+            "clamped to eleven bits: {out:?}"
+        );
+    }
+
+    /// A one-entry little-endian TIFF holding just the tone curve,
+    /// for `tone_curve`: header, an IFD of one SHORT[4] entry whose
+    /// value sits after the directory.
+    fn curve_tiff(values: [u16; 4]) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"II*\0");
+        bytes.extend_from_slice(&8u32.to_le_bytes());
+        bytes.extend_from_slice(&1u16.to_le_bytes());
+        bytes.extend_from_slice(&stags::TONE_CURVE.to_le_bytes());
+        bytes.extend_from_slice(&3u16.to_le_bytes());
+        bytes.extend_from_slice(&4u32.to_le_bytes());
+        bytes.extend_from_slice(&26u32.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        for v in values {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        bytes
+    }
+
+    #[test]
+    fn tone_curve_follows_its_knees() {
+        let bytes = curve_tiff([8000, 10400, 12900, 14100]);
+        let tiff = Tiff::parse(&bytes).expect("hand-built TIFF parses");
+        let curve = tone_curve(tiff.root()).expect("a well-formed curve");
+        // Knees at 2000, 2600, 3225, 3525 with slopes 1, 2, 4, 8, 16.
+        assert_eq!(curve[0], 0);
+        assert_eq!(curve[2000], 2000);
+        assert_eq!(curve[2600], 3200);
+        assert_eq!(curve[3225], 5700);
+        assert_eq!(curve[3525], 8100);
+        assert_eq!(curve[4095], 17220.min(u16::MAX as u32) as u16);
+        // The eleven-bit domain is entered at twice the sample value.
+        assert_eq!(curve[338 << 1], 676);
+    }
+
+    #[test]
+    fn tone_curve_rejects_a_curve_that_does_not_rise() {
+        let flat = curve_tiff([0, 0, 0, 0]);
+        let tiff = Tiff::parse(&flat).expect("hand-built TIFF parses");
+        assert!(matches!(
+            tone_curve(tiff.root()),
+            Err(Error::Unsupported(_))
+        ));
+        let jumbled = curve_tiff([12900, 10400, 8000, 14100]);
+        let tiff = Tiff::parse(&jumbled).expect("hand-built TIFF parses");
+        assert!(matches!(
+            tone_curve(tiff.root()),
+            Err(Error::Unsupported(_))
+        ));
+    }
+
+    #[test]
+    fn arw1_table_is_a_complete_code() {
+        let table = arw1_table();
+        assert_eq!(
+            table.len(),
+            1 << 15,
+            "the eighteen codes tile the whole lookup"
+        );
+        // The first two entries are the 15-bit codes, the last block
+        // the 2-bit one; every entry names a length and a bit count.
+        assert_eq!(table[0], (15, 17));
+        assert_eq!(table[1], (15, 16));
+        assert_eq!(table[1 << 14], (2, 2));
+        assert_eq!(table[(1 << 15) - 1], (2, 1));
+        let kraft: f64 = ARW1_CODES
+            .iter()
+            .map(|(len, _)| 2f64.powi(-(*len as i32)))
+            .sum();
+        assert!((kraft - 1.0).abs() < 1e-12, "Kraft sum {kraft}");
+    }
+
+    #[test]
+    fn lfsr_is_its_own_inverse() {
+        let plain: Vec<u8> = (0..64u8).collect();
+        let once = sony_decrypt(&plain, 0x4433_2211);
+        assert_ne!(once, plain);
+        assert_eq!(
+            sony_decrypt(&once, 0x4433_2211),
+            plain,
+            "XOR twice is identity"
+        );
+        // A different key gives a different stream.
+        assert_ne!(sony_decrypt(&plain, 0x4433_2212), once);
+        // Bytes past the last whole word are left alone.
+        let odd = sony_decrypt(&[1, 2, 3, 4, 5, 6], 7);
+        assert_eq!(&odd[4..], &[5, 6]);
+    }
+
+    #[test]
+    fn packed_twelve_unpacks_low_bits_first() {
+        // 0xABC and 0x123 written as Sony writes them.
+        let out = decode_packed12(&[0xbc, 0x3a, 0x12], 2);
+        assert_eq!(out, vec![0x0abc, 0x0123]);
+    }
+
+    #[test]
+    fn words_read_in_both_orders() {
+        assert_eq!(decode_words(&[0x34, 0x12], 1, true), vec![0x1234]);
+        assert_eq!(decode_words(&[0x12, 0x34], 1, false), vec![0x1234]);
+    }
+
+    #[test]
+    fn word_order_is_judged_by_which_way_round_fits_fourteen_bits() {
+        // Fourteen-bit samples written little-endian: read the other
+        // way round nearly every one of them overflows.
+        let little: Vec<u8> = (0..4096u16)
+            .flat_map(|i| (i % 0x3fff).to_le_bytes())
+            .collect();
+        assert!(words_look_little_endian(&little, false));
+        let big: Vec<u8> = (1..4096u16).flat_map(|i| (i * 4).to_be_bytes()).collect();
+        assert!(!words_look_little_endian(&big, true));
+    }
+
+    #[test]
+    fn a_row_of_blocks_lands_in_two_interleaved_colour_streams() {
+        // Two blocks, each sixteen pixels of one colour: the first
+        // fills the even columns of 0..32, the second the odd ones.
+        let curve: Vec<u16> = (0..4096u32).map(|v| v as u16).collect();
+        let mut chunk = Vec::new();
+        chunk.extend_from_slice(&block(100, 100, 0, 1, [0; 14]).to_le_bytes());
+        chunk.extend_from_slice(&block(200, 200, 0, 1, [0; 14]).to_le_bytes());
+        let row = decode_blocks(&chunk, 32, 1, &curve).expect("a 32-pixel row");
+        assert_eq!(row.len(), 32);
+        assert!(
+            row.iter().step_by(2).all(|v| *v == 200),
+            "even columns: {row:?}"
+        );
+        assert!(row[1..].iter().step_by(2).all(|v| *v == 400), "odd columns");
+    }
+
+    #[test]
+    fn a_frame_that_is_not_whole_blocks_is_unsupported() {
+        let curve = vec![0u16; 4096];
+        assert!(matches!(
+            decode_blocks(&[0; 16], 16, 1, &curve),
+            Err(Error::Unsupported(_))
+        ));
+    }
+
+    #[test]
+    fn garbage_is_never_a_raw() {
+        assert!(decode(&[]).is_err());
+        assert!(decode(b"II*\0\x08\0\0\0").is_err());
+        let mut noise: Vec<u8> = b"II*\0\x08\0\0\0".to_vec();
+        noise.extend((0..4096u32).map(|i| i.wrapping_mul(2654435761).to_le_bytes()[0]));
+        assert!(decode(&noise).is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // Corpus. SCHIST_RAW_CORPUS points at a directory of real files
+    // with LibRaw's `unprocessed_raw -T` output beside each as
+    // `<file>.tiff` and `raw-identify -v -w` as `<file>.identify.txt`.
+    // ---------------------------------------------------------------
+
+    /// Files this module knowingly does not reproduce exactly, and why.
+    fn deviations(name: &str) -> Option<&'static str> {
+        match name {
+            // LibRaw shows this four-colour RGBE sensor with a
+            // five-column left margin and a 3287-pixel width, both of
+            // which come from its own model table rather than from the
+            // file. Nothing in the SRF records an active area, so the
+            // whole frame is shown and the pattern is reported at the
+            // frame's own origin (RGGB-shaped RE/GB, which is LibRaw's
+            // ERBG shifted one column left).
+            "DSC-F828-DSC06227.SRF" => {
+                Some("SRF: no recorded crop, so the whole frame with the pattern at its origin")
+            }
+            // LibRaw keeps the A100's last, never-written row and
+            // shows the full 3881-column frame. The camera's own MRW
+            // block says the picture is 3872x2592, which is what the
+            // crop follows.
+            "DSLR-A100-_DSC0258.ARW" => {
+                Some("A100: crop from the camera's MRW block, not LibRaw's full frame")
+            }
+            _ => None,
+        }
+    }
+
+    /// Samples `crate::probe` does not recognise today, with the
+    /// reason. The fix belongs in lib.rs, which this worker does not
+    /// own; `formats::arw::decode` handles both.
+    fn unprobeable(name: &str) -> Option<&'static str> {
+        match name {
+            // `probe_tiff` needs an IFD with StripOffsets to call a
+            // deep-strip directory sensor data, and the F828 records
+            // byte counts but no offset at all.
+            "DSC-F828-DSC06227.SRF" => Some("SRF has no StripOffsets for probe_tiff to find"),
+            // The A100's SubIFDs tag points at raw bytes rather than a
+            // directory, so the walk finds no CFA photometric.
+            "DSLR-A100-_DSC0258.ARW" => Some("A100's SubIFDs tag is a data offset, not an IFD"),
+            _ => None,
+        }
+    }
+
+    fn is_sony(path: &Path) -> bool {
+        let ext = path
+            .extension()
+            .map(|e| e.to_string_lossy().to_ascii_lowercase())
+            .unwrap_or_default();
+        matches!(ext.as_str(), "arw" | "sr2" | "srf")
+    }
+
+    /// The `raw-identify -v -w` sidecar, as its non-empty lines.
+    fn identify(path: &Path) -> Option<Vec<String>> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".identify.txt");
+        let text = std::fs::read_to_string(PathBuf::from(name)).ok()?;
+        Some(text.lines().map(|l| l.trim().to_string()).collect())
+    }
+
+    /// The numbers on the identify line starting with `prefix`.
+    fn numbers(lines: &[String], prefix: &str) -> Option<Vec<i64>> {
+        let line = lines.iter().find(|l| l.starts_with(prefix))?;
+        Some(
+            line[prefix.len()..]
+                .split(|c: char| !(c.is_ascii_digit() || c == '-'))
+                .filter(|s| !s.is_empty())
+                .filter_map(|s| s.parse::<i64>().ok())
+                .collect(),
+        )
+    }
+
+    /// The filter array as raw-identify prints it: sixteen letters,
+    /// the colour at (row = i / 2, column = i % 2) of the *cropped*
+    /// image.
+    fn pattern_string(cfa: &Cfa) -> String {
+        (0..16)
+            .map(|i| match cfa.color_at(i % 2, i / 2) {
+                Some(CfaColor::Red) => 'R',
+                Some(CfaColor::Green) | Some(CfaColor::Green2) => 'G',
+                Some(CfaColor::Blue) => 'B',
+                Some(CfaColor::Emerald) => 'E',
+                Some(CfaColor::Cyan) => 'C',
+                Some(CfaColor::Magenta) => 'M',
+                Some(CfaColor::Yellow) => 'Y',
+                None => '?',
+            })
+            .collect()
+    }
+
+    fn oracle(path: &Path) -> Option<(usize, usize, Vec<u16>)> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".tiff");
+        let image = image::open(PathBuf::from(name)).ok()?.into_luma16();
+        Some((
+            image.width() as usize,
+            image.height() as usize,
+            image.into_raw(),
+        ))
+    }
+
+    #[test]
+    fn corpus_matches_the_oracle() {
+        let Some(root) = corpus() else { return };
+        let mut seen = 0;
+        let mut problems: Vec<String> = Vec::new();
+        for path in samples(&root).into_iter().filter(|p| is_sony(p)) {
+            let name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            let Ok(bytes) = std::fs::read(&path) else {
+                continue;
+            };
+            seen += 1;
+
+            match crate::probe(&bytes) {
+                Some(Format::Arw) => {}
+                other if unprobeable(&name).is_some() => {
+                    // Known, and not this module's to fix: `probe`
+                    // lives in lib.rs. Decoding still has to work.
+                    assert!(other.is_none(), "{name}: probe says {other:?}");
+                }
+                other => {
+                    problems.push(format!("{name}: probe says {other:?}, not Arw"));
+                    continue;
+                }
+            }
+            let raw = match decode(&bytes) {
+                Ok(raw) => raw,
+                Err(e) => {
+                    problems.push(format!("{name}: decode failed: {e}"));
+                    continue;
+                }
+            };
+            if let Err(e) = raw.validate() {
+                problems.push(format!("{name}: validate: {e}"));
+                continue;
+            }
+            let deviation = deviations(&name);
+
+            // The sensor data, sample for sample.
+            if let Some((width, height, want)) = oracle(&path) {
+                if (width, height) != (raw.width, raw.height) {
+                    problems.push(format!(
+                        "{name}: {}x{} decoded, oracle is {width}x{height}",
+                        raw.width, raw.height
+                    ));
+                } else {
+                    let RawData::U16(got) = &raw.data else {
+                        problems.push(format!("{name}: not 16-bit data"));
+                        continue;
+                    };
+                    let mismatches: Vec<usize> = got
+                        .iter()
+                        .zip(want.iter())
+                        .enumerate()
+                        .filter(|(_, (a, b))| a != b)
+                        .map(|(i, _)| i)
+                        .take(6)
+                        .collect();
+                    let total = got.iter().zip(want.iter()).filter(|(a, b)| a != b).count();
+                    if total > 0 {
+                        let first: Vec<String> = mismatches
+                            .iter()
+                            .map(|i| {
+                                format!(
+                                    "({},{}) got {} want {}",
+                                    i % width,
+                                    i / width,
+                                    got[*i],
+                                    want[*i]
+                                )
+                            })
+                            .collect();
+                        problems.push(format!(
+                            "{name}: {total} of {} samples differ: {}",
+                            got.len(),
+                            first.join(", ")
+                        ));
+                    }
+                }
+            } else {
+                problems.push(format!("{name}: no <file>.tiff oracle beside it"));
+            }
+
+            let Some(lines) = identify(&path) else {
+                problems.push(format!("{name}: no identify.txt beside it"));
+                continue;
+            };
+
+            // Frame size, black, white balance, orientation.
+            if let Some([w, h]) = numbers(&lines, "Full size:").as_deref() {
+                if (*w as usize, *h as usize) != (raw.width, raw.height) {
+                    problems.push(format!(
+                        "{name}: full size {w}x{h}, decoded {}x{}",
+                        raw.width, raw.height
+                    ));
+                }
+            }
+            // raw-identify prints "black:" for a single level and
+            // "cblack[0 .. 3]:" when the four positions differ; it
+            // prints neither when the file records none, and then the
+            // camera table is free to supply one.
+            if let Some(black) =
+                numbers(&lines, "cblack[0 .. 3]:").or_else(|| numbers(&lines, "black:"))
+            {
+                let black: Vec<f32> = black.iter().map(|v| *v as f32).collect();
+                let want_black = match black.as_slice() {
+                    [one] => [*one; 4],
+                    [a, b, c, d, ..] => [*a, *b, *c, *d],
+                    _ => [0.0; 4],
+                };
+                if raw.black_levels != want_black {
+                    problems.push(format!(
+                        "{name}: black {:?}, identify says {want_black:?}",
+                        raw.black_levels
+                    ));
+                }
+            }
+            if let Some(shot) = numbers(&lines, "As shot") {
+                // The line is four levels then four EVs; the decimal
+                // points split into extra "numbers", so only the first
+                // four are the multipliers.
+                if let [r, g, b, g2, ..] = shot[..] {
+                    let want = [
+                        r as f32 / g as f32,
+                        1.0,
+                        b as f32 / g as f32,
+                        g2 as f32 / g as f32,
+                    ];
+                    let off = (0..4).any(|i| (raw.wb_coeffs[i] - want[i]).abs() > 1e-4);
+                    if off {
+                        problems.push(format!(
+                            "{name}: wb {:?}, identify says {want:?}",
+                            raw.wb_coeffs
+                        ));
+                    }
+                }
+            }
+            if let Some([flip]) = numbers(&lines, "Image flip:").as_deref() {
+                let want = match flip {
+                    3 => Orientation::Rotate180,
+                    5 => Orientation::Rotate270CW,
+                    6 => Orientation::Rotate90CW,
+                    _ => Orientation::Normal,
+                };
+                if raw.orientation != want {
+                    problems.push(format!(
+                        "{name}: orientation {:?}, flip {flip}",
+                        raw.orientation
+                    ));
+                }
+            }
+
+            // The filter array, anchored where the crop starts.
+            if let Some(line) = lines.iter().find(|l| l.starts_with("Filter pattern:")) {
+                let want = line["Filter pattern:".len()..].trim();
+                let got = pattern_string(&raw.cfa.shifted(raw.crop.x, raw.crop.y));
+                if got != want && deviation.is_none() {
+                    problems.push(format!("{name}: pattern {got}, identify says {want}"));
+                }
+            }
+
+            // The crop, against LibRaw's own "Raw inset" where the
+            // file records one.
+            if let Some(inset) = numbers(&lines, "Raw inset, width x height:") {
+                let (want, origin) = match inset[..] {
+                    [w, h] => (Some((w as usize, h as usize)), (0, 0)),
+                    [w, h, x, y, ..] => (Some((w as usize, h as usize)), (x as usize, y as usize)),
+                    _ => (None, (0, 0)),
+                };
+                if let Some((w, h)) = want {
+                    if (raw.crop.width, raw.crop.height) != (w, h) {
+                        problems.push(format!("{name}: crop {:?}, raw inset {w}x{h}", raw.crop));
+                    }
+                    // LibRaw only prints the inset's origin when it
+                    // knows one; where it does not, ours comes from
+                    // the file's own 0x74C3 and is left unchecked.
+                    if origin != (0, 0) && (raw.crop.x, raw.crop.y) != origin {
+                        problems.push(format!(
+                            "{name}: crop origin {:?}, raw inset at {origin:?}",
+                            raw.crop
+                        ));
+                    }
+                }
+            }
+
+            // The preview has to be a picture.
+            match &raw.preview {
+                Some(jpeg) => {
+                    if image::load_from_memory(jpeg).is_err() {
+                        problems.push(format!("{name}: preview does not decode"));
+                    }
+                }
+                None => problems.push(format!("{name}: no preview")),
+            }
+        }
+        assert!(seen > 0, "SCHIST_RAW_CORPUS holds no Sony samples");
+        assert!(
+            problems.is_empty(),
+            "{} problems:\n{}",
+            problems.len(),
+            problems.join("\n")
+        );
+    }
+
+    #[test]
+    fn truncated_files_never_panic() {
+        let Some(root) = corpus() else { return };
+        for path in samples(&root).into_iter().filter(|p| is_sony(p)) {
+            let Ok(bytes) = std::fs::read(&path) else {
+                continue;
+            };
+            // Ten cuts spread over the file, plus the awkward ones
+            // right at the header and right before the end.
+            let mut cuts: Vec<usize> = (1..=10).map(|i| bytes.len() * i / 11).collect();
+            cuts.extend([0, 4, 8, 16, bytes.len() - 1]);
+            for cut in cuts {
+                let _ = decode(&bytes[..cut]);
+                let _ = preview(&bytes[..cut]);
+                let _ = crate::probe(&bytes[..cut]);
+            }
+            // And a middle byte flipped, which is the other way a
+            // decoder gets asked to read past its buffers.
+            let mut damaged = bytes.clone();
+            let middle = damaged.len() / 2;
+            damaged[middle] ^= 0xff;
+            let _ = decode(&damaged);
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/cr2.rs
+++ b/crates/codec-raw/src/formats/cr2.rs
@@ -1,0 +1,984 @@
+//! Canon CR2: a TIFF whose last IFD holds the sensor frame as a
+//! lossless JPEG, cut into vertical slices.
+//!
+//! The container is an ordinary little-endian TIFF with a four-byte
+//! extra signature (`CR`, major, minor) at byte 8 and, at byte 12, the
+//! offset of the IFD that holds the sensor data. The four directories
+//! are always the same four things: IFD0 the full-size JPEG the camera
+//! would have written on its own, IFD1 the 160x120 thumbnail, IFD2 a
+//! small uncompressed RGB preview, IFD3 the raw.
+//!
+//! The raw IFD carries no ImageWidth or ImageLength — the lossless
+//! JPEG's own frame header carries the shape — and its `StripOffsets`
+//! points at a complete SOF3 stream. That stream is *not* the sensor
+//! frame in reading order. Canon splits the frame into vertical
+//! slices, each of which is compressed as a full-height column and
+//! written one after another, and describes the cut with tag 0xC640:
+//! `[n, first, last]` means `n` slices `first` samples wide followed by
+//! one `last` wide, so the frame is `n * first + last` samples across.
+//! The JPEG's own width times its component count is that same number,
+//! which is how a decoder that hands back samples in stream order (as
+//! [`crate::ljpeg`] does) can be un-sliced with three integers and no
+//! knowledge of how the encoder grouped columns into components.
+//!
+//! Everything else about the picture — the crop, the white balance, the
+//! black level — lives in the Canon makernote, an ordinary IFD in the
+//! file's byte order whose offsets are absolute.
+//!
+//! Clean-room: written from the TIFF 6.0 and ITU T.81 specifications,
+//! published third-party CR2 write-ups, ExifTool's tag documentation,
+//! and measurement of the sample files named in this module's tests.
+
+use crate::formats::common;
+use crate::tiff::{tags, Entry, Ifd, Tiff, Value};
+use crate::{ljpeg, Cfa, CfaColor, Error, Format, RawData, RawImage, Rect, Result};
+
+/// Tag 0xC640, `[slice count, first slice width, last slice width]`.
+const CR2_SLICE: u16 = 0xC640;
+/// Tag 0xC5E0, the Bayer phase of the sensor frame as a small enum.
+const CR2_CFA_PATTERN: u16 = 0xC5E0;
+
+/// Canon makernote tags this module reads.
+mod canon {
+    /// SensorInfo: the full sensor size, the borders of the area the
+    /// camera itself would show, and the optically black mask.
+    pub const SENSOR_INFO: u16 = 0x00E0;
+    /// ColorData: a long, version-stamped block of colour numbers.
+    pub const COLOR_DATA: u16 = 0x4001;
+}
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let tiff = Tiff::parse(bytes)?;
+    let raw_ifd =
+        raw_ifd(&tiff).ok_or_else(|| Error::Corrupt("cr2: no IFD holds sensor data".into()))?;
+    let stream = raw_stream(&tiff, raw_ifd)?;
+
+    // sRAW and mRAW keep a subsampled YCbCr picture rather than a CFA,
+    // in a three-component frame; every Bayer CR2 ever written has two
+    // or four. Say so before the lossless decoder refuses the sampling
+    // factors, which would be a much less helpful message.
+    let shape = ljpeg::header(stream)?;
+    if shape.components == 3 {
+        return Err(Error::Unsupported(
+            "cr2: sRAW/mRAW (subsampled YCbCr, not a colour filter array)".into(),
+        ));
+    }
+    let frame = ljpeg::decode(stream)?;
+    let row = frame
+        .width
+        .checked_mul(frame.components)
+        .ok_or_else(|| Error::Corrupt("cr2: lossless JPEG frame too wide".into()))?;
+    let (width, data) = deslice(&frame.data, row, frame.height, slices(raw_ifd, row))?;
+    let height = frame.height;
+
+    let mut raw = RawImage::new(
+        Format::Cr2,
+        width,
+        height,
+        1,
+        RawData::U16(data),
+        cfa(&tiff, raw_ifd),
+    );
+    let (make, model) = tiff.make_model();
+    raw.set_camera(&make, &model);
+    raw.orientation = common::orientation(&tiff);
+    raw.metadata = common::metadata(&tiff);
+    raw.preview = common::largest_jpeg(&tiff);
+
+    // The lossless JPEG's precision is the sensor's: 12-bit on the
+    // compacts and the pre-2007 bodies, 14 since. Canon's real
+    // saturation is a little under that on most bodies and only the
+    // makernote or a camera table knows it, so a full-scale white here
+    // is the safe end of the error: highlights stay neutral, they just
+    // do not reach 1.0.
+    raw.white_level = ((1u32 << shape.precision.clamp(1, 16)) - 1) as f32;
+
+    if let Some(makernote) = makernote(&tiff) {
+        let root = makernote.root();
+        let little_endian = makernote.little_endian();
+        let sensor = sensor_info(root, little_endian);
+        if let Some(sensor) = &sensor {
+            if let Some(crop) = sensor.crop(width, height) {
+                raw.crop = crop;
+            }
+        }
+        if let Some(color) = color_data(root, little_endian) {
+            if let Some(wb) = color.as_shot_wb() {
+                raw.wb_coeffs = wb;
+            }
+            if let Some(black) = color.black_levels() {
+                raw.black_levels = spread_black(black, &raw.cfa);
+            }
+        }
+        // Canon does not always record a black level, and even where it
+        // does the masked border is the same number measured on this
+        // frame at this temperature. Fall back to it.
+        if raw.black_levels == [0.0; 4] {
+            if let Some(black) = masked_black(&raw, sensor.as_ref()) {
+                raw.black_levels = black;
+            }
+        }
+    }
+    if !raw.black_levels.iter().all(|b| *b < raw.white_level) {
+        // A black level at or above saturation is a table or a parse
+        // gone wrong; an unbalanced picture beats a refusal.
+        raw.black_levels = [0.0; 4];
+    }
+
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    Ok(common::largest_jpeg(&Tiff::parse(bytes)?))
+}
+
+// ------------------------------------------------------------ container
+
+/// The IFD holding the sensor data.
+///
+/// Byte 12 of a CR2 points straight at it, which is the only way to be
+/// sure on a file whose IFD order is unusual; the search that follows
+/// is for the odd file (and for the truncated ones a fuzzer builds)
+/// whose header pointer does not land on a directory this parser read.
+fn raw_ifd<'a>(tiff: &'a Tiff<'_>) -> Option<&'a Ifd> {
+    let ifds = tiff.all();
+    if let Some(offset) = tiff.u32_at(12) {
+        let offset = offset as usize + tiff.base();
+        if let Some(ifd) = ifds
+            .iter()
+            .find(|i| i.offset == offset && i.has(tags::STRIP_OFFSETS))
+        {
+            return Some(ifd);
+        }
+    }
+    // The slice tag only ever appears on the raw IFD.
+    if let Some(ifd) = ifds.iter().find(|i| i.has(CR2_SLICE)) {
+        return Some(ifd);
+    }
+    // Last resort: the IFD whose single strip is a lossless JPEG.
+    ifds.iter()
+        .find(|i| raw_stream(tiff, i).map(is_lossless_jpeg).unwrap_or(false))
+        .copied()
+}
+
+/// Whether a stream is SOF3 — a raw frame rather than a picture.
+fn is_lossless_jpeg(stream: &[u8]) -> bool {
+    ljpeg::header(stream).is_ok()
+}
+
+/// The raw IFD's one strip. [`crate::tiff::ImageLayout`] cannot be used
+/// here: the raw IFD has no ImageWidth or ImageLength for it to read.
+fn raw_stream<'a>(tiff: &Tiff<'a>, ifd: &Ifd) -> Result<&'a [u8]> {
+    let offsets = ifd
+        .get(tags::STRIP_OFFSETS)
+        .map(|e| e.u64s())
+        .unwrap_or_default();
+    let counts = ifd
+        .get(tags::STRIP_BYTE_COUNTS)
+        .map(|e| e.u64s())
+        .unwrap_or_default();
+    let (&offset, &count) = match (offsets.first(), counts.first()) {
+        (Some(offset), Some(count)) => (offset, count),
+        _ => return Err(Error::Corrupt("cr2: raw IFD without a strip".into())),
+    };
+    let bytes = tiff.bytes();
+    let start = usize::try_from(offset)
+        .ok()
+        .and_then(|o| o.checked_add(tiff.base()))
+        .ok_or_else(|| Error::Corrupt("cr2: strip offset out of range".into()))?;
+    let end = usize::try_from(count)
+        .ok()
+        .and_then(|c| start.checked_add(c))
+        .ok_or_else(|| Error::Corrupt("cr2: strip length out of range".into()))?;
+    bytes
+        .get(start..end)
+        .ok_or_else(|| Error::Corrupt(format!("cr2: strip {start}..{end} lies outside the file")))
+}
+
+/// Tag 0xC640, or the single full-width slice a file without it means.
+fn slices(ifd: &Ifd, row: usize) -> [usize; 3] {
+    match ifd.get(CR2_SLICE) {
+        // A file that has the tag but has written it short is a file
+        // whose slicing cannot be trusted; fall through to one slice.
+        Some(entry) if entry.count >= 3 => {
+            let at = |i| entry.u32(i).unwrap_or(0) as usize;
+            [at(0), at(1), at(2)]
+        }
+        // The 20D and the 1D Mark II generation compress the whole
+        // frame as one slice and leave the tag out.
+        _ => [0, 0, row],
+    }
+}
+
+/// Put Canon's vertical slices back into one raster.
+///
+/// `samples` is the lossless JPEG's output in stream order: `row`
+/// samples a line, `height` lines. Each slice was compressed as a
+/// full-height column, so the stream holds slice 0's `height` lines of
+/// `first` samples, then slice 1's, and so on, with a final slice
+/// `last` wide. Returns the frame width and the reassembled raster.
+fn deslice(
+    samples: &[u16],
+    row: usize,
+    height: usize,
+    slices: [usize; 3],
+) -> Result<(usize, Vec<u16>)> {
+    let [count, first, last] = slices;
+    let width = count
+        .checked_mul(first)
+        .and_then(|w| w.checked_add(last))
+        .ok_or_else(|| Error::Corrupt("cr2: slice widths overflow".into()))?;
+    if width != row {
+        return Err(Error::Corrupt(format!(
+            "cr2: slices {count}x{first}+{last} make {width} samples a row, the frame has {row}"
+        )));
+    }
+    let total = width
+        .checked_mul(height)
+        .ok_or_else(|| Error::Corrupt("cr2: frame too large".into()))?;
+    if samples.len() != total {
+        return Err(Error::Corrupt(format!(
+            "cr2: {} samples for a {width}x{height} frame",
+            samples.len()
+        )));
+    }
+    // One slice is the whole frame already in reading order.
+    if count == 0 || first == 0 {
+        return Ok((width, samples.to_vec()));
+    }
+    let mut out = vec![0u16; total];
+    let mut read = 0;
+    let mut x = 0;
+    for slice in 0..=count {
+        let slice_width = if slice < count { first } else { last };
+        if slice_width == 0 {
+            continue;
+        }
+        for y in 0..height {
+            let from = samples
+                .get(read..read + slice_width)
+                .ok_or_else(|| Error::Corrupt("cr2: slice runs past the frame".into()))?;
+            let at = y * width + x;
+            out.get_mut(at..at + slice_width)
+                .ok_or_else(|| Error::Corrupt("cr2: slice runs past the frame".into()))?
+                .copy_from_slice(from);
+            read += slice_width;
+        }
+        x += slice_width;
+    }
+    Ok((width, out))
+}
+
+/// The Bayer phase at the sensor frame's origin.
+///
+/// Tag 0xC5E0 names it as a small enum (ExifTool documents the four
+/// values as CR2CFAPattern). Canon has never shipped anything but a
+/// Bayer CR2, so an absent or unknown tag falls back to RGGB, the
+/// commonest of the four, rather than failing the decode.
+fn cfa(tiff: &Tiff<'_>, raw_ifd: &Ifd) -> Cfa {
+    let value = raw_ifd
+        .get(CR2_CFA_PATTERN)
+        .or_else(|| tiff.find(CR2_CFA_PATTERN))
+        .and_then(|e| e.u32(0));
+    match value {
+        Some(2) => Cfa::BGGR,
+        Some(3) => Cfa::GBRG,
+        Some(4) => Cfa::GRBG,
+        _ => Cfa::RGGB,
+    }
+}
+
+// ------------------------------------------------------------ makernote
+
+/// The Canon makernote as a directory of its own.
+///
+/// It is a plain IFD in the file's byte order whose value offsets are
+/// measured from the start of the file like any other, so it needs no
+/// base and no header — only its position, which is where the
+/// MakerNote tag's value sits.
+fn makernote<'a>(tiff: &Tiff<'a>) -> Option<Tiff<'a>> {
+    let entry = tiff.find(tags::MAKER_NOTE)?;
+    Tiff::parse_at(tiff.bytes(), entry.offset, tiff.little_endian()).ok()
+}
+
+/// Makernote 0x00E0: where the picture sits on the sensor.
+///
+/// A SHORT array whose first element is the record's own length in
+/// bytes; the rest are documented by ExifTool as SensorWidth,
+/// SensorHeight, two reserved words, the four borders of the area the
+/// camera would show, and the four borders of the optically black
+/// mask (all zero on the bodies that have no mask inside the frame).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SensorInfo {
+    left: usize,
+    top: usize,
+    right: usize,
+    bottom: usize,
+    mask: Option<Rect>,
+}
+
+/// A makernote record's values as 16-bit words.
+///
+/// Canon writes SensorInfo and ColorData as SHORT arrays on the EOS
+/// bodies and as an UNDEFINED byte blob on the PowerShot compacts —
+/// the same little-endian words either way, but a reader that trusted
+/// the field type would take every compact's colour block for a list
+/// of bytes and index it at half the stride.
+fn shorts(entry: &Entry, little_endian: bool) -> Vec<u16> {
+    match &entry.value {
+        Value::Short(values) => values.clone(),
+        Value::Byte(bytes) | Value::Undefined(bytes) => {
+            let (pairs, _) = bytes.as_chunks::<2>();
+            pairs
+                .iter()
+                .map(|pair| {
+                    if little_endian {
+                        u16::from_le_bytes(*pair)
+                    } else {
+                        u16::from_be_bytes(*pair)
+                    }
+                })
+                .collect()
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn sensor_info(mn: &Ifd, little_endian: bool) -> Option<SensorInfo> {
+    let values = shorts(mn.get(canon::SENSOR_INFO)?, little_endian);
+    let at = |i: usize| values.get(i).map(|v| *v as usize);
+    let (left, top, right, bottom) = (at(5)?, at(6)?, at(7)?, at(8)?);
+    if right <= left || bottom <= top {
+        return None;
+    }
+    // The mask borders are inclusive like the picture's, and all four
+    // are zero when the frame holds no mask.
+    let mask = match (at(9), at(10), at(11), at(12)) {
+        (Some(l), Some(t), Some(r), Some(b)) if r > l && b > t => Some(Rect {
+            x: l,
+            y: t,
+            width: r - l + 1,
+            height: b - t + 1,
+        }),
+        _ => None,
+    };
+    Some(SensorInfo {
+        left,
+        top,
+        right,
+        bottom,
+        mask,
+    })
+}
+
+impl SensorInfo {
+    /// The borders as a rectangle, when they lie inside the frame.
+    ///
+    /// Canon's borders are inclusive, and the top border is odd on
+    /// several bodies (the 1Ds Mark III's is 25) — the crop then starts
+    /// on the other Bayer phase from the frame, which is exactly what
+    /// [`crate::Cfa`] anchored at the frame origin is for. LibRaw
+    /// rounds such a top up to keep its own single pattern usable and
+    /// loses a row; this keeps Canon's number.
+    fn crop(&self, width: usize, height: usize) -> Option<Rect> {
+        let crop = Rect {
+            x: self.left,
+            y: self.top,
+            width: self.right.checked_sub(self.left)? + 1,
+            height: self.bottom.checked_sub(self.top)? + 1,
+        };
+        (crop.x + crop.width <= width && crop.y + crop.height <= height).then_some(crop)
+    }
+}
+
+/// Makernote 0x4001: colour numbers, laid out by version.
+///
+/// The block is a SHORT array a few thousand entries long whose shape
+/// changed with nearly every camera generation. Its first element is a
+/// version stamp (negative on the PowerShot compacts), and ExifTool's
+/// tag documentation splits the versions into a dozen tables. Only two
+/// fields are wanted here, and only one of them at an offset that
+/// varies: the as-shot white balance sits at element 25 in the oldest
+/// layout (the 20D and 350D generation, 582 entries), at 24 in the next
+/// (653), at 71 on the PowerShot compacts, and at 63 in every layout
+/// since — which covers every EOS body from the 1D Mark II N on.
+struct ColorData {
+    values: Vec<u16>,
+    version: i32,
+}
+
+fn color_data(mn: &Ifd, little_endian: bool) -> Option<ColorData> {
+    let values = shorts(mn.get(canon::COLOR_DATA)?, little_endian);
+    if values.len() < 32 {
+        return None;
+    }
+    // The version stamp is signed: the compacts use -3 and -4.
+    let version = *values.first()? as i16 as i32;
+    Some(ColorData { values, version })
+}
+
+impl ColorData {
+    fn count(&self) -> usize {
+        self.values.len()
+    }
+
+    fn short(&self, i: usize) -> Option<u16> {
+        self.values.get(i).copied()
+    }
+
+    /// Where `WB_RGGBLevelsAsShot` starts, or `None` for a block too
+    /// short to hold it there.
+    fn as_shot_offset(&self) -> Option<usize> {
+        let offset = match self.count() {
+            // ColorData1: EOS 20D, 350D. Verified on both.
+            582 => 25,
+            // ColorData2: the 1D Mark II and 1Ds Mark II. ExifTool's
+            // documented offset; no sample of this generation was to
+            // hand, so this one line is unverified.
+            653 => 24,
+            // ColorData5, the PowerShot compacts, which stamp a
+            // negative version. Verified on the G11, S110 and G1 X
+            // Mark III.
+            _ if self.version < 0 => 71,
+            // Every EOS layout from the 1D Mark II N on. Verified on
+            // the 1D Mark II N, 40D, 1Ds Mark III, 450D, 50D, 550D,
+            // M2 and Rebel T6 — versions 1, 3, 4, 5, 6, 7, 10 and 14.
+            _ => 63,
+        };
+        (offset + 4 <= self.count()).then_some(offset)
+    }
+
+    /// R, G, B, G2 multipliers normalised so green is 1.
+    ///
+    /// Canon stores four levels in RGGB order — the two greens
+    /// separately — as integers around 1024, which is the same
+    /// convention as `RawImage::wb_coeffs` before normalisation.
+    fn as_shot_wb(&self) -> Option<[f32; 4]> {
+        let at = self.as_shot_offset()?;
+        let levels: Vec<u16> = (0..4).map_while(|i| self.short(at + i)).collect();
+        let [r, g1, g2, b] = <[u16; 4]>::try_from(levels).ok()?;
+        if g1 == 0 || r == 0 || b == 0 {
+            return None;
+        }
+        let g = g1 as f32;
+        Some([r as f32 / g, 1.0, b as f32 / g, g2 as f32 / g])
+    }
+
+    /// `PerChannelBlackLevel`, in the same RGGB order.
+    ///
+    /// Its offset moves with the version rather than with the block
+    /// length, and in the layouts here it is always followed by
+    /// NormalWhiteLevel and SpecularWhiteLevel. Only versions measured
+    /// against a real file are listed; anything else falls back to the
+    /// masked border, which is what LibRaw measures anyway and is
+    /// never more than two counts away from what the camera wrote on
+    /// the files where both exist.
+    ///
+    /// The PowerShot layouts are deliberately absent: their blocks
+    /// hold the black level twice at two different offsets and every
+    /// compact in the corpus writes the same constant at both, so
+    /// there is no way to tell from a sample which one ExifTool means.
+    fn black_levels(&self) -> Option<[u16; 4]> {
+        // ColorData1 (582 entries) has no black level at all, and its
+        // first word is not a version — the 20D's reads 1164 — so a
+        // file of that generation must never reach the table below.
+        if self.count() < 653 {
+            return None;
+        }
+        let at = match self.version {
+            1 => 196,
+            4 | 5 => 692,
+            6 | 7 => 715,
+            10 => 504,
+            14 => 556,
+            _ => return None,
+        };
+        if at + 4 > self.count() {
+            return None;
+        }
+        let levels: Vec<u16> = (0..4).map_while(|i| self.short(at + i)).collect();
+        let levels = <[u16; 4]>::try_from(levels).ok()?;
+        // A plausible black is a small fraction of full scale and the
+        // four channels agree closely; anything else means the offset
+        // is wrong for this file and the masked border should decide.
+        let (low, high) = (
+            *levels.iter().min().unwrap_or(&0),
+            *levels.iter().max().unwrap_or(&0),
+        );
+        (high < 8192 && high - low <= 64).then_some(levels)
+    }
+}
+
+/// Canon's four RGGB levels put on the four positions of a Bayer tile.
+///
+/// The file names them by colour, the field wants them by position, and
+/// which of the two greens is "first" depends on where the frame's
+/// origin falls — so the greens are matched in raster order, which is
+/// the only reading that agrees with itself whatever the phase. The two
+/// greens differ by a count or two at most, so nothing rides on it.
+fn spread_black(levels: [u16; 4], cfa: &Cfa) -> [f32; 4] {
+    let mut out = [levels[1] as f32; 4];
+    let mut greens = 0;
+    for (i, slot) in out.iter_mut().enumerate() {
+        *slot = match cfa.color_at(i % 2, i / 2) {
+            Some(CfaColor::Red) => levels[0] as f32,
+            Some(CfaColor::Blue) => levels[3] as f32,
+            _ => {
+                greens += 1;
+                levels[if greens > 1 { 2 } else { 1 }] as f32
+            }
+        };
+    }
+    out
+}
+
+/// The black level measured on the frame's own masked pixels.
+///
+/// Canon leaves a strip of the sensor under metal, and says where in
+/// SensorInfo: either as an explicit mask rectangle, or — on the bodies
+/// that leave those four words zero — as the space to the left of the
+/// picture's own border. Both are read here as a median per Bayer
+/// position, because the first row of a Canon frame is regularly junk
+/// (on the 50D it averages nine times the black level) and a median
+/// ignores it where a mean does not.
+fn masked_black(raw: &RawImage, sensor: Option<&SensorInfo>) -> Option<[f32; 4]> {
+    let sensor = sensor?;
+    let RawData::U16(data) = &raw.data else {
+        return None;
+    };
+    let area = match sensor.mask {
+        Some(mask) => mask,
+        // Two columns of guard on the picture side: the transition out
+        // of the mask is not sharp.
+        None if sensor.left >= 8 => Rect {
+            x: 0,
+            y: 0,
+            width: sensor.left - 4,
+            height: raw.height,
+        },
+        None => return None,
+    };
+    if area.x + area.width > raw.width || area.y + area.height > raw.height {
+        return None;
+    }
+    let mut out = [0.0f32; 4];
+    for (phase, slot) in out.iter_mut().enumerate() {
+        let (px, py) = (phase % 2, phase / 2);
+        let mut samples: Vec<u16> = Vec::new();
+        let mut y = area.y + (py + 2 - area.y % 2) % 2;
+        while y < area.y + area.height {
+            let mut x = area.x + (px + 2 - area.x % 2) % 2;
+            while x < area.x + area.width {
+                samples.push(data[y * raw.width + x]);
+                x += 2;
+            }
+            y += 2;
+        }
+        if samples.is_empty() {
+            return None;
+        }
+        let mid = samples.len() / 2;
+        samples.sort_unstable();
+        *slot = samples[mid] as f32;
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CfaColor::{Blue, Green, Red};
+    use crate::Orientation;
+    use std::path::PathBuf;
+
+    // ------------------------------------------------------- mechanics
+
+    /// A frame whose samples say where they belong, so a wrong
+    /// reassembly is visible rather than merely unequal.
+    fn ramp(width: usize, height: usize) -> Vec<u16> {
+        (0..width * height).map(|i| i as u16).collect()
+    }
+
+    /// Slice a frame the way Canon's encoder does, for `deslice` to
+    /// put back.
+    fn slice_up(frame: &[u16], width: usize, height: usize, widths: &[usize]) -> Vec<u16> {
+        let mut out = Vec::with_capacity(frame.len());
+        let mut x = 0;
+        for slice in widths {
+            for y in 0..height {
+                out.extend_from_slice(&frame[y * width + x..y * width + x + slice]);
+            }
+            x += slice;
+        }
+        out
+    }
+
+    #[test]
+    fn deslice_rebuilds_the_frame_from_its_columns() {
+        // The 50D's shape in miniature: two slices of one width and a
+        // narrower last one.
+        let (width, height) = (10, 4);
+        let frame = ramp(width, height);
+        let stream = slice_up(&frame, width, height, &[4, 4, 2]);
+        assert_eq!(
+            deslice(&stream, width, height, [2, 4, 2]).unwrap(),
+            (width, frame)
+        );
+    }
+
+    #[test]
+    fn deslice_passes_a_single_slice_through() {
+        // The G1 X Mark III writes [0, 0, width]; the 20D leaves the
+        // tag out entirely and this module supplies the same triple.
+        let (width, height) = (6, 3);
+        let frame = ramp(width, height);
+        assert_eq!(
+            deslice(&frame, width, height, [0, 0, width]).unwrap(),
+            (width, frame.clone())
+        );
+        assert_eq!(
+            deslice(&frame, width, height, [1, 6, 0]).unwrap(),
+            (width, frame)
+        );
+    }
+
+    #[test]
+    fn deslice_rejects_a_cut_that_does_not_add_up() {
+        let frame = ramp(10, 4);
+        // Slices that make a different width than the JPEG's raster.
+        assert!(matches!(
+            deslice(&frame, 10, 4, [2, 4, 4]),
+            Err(Error::Corrupt(_))
+        ));
+        // A raster the sample count does not match.
+        assert!(matches!(
+            deslice(&frame, 10, 5, [0, 0, 10]),
+            Err(Error::Corrupt(_))
+        ));
+        // Widths that would overflow rather than wrap.
+        assert!(matches!(
+            deslice(&frame, 10, 4, [usize::MAX, usize::MAX, 0]),
+            Err(Error::Corrupt(_))
+        ));
+    }
+
+    #[test]
+    fn slices_falls_back_to_one_full_width_slice() {
+        // An IFD with no tag at all, as the 20D and 1D Mark II write.
+        let empty = Ifd::default();
+        assert_eq!(slices(&empty, 3596), [0, 0, 3596]);
+    }
+
+    #[test]
+    fn spread_black_follows_the_bayer_phase() {
+        // Canon names its four levels by colour in RGGB order; the
+        // field wants them by position, so a GBRG frame moves them.
+        let levels = [100, 200, 201, 300];
+        assert_eq!(
+            spread_black(levels, &Cfa::RGGB),
+            [100.0, 200.0, 201.0, 300.0]
+        );
+        assert_eq!(
+            spread_black(levels, &Cfa::GBRG),
+            [200.0, 300.0, 100.0, 201.0]
+        );
+        assert_eq!(
+            spread_black(levels, &Cfa::BGGR),
+            [300.0, 200.0, 201.0, 100.0]
+        );
+    }
+
+    #[test]
+    fn cfa_reads_canons_pattern_tag() {
+        assert_eq!(cfa_of(Some(1)), Cfa::RGGB);
+        assert_eq!(cfa_of(Some(3)), Cfa::GBRG);
+        // An unknown or absent value is RGGB, the commonest phase.
+        assert_eq!(cfa_of(Some(99)), Cfa::RGGB);
+        assert_eq!(cfa_of(None), Cfa::RGGB);
+        assert_eq!(Cfa::GBRG, Cfa::Bayer([Green, Blue, Red, Green]));
+    }
+
+    /// `cfa` without a whole TIFF around it.
+    fn cfa_of(value: Option<u32>) -> Cfa {
+        match value {
+            Some(2) => Cfa::BGGR,
+            Some(3) => Cfa::GBRG,
+            Some(4) => Cfa::GRBG,
+            _ => Cfa::RGGB,
+        }
+    }
+
+    #[test]
+    fn hostile_input_is_an_error_not_a_panic() {
+        for bytes in [
+            &b""[..],
+            &b"II*\0"[..],
+            &b"II*\0\x08\0\0\0CR\x02\0\xff\xff\xff\xff"[..],
+            &[0xff; 64][..],
+        ] {
+            assert!(decode(bytes).is_err());
+            // A file whose directory reads but holds nothing has no
+            // preview rather than a broken one.
+            assert!(matches!(preview(bytes), Err(_) | Ok(None)));
+        }
+    }
+
+    // ---------------------------------------------------------- corpus
+
+    /// Files LibRaw's oracle covers but this decoder knowingly does
+    /// not, with the reason. Both are Canon's subsampled raws: the
+    /// frame is a YCbCr picture at half or quarter resolution, not a
+    /// colour filter array, and `crate::ljpeg` refuses the sampling
+    /// factors.
+    const UNSUPPORTED: &[&str] = &["EOS_50D-IMG_9517.CR2", "EOS_50D-IMG_9518.CR2"];
+
+    fn corpus() -> Option<PathBuf> {
+        std::env::var_os("SCHIST_RAW_CORPUS").map(PathBuf::from)
+    }
+
+    /// Every CR2 under `dir`, recursively.
+    fn cr2_files(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                cr2_files(&path, out);
+            } else if path
+                .extension()
+                .is_some_and(|e| e.eq_ignore_ascii_case("cr2"))
+            {
+                out.push(path);
+            }
+        }
+    }
+
+    /// The handful of lines of `raw-identify -v -w` this module checks
+    /// itself against.
+    #[derive(Debug, Default)]
+    struct Identify {
+        full: Option<(usize, usize)>,
+        inset: Option<(usize, usize, usize, usize)>,
+        flip: Option<u32>,
+        pattern: Option<String>,
+        as_shot: Option<[f64; 4]>,
+    }
+
+    fn identify(path: &std::path::Path) -> Option<Identify> {
+        let text = std::fs::read_to_string(path.with_file_name(format!(
+            "{}.identify.txt",
+            path.file_name()?.to_string_lossy()
+        )))
+        .ok()?;
+        let mut out = Identify::default();
+        for line in text.lines() {
+            let words: Vec<&str> = line.split_whitespace().collect();
+            let word = |i: usize| words.get(i).map(|w| w.trim_end_matches(':'));
+            let size = |i: usize| word(i).and_then(|w| w.parse::<usize>().ok());
+            let level = |i: usize| word(i).and_then(|w| w.parse::<f64>().ok());
+            match words.as_slice() {
+                ["Full", "size:", ..] => out.full = Some((size(2)?, size(4)?)),
+                // "Raw inset, width x height: W x H left: L top: T"
+                ["Raw", "inset,", ..] => {
+                    out.inset = Some((size(5)?, size(7)?, size(9)?, size(11)?))
+                }
+                ["Image", "flip:", ..] => out.flip = word(2).and_then(|w| w.parse().ok()),
+                ["Filter", "pattern:", p] => out.pattern = Some(p.to_string()),
+                ["As", "shot", ..] => {
+                    out.as_shot = Some([level(2)?, level(3)?, level(4)?, level(5)?])
+                }
+                _ => {}
+            }
+        }
+        Some(out)
+    }
+
+    /// LibRaw's `unprocessed_raw -T` output for a sample: the whole
+    /// sensor frame, 16-bit grey, black not subtracted.
+    fn oracle(path: &std::path::Path) -> Option<(usize, usize, Vec<u16>)> {
+        let tiff = path.with_file_name(format!("{}.tiff", path.file_name()?.to_string_lossy()));
+        let image = image::open(tiff).ok()?.into_luma16();
+        let (width, height) = (image.width() as usize, image.height() as usize);
+        Some((width, height, image.into_raw()))
+    }
+
+    #[test]
+    fn corpus_decodes_and_matches_the_oracle() {
+        let Some(dir) = corpus() else { return };
+        let mut files = Vec::new();
+        cr2_files(&dir, &mut files);
+        files.sort();
+        assert!(!files.is_empty(), "no CR2 under {}", dir.display());
+        let mut checked = 0;
+        for path in &files {
+            let name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            let bytes = std::fs::read(path).expect("read sample");
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(Format::Cr2),
+                "{name} probes as CR2"
+            );
+            let raw = match crate::decode(&bytes) {
+                Ok(raw) => raw,
+                Err(Error::Unsupported(why)) if UNSUPPORTED.contains(&name.as_str()) => {
+                    assert!(why.contains("sRAW"), "{name}: {why}");
+                    // The picture is still there even when the sensor
+                    // data cannot be read.
+                    let jpeg = super::preview(&bytes).unwrap().expect("preview");
+                    image::load_from_memory(&jpeg)
+                        .unwrap_or_else(|e| panic!("{name} preview: {e}"));
+                    continue;
+                }
+                Err(why) => panic!("{name}: {why}"),
+            };
+            raw.validate().unwrap_or_else(|e| panic!("{name}: {e}"));
+            assert_eq!(raw.format, Format::Cr2);
+            assert_eq!(raw.make, "Canon", "{name}");
+            assert!(!raw.model.is_empty(), "{name} has a model");
+
+            if let Some((width, height, want)) = oracle(path) {
+                assert_eq!(
+                    (raw.width, raw.height),
+                    (width, height),
+                    "{name} frame size"
+                );
+                let RawData::U16(got) = &raw.data else {
+                    panic!("{name} is not 16-bit")
+                };
+                let wrong: Vec<usize> = got
+                    .iter()
+                    .zip(&want)
+                    .enumerate()
+                    .filter(|(_, (a, b))| a != b)
+                    .map(|(i, _)| i)
+                    .take(8)
+                    .collect();
+                assert!(
+                    wrong.is_empty(),
+                    "{name}: samples differ from the oracle at {:?} (got {:?}, want {:?})",
+                    wrong,
+                    wrong.iter().map(|i| got[*i]).collect::<Vec<_>>(),
+                    wrong.iter().map(|i| want[*i]).collect::<Vec<_>>(),
+                );
+                checked += 1;
+            }
+
+            if let Some(identify) = identify(path) {
+                if let Some(full) = identify.full {
+                    assert_eq!((raw.width, raw.height), full, "{name} full size");
+                }
+                if let Some((width, height, left, top)) = identify.inset {
+                    // LibRaw rounds an odd top border up so that its
+                    // single Bayer phase still describes the crop, and
+                    // loses the last row doing it; this decoder keeps
+                    // Canon's own borders, so a one-pixel disagreement
+                    // in y is expected on those bodies.
+                    assert_eq!((raw.crop.x, raw.crop.width), (left, width), "{name} crop x");
+                    assert!(
+                        raw.crop.y.abs_diff(top) <= 1 && raw.crop.height.abs_diff(height) <= 1,
+                        "{name} crop y: {:?} against LibRaw's {top}+{height}",
+                        raw.crop
+                    );
+                }
+                if let Some(flip) = identify.flip {
+                    let want = match flip {
+                        3 => Orientation::Rotate180,
+                        5 => Orientation::Rotate270CW,
+                        6 => Orientation::Rotate90CW,
+                        _ => Orientation::Normal,
+                    };
+                    assert_eq!(raw.orientation, want, "{name} orientation");
+                }
+                if let Some(pattern) = &identify.pattern {
+                    let want: Vec<CfaColor> = pattern[..4]
+                        .chars()
+                        .map(|c| match c {
+                            'R' => Red,
+                            'B' => Blue,
+                            _ => Green,
+                        })
+                        .collect();
+                    let got: Vec<CfaColor> = (0..4)
+                        .map(|i| raw.cfa.color_at(i % 2, i / 2).unwrap())
+                        .map(|c| if c == CfaColor::Green2 { Green } else { c })
+                        .collect();
+                    assert_eq!(got, want, "{name} filter pattern");
+                }
+                if let Some(levels) = identify.as_shot {
+                    let want = [
+                        levels[0] / levels[1],
+                        1.0,
+                        levels[2] / levels[1],
+                        levels[3] / levels[1],
+                    ];
+                    for (got, want) in raw.wb_coeffs.iter().zip(&want) {
+                        assert!(
+                            (*got as f64 - want).abs() < 1e-3,
+                            "{name} white balance {:?} against LibRaw's {want:?}",
+                            raw.wb_coeffs
+                        );
+                    }
+                }
+            }
+
+            // Levels: the black must be a small, nearly uniform lift
+            // and the white the bit depth's full scale.
+            assert!(
+                raw.white_level == 4095.0 || raw.white_level == 16383.0,
+                "{name} white {}",
+                raw.white_level
+            );
+            let black = raw.black_levels;
+            let (low, high) = (
+                black.iter().cloned().fold(f32::MAX, f32::min),
+                black.iter().cloned().fold(0.0, f32::max),
+            );
+            assert!(
+                high < raw.white_level / 4.0 && high - low <= 4.0,
+                "{name} black {black:?}"
+            );
+            assert!(high > 0.0, "{name} found no black level");
+
+            let preview = raw
+                .preview
+                .as_ref()
+                .unwrap_or_else(|| panic!("{name} has no preview"));
+            image::load_from_memory(preview).unwrap_or_else(|e| panic!("{name} preview: {e}"));
+            assert_eq!(
+                super::preview(&bytes).unwrap().as_deref(),
+                Some(&preview[..]),
+                "{name}: the cheap preview path differs"
+            );
+        }
+        assert!(checked > 0, "no oracle TIFF beside any sample");
+    }
+
+    #[test]
+    fn truncated_corpus_files_never_panic() {
+        let Some(dir) = corpus() else { return };
+        let mut files = Vec::new();
+        cr2_files(&dir, &mut files);
+        files.sort();
+        for path in &files {
+            let bytes = std::fs::read(path).expect("read sample");
+            // Cuts across the header, the directories, the makernote
+            // and well into the compressed data.
+            for cut in [0, 1, 15, 16, 64, 4096, 44338, 100_000, 1 << 20] {
+                let cut = cut.min(bytes.len());
+                let _ = decode(&bytes[..cut]);
+                let _ = preview(&bytes[..cut]);
+            }
+            for n in 1..=6 {
+                let cut = bytes.len() * n / 7;
+                let _ = decode(&bytes[..cut]);
+                let _ = preview(&bytes[..cut]);
+            }
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/cr3.rs
+++ b/crates/codec-raw/src/formats/cr3.rs
@@ -1,0 +1,1082 @@
+//! Canon CR3: an ISO-BMFF file with the CRX codec inside.
+//!
+//! A CR3 is a QuickTime-shaped movie of still tracks. `moov` holds a
+//! `uuid` box of Canon's own (see [`crate::bmff::UUID_CANON_CRAW`])
+//! with the file's metadata, and one `trak` per image:
+//!
+//! * a full-size preview — a `JPEG` sample entry on bodies up to the
+//!   R6 generation, an HEVC one on the R8 and its contemporaries;
+//! * a small "SD" raw, a quarter the size, that nothing here wants;
+//! * the full "HD" raw, a `CRAW` sample entry whose `CMP1` box says
+//!   how the CRX stream is shaped and whose `CDI1`/`IAD1` box gives
+//!   the sensor's active area;
+//! * `CTMD`, Canon's timed metadata, which is where the CR3 keeps the
+//!   `ColorData` record — the white balance, the per-channel black
+//!   level and the saturation point all live there, not in the
+//!   makernote IFD where a CR2 keeps them.
+//!
+//! Dual-pixel files add a fifth track holding the second half of the
+//! split photosites; it is a whole extra frame and is not decoded.
+//!
+//! The metadata blocks CMT1..CMT4 are complete little TIFFs: IFD0,
+//! the Exif IFD, the Canon makernote IFD and GPS.
+
+use crate::bmff::{self, Box_, UUID_CANON_CRAW, UUID_CANON_PREVIEW};
+use crate::formats::common;
+use crate::formats::crx;
+use crate::tiff::{tags, Tiff};
+use crate::{Cfa, Error, Format, Orientation, RawData, RawImage, Rect, Result};
+
+/// Canon's makernote tags this decoder reads, all in CMT3.
+mod canon {
+    /// SensorInfo: an int16 array whose 1..=2 are the raw frame and
+    /// 5..=8 the inclusive borders of the area Canon calls the image.
+    pub const SENSOR_INFO: u16 = 0x00E0;
+    /// ColorData, in the CTMD track's makernote for a CR3.
+    pub const COLOR_DATA: u16 = 0x4001;
+}
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let file = File::parse(bytes)?;
+    let raw = file.raw_track()?;
+    let header = file.image_header(
+        raw.cmp1
+            .clone()
+            .ok_or_else(|| Error::Corrupt("CR3 raw track has no CMP1".into()))?,
+    )?;
+
+    let sample = raw
+        .sample(0)
+        .and_then(|(at, len)| bytes.get(at..at.checked_add(len)?))
+        .ok_or_else(|| Error::Corrupt("CR3 raw track has no sample in the file".into()))?;
+    let data = crx::decode(&header, sample)?;
+
+    let mut image = RawImage::new(
+        Format::Cr3,
+        header.width,
+        header.height,
+        1,
+        RawData::U16(data),
+        // Every CR3 body is RGGB at the origin of the full frame, and
+        // the CMP1 layout nibble is 0 to say so on the full-size raw
+        // track. (The small SD track uses 1, but nothing decodes it.)
+        Cfa::RGGB,
+    );
+    file.describe(&mut image);
+    image.apply_camera_table();
+    Ok(image)
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    Ok(File::parse(bytes)?.preview())
+}
+
+/// A parsed CR3: the box tree plus the pieces of it worth naming.
+struct File<'a> {
+    bytes: &'a [u8],
+    boxes: Vec<Box_>,
+    /// The four CMT TIFFs, when present and parseable.
+    cmt1: Option<Tiff<'a>>,
+    cmt2: Option<Tiff<'a>>,
+    cmt3: Option<Tiff<'a>>,
+    tracks: Vec<Track>,
+}
+
+/// One `trak`: its sample entry and its sample table.
+struct Track {
+    /// The fourcc of the single `stsd` entry: `CRAW`, `JPEG`, `CTMD`.
+    kind: [u8; 4],
+    /// The payload of the entry's `CMP1` child, if it has one.
+    cmp1: Option<std::ops::Range<usize>>,
+    /// The payload of the `IAD1` inside the entry's `CDI1` child.
+    iad1: Option<std::ops::Range<usize>>,
+    /// Whether the sample entry holds an `HEVC` child, which marks the
+    /// R8 generation's preview track as one we cannot hand out.
+    hevc: bool,
+    /// Absolute file offsets of the samples and their lengths.
+    offsets: Vec<usize>,
+    sizes: Vec<usize>,
+}
+
+impl Track {
+    fn sample(&self, i: usize) -> Option<(usize, usize)> {
+        Some((*self.offsets.get(i)?, *self.sizes.get(i)?))
+    }
+}
+
+impl<'a> File<'a> {
+    fn parse(bytes: &'a [u8]) -> Result<File<'a>> {
+        let boxes = bmff::parse(bytes)?;
+        let craw = find_uuid(&boxes, &UUID_CANON_CRAW);
+        let cmt = |kind: &[u8; 4]| {
+            craw.and_then(|craw| craw.child(kind))
+                .and_then(|b| Tiff::parse_embedded(bytes, b.data.start).ok())
+        };
+        let tracks = boxes
+            .iter()
+            .filter(|b| &b.kind == b"moov")
+            .flat_map(|moov| moov.children.iter())
+            .filter(|b| &b.kind == b"trak")
+            .filter_map(|trak| track(bytes, trak))
+            .collect();
+        Ok(File {
+            bytes,
+            cmt1: cmt(b"CMT1"),
+            cmt2: cmt(b"CMT2"),
+            cmt3: cmt(b"CMT3"),
+            boxes,
+            tracks,
+        })
+    }
+
+    /// The full-size raw track: the largest `CRAW` entry that carries
+    /// a `CMP1`. On a dual-pixel file two tracks are that size — the
+    /// second holds one half of the split photosites, a separate
+    /// image — so the first of them wins.
+    fn raw_track(&self) -> Result<&Track> {
+        let mut best: Option<(usize, &Track)> = None;
+        for track in &self.tracks {
+            if &track.kind != b"CRAW" {
+                continue;
+            }
+            let Some(header) = track.cmp1.clone().and_then(|r| self.image_header(r).ok()) else {
+                continue;
+            };
+            let area = header.width * header.height;
+            if best.is_none_or(|(best, _)| area > best) {
+                best = Some((area, track));
+            }
+        }
+        best.map(|(_, track)| track)
+            .ok_or_else(|| Error::Corrupt("CR3 with no CRAW track".into()))
+    }
+
+    fn image_header(&self, cmp1: std::ops::Range<usize>) -> Result<crx::ImageHeader> {
+        let payload = self
+            .bytes
+            .get(cmp1)
+            .ok_or_else(|| Error::Corrupt("CMP1 outside the file".into()))?;
+        crx::ImageHeader::parse(payload)
+    }
+
+    /// Fill in everything about the image that is not pixels.
+    fn describe(&self, image: &mut RawImage) {
+        let (make, model) = self.cmt1.as_ref().map(Tiff::make_model).unwrap_or_default();
+        image.set_camera(&make, &model);
+        image.orientation = self
+            .cmt1
+            .as_ref()
+            .map(common::orientation)
+            .unwrap_or(Orientation::Normal);
+        if let Some(cmt2) = &self.cmt2 {
+            image.metadata = common::metadata(cmt2);
+        }
+        // Canon's lens name is a makernote string, not Exif's
+        // LensModel, on every body that writes a CR3.
+        if image.metadata.lens.is_none() {
+            image.metadata.lens = self
+                .cmt3
+                .as_ref()
+                .and_then(|t| t.find(0x0095))
+                .and_then(|e| e.str())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+        }
+        if let Some(crop) = self.crop(image.width, image.height) {
+            image.crop = crop;
+        }
+        self.levels_and_white_balance(image);
+        image.preview = self.preview();
+    }
+
+    /// The area Canon calls the image: SensorInfo's inclusive borders,
+    /// with the raw track's `IAD1` box saying the same thing when the
+    /// makernote is missing.
+    ///
+    /// This is the crop LibRaw reports as "Raw inset". Its own "Image
+    /// size" is a different, per-generation rectangle — one pixel
+    /// narrower on the R5 and R8, and neither the inset nor the active
+    /// area on the EOS R and 90D — so it is not what this follows.
+    fn crop(&self, width: usize, height: usize) -> Option<Rect> {
+        let borders = self
+            .sensor_info()
+            .or_else(|| self.iad1_crop())
+            .filter(|[l, t, r, b]| r > l && b > t)?;
+        let [left, top, right, bottom] = borders.map(|v| v as usize);
+        (right < width && bottom < height).then_some(Rect {
+            x: left,
+            y: top,
+            width: right - left + 1,
+            height: bottom - top + 1,
+        })
+    }
+
+    /// SensorInfo's left, top, right, bottom.
+    fn sensor_info(&self) -> Option<[u32; 4]> {
+        let entry = self.cmt3.as_ref()?.find(canon::SENSOR_INFO)?;
+        Some([entry.u32(5)?, entry.u32(6)?, entry.u32(7)?, entry.u32(8)?])
+    }
+
+    /// The first rectangle of the raw track's `IAD1`, which carries
+    /// the same borders as SensorInfo: after a version word and the
+    /// frame size come two flag words and then the crop, as four
+    /// big-endian 16-bit inclusive edges.
+    fn iad1_crop(&self) -> Option<[u32; 4]> {
+        let range = self.raw_track().ok()?.iad1.clone()?;
+        let payload = self.bytes.get(range)?;
+        let at = |i: usize| -> Option<u32> {
+            let b = payload.get(i..i + 2)?;
+            Some(u16::from_be_bytes([b[0], b[1]]) as u32)
+        };
+        Some([at(16)?, at(18)?, at(20)?, at(22)?])
+    }
+
+    /// Black level, white level and as-shot white balance, from the
+    /// ColorData record in the CTMD track.
+    fn levels_and_white_balance(&self, image: &mut RawImage) {
+        let Some(color_data) = self.color_data() else {
+            return;
+        };
+        let Some(layout) = ColorDataLayout::of(&color_data) else {
+            log::debug!(
+                "cr3: ColorData version {:?} is not one this knows; leaving levels to the camera table",
+                color_data.first()
+            );
+            return;
+        };
+        let at = |i: usize| color_data.get(i).copied().map(f32::from);
+        // WB_RGGBLevelsAsShot is four levels in CFA order — red, the
+        // two greens, blue — and a multiplier is a level over green,
+        // which is the convention `wb_coeffs` and LibRaw's `cam_mul`
+        // share.
+        if let (Some(r), Some(g1), Some(g2), Some(b)) = (
+            at(layout.white_balance),
+            at(layout.white_balance + 1),
+            at(layout.white_balance + 2),
+            at(layout.white_balance + 3),
+        ) {
+            if g1 > 0.0 && r > 0.0 && b > 0.0 && g2 > 0.0 {
+                image.wb_coeffs = [r / g1, 1.0, b / g1, g2 / g1];
+            }
+        }
+        if let Some(white) = at(layout.white_level).filter(|w| *w > 0.0) {
+            image.white_level = white;
+        }
+        let black: Vec<f32> = (0..4).filter_map(|i| at(layout.black_level + i)).collect();
+        if let Ok(black) = <[f32; 4]>::try_from(black) {
+            if black.iter().all(|b| *b < image.white_level) {
+                image.black_levels = black;
+            }
+        }
+    }
+
+    /// The ColorData (0x4001) array out of the CTMD track.
+    ///
+    /// A CTMD sample is a run of records — `u32 size`, `u16 type`,
+    /// `u16` — of which types 7, 8 and 9 hold, after four bytes of
+    /// their own, a sequence of blocks: `u32 size`, `u32 tag`, then a
+    /// complete little-endian TIFF. The block tagged 0x927C is a Canon
+    /// makernote IFD, and ColorData is an entry in it.
+    fn color_data(&self) -> Option<Vec<u16>> {
+        for track in &self.tracks {
+            if &track.kind != b"CTMD" {
+                continue;
+            }
+            for i in 0..track.offsets.len() {
+                let (start, len) = track.sample(i)?;
+                let sample = self.bytes.get(start..start.checked_add(len)?)?;
+                if let Some(found) = color_data_in(self.bytes, start, sample) {
+                    return Some(found);
+                }
+            }
+        }
+        None
+    }
+
+    /// The largest JPEG in the file: the preview track's sample, the
+    /// `PRVW` box in the top-level preview uuid, or the thumbnail in
+    /// `THMB`. The R8 generation codes the first two as HEVC and there
+    /// is no JPEG in the file at all, so this returns `None` there
+    /// rather than something a viewer cannot open.
+    fn preview(&self) -> Option<Vec<u8>> {
+        let mut best: Option<&[u8]> = None;
+        let mut consider = |candidate: Option<&'a [u8]>| {
+            if let Some(jpeg) = candidate.filter(|j| j.starts_with(&[0xff, 0xd8])) {
+                if best.is_none_or(|best| jpeg.len() > best.len()) {
+                    best = Some(jpeg);
+                }
+            }
+        };
+        for track in &self.tracks {
+            // A CRAW entry holding an HEVC box is the R8's preview
+            // track: a still HEVC frame, not a JPEG.
+            if track.hevc || &track.kind == b"CTMD" || track.cmp1.is_some() {
+                continue;
+            }
+            if let Some((at, len)) = track.sample(0) {
+                consider(self.bytes.get(at..at.checked_add(len)?));
+            }
+        }
+        // PRVW: a version word, the preview's size in pixels, a count
+        // and the JPEG's length, then the stream — sixteen bytes in
+        // front of it. Version 1, on the R8, describes an HEVC frame
+        // instead, and the `starts_with` test drops it.
+        if let Some(prvw) =
+            find_uuid(&self.boxes, &UUID_CANON_PREVIEW).and_then(|b| b.child(b"PRVW"))
+        {
+            consider(self.bytes.get(prvw.data.start + 16..prvw.data.end));
+        }
+        // THMB has the same shape and holds the little 160x120 one.
+        if let Some(thmb) = find_uuid(&self.boxes, &UUID_CANON_CRAW).and_then(|b| b.child(b"THMB"))
+        {
+            consider(self.bytes.get(thmb.data.start + 16..thmb.data.end));
+        }
+        best.map(<[u8]>::to_vec)
+    }
+}
+
+/// Where the fields this decoder wants sit in a ColorData record.
+///
+/// Canon rewrites the layout every few generations and marks it with
+/// the version in the first int16. The positions below are the ones
+/// ExifTool documents for the three layouts that appear in CR3 files,
+/// checked against every sample in the corpus; a version outside them
+/// is left alone rather than read at the wrong offset.
+#[derive(Debug, Clone, Copy)]
+struct ColorDataLayout {
+    white_balance: usize,
+    black_level: usize,
+    white_level: usize,
+}
+
+impl ColorDataLayout {
+    fn of(color_data: &[u16]) -> Option<ColorDataLayout> {
+        let layout = match *color_data.first()? {
+            // EOS R, RP, M50, 90D, M6 II, M200, 850D.
+            17..=19 => ColorDataLayout {
+                white_balance: 0x47,
+                black_level: 0x149,
+                // NormalWhiteLevel is at 0x31c and the saturation
+                // point — what LibRaw calls the linearity limit and
+                // what a developer must clip at — at 0x31d.
+                white_level: 0x31d,
+            },
+            // 1D X Mark III, R5, R6.
+            32..=34 => ColorDataLayout {
+                white_balance: 0x55,
+                black_level: 0x157,
+                white_level: 0x32b,
+            },
+            // R3, R7, R10, R6 Mark II, R8, R50.
+            42..=48 => ColorDataLayout {
+                white_balance: 0x69,
+                black_level: 0x16b,
+                white_level: 0x281,
+            },
+            _ => return None,
+        };
+        // Canon's greens are both 1024 in every as-shot record; if
+        // they are not, the offset is wrong for this file and the
+        // values would be noise.
+        let green = |i: usize| color_data.get(i).copied();
+        (green(layout.white_balance + 1) == Some(1024)
+            && green(layout.white_balance + 2) == Some(1024))
+        .then_some(layout)
+    }
+}
+
+/// The ColorData array inside one CTMD sample, `sample` starting at
+/// absolute offset `base` in `bytes`.
+fn color_data_in(bytes: &[u8], base: usize, sample: &[u8]) -> Option<Vec<u16>> {
+    let u32_at = |at: usize| -> Option<u32> {
+        let b = sample.get(at..at + 4)?;
+        Some(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+    };
+    let mut at = 0usize;
+    while at + 8 <= sample.len() {
+        let size = u32_at(at)? as usize;
+        let kind = u16::from_le_bytes([*sample.get(at + 4)?, *sample.get(at + 5)?]);
+        if size < 8 || at + size > sample.len() {
+            return None;
+        }
+        if matches!(kind, 7..=9) {
+            // Four bytes of the record's own, then the blocks.
+            let mut block = at + 12;
+            while block + 8 <= at + size {
+                let block_size = u32_at(block)? as usize;
+                let tag = u32_at(block + 4)?;
+                if block_size < 8 || block + block_size > at + size {
+                    break;
+                }
+                if tag == tags::MAKER_NOTE as u32 {
+                    // The block's TIFF has its own header, and every
+                    // offset in it is relative to that header.
+                    if let Ok(tiff) = Tiff::parse_embedded(bytes, base + block + 8) {
+                        if let Some(entry) = tiff.find(canon::COLOR_DATA) {
+                            let values: Vec<u16> = (0..entry.count)
+                                .map_while(|i| entry.u32(i).map(|v| v as u16))
+                                .collect();
+                            if values.len() > 0x100 {
+                                return Some(values);
+                            }
+                        }
+                    }
+                }
+                block += block_size;
+            }
+        }
+        at += size;
+    }
+    None
+}
+
+/// The first `uuid` box anywhere in the tree with this type.
+fn find_uuid<'b>(boxes: &'b [Box_], id: &[u8; 16]) -> Option<&'b Box_> {
+    for b in boxes {
+        if b.uuid.as_ref() == Some(id) {
+            return Some(b);
+        }
+        if let Some(found) = find_uuid(&b.children, id) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// One `trak`, if it has a sample entry and a sample table.
+fn track(bytes: &[u8], trak: &Box_) -> Option<Track> {
+    let stbl = trak.find_all(b"stbl").into_iter().next()?;
+    let entry = stbl.child(b"stsd")?.children.first()?;
+    let sizes = sample_sizes(bytes, stbl)?;
+    let offsets = chunk_offsets(bytes, stbl)?;
+    Some(Track {
+        kind: entry.kind,
+        cmp1: entry.child(b"CMP1").map(|b| b.data.clone()),
+        // CDI1 is a full box: four bytes of version and flags, then
+        // the IAD1 box with the sensor's rectangles.
+        iad1: entry
+            .child(b"CDI1")
+            .and_then(|cdi1| child_box(bytes, &cdi1.data, b"IAD1")),
+        hevc: entry.child(b"HEVC").is_some(),
+        offsets,
+        sizes,
+    })
+}
+
+/// The payload range of a child box inside a range that is not parsed
+/// as a container — CDI1's IAD1, which sits after CDI1's own version
+/// word.
+fn child_box(
+    bytes: &[u8],
+    parent: &std::ops::Range<usize>,
+    kind: &[u8; 4],
+) -> Option<std::ops::Range<usize>> {
+    let mut at = parent.start + 4;
+    while at + 8 <= parent.end {
+        let size = u32::from_be_bytes(bytes.get(at..at + 4)?.try_into().ok()?) as usize;
+        if size < 8 || at + size > parent.end {
+            return None;
+        }
+        if bytes.get(at + 4..at + 8)? == kind {
+            return Some(at + 8..at + size);
+        }
+        at += size;
+    }
+    None
+}
+
+/// `stsz`: a version word, a sample size that is zero when the sizes
+/// are listed one by one, and a count.
+fn sample_sizes(bytes: &[u8], stbl: &Box_) -> Option<Vec<usize>> {
+    let stsz = stbl.child(b"stsz")?;
+    let p = bytes.get(stsz.data.clone())?;
+    let u32_at = |at: usize| -> Option<usize> {
+        Some(u32::from_be_bytes(p.get(at..at + 4)?.try_into().ok()?) as usize)
+    };
+    let uniform = u32_at(4)?;
+    let count = u32_at(8)?.min(MAX_SAMPLES);
+    if uniform != 0 {
+        return Some(vec![uniform; count]);
+    }
+    (0..count).map(|i| u32_at(12 + 4 * i)).collect()
+}
+
+/// `co64` (64-bit) or `stco` (32-bit): the absolute file offset of
+/// each chunk. A CR3 track is one sample a chunk, so these are the
+/// sample offsets.
+fn chunk_offsets(bytes: &[u8], stbl: &Box_) -> Option<Vec<usize>> {
+    let (b, wide) = match (stbl.child(b"co64"), stbl.child(b"stco")) {
+        (Some(co64), _) => (co64, true),
+        (None, Some(stco)) => (stco, false),
+        (None, None) => return None,
+    };
+    let p = bytes.get(b.data.clone())?;
+    let count = (u32::from_be_bytes(p.get(4..8)?.try_into().ok()?) as usize).min(MAX_SAMPLES);
+    (0..count)
+        .map(|i| {
+            if wide {
+                let at = 8 + 8 * i;
+                usize::try_from(u64::from_be_bytes(p.get(at..at + 8)?.try_into().ok()?)).ok()
+            } else {
+                let at = 8 + 4 * i;
+                Some(u32::from_be_bytes(p.get(at..at + 4)?.try_into().ok()?) as usize)
+            }
+        })
+        .collect()
+}
+
+/// A still CR3 track holds one sample; the cap is only so a corrupt
+/// count cannot make us allocate.
+const MAX_SAMPLES: usize = 1024;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tiff::tests::{corpus, samples};
+
+    // ---------------------------------------------------------------
+    // Hand-built files.
+    // ---------------------------------------------------------------
+
+    fn box_(kind: &[u8; 4], payload: &[u8]) -> Vec<u8> {
+        let mut out = ((payload.len() + 8) as u32).to_be_bytes().to_vec();
+        out.extend_from_slice(kind);
+        out.extend_from_slice(payload);
+        out
+    }
+
+    fn uuid_box(id: &[u8; 16], payload: &[u8]) -> Vec<u8> {
+        let mut body = id.to_vec();
+        body.extend_from_slice(payload);
+        box_(b"uuid", &body)
+    }
+
+    /// A little-endian TIFF of one IFD with these entries, each
+    /// `(tag, kind, count, value-or-offset)`, and the blob its
+    /// out-of-line values live in appended after it.
+    fn tiff(entries: &[(u16, u16, u32, u32)], tail: &[u8]) -> Vec<u8> {
+        let mut out = b"II*\0".to_vec();
+        out.extend(8u32.to_le_bytes());
+        out.extend((entries.len() as u16).to_le_bytes());
+        for (tag, kind, count, value) in entries {
+            out.extend(tag.to_le_bytes());
+            out.extend(kind.to_le_bytes());
+            out.extend(count.to_le_bytes());
+            out.extend(value.to_le_bytes());
+        }
+        out.extend(0u32.to_le_bytes());
+        out.extend_from_slice(tail);
+        out
+    }
+
+    /// A JFIF-shaped stream a viewer would accept.
+    fn jpeg(padding: usize) -> Vec<u8> {
+        let mut out = vec![0xff, 0xd8, 0xff, 0xc0, 0, 11, 8, 0, 1, 0, 1, 1, 0x11, 0];
+        out.extend(std::iter::repeat_n(0u8, padding));
+        out.extend([0xff, 0xd9]);
+        out
+    }
+
+    /// A sample table for one sample at `offset` of `size` bytes.
+    fn sample_table(entry: Vec<u8>, offset: u64, size: u32) -> Vec<u8> {
+        let mut stsd = vec![0, 0, 0, 0, 0, 0, 0, 1];
+        stsd.extend(entry);
+        let mut stsz = vec![0u8; 8];
+        stsz.extend(1u32.to_be_bytes());
+        stsz.extend(size.to_be_bytes());
+        let mut co64 = vec![0u8; 4];
+        co64.extend(1u32.to_be_bytes());
+        co64.extend(offset.to_be_bytes());
+        box_(
+            b"stbl",
+            &[
+                box_(b"stsd", &stsd),
+                box_(b"stsz", &stsz),
+                box_(b"co64", &co64),
+            ]
+            .concat(),
+        )
+    }
+
+    fn trak(stbl: Vec<u8>) -> Vec<u8> {
+        box_(b"trak", &box_(b"mdia", &box_(b"minf", &stbl)))
+    }
+
+    /// A CRAW sample entry: 82 bytes of fixed fields, then the boxes.
+    fn craw_entry(children: &[u8]) -> Vec<u8> {
+        let mut payload = vec![0u8; 82];
+        payload.extend_from_slice(children);
+        box_(b"CRAW", &payload)
+    }
+
+    fn cmp1_box(width: u32, height: u32, levels: u8, header: u32) -> Vec<u8> {
+        let mut p = vec![0u8; 52];
+        p[0..2].copy_from_slice(&0xff00u16.to_be_bytes());
+        p[2..4].copy_from_slice(&0x0030u16.to_be_bytes());
+        p[4..6].copy_from_slice(&1u16.to_be_bytes());
+        p[8..12].copy_from_slice(&width.to_be_bytes());
+        p[12..16].copy_from_slice(&height.to_be_bytes());
+        p[16..20].copy_from_slice(&width.to_be_bytes());
+        p[20..24].copy_from_slice(&height.to_be_bytes());
+        p[24] = 14;
+        p[25] = 0x40;
+        p[26] = levels;
+        p[28..32].copy_from_slice(&header.to_be_bytes());
+        box_(b"CMP1", &p)
+    }
+
+    /// CDI1 wrapping an IAD1 whose first rectangle is this crop.
+    fn cdi1_box(width: u16, height: u16, crop: [u16; 4]) -> Vec<u8> {
+        let mut iad1 = vec![0u8; 4];
+        iad1.extend(width.to_be_bytes());
+        iad1.extend(height.to_be_bytes());
+        iad1.extend([0, 1, 0, 0, 0, 1, 0, 0]);
+        for edge in crop {
+            iad1.extend(edge.to_be_bytes());
+        }
+        let mut cdi1 = vec![0u8; 4];
+        cdi1.extend(box_(b"IAD1", &iad1));
+        box_(b"CDI1", &cdi1)
+    }
+
+    /// A CR3 with a preview track, a raw track and Canon's metadata
+    /// uuid. `mdat` holds the preview JPEG then the raw sample.
+    fn synthetic_cr3(raw_sample: &[u8], levels: u8, mdat_header: u32) -> Vec<u8> {
+        let preview = jpeg(200);
+        // Build the moov first with placeholder offsets, then fix them
+        // up once its length is known: mdat follows moov.
+        let build = |mdat_at: u64| -> Vec<u8> {
+            let cmt1 = tiff(
+                &[
+                    // Three entries make the directory 50 bytes, so
+                    // the strings after it start at 0x32.
+                    (tags::MAKE, 2, 6, 0x32),
+                    (tags::MODEL, 2, 12, 0x38),
+                    (tags::ORIENTATION, 3, 1, 6),
+                ],
+                b"Canon\0Canon EOS R\0",
+            );
+            let cmt2 = tiff(&[(tags::ISO, 3, 1, 400)], b"");
+            let cmt3 = tiff(&[(canon::SENSOR_INFO, 3, 17, 0x1a)], &{
+                let mut v = Vec::new();
+                for x in [34u16, 64, 32, 1, 1, 4, 2, 59, 29, 0, 0, 0, 0, 0, 0, 0, 0] {
+                    v.extend(x.to_le_bytes());
+                }
+                v
+            });
+            let craw_uuid = uuid_box(
+                &UUID_CANON_CRAW,
+                &[
+                    box_(b"CNCV", b"CanonCR3_001/00.09.00/00.00.00"),
+                    box_(b"CMT1", &cmt1),
+                    box_(b"CMT2", &cmt2),
+                    box_(b"CMT3", &cmt3),
+                    box_(b"THMB", &[vec![0u8; 16], jpeg(4)].concat()),
+                ]
+                .concat(),
+            );
+            let preview_trak = trak(sample_table(
+                box_(b"JPEG", &[0u8; 78]),
+                mdat_at,
+                preview.len() as u32,
+            ));
+            let raw_trak = trak(sample_table(
+                craw_entry(
+                    &[
+                        cmp1_box(64, 32, levels, mdat_header),
+                        cdi1_box(64, 32, [4, 2, 59, 29]),
+                    ]
+                    .concat(),
+                ),
+                mdat_at + preview.len() as u64,
+                raw_sample.len() as u32,
+            ));
+            box_(b"moov", &[craw_uuid, preview_trak, raw_trak].concat())
+        };
+        let ftyp = box_(b"ftyp", b"crx isom");
+        let moov = build(0);
+        let mdat_at = (ftyp.len() + moov.len() + 8) as u64;
+        let moov = build(mdat_at);
+        assert_eq!(
+            mdat_at,
+            (ftyp.len() + moov.len() + 8) as u64,
+            "moov length must not shift"
+        );
+        [
+            ftyp,
+            moov,
+            box_(b"mdat", &[preview.clone(), raw_sample.to_vec()].concat()),
+        ]
+        .concat()
+    }
+
+    #[test]
+    fn probe_and_metadata_of_a_synthetic_file() {
+        let file = synthetic_cr3(&[0u8; 16], 0, 16);
+        assert_eq!(crate::probe(&file), Some(Format::Cr3));
+        let parsed = File::parse(&file).unwrap();
+        let mut image = RawImage::new(
+            Format::Cr3,
+            64,
+            32,
+            1,
+            RawData::U16(vec![0; 64 * 32]),
+            Cfa::RGGB,
+        );
+        parsed.describe(&mut image);
+        assert_eq!(image.make, "Canon");
+        assert_eq!(image.model, "Canon EOS R");
+        assert_eq!(image.orientation, Orientation::Rotate90CW);
+        assert_eq!(image.metadata.iso, Some(400.0));
+        // SensorInfo's borders are inclusive, so 4..=59 is 56 wide.
+        assert_eq!(
+            image.crop,
+            Rect {
+                x: 4,
+                y: 2,
+                width: 56,
+                height: 28
+            }
+        );
+        // The track's JPEG is bigger than the one in THMB.
+        let preview = image.preview.expect("a preview");
+        assert_eq!(preview.len(), jpeg(200).len());
+        assert_eq!(super::preview(&file).unwrap(), Some(preview));
+    }
+
+    #[test]
+    fn the_crop_falls_back_to_iad1_without_a_makernote() {
+        let mut file = synthetic_cr3(&[0u8; 16], 0, 16);
+        // Break CMT3's fourcc so the makernote cannot be found; IAD1
+        // carries the same rectangle.
+        let at = file.windows(4).position(|w| w == b"CMT3").unwrap();
+        file[at..at + 4].copy_from_slice(b"CMTX");
+        let parsed = File::parse(&file).unwrap();
+        let mut image = RawImage::new(
+            Format::Cr3,
+            64,
+            32,
+            1,
+            RawData::U16(vec![0; 64 * 32]),
+            Cfa::RGGB,
+        );
+        parsed.describe(&mut image);
+        assert_eq!(image.crop.width, 56);
+        assert_eq!(image.crop.height, 28);
+    }
+
+    #[test]
+    fn an_unsupported_codec_variant_says_so() {
+        // Three wavelet levels with a header that describes nothing.
+        let file = synthetic_cr3(&[0u8; 16], 3, 0);
+        assert!(matches!(
+            decode(&file),
+            Err(Error::Unsupported(_)) | Err(Error::Corrupt(_))
+        ));
+        // The preview is still reachable without the sensor data.
+        assert!(preview(&file).unwrap().is_some());
+    }
+
+    #[test]
+    fn truncated_and_garbage_files_are_errors_not_panics() {
+        let file = synthetic_cr3(&[0u8; 64], 0, 16);
+        for cut in 0..file.len() {
+            let head = &file[..cut];
+            assert!(
+                std::panic::catch_unwind(|| {
+                    let _ = decode(head);
+                    let _ = preview(head);
+                })
+                .is_ok(),
+                "panic on a {cut}-byte prefix"
+            );
+        }
+        for garbage in [vec![0u8; 64], b"ftypcrx ".to_vec(), vec![0xff; 4096]] {
+            assert!(std::panic::catch_unwind(|| {
+                let _ = decode(&garbage);
+                let _ = preview(&garbage);
+            })
+            .is_ok());
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Corpus.
+    // ---------------------------------------------------------------
+
+    /// A field of `raw-identify -v -w` output.
+    fn identify(path: &std::path::Path) -> Option<String> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".identify.txt");
+        std::fs::read_to_string(std::path::PathBuf::from(name)).ok()
+    }
+
+    /// The numbers on the line beginning `key`.
+    fn numbers(text: &str, key: &str) -> Vec<f64> {
+        text.lines()
+            .find(|l| l.trim_start().starts_with(key))
+            .map(|line| {
+                line[line.find(key).unwrap() + key.len()..]
+                    .split(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
+                    .filter_map(|t| t.parse::<f64>().ok())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// `unprocessed_raw -T`'s output beside a sample.
+    fn oracle_frame(path: &std::path::Path) -> Option<(usize, usize, Vec<u16>)> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".tiff");
+        let image = image::open(std::path::PathBuf::from(name))
+            .ok()?
+            .into_luma16();
+        Some((
+            image.width() as usize,
+            image.height() as usize,
+            image.into_raw(),
+        ))
+    }
+
+    /// Files whose CRX variant this decoder knows it cannot do yet,
+    /// with why. Anything else that fails is a bug.
+    ///
+    /// Every CR3 is on this list at the moment: the container, the
+    /// metadata, the preview and every layer of the CRX headers are
+    /// read, but the entropy-coded coefficients are not decoded, so
+    /// `decode` reports the codec as unsupported and only `preview`
+    /// and the metadata below are exercised against real files.
+    fn unsupported_reason(_name: &str) -> Option<&'static str> {
+        Some("the CRX entropy coder is not implemented")
+    }
+
+    #[test]
+    fn corpus_cr3_files_decode_and_match_the_oracle() {
+        let Some(root) = corpus() else { return };
+        let mut problems: Vec<String> = Vec::new();
+        let mut decoded = 0;
+        let mut skipped = 0;
+        for path in samples(&root) {
+            let is_cr3 = path
+                .extension()
+                .map(|e| e.to_string_lossy().to_ascii_uppercase() == "CR3")
+                .unwrap_or(false);
+            if !is_cr3 {
+                continue;
+            }
+            let Ok(bytes) = std::fs::read(&path) else {
+                continue;
+            };
+            let name = path
+                .strip_prefix(&root)
+                .unwrap_or(&path)
+                .display()
+                .to_string();
+            macro_rules! note {
+                ($what:expr) => {
+                    problems.push(format!("{}: {}", name, $what))
+                };
+            }
+
+            if crate::probe(&bytes) != Some(Format::Cr3) {
+                note!("probe does not say Cr3");
+                continue;
+            }
+            // The preview is reachable whatever the codec does. The
+            // R8 generation writes HEVC for both its previews, so
+            // `None` is the right answer there and the identify
+            // oracle agrees with a thumbnail size of zero.
+            let text = identify(&path).unwrap_or_default();
+            let thumb = numbers(&text, "Thumb size:");
+            match preview(&bytes) {
+                Ok(Some(jpeg)) => {
+                    if image::load_from_memory(&jpeg).is_err() {
+                        note!("the preview does not decode");
+                    }
+                    if thumb.first() == Some(&0.0) {
+                        note!("a preview where LibRaw found none");
+                    }
+                }
+                Ok(None) => {
+                    if thumb.first().is_some_and(|w| *w > 0.0) {
+                        note!(format!("no preview, LibRaw found {thumb:?}"));
+                    }
+                }
+                Err(e) => note!(format!("preview: {e}")),
+            }
+
+            // Ten cuts through a real file: none may panic, and a
+            // prefix that still holds the moov must still probe.
+            for i in 0..10 {
+                let cut = bytes.len() * (i * 7 + 3) / 71;
+                let head = &bytes[..cut];
+                let survived = std::panic::catch_unwind(|| {
+                    let _ = decode(head);
+                    let _ = preview(head);
+                    let _ = crate::probe(head);
+                });
+                if survived.is_err() {
+                    note!(format!("panic on a {cut}-byte prefix"));
+                }
+            }
+
+            let image = match decode(&bytes) {
+                Ok(image) => image,
+                Err(Error::Unsupported(why)) => {
+                    match unsupported_reason(&name) {
+                        Some(_) => skipped += 1,
+                        None => note!(format!("unexpectedly unsupported: {why}")),
+                    }
+                    // Metadata is worth checking even when the pixels
+                    // are out of reach.
+                    let parsed = File::parse(&bytes).unwrap();
+                    let mut image =
+                        RawImage::new(Format::Cr3, 2, 2, 1, RawData::U16(vec![0; 4]), Cfa::RGGB);
+                    let full = numbers(&text, "Full size:");
+                    if let [w, h] = full[..] {
+                        image.width = w as usize;
+                        image.height = h as usize;
+                        image.data = RawData::U16(vec![0; image.width * image.height]);
+                        image.crop = Rect {
+                            x: 0,
+                            y: 0,
+                            width: image.width,
+                            height: image.height,
+                        };
+                    }
+                    parsed.describe(&mut image);
+                    check_metadata(&name, &image, &text, &mut problems);
+                    continue;
+                }
+                Err(e) => {
+                    note!(format!("decode: {e}"));
+                    continue;
+                }
+            };
+            decoded += 1;
+            if let Err(e) = image.validate() {
+                note!(format!("validate: {e}"));
+            }
+            check_metadata(&name, &image, &text, &mut problems);
+            match oracle_frame(&path) {
+                None => note!("no oracle TIFF beside it"),
+                Some((width, height, want)) => {
+                    if (width, height) != (image.width, image.height) {
+                        note!(format!(
+                            "{}x{} against the oracle's {width}x{height}",
+                            image.width, image.height
+                        ));
+                        continue;
+                    }
+                    let RawData::U16(have) = &image.data else {
+                        note!("not 16-bit samples");
+                        continue;
+                    };
+                    let mut wrong = Vec::new();
+                    let mut count = 0usize;
+                    for (i, (a, b)) in have.iter().zip(&want).enumerate() {
+                        if a != b {
+                            count += 1;
+                            if wrong.len() < 6 {
+                                wrong.push(format!("[{},{}] {a} != {b}", i % width, i / width));
+                            }
+                        }
+                    }
+                    if count > 0 {
+                        note!(format!("{count} samples differ: {}", wrong.join(", ")));
+                    }
+                }
+            }
+        }
+        assert!(
+            problems.is_empty(),
+            "{} problems:\n{}",
+            problems.len(),
+            problems.join("\n")
+        );
+        eprintln!("corpus: {decoded} CR3 files decoded, {skipped} unsupported variants skipped");
+    }
+
+    /// Levels, white balance, crop, orientation and CFA against
+    /// `raw-identify`.
+    fn check_metadata(name: &str, image: &RawImage, text: &str, problems: &mut Vec<String>) {
+        let mut note = |what: String| problems.push(format!("{name}: {what}"));
+        if !image.make.eq_ignore_ascii_case("Canon") {
+            note(format!("make {:?}", image.make));
+        }
+        let full = numbers(text, "Full size:");
+        if let [w, h] = full[..] {
+            if (image.width, image.height) != (w as usize, h as usize) {
+                note(format!(
+                    "frame {}x{}, LibRaw {w}x{h}",
+                    image.width, image.height
+                ));
+            }
+        }
+        // "Raw inset, width x height: 6720 x 4480 left: 156 top: 58".
+        let inset = numbers(text, "Raw inset, width x height:");
+        if let [w, h, x, y] = inset[..] {
+            let want = Rect {
+                x: x as usize,
+                y: y as usize,
+                width: w as usize,
+                height: h as usize,
+            };
+            if image.crop != want {
+                note(format!("crop {:?}, LibRaw's inset {want:?}", image.crop));
+            }
+        }
+        if let [flip] = numbers(text, "Image flip:")[..] {
+            let want = match flip as u32 {
+                3 => Orientation::Rotate180,
+                5 => Orientation::Rotate270CW,
+                6 => Orientation::Rotate90CW,
+                _ => Orientation::Normal,
+            };
+            if image.orientation != want {
+                note(format!(
+                    "orientation {:?}, LibRaw {want:?}",
+                    image.orientation
+                ));
+            }
+        }
+        if let Some(pattern) = text.lines().find(|l| l.starts_with("Filter pattern:")) {
+            if !pattern.contains("RGGB") || image.cfa != Cfa::RGGB {
+                note(format!("CFA {:?} against {pattern:?}", image.cfa));
+            }
+        }
+        if let Some(&white) = numbers(text, "Highlight linearity limits:").first() {
+            if image.white_level != white as f32 {
+                note(format!("white {}, LibRaw {white}", image.white_level));
+            }
+        }
+        // LibRaw only prints cblack for the generations it reads a
+        // per-channel black for; where it does, it must agree.
+        let cblack = numbers(text, "cblack[0 .. 3]:");
+        if cblack.len() == 4 {
+            let want: Vec<f32> = cblack.iter().map(|v| *v as f32).collect();
+            if image.black_levels.to_vec() != want {
+                note(format!("black {:?}, LibRaw {want:?}", image.black_levels));
+            }
+        } else if image.black_levels == [0.0; 4] {
+            note("no black level at all".into());
+        }
+        // "As shot   2001 1024 1582 1024" is R, G, B, G2 unnormalised.
+        let shot = numbers(text, "As shot");
+        if let [r, g, b, g2] = shot[..] {
+            let want = [
+                r as f32 / g as f32,
+                1.0,
+                b as f32 / g as f32,
+                g2 as f32 / g as f32,
+            ];
+            let off = (0..4).any(|i| (image.wb_coeffs[i] - want[i]).abs() > 1e-4);
+            if off {
+                note(format!(
+                    "white balance {:?}, LibRaw {want:?}",
+                    image.wb_coeffs
+                ));
+            }
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/crw.rs
+++ b/crates/codec-raw/src/formats/crw.rs
@@ -1,0 +1,734 @@
+//! Canon CRW: the CIFF container, and what can honestly be done with
+//! what is inside it.
+//!
+//! CIFF is a heap of typed records read from the back. A 26-byte header
+//! (`II`/`MM`, the header length, the signature `HEAPCCDR`, a version)
+//! is followed by one big heap running to the end of the file; the last
+//! four bytes of a heap give the offset of its directory, relative to
+//! the heap's own start, and the directory is a count followed by
+//! ten-byte entries of tag, length and offset. Offsets inside a heap
+//! are relative to that heap, so a sub-heap is just the same structure
+//! again with a new origin.
+//!
+//! The tag says how to read the value as well as what it means: bits
+//! 11..13 are a type (ASCII, u16, u32, bytes, or a sub-heap) and bit 14
+//! says the value is small enough to live in the entry's own eight
+//! bytes instead of the heap. Everything a decoder wants is a record:
+//! `0x080A` the make and model as two NUL-separated strings, `0x1810`
+//! the picture's size and rotation, `0x1031` the sensor's size and the
+//! borders of the picture within it, `0x10A9` the white balance table,
+//! `0x2005` the sensor data, `0x2007` the full-size JPEG, `0x1835` the
+//! index of the Huffman table set the sensor data was compressed with.
+//!
+//! # What is decoded
+//!
+//! The oldest bodies — the PowerShot Pro70 generation — store the
+//! sensor uncompressed, ten bits a sample, and those decode here.
+//!
+//! Every EOS CRW and every later PowerShot compresses, and the three
+//! Huffman table sets its decoder picks between are *not* in the file.
+//! Record `0x1835` gives only the index of the set to use; the tables
+//! themselves appear in no specification and in no published format
+//! write-up, only in the source of the copyleft decoders this crate
+//! may not read. They cannot be guessed and may not be copied, so a
+//! compressed image is [`Error::Unsupported`] and the message says
+//! why rather than pretending the file is broken.
+//!
+//! [`preview`] still works on those files: the camera's own full-size
+//! JPEG is a record like any other, and it is the whole picture.
+//!
+//! Clean-room: written from the public CIFF 1.0 specification and
+//! third-party descriptions of it, ExifTool's tag documentation, and
+//! measurement of the sample files named in this module's tests.
+
+use crate::bits::{BitPump, BitPumpMsb};
+use crate::{Cfa, CfaColor, Error, Format, Metadata, Orientation, RawData, RawImage, Rect, Result};
+
+/// Records this module reads. The low eleven bits are the identity;
+/// the rest is type and storage, so the constants are whole tags.
+mod tag {
+    /// "Canon\0Canon EOS D60\0" — make and model in one ASCII record.
+    pub const MAKE_MODEL: u16 = 0x080A;
+    /// Focal length: record length, focal type, focal length, and the
+    /// focal plane's size in the camera's own units.
+    pub const FOCAL_LENGTH: u16 = 0x1029;
+    /// The sensor frame and the picture's borders within it.
+    pub const SENSOR_INFO: u16 = 0x1031;
+    /// Which of the compressor's Huffman table sets the image used —
+    /// present only on a compressed image, which makes it the marker.
+    pub const DECODER_TABLE: u16 = 0x1835;
+    /// White balance levels, several sets of four.
+    pub const WHITE_BALANCE: u16 = 0x10A9;
+    /// The picture's width, height, aspect and rotation.
+    pub const IMAGE_INFO: u16 = 0x1810;
+    /// The sensor data.
+    pub const IMAGE_DATA: u16 = 0x2005;
+    /// The camera's own full-size JPEG.
+    pub const JPEG: u16 = 0x2007;
+}
+
+/// A record's type, from bits 11..13 of its tag.
+const TYPE_HEAP1: u16 = 5;
+const TYPE_HEAP2: u16 = 6;
+/// Bit 14: the value is the entry's own last eight bytes.
+const IN_RECORD: u16 = 0x4000;
+
+/// Ceilings so a corrupt or hostile file cannot make the walk loop or
+/// allocate. A real CRW has a few dozen records nested three deep.
+const MAX_RECORDS: usize = 4096;
+const MAX_DEPTH: usize = 6;
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let ciff = Ciff::parse(bytes)?;
+    let (make, model) = ciff.make_model();
+
+    let image = ciff
+        .find(tag::IMAGE_DATA)
+        .ok_or_else(|| Error::Corrupt("crw: no image record (0x2005)".into()))?;
+    if ciff.find(tag::DECODER_TABLE).is_some() {
+        return Err(Error::Unsupported(format!(
+            "crw: {model}'s image is Canon's compressed CIFF data; its Huffman \
+             tables are published nowhere this clean-room decoder may read"
+        )));
+    }
+
+    let sensor = ciff.sensor_info();
+    let info = ciff.image_info();
+    // An uncompressed CIFF says its size in two places and neither is
+    // the sensor frame: SensorInfo has it on the bodies that write one,
+    // and on the bodies that do not (the Pro70 generation) only the
+    // record's own length does — ten bits a sample over the picture's
+    // number of rows.
+    let (width, height) = match sensor {
+        Some(sensor) => (sensor.width, sensor.height),
+        None => {
+            let height = info
+                .map(|info| info.height)
+                .filter(|h| *h > 0)
+                .ok_or_else(|| Error::Corrupt("crw: no image dimensions".into()))?;
+            let samples = image.len.checked_mul(8).unwrap_or(0) / 10;
+            (samples / height, height)
+        }
+    };
+    if width == 0 || height == 0 || image.len * 8 != width * height * 10 {
+        return Err(Error::Unsupported(format!(
+            "crw: {} bytes of uncompressed image for a {width}x{height} frame is \
+             not the ten bits a sample this decoder knows",
+            image.len
+        )));
+    }
+    let cfa = uncompressed_cfa(&model).ok_or_else(|| {
+        Error::Unsupported(format!(
+            "crw: uncompressed CIFF from {model}: this decoder does not know its filter array"
+        ))
+    })?;
+
+    let data = unpack10(ciff.slice(image)?, width * height);
+    let mut raw = RawImage::new(Format::Crw, width, height, 1, RawData::U16(data), cfa);
+    raw.set_camera(&make, &model);
+    // Ten bits a sample, and no record says the sensor saturates
+    // earlier.
+    raw.white_level = 1023.0;
+    if let Some(sensor) = sensor {
+        if let Some(crop) = sensor.crop(width, height) {
+            raw.crop = crop;
+        }
+    }
+    if let Some(info) = info {
+        raw.orientation = info.orientation;
+    }
+    if let Some(wb) = ciff.as_shot_wb() {
+        raw.wb_coeffs = wb;
+    }
+    raw.metadata = ciff.metadata();
+    raw.preview = ciff.jpeg();
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    Ok(Ciff::parse(bytes)?.jpeg())
+}
+
+/// The filter array of the bodies that wrote uncompressed CIFF.
+///
+/// Nothing in the file describes it, and the handful of cameras
+/// concerned are all 1997–98 compacts with complementary-colour CCDs,
+/// so it can only be recognised by name. The Pro70's array is the one
+/// measured here — four rows of alternating pairs, yellow/cyan over
+/// magenta/green, the pairs swapping every other row — against its
+/// sample frame, where the four phases separate cleanly into two bright
+/// and two dark.
+///
+/// `None` for anything else: a wrong filter array makes a picture that
+/// looks decoded and is not, which is worse than refusing.
+fn uncompressed_cfa(model: &str) -> Option<Cfa> {
+    use CfaColor::{Cyan, Green, Magenta, Yellow};
+    model.contains("Pro70").then(|| Cfa::Pattern {
+        width: 2,
+        height: 4,
+        colors: vec![Yellow, Cyan, Magenta, Green, Cyan, Yellow, Green, Magenta],
+    })
+}
+
+/// Ten-bit samples, most significant bit first, in little-endian
+/// sixteen-bit words.
+///
+/// Canon wrote the frame as a big-endian bit stream and then stored it
+/// as machine-order words, so every pair of bytes arrives swapped: the
+/// bits of the first four samples of the Pro70's frame are the second
+/// byte then the first, the fourth then the third. Undoing the swap
+/// first leaves an ordinary MSB-first stream.
+fn unpack10(bytes: &[u8], samples: usize) -> Vec<u16> {
+    let mut swapped = Vec::with_capacity(bytes.len());
+    for pair in bytes.chunks(2) {
+        match pair {
+            [a, b] => swapped.extend_from_slice(&[*b, *a]),
+            rest => swapped.extend_from_slice(rest),
+        }
+    }
+    let mut pump = BitPumpMsb::new(&swapped);
+    (0..samples).map(|_| pump.get(10) as u16).collect()
+}
+
+// ----------------------------------------------------------------- CIFF
+
+/// One record, resolved to a position in the file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Record {
+    tag: u16,
+    /// Where the value's bytes are, absolute.
+    at: usize,
+    len: usize,
+}
+
+/// A parsed CIFF: every record in the file, in the order the heaps put
+/// them, with the byte order the header names.
+struct Ciff<'a> {
+    bytes: &'a [u8],
+    little_endian: bool,
+    records: Vec<Record>,
+}
+
+impl<'a> Ciff<'a> {
+    fn parse(bytes: &'a [u8]) -> Result<Ciff<'a>> {
+        if bytes.get(6..14) != Some(b"HEAPCCDR") {
+            return Err(Error::Corrupt("crw: not a HEAPCCDR file".into()));
+        }
+        let little_endian = match bytes.get(0..2) {
+            Some(b"II") => true,
+            Some(b"MM") => false,
+            _ => return Err(Error::Corrupt("crw: no byte order mark".into())),
+        };
+        let mut ciff = Ciff {
+            bytes,
+            little_endian,
+            records: Vec::new(),
+        };
+        // The header length is where the root heap begins; it has been
+        // 26 on every file ever written, but the field is there to be
+        // read.
+        let start = ciff.u32(2).unwrap_or(0) as usize;
+        let len = bytes.len().saturating_sub(start);
+        ciff.walk(start, len, 0);
+        if ciff.records.is_empty() {
+            return Err(Error::Corrupt("crw: no readable records".into()));
+        }
+        Ok(ciff)
+    }
+
+    fn u16(&self, at: usize) -> Option<u16> {
+        let b: [u8; 2] = self.bytes.get(at..at.checked_add(2)?)?.try_into().ok()?;
+        Some(if self.little_endian {
+            u16::from_le_bytes(b)
+        } else {
+            u16::from_be_bytes(b)
+        })
+    }
+
+    fn u32(&self, at: usize) -> Option<u32> {
+        let b: [u8; 4] = self.bytes.get(at..at.checked_add(4)?)?.try_into().ok()?;
+        Some(if self.little_endian {
+            u32::from_le_bytes(b)
+        } else {
+            u32::from_be_bytes(b)
+        })
+    }
+
+    /// Read one heap's directory and every sub-heap under it.
+    ///
+    /// A heap keeps its directory at the end and points at it with the
+    /// last four bytes, so the walk is back to front; a record that
+    /// does not lie inside its own heap is dropped rather than
+    /// followed, which is what keeps a truncated file harmless.
+    fn walk(&mut self, base: usize, len: usize, depth: usize) {
+        if depth > MAX_DEPTH || len < 4 || self.records.len() >= MAX_RECORDS {
+            return;
+        }
+        let Some(end) = base.checked_add(len) else {
+            return;
+        };
+        if end > self.bytes.len() {
+            return;
+        }
+        let Some(directory) = self
+            .u32(end - 4)
+            .map(|d| d as usize)
+            .and_then(|d| base.checked_add(d))
+        else {
+            return;
+        };
+        let Some(count) = self.u16(directory) else {
+            return;
+        };
+        for i in 0..count as usize {
+            if self.records.len() >= MAX_RECORDS {
+                return;
+            }
+            let entry = match directory.checked_add(2 + i * 10) {
+                Some(entry) if entry + 10 <= end => entry,
+                _ => return,
+            };
+            let (Some(tag), Some(length), Some(offset)) =
+                (self.u16(entry), self.u32(entry + 2), self.u32(entry + 6))
+            else {
+                return;
+            };
+            let (at, length) = if tag & IN_RECORD != 0 {
+                // The value replaces the length and offset fields.
+                (entry + 2, 8)
+            } else {
+                let at = match base.checked_add(offset as usize) {
+                    Some(at) => at,
+                    None => continue,
+                };
+                let length = length as usize;
+                if at
+                    .checked_add(length)
+                    .is_none_or(|value_end| value_end > end)
+                {
+                    continue;
+                }
+                (at, length)
+            };
+            self.records.push(Record {
+                tag,
+                at,
+                len: length,
+            });
+            if matches!((tag >> 11) & 7, TYPE_HEAP1 | TYPE_HEAP2) && tag & IN_RECORD == 0 {
+                self.walk(at, length, depth + 1);
+            }
+        }
+    }
+
+    fn find(&self, tag: u16) -> Option<Record> {
+        self.records.iter().copied().find(|r| r.tag == tag)
+    }
+
+    fn slice(&self, record: Record) -> Result<&'a [u8]> {
+        self.bytes
+            .get(record.at..record.at + record.len)
+            .ok_or_else(|| {
+                Error::Corrupt(format!(
+                    "crw: record {:04x} lies outside the file",
+                    record.tag
+                ))
+            })
+    }
+
+    /// A record's u16 elements. Canon prefixes these arrays with their
+    /// own length in bytes, which is left in place: every documented
+    /// index into them counts from the length word.
+    fn shorts(&self, tag: u16) -> Vec<u16> {
+        let Some(record) = self.find(tag) else {
+            return Vec::new();
+        };
+        (0..record.len / 2)
+            .map_while(|i| self.u16(record.at + i * 2))
+            .collect()
+    }
+
+    fn longs(&self, tag: u16) -> Vec<u32> {
+        let Some(record) = self.find(tag) else {
+            return Vec::new();
+        };
+        (0..record.len / 4)
+            .map_while(|i| self.u32(record.at + i * 4))
+            .collect()
+    }
+
+    /// `0x080A`: the make, a NUL, the model, a NUL, padding.
+    fn make_model(&self) -> (String, String) {
+        let Some(record) = self.find(tag::MAKE_MODEL) else {
+            return (String::new(), String::new());
+        };
+        let Ok(text) = self.slice(record) else {
+            return (String::new(), String::new());
+        };
+        let mut parts = text.split(|b| *b == 0).map(|part| {
+            String::from_utf8_lossy(part)
+                .chars()
+                .filter(|c| !c.is_control())
+                .collect::<String>()
+                .trim()
+                .to_string()
+        });
+        let make = parts.next().unwrap_or_default();
+        let model = parts.next().unwrap_or_default();
+        (make, model)
+    }
+
+    fn sensor_info(&self) -> Option<SensorInfo> {
+        let values = self.shorts(tag::SENSOR_INFO);
+        let at = |i: usize| values.get(i).map(|v| *v as usize);
+        let info = SensorInfo {
+            width: at(1)?,
+            height: at(2)?,
+            left: at(5)?,
+            top: at(6)?,
+            right: at(7)?,
+            bottom: at(8)?,
+        };
+        (info.width > 0 && info.height > 0).then_some(info)
+    }
+
+    fn image_info(&self) -> Option<ImageInfo> {
+        let values = self.longs(tag::IMAGE_INFO);
+        Some(ImageInfo {
+            height: *values.get(1)? as usize,
+            // The rotation is in degrees clockwise, and negative
+            // quarter turns appear as 270 and as -90 both.
+            orientation: match (*values.get(3)? as i32).rem_euclid(360) {
+                90 => Orientation::Rotate90CW,
+                180 => Orientation::Rotate180,
+                270 => Orientation::Rotate270CW,
+                _ => Orientation::Normal,
+            },
+        })
+    }
+
+    /// The as-shot white balance, R G B G2 with green at 1.
+    ///
+    /// `0x10A9` is a run of four-level groups in Canon's RGGB order
+    /// after the length word, the first of which is the balance the
+    /// shot was taken at — checked against the EOS D60 sample, whose
+    /// first group is exactly the multipliers LibRaw reports for it.
+    fn as_shot_wb(&self) -> Option<[f32; 4]> {
+        let values = self.shorts(tag::WHITE_BALANCE);
+        let levels: Vec<u16> = values.get(1..5)?.to_vec();
+        let [r, g1, g2, b] = <[u16; 4]>::try_from(levels).ok()?;
+        if r == 0 || g1 == 0 || b == 0 {
+            return None;
+        }
+        let g = g1 as f32;
+        Some([r as f32 / g, 1.0, b as f32 / g, g2 as f32 / g])
+    }
+
+    /// `0x2007`, the camera's own full-size JPEG.
+    fn jpeg(&self) -> Option<Vec<u8>> {
+        let record = self.find(tag::JPEG)?;
+        let stream = self.slice(record).ok()?;
+        stream.starts_with(&[0xff, 0xd8]).then(|| stream.to_vec())
+    }
+
+    /// What little of the shot CIFF records in a form worth carrying:
+    /// the focal length, in millimetres, from `0x1029`.
+    ///
+    /// The rest of a CRW's shooting data lives in `0x102A`/`0x102D` as
+    /// arrays of camera-specific codes rather than physical units, and
+    /// is left to a metadata reader that has ExifTool's tables.
+    fn metadata(&self) -> Metadata {
+        let focal = self.shorts(tag::FOCAL_LENGTH);
+        Metadata {
+            focal_length: focal.get(2).map(|v| *v as f32).filter(|v| *v > 0.0),
+            ..Metadata::default()
+        }
+    }
+}
+
+/// `0x1031`: the sensor frame, and the picture's inclusive borders in
+/// it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct SensorInfo {
+    width: usize,
+    height: usize,
+    left: usize,
+    top: usize,
+    right: usize,
+    bottom: usize,
+}
+
+impl SensorInfo {
+    fn crop(&self, width: usize, height: usize) -> Option<Rect> {
+        let crop = Rect {
+            x: self.left,
+            y: self.top,
+            width: self.right.checked_sub(self.left)? + 1,
+            height: self.bottom.checked_sub(self.top)? + 1,
+        };
+        (crop.x + crop.width <= width && crop.y + crop.height <= height).then_some(crop)
+    }
+}
+
+/// `0x1810`: what the camera would have made of the frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ImageInfo {
+    height: usize,
+    orientation: Orientation,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    // ------------------------------------------------------- mechanics
+
+    /// A CIFF around one heap of records, built by hand so the tests
+    /// exercise the bytes a camera writes.
+    fn ciff(records: &[(u16, Vec<u8>)]) -> Vec<u8> {
+        let mut heap = Vec::new();
+        let mut directory = Vec::new();
+        directory.extend_from_slice(&(records.len() as u16).to_le_bytes());
+        for (tag, value) in records {
+            directory.extend_from_slice(&tag.to_le_bytes());
+            if tag & IN_RECORD != 0 {
+                // The value is the entry's own eight bytes.
+                let mut fixed = value.clone();
+                fixed.resize(8, 0);
+                directory.extend_from_slice(&fixed);
+            } else {
+                directory.extend_from_slice(&(value.len() as u32).to_le_bytes());
+                directory.extend_from_slice(&(heap.len() as u32).to_le_bytes());
+                heap.extend_from_slice(value);
+            }
+        }
+        let at = heap.len() as u32;
+        heap.extend_from_slice(&directory);
+        heap.extend_from_slice(&at.to_le_bytes());
+
+        let mut out = Vec::new();
+        out.extend_from_slice(b"II");
+        out.extend_from_slice(&26u32.to_le_bytes());
+        out.extend_from_slice(b"HEAPCCDR");
+        out.extend_from_slice(&0x0001_0002u32.to_le_bytes());
+        out.extend_from_slice(&[0; 8]);
+        out.extend_from_slice(&heap);
+        out
+    }
+
+    #[test]
+    fn walks_a_heap_and_its_records() {
+        let file = ciff(&[
+            (
+                tag::MAKE_MODEL,
+                b"Canon\0Canon PowerShot Pro70\0\0\0\0\0".to_vec(),
+            ),
+            (tag::IMAGE_INFO, {
+                let mut v = Vec::new();
+                for word in [1536u32, 1024, 0x3f80_0000, 180, 8, 24, 257] {
+                    v.extend_from_slice(&word.to_le_bytes());
+                }
+                v
+            }),
+        ]);
+        let ciff = Ciff::parse(&file).unwrap();
+        assert_eq!(
+            ciff.make_model(),
+            ("Canon".to_string(), "Canon PowerShot Pro70".to_string())
+        );
+        let info = ciff.image_info().unwrap();
+        assert_eq!(info.height, 1024);
+        assert_eq!(info.orientation, Orientation::Rotate180);
+    }
+
+    #[test]
+    fn reads_a_value_stored_in_its_own_entry() {
+        // Bit 14 says the eight bytes of length and offset *are* the
+        // value; a walker that followed them as an offset would read
+        // somewhere else entirely.
+        let file = ciff(&[(0x5814, 1234u32.to_le_bytes().to_vec())]);
+        let ciff = Ciff::parse(&file).unwrap();
+        let record = ciff.find(0x5814).unwrap();
+        assert_eq!(record.len, 8);
+        assert_eq!(ciff.u32(record.at), Some(1234));
+    }
+
+    #[test]
+    fn unpack10_undoes_the_word_swap() {
+        // The first bytes of the Pro70 sample, whose first three
+        // samples LibRaw unpacks as 496, 541 and 485.
+        assert_eq!(unpack10(&[0x21, 0x7c, 0x96, 0xd7], 3), vec![496, 541, 485]);
+        // Past the end the pump gives zeros rather than panicking.
+        assert_eq!(unpack10(&[0x21], 2), vec![0x84, 0]);
+    }
+
+    #[test]
+    fn hostile_input_is_an_error_not_a_panic() {
+        for bytes in [
+            &b""[..],
+            &b"II"[..],
+            &b"II\x1a\0\0\0HEAPCCDR"[..],
+            // A heap whose directory offset points past its own end.
+            &b"II\x1a\0\0\0HEAPCCDR\x02\0\x01\0\0\0\0\0\0\0\xff\xff\xff\xff"[..],
+            &[0xff; 128][..],
+        ] {
+            assert!(decode(bytes).is_err());
+            assert!(preview(bytes).is_err() || preview(bytes).unwrap().is_none());
+        }
+    }
+
+    // ---------------------------------------------------------- corpus
+
+    /// Compressed CIFF is refused on purpose: see this module's header.
+    /// Everything the corpus holds but the Pro70 is compressed.
+    fn corpus() -> Option<PathBuf> {
+        std::env::var_os("SCHIST_RAW_CORPUS").map(PathBuf::from)
+    }
+
+    fn crw_files(dir: &std::path::Path, out: &mut Vec<PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                crw_files(&path, out);
+            } else if path
+                .extension()
+                .is_some_and(|e| e.eq_ignore_ascii_case("crw"))
+            {
+                out.push(path);
+            }
+        }
+    }
+
+    fn oracle(path: &std::path::Path) -> Option<(usize, usize, Vec<u16>)> {
+        let tiff = path.with_file_name(format!("{}.tiff", path.file_name()?.to_string_lossy()));
+        let image = image::open(tiff).ok()?.into_luma16();
+        let (width, height) = (image.width() as usize, image.height() as usize);
+        Some((width, height, image.into_raw()))
+    }
+
+    #[test]
+    fn corpus_decodes_what_it_can_and_refuses_the_rest() {
+        let Some(dir) = corpus() else { return };
+        let mut files = Vec::new();
+        crw_files(&dir, &mut files);
+        files.sort();
+        let (mut uncompressed, mut decoded) = (0, 0);
+        for path in &files {
+            let name = path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            let bytes = std::fs::read(path).expect("read sample");
+            // Files named .CRW that are not CIFF at all: CHDK, the
+            // third-party PowerShot firmware, writes headerless dumps
+            // of the sensor under that extension. They carry nothing
+            // that says what shape they are, so `probe` rejects them
+            // and this decoder never sees them.
+            if bytes.get(6..14) != Some(b"HEAPCCDR") {
+                assert_eq!(
+                    crate::probe(&bytes),
+                    None,
+                    "{name} is not CIFF but probes as raw"
+                );
+                continue;
+            }
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(Format::Crw),
+                "{name} probes as CRW"
+            );
+            // An image record with no decoder-table index beside it is
+            // one this module is meant to decode, so a refusal on one
+            // of those would be a bug rather than the documented gap.
+            let ciff = Ciff::parse(&bytes).unwrap_or_else(|e| panic!("{name}: {e}"));
+            if ciff.find(tag::DECODER_TABLE).is_none() && ciff.find(tag::IMAGE_DATA).is_some() {
+                uncompressed += 1;
+            }
+
+            // The camera's own JPEG comes out of any CRW that has one,
+            // compressed image or not.
+            if let Some(jpeg) = preview(&bytes).expect("preview") {
+                image::load_from_memory(&jpeg).unwrap_or_else(|e| panic!("{name} preview: {e}"));
+            }
+
+            let raw = match decode(&bytes) {
+                Ok(raw) => raw,
+                Err(Error::Unsupported(why)) => {
+                    assert!(
+                        why.contains("compressed") || why.contains("filter array"),
+                        "{name}: {why}"
+                    );
+                    continue;
+                }
+                Err(why) => panic!("{name}: {why}"),
+            };
+            raw.validate().unwrap_or_else(|e| panic!("{name}: {e}"));
+            assert_eq!(raw.format, Format::Crw);
+            assert_eq!(raw.make, "Canon", "{name}");
+            decoded += 1;
+
+            let Some((width, height, want)) = oracle(path) else {
+                continue;
+            };
+            assert_eq!(
+                (raw.width, raw.height),
+                (width, height),
+                "{name} frame size"
+            );
+            let RawData::U16(got) = &raw.data else {
+                panic!("{name} is not 16-bit")
+            };
+            let wrong: Vec<usize> = got
+                .iter()
+                .zip(&want)
+                .enumerate()
+                .filter(|(_, (a, b))| a != b)
+                .map(|(i, _)| i)
+                .take(8)
+                .collect();
+            assert!(
+                wrong.is_empty(),
+                "{name}: samples differ from the oracle at {:?} (got {:?}, want {:?})",
+                wrong,
+                wrong.iter().map(|i| got[*i]).collect::<Vec<_>>(),
+                wrong.iter().map(|i| want[*i]).collect::<Vec<_>>(),
+            );
+        }
+        assert_eq!(
+            decoded, uncompressed,
+            "every uncompressed CIFF in the corpus should decode"
+        );
+    }
+
+    #[test]
+    fn truncated_corpus_files_never_panic() {
+        let Some(dir) = corpus() else { return };
+        let mut files = Vec::new();
+        crw_files(&dir, &mut files);
+        for path in &files {
+            let bytes = std::fs::read(path).expect("read sample");
+            for cut in [0, 1, 13, 14, 26, 27, 1024] {
+                let cut = cut.min(bytes.len());
+                let _ = decode(&bytes[..cut]);
+                let _ = preview(&bytes[..cut]);
+            }
+            for n in 1..=6 {
+                let cut = bytes.len() * n / 7;
+                let _ = decode(&bytes[..cut]);
+                let _ = preview(&bytes[..cut]);
+            }
+            // And the tail cut off, which moves the root directory.
+            for n in 1..=4 {
+                let cut = bytes.len() - n;
+                let _ = decode(&bytes[..cut]);
+                let _ = preview(&bytes[..cut]);
+            }
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/crx.rs
+++ b/crates/codec-raw/src/formats/crx.rs
@@ -1,0 +1,728 @@
+//! Canon's CRX codec: the wavelet-and-Golomb scheme inside a CR3.
+//!
+//! A CRX image is a grid of *tiles*. Each tile holds one *plane* per
+//! colour-filter position — a Bayer frame is split into its four 2x2
+//! sub-planes, so a plane is half the tile wide and half as tall — and
+//! each plane holds one *subband* per wavelet band. With zero wavelet
+//! levels (what Canon's "RAW" quality writes) a plane is a single LL
+//! band and the coefficients are the sensor samples themselves; with
+//! levels (what "CRAW" writes) there are `3 * levels + 1` bands and a
+//! 5/3-style integer lifting wavelet to invert, with a per-band
+//! quantiser in the lossy case.
+//!
+//! The shapes and sizes come from two places: the `CMP1` box in the
+//! track's sample entry ([`ImageHeader`]), and a header of small
+//! tag/size records in front of the sample data in `mdat`
+//! ([`parse_tiles`]). Nothing about the layouts here is guessed from
+//! another decoder's source: the record tags and field positions were
+//! read off real files and cross-checked against the public CR3 notes.
+
+//! ## What is known about the coefficient bitstream
+//!
+//! [`decode`] does not decode coefficients yet, and this is what was
+//! established about them from the corpus, so the next hand does not
+//! start from nothing. All of it was checked against
+//! `unprocessed_raw`'s output for `EOS R RAW`, tile 0 plane 0 — a
+//! lossless zero-level band, 1722 by 2273 coefficients — and none of
+//! it comes from another decoder.
+//!
+//! Bits are read most-significant first, straight down the bytes
+//! ([`crate::bits::BitPumpMsb`]), from the band's first byte. A
+//! coefficient is coded as its prediction residual `d`, folded to a
+//! non-negative `m`: `m = 2d` for `d >= 0`, `m = -2d - 1` for `d < 0`.
+//! `m` is then a Rice code with a running parameter `k`: the quotient
+//! `m >> k` in unary — that many zero bits, then a one — followed by
+//! the low `k` bits of `m`. `k` starts at 0 at the head of a band. A
+//! quotient reaching 42 escapes: 42 zeros, a one, then `m` in a
+//! 21-bit field.
+//!
+//! `k` is updated after every coefficient from
+//!
+//! ```text
+//! s = m + (the folded magnitude one to the right on the line above)
+//! raise k while s >= 6 << k, by at most two;
+//! if it did not rise and s < (1 << k) - 1, lower it by one.
+//! ```
+//!
+//! On the first line, which has no line above, `s = 2m` — the same
+//! rule with the coefficient standing in for its own neighbour. `k`
+//! carries across the line boundary. An accumulator scheme in the
+//! manner of JPEG-LS was tried and does not reproduce the stream, and
+//! neither does a `k` read only from the line above: it is a running
+//! state that the line above steers.
+//!
+//! The first line predicts from the left, with `1 << (bits - 1)`
+//! standing in for the pixel before the first — which is why every
+//! lossless band opens with the escape, its first residual being
+//! about `black - 8192`. Later lines predict with the gradient median
+//! of the left, above and above-left neighbours (`min(a, b)` when
+//! `c >= max(a, b)`, `max(a, b)` when `c <= min(a, b)`, else
+//! `a + b - c`).
+//!
+//! That decodes the whole of line 0 exactly, and line 1 exactly up to
+//! its 53rd coefficient. There it wants `k` to fall and then rise
+//! again over two coefficients that the rule above holds steady, and
+//! wants `min(a, b)` where the gradient median gives `max(a, b)` —
+//! two symptoms at one spot, which is what a mode switch looks like:
+//! most likely the zero-run mode that the magnitudes of the line
+//! above select into. Finding that is all that stands between this
+//! and lossless CR3 frames.
+
+use crate::{Error, Result};
+
+/// The `CMP1` box: what shape the coded image is.
+///
+/// The first four bytes are a marker (0xff00 or 0xff10) and the size
+/// of the rest, then a version that says which of the two record
+/// dialects the `mdat` header speaks (see [`parse_tiles`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImageHeader {
+    /// 1 on the EOS R / RP / M50 / 90D generation, 2 from the R5 on.
+    pub version: u8,
+    /// The whole coded frame, which is also the raw sensor frame.
+    pub width: usize,
+    pub height: usize,
+    /// One tile of it. Tiles divide the frame left to right, top to
+    /// bottom; the last tile in a row or column is whatever is left.
+    pub tile_width: usize,
+    pub tile_height: usize,
+    /// Bits per sensor sample, 14 on every body seen.
+    pub bits: u32,
+    /// Planes per tile: 4, the Bayer sub-planes, in the order
+    /// top-left, top-right, bottom-left, bottom-right.
+    pub planes: usize,
+    /// Which 2x2 phase the frame starts on. 0 everywhere on the
+    /// full-size raw track; the small "SD" raw track uses 1.
+    pub cfa_layout: u8,
+    /// Wavelet levels: 0 for lossless RAW, 3 for cRAW so far.
+    pub levels: u32,
+    /// Whether the wavelet runs across tile columns / rows, which the
+    /// encoder only sets when there is both a wavelet and more than
+    /// one tile in that direction.
+    pub tile_cols_linked: bool,
+    pub tile_rows_linked: bool,
+    /// Bytes of tag/size records in front of the sample data.
+    pub mdat_header_size: usize,
+}
+
+impl ImageHeader {
+    /// Parse the payload of a `CMP1` box (the 52 bytes after its
+    /// 8-byte box header).
+    pub fn parse(payload: &[u8]) -> Result<ImageHeader> {
+        if payload.len() < 32 {
+            return Err(Error::Corrupt(format!("CMP1 is {} bytes", payload.len())));
+        }
+        let u32_at = |at: usize| {
+            u32::from_be_bytes([
+                payload[at],
+                payload[at + 1],
+                payload[at + 2],
+                payload[at + 3],
+            ])
+        };
+        // Byte 4 is the record dialect of the mdat header — 1 or 2,
+        // with the byte after it zero — and byte 24 onwards is a run
+        // of small fields, one or two to the byte. Everything wider
+        // than a byte in here is big-endian.
+        let version = payload[4];
+        let width = u32_at(8) as usize;
+        let height = u32_at(12) as usize;
+        let tile_width = u32_at(16) as usize;
+        let tile_height = u32_at(20) as usize;
+        let bits = payload[24] as u32;
+        let planes = (payload[25] >> 4) as usize;
+        let cfa_layout = payload[25] & 0xf;
+        let levels = (payload[26] & 0xf) as u32;
+        let flags = payload[27];
+        let mdat_header_size = u32_at(28) as usize;
+
+        if width == 0 || height == 0 || tile_width == 0 || tile_height == 0 {
+            return Err(Error::Corrupt("CMP1 with a zero dimension".into()));
+        }
+        // Everything downstream indexes a u16 buffer of width*height
+        // and slices tiles out of it; a frame that cannot be allocated
+        // is a file lying about itself, not a decode we should attempt.
+        if width > 1 << 17 || height > 1 << 17 {
+            return Err(Error::Corrupt(format!("CMP1 frame {width}x{height}")));
+        }
+        if !(1..=16).contains(&bits) {
+            return Err(Error::Corrupt(format!("CMP1 says {bits} bits a sample")));
+        }
+        Ok(ImageHeader {
+            version,
+            width,
+            height,
+            tile_width,
+            tile_height,
+            bits,
+            planes,
+            cfa_layout,
+            levels,
+            tile_cols_linked: flags & 0x80 != 0,
+            tile_rows_linked: flags & 0x40 != 0,
+            mdat_header_size,
+        })
+    }
+
+    /// Tiles across and down.
+    pub fn tile_grid(&self) -> (usize, usize) {
+        (
+            self.width.div_ceil(self.tile_width),
+            self.height.div_ceil(self.tile_height),
+        )
+    }
+
+    /// Bands in one plane: one LL band, then HL/LH/HH per level.
+    pub fn bands(&self) -> usize {
+        3 * self.levels as usize + 1
+    }
+}
+
+/// One subband's slice of a plane's data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Band {
+    /// Where the band's bits are, inside the whole `mdat` sample.
+    pub data: std::ops::Range<usize>,
+    /// Index within the plane, 0 for LL.
+    pub index: usize,
+    /// The twelve bits under the band counter in the record's flags.
+    /// Every band of a lossless frame carries 32 here; in a version-1
+    /// cRAW frame it grows with the wavelet level (32 for the level-3
+    /// bands, up to 256 for the finest), which is what a quantiser
+    /// looks like. Version 2 leaves it zero and puts a quantiser
+    /// table at the front of the tile instead.
+    pub q_step: u32,
+    /// The whole flags word as written, for a caller that wants to
+    /// report on the bits whose meaning is not established here.
+    pub flags: u32,
+}
+
+/// One Bayer sub-plane of a tile.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Plane {
+    pub data: std::ops::Range<usize>,
+    pub index: usize,
+    /// Bit 27 of the flags, set in every file seen.
+    pub extra_flag: bool,
+    /// The whole flags word as written; its top nibble is the plane
+    /// counter and the rest is not established here.
+    pub flags: u32,
+    pub bands: Vec<Band>,
+}
+
+/// One tile of the frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tile {
+    pub data: std::ops::Range<usize>,
+    /// Position in the tile grid.
+    pub col: usize,
+    pub row: usize,
+    /// Pixels of the frame this tile covers.
+    pub x: usize,
+    pub y: usize,
+    pub width: usize,
+    pub height: usize,
+    /// Version 2 only: the quantiser table that precedes the plane
+    /// data inside the tile, in bytes.
+    pub qp_table_size: usize,
+    pub planes: Vec<Plane>,
+}
+
+/// A record in the `mdat` header: a big-endian tag, a big-endian
+/// payload length, then the payload.
+struct Record<'a> {
+    tag: u16,
+    payload: &'a [u8],
+}
+
+fn records(header: &[u8]) -> Result<Vec<Record<'_>>> {
+    let mut out = Vec::new();
+    let mut at = 0usize;
+    while at + 4 <= header.len() {
+        let tag = u16::from_be_bytes([header[at], header[at + 1]]);
+        let len = u16::from_be_bytes([header[at + 2], header[at + 3]]) as usize;
+        let end = at + 4 + len;
+        if end > header.len() {
+            return Err(Error::Corrupt(
+                "CRX header record runs past the header".into(),
+            ));
+        }
+        out.push(Record {
+            tag,
+            payload: &header[at + 4..end],
+        });
+        at = end;
+    }
+    Ok(out)
+}
+
+fn be32(b: &[u8], at: usize) -> Result<u32> {
+    b.get(at..at + 4)
+        .map(|s| u32::from_be_bytes([s[0], s[1], s[2], s[3]]))
+        .ok_or_else(|| Error::Corrupt("short CRX header record".into()))
+}
+
+/// Read the tag/size records in front of a sample and turn them into
+/// the tile / plane / band tree, with each node's byte range inside
+/// `sample` filled in.
+///
+/// The records come in two dialects. Version 1 (EOS R generation) uses
+/// tags 0xff01 tile, 0xff02 plane, 0xff03 band, each with an 8-byte
+/// payload of a size and a flags word. Version 2 (R5 onwards) uses
+/// 0xff11 / 0xff12 / 0xff13, and the tile and band records carry
+/// sixteen bytes: the tile's says how much of the tile is a quantiser
+/// table before the planes start. In both, a node's children tile its
+/// bytes exactly and the tiles tile the sample after the header.
+pub fn parse_tiles(header: &ImageHeader, sample: &[u8]) -> Result<Vec<Tile>> {
+    if header.mdat_header_size > sample.len() {
+        return Err(Error::Corrupt(format!(
+            "CRX header of {} bytes in a {}-byte sample",
+            header.mdat_header_size,
+            sample.len()
+        )));
+    }
+    let (tile_tag, plane_tag, band_tag) = match header.version {
+        1 => (0xff01u16, 0xff02u16, 0xff03u16),
+        2 => (0xff11, 0xff12, 0xff13),
+        other => return Err(Error::Unsupported(format!("CRX header version {other}"))),
+    };
+    let (cols, rows) = header.tile_grid();
+    let mut tiles: Vec<Tile> = Vec::new();
+    // Where the next node of each kind starts: tiles follow the
+    // header, planes follow the previous plane inside their tile,
+    // bands the previous band inside their plane.
+    let mut tile_at = header.mdat_header_size;
+    let mut plane_at = 0usize;
+    let mut band_at = 0usize;
+
+    for record in records(&sample[..header.mdat_header_size])? {
+        if record.tag == tile_tag {
+            let size = be32(record.payload, 0)? as usize;
+            let qp_table_size = if header.version >= 2 {
+                be32(record.payload, 8)? as usize
+            } else {
+                0
+            };
+            let index = tiles.len();
+            if index >= cols * rows {
+                return Err(Error::Corrupt("more CRX tiles than the grid holds".into()));
+            }
+            let (col, row) = (index % cols, index / cols);
+            let x = col * header.tile_width;
+            let y = row * header.tile_height;
+            let end = tile_at
+                .checked_add(size)
+                .filter(|end| *end <= sample.len())
+                .ok_or_else(|| Error::Corrupt("CRX tile runs past the sample".into()))?;
+            tiles.push(Tile {
+                data: tile_at..end,
+                col,
+                row,
+                x,
+                y,
+                width: header.tile_width.min(header.width - x),
+                height: header.tile_height.min(header.height - y),
+                qp_table_size,
+                planes: Vec::new(),
+            });
+            // Version 2 puts the quantiser table at the front of the
+            // tile, so the first plane starts after it.
+            plane_at = tile_at + qp_table_size.min(size);
+            tile_at = end;
+        } else if record.tag == plane_tag {
+            let size = be32(record.payload, 0)? as usize;
+            let flags = be32(record.payload, 4)?;
+            let tile = tiles
+                .last_mut()
+                .ok_or_else(|| Error::Corrupt("CRX plane before any tile".into()))?;
+            let end = plane_at
+                .checked_add(size)
+                .filter(|end| *end <= tile.data.end)
+                .ok_or_else(|| Error::Corrupt("CRX plane runs past its tile".into()))?;
+            tile.planes.push(Plane {
+                data: plane_at..end,
+                index: tile.planes.len(),
+                extra_flag: flags & 0x0800_0000 != 0,
+                flags,
+                bands: Vec::new(),
+            });
+            band_at = plane_at;
+            plane_at = end;
+        } else if record.tag == band_tag {
+            let size = be32(record.payload, 0)? as usize;
+            let flags = be32(record.payload, 4)?;
+            let plane = tiles
+                .last_mut()
+                .and_then(|t| t.planes.last_mut())
+                .ok_or_else(|| Error::Corrupt("CRX band before any plane".into()))?;
+            let end = band_at
+                .checked_add(size)
+                .filter(|end| *end <= plane.data.end)
+                .ok_or_else(|| Error::Corrupt("CRX band runs past its plane".into()))?;
+            plane.bands.push(Band {
+                data: band_at..end,
+                index: plane.bands.len(),
+                // The quantiser sits in the twelve bits under the
+                // band counter; 0x20 is unity and every lossless band
+                // carries exactly that.
+                q_step: (flags >> 16) & 0xfff,
+                flags,
+            });
+            band_at = end;
+        }
+        // Anything else in the header is not a node of the tree; the
+        // parser ignores it rather than failing, so a body that adds a
+        // record still decodes.
+    }
+
+    if tiles.len() != cols * rows {
+        return Err(Error::Corrupt(format!(
+            "CRX header has {} tiles, the grid wants {}",
+            tiles.len(),
+            cols * rows
+        )));
+    }
+    for tile in &tiles {
+        if tile.planes.len() != header.planes {
+            return Err(Error::Corrupt(format!(
+                "CRX tile has {} planes, CMP1 says {}",
+                tile.planes.len(),
+                header.planes
+            )));
+        }
+        for plane in &tile.planes {
+            if plane.bands.len() != header.bands() {
+                return Err(Error::Corrupt(format!(
+                    "CRX plane has {} bands, {} levels wants {}",
+                    plane.bands.len(),
+                    header.levels,
+                    header.bands()
+                )));
+            }
+        }
+    }
+    Ok(tiles)
+}
+
+/// Decode one CRX sample into the full frame, `width * height`
+/// samples row-major with the Bayer planes interleaved back.
+pub fn decode(header: &ImageHeader, sample: &[u8]) -> Result<Vec<u16>> {
+    // Parsed even though the coefficients are out of reach, so that a
+    // file whose header does not describe itself is reported as the
+    // corruption it is rather than as an unsupported variant.
+    let tiles = parse_tiles(header, sample)?;
+    let bands: usize = tiles
+        .iter()
+        .flat_map(|t| &t.planes)
+        .map(|p| p.bands.len())
+        .sum();
+    Err(Error::Unsupported(format!(
+        "the CRX entropy coder (v{}, {} wavelet levels, {} tile(s), {bands} bands): \
+         the container and every header are read, the coefficients are not",
+        header.version,
+        header.levels,
+        tiles.len(),
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A CMP1 payload shaped like the ones real files carry.
+    fn cmp1(version: u8, w: u32, h: u32, tw: u32, th: u32, levels: u8, hdr: u32) -> Vec<u8> {
+        let mut p = vec![0u8; 52];
+        p[0..2].copy_from_slice(&0xff00u16.to_be_bytes());
+        p[2..4].copy_from_slice(&0x0030u16.to_be_bytes());
+        p[4] = version;
+        p[8..12].copy_from_slice(&w.to_be_bytes());
+        p[12..16].copy_from_slice(&h.to_be_bytes());
+        p[16..20].copy_from_slice(&tw.to_be_bytes());
+        p[20..24].copy_from_slice(&th.to_be_bytes());
+        p[24] = 14;
+        p[25] = 0x40;
+        p[26] = levels;
+        p[28..32].copy_from_slice(&hdr.to_be_bytes());
+        p
+    }
+
+    fn record(tag: u16, payload: &[u8]) -> Vec<u8> {
+        let mut out = tag.to_be_bytes().to_vec();
+        out.extend_from_slice(&(payload.len() as u16).to_be_bytes());
+        out.extend_from_slice(payload);
+        out
+    }
+
+    fn sizes(size: u32, flags: u32) -> Vec<u8> {
+        let mut out = size.to_be_bytes().to_vec();
+        out.extend_from_slice(&flags.to_be_bytes());
+        out
+    }
+
+    #[test]
+    fn image_header_fields() {
+        let header = ImageHeader::parse(&cmp1(1, 6888, 4546, 3444, 4546, 0, 216)).unwrap();
+        assert_eq!(header.version, 1);
+        assert_eq!((header.width, header.height), (6888, 4546));
+        assert_eq!(header.tile_grid(), (2, 1));
+        assert_eq!(header.bits, 14);
+        assert_eq!(header.planes, 4);
+        assert_eq!(header.bands(), 1);
+        let lossy = ImageHeader::parse(&cmp1(1, 6888, 4546, 3444, 4546, 3, 1080)).unwrap();
+        assert_eq!(lossy.bands(), 10);
+    }
+
+    #[test]
+    fn a_short_or_impossible_cmp1_is_corrupt() {
+        assert!(ImageHeader::parse(&[0u8; 8]).is_err());
+        assert!(ImageHeader::parse(&cmp1(1, 0, 4546, 3444, 4546, 0, 216)).is_err());
+        let mut deep = cmp1(1, 100, 100, 100, 100, 0, 16);
+        deep[24] = 0;
+        assert!(ImageHeader::parse(&deep).is_err());
+    }
+
+    #[test]
+    fn tiles_planes_and_bands_tile_their_parents() {
+        // Two tiles of four planes, one band each: the shape of a
+        // lossless EOS R frame, in miniature.
+        let mut hdr = Vec::new();
+        for tile in 0..2u32 {
+            hdr.extend(record(0xff01, &sizes(40, tile << 16)));
+            for plane in 0..4u32 {
+                hdr.extend(record(0xff02, &sizes(10, 0x0800_0000 | (plane << 28))));
+                hdr.extend(record(0xff03, &sizes(10, 0x0020_0000)));
+            }
+        }
+        let header = ImageHeader::parse(&cmp1(1, 8, 4, 4, 4, 0, hdr.len() as u32)).unwrap();
+        let mut sample = hdr.clone();
+        sample.extend(std::iter::repeat_n(0u8, 80));
+        let tiles = parse_tiles(&header, &sample).unwrap();
+        assert_eq!(tiles.len(), 2);
+        assert_eq!(tiles[0].data, hdr.len()..hdr.len() + 40);
+        assert_eq!(tiles[1].data, hdr.len() + 40..hdr.len() + 80);
+        assert_eq!(tiles[1].col, 1);
+        assert_eq!(tiles[0].planes[1].data, hdr.len() + 10..hdr.len() + 20);
+        assert!(tiles[0].planes[0].extra_flag);
+        assert_eq!(tiles[0].planes[0].bands[0].q_step, 32);
+        assert_eq!(
+            tiles[0].planes[3].bands[0].data,
+            hdr.len() + 30..hdr.len() + 40
+        );
+    }
+
+    #[test]
+    fn a_header_that_does_not_add_up_is_rejected() {
+        let header = ImageHeader::parse(&cmp1(1, 8, 4, 4, 4, 0, 12)).unwrap();
+        // One tile record for a two-tile grid.
+        let hdr = record(0xff01, &sizes(8, 0));
+        let mut sample = hdr.clone();
+        sample.extend([0u8; 8]);
+        assert!(parse_tiles(&header, &sample).is_err());
+        // A tile bigger than the sample.
+        let hdr = record(0xff01, &sizes(1 << 20, 0));
+        let mut sample = hdr.clone();
+        sample.extend([0u8; 8]);
+        assert!(parse_tiles(&header, &sample).is_err());
+        // A header longer than the sample it describes.
+        let header = ImageHeader::parse(&cmp1(1, 8, 4, 8, 4, 0, 1 << 20)).unwrap();
+        assert!(parse_tiles(&header, &[0u8; 32]).is_err());
+    }
+
+    #[test]
+    fn an_unknown_record_dialect_is_unsupported() {
+        let header = ImageHeader::parse(&cmp1(7, 8, 4, 8, 4, 0, 0)).unwrap();
+        assert!(matches!(
+            parse_tiles(&header, &[0u8; 8]),
+            Err(Error::Unsupported(_))
+        ));
+    }
+
+    // ---------------------------------------------------------------
+    // Corpus: the headers of real CRX streams.
+    // ---------------------------------------------------------------
+
+    /// Every CMP1 in the corpus, with the sample its track points at.
+    #[test]
+    fn corpus_crx_headers_describe_their_samples() {
+        let Some(root) = crate::tiff::tests::corpus() else {
+            return;
+        };
+        let mut problems: Vec<String> = Vec::new();
+        let mut seen: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        let mut checked = 0;
+        for path in crate::tiff::tests::samples(&root) {
+            let is_cr3 = path
+                .extension()
+                .map(|e| e.to_string_lossy().to_ascii_uppercase() == "CR3")
+                .unwrap_or(false);
+            if !is_cr3 {
+                continue;
+            }
+            let Ok(bytes) = std::fs::read(&path) else {
+                continue;
+            };
+            let name = path
+                .strip_prefix(&root)
+                .unwrap_or(&path)
+                .display()
+                .to_string();
+            let Ok(boxes) = crate::bmff::parse(&bytes) else {
+                problems.push(format!("{name}: does not parse"));
+                continue;
+            };
+            for trak in boxes
+                .iter()
+                .filter(|b| &b.kind == b"moov")
+                .flat_map(|m| m.children.iter())
+                .filter(|b| &b.kind == b"trak")
+            {
+                let Some(stbl) = trak.find_all(b"stbl").into_iter().next() else {
+                    continue;
+                };
+                let Some(entry) = stbl.child(b"stsd").and_then(|s| s.children.first()) else {
+                    continue;
+                };
+                let Some(cmp1) = entry.child(b"CMP1") else {
+                    continue;
+                };
+                let header = match ImageHeader::parse(&bytes[cmp1.data.clone()]) {
+                    Ok(header) => header,
+                    Err(e) => {
+                        problems.push(format!("{name}: CMP1: {e}"));
+                        continue;
+                    }
+                };
+                // The sample entry's own VisualSampleEntry width and
+                // height are the frame on the EOS R generation and
+                // the crop on the R5 and later, so they only bound
+                // CMP1's rather than matching it — enough to catch a
+                // field read at the wrong offset.
+                let visual = &bytes[entry.data.clone()];
+                let dim = |at: usize| u16::from_be_bytes([visual[at], visual[at + 1]]) as usize;
+                if dim(24) > header.width || dim(26) > header.height || dim(24) * 2 < header.width {
+                    problems.push(format!(
+                        "{name}: CMP1 {}x{}, sample entry {}x{}",
+                        header.width,
+                        header.height,
+                        dim(24),
+                        dim(26)
+                    ));
+                }
+                if header.planes != 4 || header.bits != 14 {
+                    problems.push(format!(
+                        "{name}: {} planes of {} bits",
+                        header.planes, header.bits
+                    ));
+                }
+                seen.insert(format!(
+                    "v{} levels {} tiles {:?} cfa {}",
+                    header.version,
+                    header.levels,
+                    header.tile_grid(),
+                    header.cfa_layout
+                ));
+                // Find this track's single sample and check the tree.
+                let Some(sample) = sample_of(&bytes, stbl) else {
+                    problems.push(format!("{name}: no sample table"));
+                    continue;
+                };
+                match parse_tiles(&header, sample) {
+                    Err(e) => {
+                        problems.push(format!("{name}: {}x{}: {e}", header.width, header.height))
+                    }
+                    Ok(tiles) => {
+                        checked += 1;
+                        // Tiles must fill the sample after the header,
+                        // planes must fill their tile and bands their
+                        // plane, with nothing left over.
+                        let mut at = header.mdat_header_size;
+                        for tile in &tiles {
+                            if tile.data.start != at {
+                                problems
+                                    .push(format!("{name}: tile at {} not {at}", tile.data.start));
+                            }
+                            at = tile.data.end;
+                            let mut plane_at = tile.data.start + tile.qp_table_size;
+                            for plane in &tile.planes {
+                                if plane.data.start != plane_at {
+                                    problems.push(format!(
+                                        "{name}: plane at {} not {plane_at}",
+                                        plane.data.start
+                                    ));
+                                }
+                                plane_at = plane.data.end;
+                                let mut band_at = plane.data.start;
+                                for band in &plane.bands {
+                                    if band.data.start != band_at {
+                                        problems.push(format!(
+                                            "{name}: band at {} not {band_at}",
+                                            band.data.start
+                                        ));
+                                    }
+                                    band_at = band.data.end;
+                                }
+                                if band_at != plane.data.end {
+                                    problems.push(format!(
+                                        "{name}: bands leave {} bytes",
+                                        plane.data.end - band_at
+                                    ));
+                                }
+                            }
+                            // A version-2 tile pads its end to a word
+                            // or two; a version-1 one is exact.
+                            let slack = tile.data.end - plane_at;
+                            if slack > if header.version >= 2 { 7 } else { 0 } {
+                                problems.push(format!("{name}: planes leave {slack} bytes"));
+                            }
+                        }
+                        if at != sample.len() {
+                            problems
+                                .push(format!("{name}: tiles leave {} bytes", sample.len() - at));
+                        }
+                        // A lossless frame's bands all carry the unit
+                        // quantiser; a version-1 lossy one does not.
+                        let unit = tiles
+                            .iter()
+                            .flat_map(|t| &t.planes)
+                            .flat_map(|p| &p.bands)
+                            .all(|b| b.q_step == 32);
+                        if header.levels == 0 && !unit {
+                            problems.push(format!("{name}: a lossless band with a quantiser"));
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            problems.is_empty(),
+            "{} problems:\n{}",
+            problems.len(),
+            problems.join("\n")
+        );
+        eprintln!("corpus: {checked} CRX streams; shapes seen:");
+        for shape in &seen {
+            eprintln!("    {shape}");
+        }
+    }
+
+    /// The first sample of a track, from `stsz` and `co64`/`stco`.
+    fn sample_of<'a>(bytes: &'a [u8], stbl: &crate::bmff::Box_) -> Option<&'a [u8]> {
+        let stsz = bytes.get(stbl.child(b"stsz")?.data.clone())?;
+        let be = |b: &[u8], at: usize| -> Option<usize> {
+            Some(u32::from_be_bytes(b.get(at..at + 4)?.try_into().ok()?) as usize)
+        };
+        let size = match be(stsz, 4)? {
+            0 => be(stsz, 12)?,
+            uniform => uniform,
+        };
+        let offset = match (stbl.child(b"co64"), stbl.child(b"stco")) {
+            (Some(co64), _) => {
+                let p = bytes.get(co64.data.clone())?;
+                usize::try_from(u64::from_be_bytes(p.get(8..16)?.try_into().ok()?)).ok()?
+            }
+            (None, Some(stco)) => be(bytes.get(stco.data.clone())?, 8)?,
+            (None, None) => return None,
+        };
+        bytes.get(offset..offset.checked_add(size)?)
+    }
+}

--- a/crates/codec-raw/src/formats/dng.rs
+++ b/crates/codec-raw/src/formats/dng.rs
@@ -1,0 +1,2737 @@
+//! Adobe DNG, the one raw container with a published specification.
+//!
+//! A DNG is an ordinary TIFF whose sensor data lives in an IFD marked
+//! `PhotometricInterpretation` 32803 (colour filter array) or 34892
+//! (linear raw, three samples a pixel). Everything a developer needs
+//! is in tags beside it — black and white levels, the active area and
+//! the default crop, the CFA layout, the as-shot neutral, two colour
+//! matrices with the illuminants they were measured under — so this
+//! module needs no camera table and no reverse engineering: it is
+//! written from the DNG specification (1.0 through 1.7) and checked
+//! against real files.
+//!
+//! Vendors that ship DNG straight out of the camera (Pentax, Ricoh,
+//! Leica, Sigma, Apple, Google, Samsung, DJI, Hasselblad's drone
+//! bodies) all take this path, as do files converted by Adobe's DNG
+//! Converter.
+
+use std::io::Cursor;
+
+use rayon::prelude::*;
+
+use crate::bits::{BitPump, BitPumpMsb};
+use crate::formats::common;
+use crate::ljpeg;
+use crate::tiff::{tags, Ifd, ImageLayout, Tiff};
+use crate::{Cfa, CfaColor, Error, Format, RawData, RawImage, Rect, Result};
+
+/// The DNG and TIFF tags this module reads that the shared table does
+/// not already name.
+mod tag {
+    pub const PREDICTOR: u16 = 0x013D;
+    pub const SAMPLE_FORMAT: u16 = 0x0153;
+    pub const DNG_BACKWARD_VERSION: u16 = 0xC613;
+    pub const UNIQUE_CAMERA_MODEL: u16 = 0xC614;
+    pub const CFA_PLANE_COLOR: u16 = 0xC616;
+    pub const CFA_LAYOUT: u16 = 0xC617;
+    pub const LINEARIZATION_TABLE: u16 = 0xC618;
+    pub const BLACK_LEVEL_REPEAT_DIM: u16 = 0xC619;
+    pub const BLACK_LEVEL: u16 = 0xC61A;
+    pub const BLACK_LEVEL_DELTA_H: u16 = 0xC61B;
+    pub const BLACK_LEVEL_DELTA_V: u16 = 0xC61C;
+    pub const WHITE_LEVEL: u16 = 0xC61D;
+    pub const DEFAULT_CROP_ORIGIN: u16 = 0xC61F;
+    pub const DEFAULT_CROP_SIZE: u16 = 0xC620;
+    pub const COLOR_MATRIX_1: u16 = 0xC621;
+    pub const COLOR_MATRIX_2: u16 = 0xC622;
+    pub const AS_SHOT_NEUTRAL: u16 = 0xC628;
+    pub const AS_SHOT_WHITE_XY: u16 = 0xC629;
+    pub const CALIBRATION_ILLUMINANT_1: u16 = 0xC65A;
+    pub const CALIBRATION_ILLUMINANT_2: u16 = 0xC65B;
+    pub const ACTIVE_AREA: u16 = 0xC68D;
+    pub const SUB_TILE_BLOCK_SIZE: u16 = 0xC71E;
+    pub const ROW_INTERLEAVE_FACTOR: u16 = 0xC71F;
+    pub const OPCODE_LIST_1: u16 = 0xC740;
+    pub const OPCODE_LIST_2: u16 = 0xC741;
+    pub const OPCODE_LIST_3: u16 = 0xC742;
+}
+
+/// Compression codes a raw IFD may carry.
+mod compression {
+    pub const NONE: u32 = 1;
+    pub const LOSSLESS_JPEG: u32 = 7;
+    /// Deflate. 8 is the code DNG uses; 32946 is TIFF's older
+    /// synonym and means the same zlib stream.
+    pub const DEFLATE: u32 = 8;
+    pub const DEFLATE_OLD: u32 = 32946;
+    /// Baseline JPEG. The number collides with the *photometric*
+    /// code for linear raw; they are unrelated.
+    pub const LOSSY_JPEG: u32 = 34892;
+    /// DNG 1.7's JPEG XL, which this crate has no decoder for.
+    pub const JPEG_XL: u32 = 52546;
+    /// GoPro's GPR files are DNGs whose raw IFD is a VC-5 wavelet
+    /// stream. Not part of the DNG specification.
+    pub const VC5: u32 = 9;
+}
+
+const PHOTOMETRIC_CFA: u32 = 32803;
+const PHOTOMETRIC_LINEAR_RAW: u32 = 34892;
+
+/// A ceiling on the frame a raw IFD may claim, so a corrupt header
+/// cannot ask for an unbounded allocation. 512 M samples is an order
+/// of magnitude past the largest sensor shipped.
+const MAX_SAMPLES: usize = 1 << 29;
+
+/// Decode a DNG into its sensor frame and everything needed to
+/// develop it.
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let tiff = Tiff::parse(bytes)?;
+    check_version(&tiff)?;
+    let ifd = raw_ifd(&tiff)?;
+    let layout = ImageLayout::of(&tiff, ifd)?;
+
+    let (width, height) = (layout.width, layout.height);
+    let spp = layout.samples_per_pixel;
+    let (cpp, cfa) = match layout.photometric {
+        PHOTOMETRIC_CFA => {
+            if spp != 1 {
+                return Err(Error::Unsupported(format!(
+                    "DNG CFA image with {spp} samples a pixel"
+                )));
+            }
+            (1, cfa_pattern(ifd)?)
+        }
+        PHOTOMETRIC_LINEAR_RAW => {
+            // The container carries three samples a pixel and nothing
+            // else; `RawImage` has no room for a fourth plane.
+            if spp != 3 {
+                return Err(Error::Unsupported(format!(
+                    "DNG linear raw with {spp} samples a pixel"
+                )));
+            }
+            (3, Cfa::None)
+        }
+        other => return Err(Error::Unsupported(format!("DNG photometric {other}"))),
+    };
+
+    width
+        .checked_mul(height)
+        .and_then(|n| n.checked_mul(spp))
+        .filter(|n| *n > 0 && *n <= MAX_SAMPLES)
+        .ok_or_else(|| Error::Corrupt(format!("DNG raw IFD claims {width}x{height}x{spp}")))?;
+
+    reject_exotic_layout(ifd)?;
+    let bits = uniform_bits_per_sample(ifd, spp)?;
+    let data = decode_samples(&tiff, ifd, &layout, spp, bits)?;
+
+    let mut raw = RawImage::new(Format::Dng, width, height, cpp, data, cfa);
+    fill_metadata(&tiff, ifd, &mut raw, bits, spp);
+    raw.apply_camera_table();
+    // AsShotWhiteXY only becomes multipliers through a matrix, which
+    // the table may have supplied just now.
+    if raw.wb_coeffs == [1.0; 4] && raw.color_matrix.is_some() {
+        raw.wb_coeffs = white_balance(tiff.root(), ifd, raw.color_matrix.as_ref());
+    }
+    Ok(raw)
+}
+
+/// The largest embedded JPEG, without touching the sensor data.
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    let tiff = Tiff::parse(bytes)?;
+    Ok(common::largest_jpeg(&tiff))
+}
+
+// -------------------------------------------------------------------
+// Choosing the image
+// -------------------------------------------------------------------
+
+/// DNGBackwardVersion says the oldest reader that can still make sense
+/// of the file. Refusing anything newer than the specification this
+/// module was written from is the check the specification itself asks
+/// for, and it is the only thing that stops a future dialect from
+/// being silently mis-decoded.
+fn check_version(tiff: &Tiff<'_>) -> Result<()> {
+    let version = |tag| {
+        tiff.root().get(tag).map(|e| {
+            let byte = |i| e.u32(i).unwrap_or(0);
+            [byte(0), byte(1), byte(2), byte(3)]
+        })
+    };
+    let backward = version(tag::DNG_BACKWARD_VERSION)
+        .or_else(|| version(tags::DNG_VERSION))
+        .unwrap_or([1, 0, 0, 0]);
+    if backward > [1, 7, 0, 0] {
+        return Err(Error::Unsupported(format!(
+            "DNG needing a {}.{}.{}.{} reader",
+            backward[0], backward[1], backward[2], backward[3]
+        )));
+    }
+    Ok(())
+}
+
+/// The IFD holding sensor data: the largest one whose photometric says
+/// CFA or linear raw and which is not marked as a reduced-resolution
+/// copy. A DNG may hold several (an "enhanced" image beside the
+/// original, a depth map, semantic masks); the biggest raw plane is
+/// the main image, which is the only one this crate returns.
+fn raw_ifd<'a>(tiff: &'a Tiff<'_>) -> Result<&'a Ifd> {
+    let mut best: Option<(u64, &Ifd)> = None;
+    for ifd in tiff.all() {
+        let photometric = ifd.get(tags::PHOTOMETRIC).and_then(|e| e.u32(0));
+        if !matches!(photometric, Some(PHOTOMETRIC_CFA | PHOTOMETRIC_LINEAR_RAW)) {
+            continue;
+        }
+        // Bit 0 of NewSubfileType marks a reduced-resolution image.
+        // Nothing else in the word disqualifies an IFD: DNG 1.6 sets
+        // bit 16 on its enhanced image, which is still sensor data.
+        let kind = ifd
+            .get(tags::NEW_SUBFILE_TYPE)
+            .and_then(|e| e.u32(0))
+            .unwrap_or(0);
+        if kind & 1 != 0 {
+            continue;
+        }
+        let area = ifd
+            .get(tags::IMAGE_WIDTH)
+            .and_then(|e| e.u64(0))
+            .unwrap_or(0)
+            * ifd
+                .get(tags::IMAGE_LENGTH)
+                .and_then(|e| e.u64(0))
+                .unwrap_or(0);
+        if best.is_none_or(|(seen, _)| area > seen) {
+            best = Some((area, ifd));
+        }
+    }
+    best.map(|(_, ifd)| ifd)
+        .ok_or_else(|| Error::Unsupported("DNG with no CFA or linear-raw IFD".into()))
+}
+
+/// Two DNG 1.2 features that rearrange a tile's rows and pixels before
+/// they are laid down. Neither has ever been seen in a camera file and
+/// implementing them blind would be untestable, so a file that uses
+/// them is refused rather than decoded wrongly.
+fn reject_exotic_layout(ifd: &Ifd) -> Result<()> {
+    if ifd
+        .get(tags::PLANAR_CONFIGURATION)
+        .and_then(|e| e.u32(0))
+        .unwrap_or(1)
+        != 1
+    {
+        return Err(Error::Unsupported(
+            "DNG with planar (separated) samples".into(),
+        ));
+    }
+    if ifd
+        .get(tag::ROW_INTERLEAVE_FACTOR)
+        .and_then(|e| e.u32(0))
+        .unwrap_or(1)
+        != 1
+    {
+        return Err(Error::Unsupported("DNG with RowInterleaveFactor".into()));
+    }
+    if let Some(block) = ifd.get(tag::SUB_TILE_BLOCK_SIZE) {
+        if block.u32(0).unwrap_or(1) != 1 || block.u32(1).unwrap_or(1) != 1 {
+            return Err(Error::Unsupported("DNG with SubTileBlockSize".into()));
+        }
+    }
+    Ok(())
+}
+
+/// BitsPerSample, which must agree across the planes of a linear raw
+/// (the specification requires it and every file obeys).
+fn uniform_bits_per_sample(ifd: &Ifd, spp: usize) -> Result<u32> {
+    let entry = ifd
+        .get(tags::BITS_PER_SAMPLE)
+        .ok_or_else(|| Error::Corrupt("DNG raw IFD without BitsPerSample".into()))?;
+    let first = entry
+        .u32(0)
+        .ok_or_else(|| Error::Corrupt("DNG raw IFD with an unreadable BitsPerSample".into()))?;
+    for i in 1..spp.min(entry.count) {
+        if entry.u32(i) != Some(first) {
+            return Err(Error::Unsupported(
+                "DNG with unequal BitsPerSample per plane".into(),
+            ));
+        }
+    }
+    if first == 0 || first > 32 {
+        return Err(Error::Corrupt(format!("DNG with {first} bits a sample")));
+    }
+    Ok(first)
+}
+
+// -------------------------------------------------------------------
+// Sensor data
+// -------------------------------------------------------------------
+
+/// One decoded chunk, in the shape its own stream chose. `row_samples`
+/// is a whole row of the tile including every plane, which for a
+/// lossless-JPEG tile is the stream's width times its component count
+/// — a DNG encoder is free to split a tile's row across components
+/// however it likes, and they all do it differently.
+struct Tile<T> {
+    row_samples: usize,
+    rows: usize,
+    data: Vec<T>,
+}
+
+impl<T> Tile<T> {
+    fn new(data: Vec<T>, row_samples: usize, rows: usize) -> Result<Tile<T>> {
+        if row_samples == 0 || data.len() < row_samples * rows {
+            return Err(Error::Corrupt(format!(
+                "decoded chunk holds {} samples for {rows} rows of {row_samples}",
+                data.len()
+            )));
+        }
+        Ok(Tile {
+            row_samples,
+            rows,
+            data,
+        })
+    }
+}
+
+/// How the chunks of an image IFD tile the frame. TIFF strips are the
+/// degenerate case: full-width tiles `RowsPerStrip` tall.
+struct Grid {
+    tile_width: usize,
+    tile_height: usize,
+    across: usize,
+    down: usize,
+    /// Tiles are always encoded at their full size and clipped by the
+    /// reader; strips at the bottom hold only the rows that remain.
+    tiled: bool,
+}
+
+impl Grid {
+    fn of(layout: &ImageLayout) -> Result<Grid> {
+        let (tile_width, tile_height) = match layout.tile {
+            Some(tile) => tile,
+            None => (layout.width, layout.rows_per_chunk),
+        };
+        if tile_width == 0 || tile_height == 0 {
+            return Err(Error::Corrupt("DNG chunk of zero size".into()));
+        }
+        let across = layout.width.div_ceil(tile_width);
+        let down = layout.height.div_ceil(tile_height);
+        if across.saturating_mul(down) != layout.chunks.len() {
+            return Err(Error::Corrupt(format!(
+                "{} chunks for a {across}x{down} grid",
+                layout.chunks.len()
+            )));
+        }
+        Ok(Grid {
+            tile_width,
+            tile_height,
+            across,
+            down,
+            tiled: layout.tile.is_some(),
+        })
+    }
+}
+
+/// Decode every chunk and lay it into the full frame.
+///
+/// The frame is split into bands of `tile_height` rows and the bands
+/// run in parallel: tiles within a band are decoded by the thread that
+/// owns the rows they land in, so no tile is ever copied twice and the
+/// peak memory is one tile a thread rather than a second whole frame.
+fn assemble<T, F>(
+    bytes: &[u8],
+    layout: &ImageLayout,
+    grid: &Grid,
+    spp: usize,
+    decode: F,
+) -> Result<Vec<T>>
+where
+    T: Copy + Default + Send + Sync,
+    F: Fn(&[u8], usize, usize) -> Result<Tile<T>> + Sync,
+{
+    let (width, height) = (layout.width, layout.height);
+    let chunk_bytes = |index: usize| -> Result<&[u8]> {
+        let (offset, len) = layout.chunks[index];
+        bytes
+            .get(offset..offset + len)
+            .ok_or_else(|| Error::Corrupt("DNG chunk outside the file".into()))
+    };
+
+    // A single chunk that is the whole frame — the shape of nearly
+    // every strip-per-image raw IFD — is handed straight out.
+    if grid.across == 1 && grid.down == 1 {
+        let tile = decode(chunk_bytes(0)?, width, height)?;
+        if tile.row_samples == width * spp && tile.rows >= height {
+            let mut data = tile.data;
+            data.truncate(width * height * spp);
+            return Ok(data);
+        }
+        let mut frame = vec![T::default(); width * height * spp];
+        place(&mut frame, &tile, width, height, spp, 0, 0);
+        return Ok(frame);
+    }
+
+    let mut frame = vec![T::default(); width * height * spp];
+    let band = grid.tile_height * width * spp;
+    frame
+        .par_chunks_mut(band)
+        .enumerate()
+        .try_for_each(|(row, rows_of_frame)| -> Result<()> {
+            let top = row * grid.tile_height;
+            let rows_here = (height - top).min(grid.tile_height);
+            for column in 0..grid.across {
+                let left = column * grid.tile_width;
+                let cols_here = (width - left).min(grid.tile_width);
+                // A tile is padded out to its nominal size, a strip is
+                // not; the decoder is told which it is being handed.
+                let (nominal_cols, nominal_rows) = if grid.tiled {
+                    (grid.tile_width, grid.tile_height)
+                } else {
+                    (cols_here, rows_here)
+                };
+                let chunk = chunk_bytes(row * grid.across + column)?;
+                let tile = decode(chunk, nominal_cols, nominal_rows)?;
+                place(rows_of_frame, &tile, width, rows_here, spp, left, 0);
+            }
+            Ok(())
+        })?;
+    Ok(frame)
+}
+
+/// Copy a decoded tile into the frame at (`left`, `top`), clipping the
+/// right and bottom edges.
+fn place<T: Copy>(
+    frame: &mut [T],
+    tile: &Tile<T>,
+    frame_width: usize,
+    rows: usize,
+    spp: usize,
+    left: usize,
+    top: usize,
+) {
+    let keep = ((frame_width - left) * spp).min(tile.row_samples);
+    for row in 0..rows.min(tile.rows) {
+        let source = row * tile.row_samples;
+        let target = (top + row) * frame_width * spp + left * spp;
+        frame[target..target + keep].copy_from_slice(&tile.data[source..source + keep]);
+    }
+}
+
+/// The sensor samples, decompressed, linearized and in the crate's
+/// representation.
+fn decode_samples(
+    tiff: &Tiff<'_>,
+    ifd: &Ifd,
+    layout: &ImageLayout,
+    spp: usize,
+    bits: u32,
+) -> Result<RawData> {
+    let grid = Grid::of(layout)?;
+    let bytes = tiff.bytes();
+    let little_endian = tiff.little_endian();
+
+    // Floating-point samples are only handled through the deflate
+    // path; read as integers they would come out as bit patterns.
+    if float_samples(ifd, spp)?
+        && !matches!(
+            layout.compression,
+            compression::DEFLATE | compression::DEFLATE_OLD
+        )
+    {
+        return Err(Error::Unsupported(format!(
+            "floating-point DNG with compression {}",
+            layout.compression
+        )));
+    }
+    let mut frame = match layout.compression {
+        compression::NONE => assemble(bytes, layout, &grid, spp, |chunk, cols, rows| {
+            unpack(chunk, cols, rows, spp, bits, little_endian)
+        })?,
+        compression::LOSSLESS_JPEG => assemble(bytes, layout, &grid, spp, |chunk, cols, _rows| {
+            lossless_jpeg_tile(chunk, cols, spp)
+        })?,
+        compression::LOSSY_JPEG => assemble(bytes, layout, &grid, spp, |chunk, cols, rows| {
+            lossy_jpeg_tile(chunk, cols, rows, spp)
+        })?,
+        compression::DEFLATE | compression::DEFLATE_OLD => {
+            let predictor = Predictor::of(ifd, spp)?;
+            // A floating-point DNG keeps its samples as floats all the
+            // way out: they are already scaled (0 is black, 1 is
+            // white) and rounding them into 16 bits would throw away
+            // the range the format exists to carry.
+            if float_samples(ifd, spp)? {
+                let frame = assemble(bytes, layout, &grid, spp, |chunk, cols, rows| {
+                    deflate_float_tile(chunk, cols, rows, spp, bits, predictor, little_endian)
+                })?;
+                return Ok(RawData::F32(frame));
+            }
+            assemble(bytes, layout, &grid, spp, |chunk, cols, rows| {
+                deflate_int_tile(chunk, cols, rows, spp, bits, predictor, little_endian)
+            })?
+        }
+        compression::JPEG_XL => {
+            return Err(Error::Unsupported("DNG 1.7 JPEG XL compression".into()))
+        }
+        compression::VC5 => {
+            return Err(Error::Unsupported(
+                "GoPro GPR: a DNG whose raw IFD is a VC-5 wavelet stream".into(),
+            ))
+        }
+        other => return Err(Error::Unsupported(format!("DNG compression {other}"))),
+    };
+
+    linearize(ifd, &mut frame);
+    Ok(RawData::U16(frame))
+}
+
+/// SampleFormat (339): 1 unsigned, 2 signed, 3 IEEE float. It must
+/// agree across the planes.
+fn float_samples(ifd: &Ifd, spp: usize) -> Result<bool> {
+    let Some(entry) = ifd.get(tag::SAMPLE_FORMAT) else {
+        return Ok(false);
+    };
+    let first = entry.u32(0).unwrap_or(1);
+    for i in 1..spp.min(entry.count) {
+        if entry.u32(i) != Some(first) {
+            return Err(Error::Unsupported("DNG with mixed SampleFormats".into()));
+        }
+    }
+    match first {
+        1 => Ok(false),
+        3 => Ok(true),
+        other => Err(Error::Unsupported(format!("DNG SampleFormat {other}"))),
+    }
+}
+
+/// Uncompressed samples, packed most-significant-bit first.
+///
+/// The bit order does not follow the file's byte order: DNG packs the
+/// bits of successive samples into successive bytes from the top bit
+/// down whichever way round the TIFF is, and each row restarts on a
+/// byte boundary. Only 8- and 16-bit samples are whole bytes and so
+/// the only ones the byte order touches.
+fn unpack(
+    chunk: &[u8],
+    cols: usize,
+    rows: usize,
+    spp: usize,
+    bits: u32,
+    little_endian: bool,
+) -> Result<Tile<u16>> {
+    if bits > 16 {
+        return Err(Error::Unsupported(format!(
+            "uncompressed DNG with {bits}-bit samples"
+        )));
+    }
+    let row_samples = cols
+        .checked_mul(spp)
+        .filter(|n| *n > 0)
+        .ok_or_else(|| Error::Corrupt("DNG chunk of zero width".into()))?;
+    let row_bytes = (row_samples * bits as usize).div_ceil(8);
+    let needed = row_bytes
+        .checked_mul(rows)
+        .ok_or_else(|| Error::Corrupt("DNG chunk larger than memory".into()))?;
+    if chunk.len() < needed {
+        return Err(Error::Corrupt(format!(
+            "uncompressed DNG chunk holds {} bytes, needs {needed}",
+            chunk.len()
+        )));
+    }
+
+    let mut data = vec![0u16; row_samples * rows];
+    for (row, out) in data.chunks_exact_mut(row_samples).enumerate() {
+        let source = &chunk[row * row_bytes..row * row_bytes + row_bytes];
+        match bits {
+            8 => {
+                for (sample, byte) in out.iter_mut().zip(source) {
+                    *sample = *byte as u16;
+                }
+            }
+            16 => {
+                let (pairs, _) = source.as_chunks::<2>();
+                for (sample, pair) in out.iter_mut().zip(pairs) {
+                    *sample = if little_endian {
+                        u16::from_le_bytes(*pair)
+                    } else {
+                        u16::from_be_bytes(*pair)
+                    };
+                }
+            }
+            _ => {
+                let mut pump = BitPumpMsb::new(source);
+                for sample in out.iter_mut() {
+                    *sample = pump.get(bits) as u16;
+                }
+            }
+        }
+    }
+    Tile::new(data, row_samples, rows)
+}
+
+/// One lossless-JPEG chunk.
+///
+/// The stream's own idea of its width and component count need not
+/// match the tile's: encoders halve the width and use two components
+/// so that a Bayer row's two colours are predicted from their own
+/// kind, and a linear raw uses three components at full width. The
+/// decoder hands back samples in stream order, which is exactly the
+/// tile's row order either way, so all that matters is that a row of
+/// the stream is a row of the tile.
+fn lossless_jpeg_tile(chunk: &[u8], cols: usize, spp: usize) -> Result<Tile<u16>> {
+    // The frame header first: a stream claiming a frame far larger
+    // than the tile would otherwise be decoded (and allocated) in full
+    // before the mismatch was noticed, on every rayon thread at once.
+    let image = ljpeg::header(chunk)?;
+    let row_samples = image
+        .width
+        .checked_mul(image.components)
+        .ok_or_else(|| Error::Corrupt("lossless JPEG frame larger than memory".into()))?;
+    if row_samples != cols * spp {
+        return Err(Error::Corrupt(format!(
+            "lossless JPEG tile is {} samples a row, the DNG tile is {}",
+            row_samples,
+            cols * spp
+        )));
+    }
+    let image = ljpeg::decode(chunk)?;
+    Tile::new(image.data, row_samples, image.height)
+}
+
+/// One baseline-JPEG chunk of a lossy DNG. The samples are eight bits
+/// and the LinearizationTable (which such a file always carries) puts
+/// them back on the sensor's scale afterwards.
+fn lossy_jpeg_tile(chunk: &[u8], cols: usize, rows: usize, spp: usize) -> Result<Tile<u16>> {
+    use image::ImageDecoder;
+    let decoder = image::codecs::jpeg::JpegDecoder::new(Cursor::new(chunk))
+        .map_err(|e| Error::Corrupt(format!("lossy DNG tile is not a JPEG: {e}")))?;
+    let (width, height) = decoder.dimensions();
+    let channels = match decoder.color_type() {
+        image::ColorType::L8 => 1,
+        image::ColorType::Rgb8 => 3,
+        other => return Err(Error::Unsupported(format!("lossy DNG tile in {other:?}"))),
+    };
+    if channels != spp {
+        return Err(Error::Corrupt(format!(
+            "lossy DNG tile has {channels} channels, the IFD says {spp}"
+        )));
+    }
+    let total = decoder.total_bytes();
+    if total > (1 << 30) {
+        return Err(Error::Corrupt("lossy DNG tile larger than memory".into()));
+    }
+    let mut buffer = vec![0u8; total as usize];
+    decoder
+        .read_image(&mut buffer)
+        .map_err(|e| Error::Corrupt(format!("lossy DNG tile: {e}")))?;
+    let (width, height) = (width as usize, height as usize);
+    if width != cols || height == 0 || height > rows {
+        return Err(Error::Corrupt(format!(
+            "lossy DNG tile decodes {width}x{height} for a {cols}x{rows} tile"
+        )));
+    }
+    let data: Vec<u16> = buffer.into_iter().map(u16::from).collect();
+    Tile::new(data, width * channels, height)
+}
+
+/// The horizontal predictor a deflated chunk was written with (tag
+/// 317).
+///
+/// TIFF has 1 (none) and 2, where a sample is stored as its difference
+/// from the one `SamplesPerPixel` earlier in the row. TIFF Technical
+/// Note 3 adds 3 for floating point, which first splits every sample
+/// into byte planes — all the high bytes of a row, then all the next
+/// bytes, and so on — because a row of floats has near-constant
+/// exponents and wildly varying mantissas, and deflate only finds the
+/// pattern once they are separated. DNG 1.4 adds four more that widen
+/// the differencing stride to two or four pixels so a Bayer row
+/// differences red against red and green against green.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Predictor {
+    None,
+    /// Differencing over whole samples, `n` pixels apart.
+    Horizontal(usize),
+    /// Byte planes, differenced `n` pixels apart within a plane.
+    FloatingPoint(usize),
+}
+
+impl Predictor {
+    fn of(ifd: &Ifd, spp: usize) -> Result<Predictor> {
+        let value = ifd.get(tag::PREDICTOR).and_then(|e| e.u32(0)).unwrap_or(1);
+        Ok(match value {
+            1 => Predictor::None,
+            2 => Predictor::Horizontal(spp),
+            3 => Predictor::FloatingPoint(spp),
+            34892 => Predictor::Horizontal(2 * spp),
+            34893 => Predictor::Horizontal(4 * spp),
+            34894 => Predictor::FloatingPoint(2 * spp),
+            34895 => Predictor::FloatingPoint(4 * spp),
+            other => return Err(Error::Unsupported(format!("DNG predictor {other}"))),
+        })
+    }
+}
+
+/// Inflate one chunk, refusing to produce more than the frame can
+/// hold: a deflate stream can expand a thousandfold and a hostile file
+/// would happily ask it to.
+fn inflate(chunk: &[u8], needed: usize) -> Result<Vec<u8>> {
+    let limit = needed.saturating_add(4096);
+    let out = miniz_oxide::inflate::decompress_to_vec_zlib_with_limit(chunk, limit)
+        .map_err(|e| Error::Corrupt(format!("deflated DNG chunk: {:?}", e.status)))?;
+    if out.len() < needed {
+        return Err(Error::Corrupt(format!(
+            "deflated DNG chunk inflates to {} bytes, needs {needed}",
+            out.len()
+        )));
+    }
+    Ok(out)
+}
+
+/// The bytes a row of `row_samples` samples occupies, or an error when
+/// the arithmetic overflows.
+fn row_bytes(row_samples: usize, rows: usize, width: usize) -> Result<(usize, usize)> {
+    let row = row_samples
+        .checked_mul(width)
+        .ok_or_else(|| Error::Corrupt("DNG chunk larger than memory".into()))?;
+    let total = row
+        .checked_mul(rows)
+        .ok_or_else(|| Error::Corrupt("DNG chunk larger than memory".into()))?;
+    Ok((row, total))
+}
+
+/// Undo horizontal differencing over 8- or 16-bit samples. The sums
+/// wrap: the encoder took them modulo the sample width.
+fn undo_horizontal_u8(row: &mut [u8], stride: usize) {
+    for i in stride..row.len() {
+        row[i] = row[i].wrapping_add(row[i - stride]);
+    }
+}
+
+fn undo_horizontal_u16(row: &mut [u16], stride: usize) {
+    for i in stride..row.len() {
+        row[i] = row[i].wrapping_add(row[i - stride]);
+    }
+}
+
+/// A deflated chunk of integer samples.
+fn deflate_int_tile(
+    chunk: &[u8],
+    cols: usize,
+    rows: usize,
+    spp: usize,
+    bits: u32,
+    predictor: Predictor,
+    little_endian: bool,
+) -> Result<Tile<u16>> {
+    let width = match bits {
+        8 => 1usize,
+        16 => 2,
+        // A 32-bit integer sample has nowhere to go: `RawData` holds
+        // 16-bit integers or floats and nothing between.
+        32 => {
+            return Err(Error::Unsupported(
+                "deflated DNG with 32-bit integer samples".into(),
+            ))
+        }
+        other => {
+            return Err(Error::Unsupported(format!(
+                "deflated DNG with {other}-bit integer samples"
+            )))
+        }
+    };
+    let stride = match predictor {
+        Predictor::None => 0,
+        Predictor::Horizontal(n) => n,
+        Predictor::FloatingPoint(_) => {
+            return Err(Error::Corrupt(
+                "DNG uses a floating-point predictor on integer samples".into(),
+            ))
+        }
+    };
+    let row_samples = cols
+        .checked_mul(spp)
+        .filter(|n| *n > 0)
+        .ok_or_else(|| Error::Corrupt("DNG chunk of zero width".into()))?;
+    let (row_len, needed) = row_bytes(row_samples, rows, width)?;
+    let mut source = inflate(chunk, needed)?;
+
+    let mut data = vec![0u16; row_samples * rows];
+    for (row, out) in data.chunks_exact_mut(row_samples).enumerate() {
+        let bytes = &mut source[row * row_len..row * row_len + row_len];
+        if width == 1 {
+            if stride > 0 {
+                undo_horizontal_u8(bytes, stride);
+            }
+            for (sample, byte) in out.iter_mut().zip(bytes.iter()) {
+                *sample = *byte as u16;
+            }
+        } else {
+            let (pairs, _) = bytes.as_chunks::<2>();
+            for (sample, pair) in out.iter_mut().zip(pairs) {
+                *sample = if little_endian {
+                    u16::from_le_bytes(*pair)
+                } else {
+                    u16::from_be_bytes(*pair)
+                };
+            }
+            if stride > 0 {
+                undo_horizontal_u16(out, stride);
+            }
+        }
+    }
+    Tile::new(data, row_samples, rows)
+}
+
+/// A deflated chunk of floating-point samples: DNG 1.4's half, 24-bit
+/// and single precision.
+///
+/// The byte planes are written most significant first, so a sample is
+/// rebuilt by reading one byte from each plane in turn; that ordering
+/// is the same whichever way round the TIFF is, and only an unshuffled
+/// (predictor 1) chunk is stored in the file's byte order.
+fn deflate_float_tile(
+    chunk: &[u8],
+    cols: usize,
+    rows: usize,
+    spp: usize,
+    bits: u32,
+    predictor: Predictor,
+    little_endian: bool,
+) -> Result<Tile<f32>> {
+    let width = match bits {
+        16 => 2usize,
+        24 => 3,
+        32 => 4,
+        other => {
+            return Err(Error::Unsupported(format!(
+                "DNG with {other}-bit floating-point samples"
+            )))
+        }
+    };
+    let row_samples = cols
+        .checked_mul(spp)
+        .filter(|n| *n > 0)
+        .ok_or_else(|| Error::Corrupt("DNG chunk of zero width".into()))?;
+    let (row_len, needed) = row_bytes(row_samples, rows, width)?;
+    let mut source = inflate(chunk, needed)?;
+
+    let mut data = vec![0f32; row_samples * rows];
+    for (row, out) in data.chunks_exact_mut(row_samples).enumerate() {
+        let bytes = &mut source[row * row_len..row * row_len + row_len];
+        match predictor {
+            Predictor::FloatingPoint(stride) => {
+                undo_horizontal_u8(bytes, stride.max(1));
+                // Plane `p` holds byte `p`, counting from the most
+                // significant, of every sample in the row.
+                for (index, sample) in out.iter_mut().enumerate() {
+                    let mut value = 0u32;
+                    for plane in 0..width {
+                        value = (value << 8) | bytes[plane * row_samples + index] as u32;
+                    }
+                    *sample = float_sample(value, width);
+                }
+            }
+            Predictor::None => {
+                for (index, sample) in out.iter_mut().enumerate() {
+                    let at = index * width;
+                    let mut value = 0u32;
+                    for byte in 0..width {
+                        let position = if little_endian {
+                            width - 1 - byte
+                        } else {
+                            byte
+                        };
+                        value = (value << 8) | bytes[at + position] as u32;
+                    }
+                    *sample = float_sample(value, width);
+                }
+            }
+            Predictor::Horizontal(_) => {
+                return Err(Error::Corrupt(
+                    "DNG uses an integer predictor on floating-point samples".into(),
+                ))
+            }
+        }
+    }
+    Tile::new(data, row_samples, rows)
+}
+
+/// A 16-, 24- or 32-bit float, as its bits, widened to `f32`.
+///
+/// The 24-bit form is DNG's own: one sign bit, eight exponent bits and
+/// fifteen of mantissa. Its exponent is already `f32`'s, so widening
+/// is a shift. Half precision has a five-bit exponent with its own
+/// bias and needs the arithmetic.
+fn float_sample(value: u32, width: usize) -> f32 {
+    match width {
+        2 => half_to_f32(value as u16),
+        3 => f32::from_bits(value << 8),
+        _ => f32::from_bits(value),
+    }
+}
+
+fn half_to_f32(half: u16) -> f32 {
+    let sign = (half as u32 & 0x8000) << 16;
+    let exponent = (half as u32 >> 10) & 0x1F;
+    let mantissa = half as u32 & 0x3FF;
+    f32::from_bits(match exponent {
+        // Zero and the subnormals, which `f32` can all represent
+        // normally once the leading one is found and shifted up.
+        0 if mantissa == 0 => sign,
+        0 => {
+            let top = 31 - mantissa.leading_zeros();
+            sign | ((103 + top) << 23) | ((mantissa & !(1 << top)) << (23 - top))
+        }
+        // Infinity and NaN keep their payload.
+        31 => sign | 0x7F80_0000 | (mantissa << 13),
+        _ => sign | ((exponent + 127 - 15) << 23) | (mantissa << 13),
+    })
+}
+
+/// Apply the LinearizationTable (0xC618): the sensor's response curve,
+/// as a lookup from the stored sample to a linear one. Values past the
+/// end of the table take its last entry, which is what the
+/// specification says a short table means.
+fn linearize(ifd: &Ifd, frame: &mut [u16]) {
+    let Some(entry) = ifd.get(tag::LINEARIZATION_TABLE) else {
+        return;
+    };
+    let table: Vec<u16> = entry
+        .u32s()
+        .into_iter()
+        .map(|v| v.min(65535) as u16)
+        .collect();
+    let Some(&last) = table.last() else {
+        return;
+    };
+    frame
+        .par_iter_mut()
+        .for_each(|sample| *sample = *table.get(*sample as usize).unwrap_or(&last));
+}
+
+// -------------------------------------------------------------------
+// Metadata
+// -------------------------------------------------------------------
+
+fn fill_metadata(tiff: &Tiff<'_>, ifd: &Ifd, raw: &mut RawImage, bits: u32, spp: usize) {
+    let (make, model) = tiff.make_model();
+    // A DNG written by something that is not a camera may leave Make
+    // and Model empty; UniqueCameraModel is mandatory and names the
+    // body the profile belongs to.
+    let unique = tiff
+        .root()
+        .get(tag::UNIQUE_CAMERA_MODEL)
+        .and_then(|e| e.str())
+        .unwrap_or("");
+    if model.is_empty() {
+        raw.set_camera(&make, unique);
+    } else {
+        raw.set_camera(&make, &model);
+    }
+
+    // A floating-point DNG is already scaled: 0 is black and 1.0 is
+    // the saturation point unless the file says otherwise.
+    let float = matches!(raw.data, RawData::F32(_));
+    let (black, white) = levels(ifd, bits, spp, float);
+    raw.black_levels = black;
+    raw.white_level = white;
+    raw.color_matrix = color_matrix(tiff.root());
+    raw.wb_coeffs = white_balance(tiff.root(), ifd, raw.color_matrix.as_ref());
+    raw.crop = crop(ifd, raw.width, raw.height);
+    raw.orientation = common::orientation(tiff);
+    raw.preview = common::largest_jpeg(tiff);
+    raw.metadata = common::metadata(tiff);
+    note_opcodes(ifd);
+}
+
+/// BlackLevel (0xC61A) folded onto the 2x2 the crate carries, and
+/// WhiteLevel (0xC61D).
+///
+/// BlackLevel repeats over a `BlackLevelRepeatDim` (0xC619) block of
+/// rows by columns, with one value per plane inside each cell. A 1x1
+/// or 2x2 block maps straight onto the crate's four positions; a
+/// larger block (nothing in the wild writes one, but the format allows
+/// up to 65535) is averaged down, which loses the fine structure and
+/// is noted here rather than silently.
+///
+/// BlackLevelDeltaH/V (0xC61B/C) add a per-column and per-row offset on
+/// top. They are ignored: the crate's black level is a single number
+/// per CFA position and there is nowhere to put a per-row curve. No
+/// file in the sample corpus carries either tag.
+fn levels(ifd: &Ifd, bits: u32, spp: usize, float: bool) -> ([f32; 4], f32) {
+    let (rows, columns) = match ifd.get(tag::BLACK_LEVEL_REPEAT_DIM) {
+        Some(entry) => (
+            entry.u32(0).unwrap_or(1).max(1) as usize,
+            entry.u32(1).unwrap_or(1).max(1) as usize,
+        ),
+        None => (1, 1),
+    };
+    let mut black = [0.0f32; 4];
+    if let Some(entry) = ifd.get(tag::BLACK_LEVEL) {
+        let at = |row: usize, column: usize, plane: usize| -> Option<f32> {
+            entry
+                .f64((row * columns + column) * spp + plane)
+                .map(|v| v as f32)
+        };
+        if spp > 1 {
+            // Linear raw: one black level a plane, averaged over the
+            // repeat block. The fourth slot is unused.
+            for (plane, level) in black.iter_mut().enumerate().take(spp.min(4)) {
+                let mut sum = 0.0;
+                let mut count = 0.0;
+                for row in 0..rows {
+                    for column in 0..columns {
+                        if let Some(v) = at(row, column, plane) {
+                            sum += v;
+                            count += 1.0;
+                        }
+                    }
+                }
+                if count > 0.0 {
+                    *level = sum / count;
+                }
+            }
+        } else {
+            for (position, level) in black.iter_mut().enumerate() {
+                let (want_row, want_column) = (position / 2, position % 2);
+                let mut sum = 0.0;
+                let mut count = 0.0;
+                for row in 0..rows {
+                    for column in 0..columns {
+                        // A block whose sides are both even lines up
+                        // with the 2x2; anything else is averaged
+                        // whole, since its phase cannot be expressed.
+                        // A side of one applies to both phases;
+                        // an even side lines up with the 2x2.
+                        let aligned =
+                            (rows == 1 || rows % 2 == 0) && (columns == 1 || columns % 2 == 0);
+                        if aligned
+                            && ((rows > 1 && row % 2 != want_row)
+                                || (columns > 1 && column % 2 != want_column))
+                        {
+                            continue;
+                        }
+                        if let Some(v) = at(row, column, 0) {
+                            sum += v;
+                            count += 1.0;
+                        }
+                    }
+                }
+                if count > 0.0 {
+                    *level = sum / count;
+                }
+            }
+        }
+        if rows > 2 || columns > 2 {
+            log::debug!("DNG BlackLevelRepeatDim {rows}x{columns} averaged onto a 2x2");
+        }
+    }
+    if ifd.has(tag::BLACK_LEVEL_DELTA_H) || ifd.has(tag::BLACK_LEVEL_DELTA_V) {
+        log::debug!("DNG BlackLevelDeltaH/V ignored: no per-row black level here");
+    }
+
+    // WhiteLevel is per plane. One number has to serve, and the
+    // brightest plane is the safe one: clipping is decided against it
+    // and a lower value would call unclipped highlights blown.
+    let default = if float {
+        1.0
+    } else if ifd.has(tag::LINEARIZATION_TABLE) {
+        // With a linearization table the samples come out on the
+        // table's scale, so the default saturation is its top entry.
+        ifd.get(tag::LINEARIZATION_TABLE)
+            .and_then(|e| e.u32s().into_iter().max())
+            .unwrap_or(65535) as f32
+    } else {
+        ((1u32 << bits.min(16)) - 1) as f32
+    };
+    let white = ifd
+        .get(tag::WHITE_LEVEL)
+        .map(|entry| {
+            (0..entry.count.max(1))
+                .filter_map(|i| entry.f64(i))
+                .fold(0.0f64, f64::max) as f32
+        })
+        .filter(|v| *v > 0.0)
+        .unwrap_or(default);
+    (black, white)
+}
+
+/// AsShotNeutral (0xC628) inverted into R, G, B, G2 multipliers with
+/// green at 1.0 — the same convention LibRaw's `cam_mul` uses.
+///
+/// AsShotWhiteXY (0xC629) is the alternative (Pixel phones write it):
+/// the white point as an xy chromaticity. The camera's response to
+/// that white is the XYZ→camera matrix applied to its XYZ (Y = 1), and
+/// the multipliers are the inverse of that response — the spec's
+/// AsShotNeutral computed on the spot. The matrix is the one already
+/// chosen for the file; the spec would interpolate between the two
+/// calibrations at that white point, which moves the answer by a
+/// percent or two and is left for a developer stage. Without a matrix
+/// the file keeps unit white balance.
+fn white_balance(root: &Ifd, ifd: &Ifd, xyz_to_camera: Option<&[[f32; 3]; 3]>) -> [f32; 4] {
+    let neutral = root
+        .get(tag::AS_SHOT_NEUTRAL)
+        .or_else(|| ifd.get(tag::AS_SHOT_NEUTRAL));
+    let Some(entry) = neutral else {
+        let xy = root
+            .get(tag::AS_SHOT_WHITE_XY)
+            .or_else(|| ifd.get(tag::AS_SHOT_WHITE_XY));
+        return match (xy, xyz_to_camera) {
+            (Some(xy), Some(m)) => {
+                let (x, y) = (
+                    xy.f64(0).unwrap_or(0.0) as f32,
+                    xy.f64(1).unwrap_or(0.0) as f32,
+                );
+                if !(x > 0.0 && y > 0.0 && x + y < 1.0) {
+                    return [1.0; 4];
+                }
+                let xyz = [x / y, 1.0, (1.0 - x - y) / y];
+                let response: [f32; 3] =
+                    std::array::from_fn(|c| m[c][0] * xyz[0] + m[c][1] * xyz[1] + m[c][2] * xyz[2]);
+                let (red, green, blue) = (response[0], response[1], response[2]);
+                if !(red > 0.0 && green > 0.0 && blue > 0.0) {
+                    return [1.0; 4];
+                }
+                [green / red, 1.0, green / blue, 1.0]
+            }
+            (Some(_), None) => {
+                log::debug!(
+                    "DNG carries AsShotWhiteXY but no colour matrix: white balance left at unity"
+                );
+                [1.0; 4]
+            }
+            _ => [1.0; 4],
+        };
+    };
+    let value = |i: usize| entry.f64(i).unwrap_or(0.0) as f32;
+    let (red, green, blue) = (value(0), value(1), value(2));
+    if !(red > 0.0 && green > 0.0 && blue > 0.0) {
+        return [1.0; 4];
+    }
+    // 1/neutral, then scaled so green is exactly one.
+    let second_green = if entry.count > 3 && value(3) > 0.0 {
+        green / value(3)
+    } else {
+        1.0
+    };
+    [green / red, 1.0, green / blue, second_green]
+}
+
+/// The XYZ-to-camera matrix, as the file stores it.
+///
+/// A DNG carries one or two ColorMatrix tags with the illuminant each
+/// was measured under. A developer that wanted to be exact would
+/// interpolate between them at the shot's own white point; this crate
+/// hands out a single matrix, so it picks the one measured nearest
+/// daylight — D65 exactly where there is one, otherwise whichever
+/// illuminant's colour temperature is closest to D65's 6504 K, which
+/// puts D50 ahead of standard light A by a wide margin.
+fn color_matrix(root: &Ifd) -> Option<[[f32; 3]; 3]> {
+    let read = |tag: u16| -> Option<[[f32; 3]; 3]> {
+        let entry = root.get(tag)?;
+        if entry.count < 9 {
+            return None;
+        }
+        let mut matrix = [[0.0f32; 3]; 3];
+        for (row, out) in matrix.iter_mut().enumerate() {
+            for (column, cell) in out.iter_mut().enumerate() {
+                *cell = entry.f64(row * 3 + column)? as f32;
+            }
+        }
+        Some(matrix)
+    };
+    let first = read(tag::COLOR_MATRIX_1);
+    let second = read(tag::COLOR_MATRIX_2);
+    let illuminant = |tag: u16| root.get(tag).and_then(|e| e.u32(0)).unwrap_or(0);
+    match (first, second) {
+        (Some(first), Some(second)) => {
+            let one = illuminant(tag::CALIBRATION_ILLUMINANT_1);
+            let two = illuminant(tag::CALIBRATION_ILLUMINANT_2);
+            Some(if daylight_rank(two) < daylight_rank(one) {
+                second
+            } else {
+                first
+            })
+        }
+        (Some(only), None) | (None, Some(only)) => Some(only),
+        (None, None) => None,
+    }
+}
+
+/// How far an EXIF LightSource code sits from D65, in kelvin. An
+/// illuminant with no known temperature ranks worse than any that has
+/// one.
+fn daylight_rank(illuminant: u32) -> f32 {
+    const D65: f32 = 6504.0;
+    let temperature = match illuminant {
+        1 | 9 | 10 => 6504.0, // Daylight, fine weather, cloudy
+        2 => 4230.0,          // Fluorescent, an average of the tubes
+        3 => 2856.0,          // Tungsten
+        4 => 5500.0,          // Flash
+        11 => 7504.0,         // Shade
+        12 => 6430.0,         // Daylight fluorescent, D 5700-7100
+        13 => 5000.0,         // Day white fluorescent, N 4600-5400
+        14 => 4200.0,         // Cool white fluorescent, W 3900-4500
+        15 => 3450.0,         // White fluorescent, WW 3200-3700
+        16 => 2940.0,         // Warm white fluorescent, L 2600-3250
+        17 => 2856.0,         // Standard light A
+        18 => 4874.0,         // Standard light B
+        19 => 6774.0,         // Standard light C
+        20 => 5503.0,         // D55
+        21 => 6504.0,         // D65
+        22 => 7504.0,         // D75
+        23 => 5003.0,         // D50
+        24 => 3200.0,         // ISO studio tungsten
+        _ => return f32::INFINITY,
+    };
+    (temperature - D65).abs()
+}
+
+/// The area worth showing: ActiveArea (0xC68D) minus the masked
+/// borders, then DefaultCropOrigin/Size (0xC61F/0xC620) inside it.
+///
+/// The default crop is measured from the top-left of the *active*
+/// area, not of the frame, so the two compose. Both crop tags may be
+/// rational — a DNG may crop on a half pixel — and are rounded to the
+/// sensor grid here.
+fn crop(ifd: &Ifd, width: usize, height: usize) -> Rect {
+    let (mut x, mut y, mut w, mut h) = (0usize, 0usize, width, height);
+    if let Some(entry) = ifd.get(tag::ACTIVE_AREA) {
+        // top, left, bottom, right.
+        let get = |i: usize| entry.u32(i).map(|v| v as usize);
+        if let (Some(top), Some(left), Some(bottom), Some(right)) = (get(0), get(1), get(2), get(3))
+        {
+            if left < right && top < bottom && right <= width && bottom <= height {
+                x = left;
+                y = top;
+                w = right - left;
+                h = bottom - top;
+            }
+        }
+    }
+    let rational = |tag: u16, i: usize| ifd.get(tag).and_then(|e| e.f64(i));
+    if let (Some(dx), Some(dy)) = (
+        rational(tag::DEFAULT_CROP_ORIGIN, 0),
+        rational(tag::DEFAULT_CROP_ORIGIN, 1),
+    ) {
+        x += dx.max(0.0).round() as usize;
+        y += dy.max(0.0).round() as usize;
+    }
+    if let (Some(cw), Some(ch)) = (
+        rational(tag::DEFAULT_CROP_SIZE, 0),
+        rational(tag::DEFAULT_CROP_SIZE, 1),
+    ) {
+        w = cw.max(1.0).round() as usize;
+        h = ch.max(1.0).round() as usize;
+    }
+    // A file whose tags do not agree with its own dimensions still has
+    // to produce a rectangle inside the frame.
+    x = x.min(width.saturating_sub(1));
+    y = y.min(height.saturating_sub(1));
+    Rect {
+        x,
+        y,
+        width: w.clamp(1, width - x),
+        height: h.clamp(1, height - y),
+    }
+}
+
+/// CFAPattern (0x828E) over CFARepeatPatternDim (0x828D), with the
+/// plane-to-colour mapping from CFAPlaneColor (0xC616).
+///
+/// CFAPattern's entries are indices into CFAPlaneColor rather than
+/// colours: `[0, 1, 1, 2]` with the default plane colours is RGGB, but
+/// a sensor that ordered its planes differently would say so. The
+/// pattern is anchored at the top-left of the IFD's image data, which
+/// is where this crate wants it; the specification requires the active
+/// area to start on an even row and column, so a reader that anchored
+/// it at the active area instead would get the same answer (and every
+/// file in the corpus does start even).
+fn cfa_pattern(ifd: &Ifd) -> Result<Cfa> {
+    if ifd.get(tag::CFA_LAYOUT).and_then(|e| e.u32(0)).unwrap_or(1) != 1 {
+        return Err(Error::Unsupported(
+            "DNG with a staggered (non-rectangular) CFA layout".into(),
+        ));
+    }
+    let dim = ifd.get(tags::CFA_REPEAT_PATTERN_DIM);
+    let (rows, columns) = match dim {
+        Some(entry) => (
+            entry.u32(0).unwrap_or(2) as usize,
+            entry.u32(1).unwrap_or(2) as usize,
+        ),
+        None => (2, 2),
+    };
+    let pattern = ifd
+        .get(tags::CFA_PATTERN)
+        .and_then(|e| e.bytes())
+        .ok_or_else(|| Error::Corrupt("DNG CFA image without CFAPattern".into()))?;
+    if rows == 0 || columns == 0 || rows > 8 || columns > 8 || pattern.len() < rows * columns {
+        return Err(Error::Corrupt(format!(
+            "DNG CFA pattern of {rows}x{columns} in {} bytes",
+            pattern.len()
+        )));
+    }
+    let planes: Vec<u32> = ifd
+        .get(tag::CFA_PLANE_COLOR)
+        .map(|e| e.u32s())
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| vec![0, 1, 2]);
+
+    let mut colors = Vec::with_capacity(rows * columns);
+    for index in &pattern[..rows * columns] {
+        let plane = planes
+            .get(*index as usize)
+            .copied()
+            .unwrap_or(*index as u32);
+        colors.push(match plane {
+            0 => CfaColor::Red,
+            1 => CfaColor::Green,
+            2 => CfaColor::Blue,
+            3 => CfaColor::Cyan,
+            4 => CfaColor::Magenta,
+            5 => CfaColor::Yellow,
+            // 6 is white: a panchromatic photosite, which the develop
+            // pipeline has no way to demosaic.
+            6 => {
+                return Err(Error::Unsupported(
+                    "DNG with a white (panchromatic) CFA plane".into(),
+                ))
+            }
+            other => {
+                return Err(Error::Corrupt(format!("DNG CFA plane colour {other}")));
+            }
+        });
+    }
+    Ok(match (rows, columns) {
+        (2, 2) => Cfa::Bayer([colors[0], colors[1], colors[2], colors[3]]),
+        (6, 6) => Cfa::XTrans(std::array::from_fn(|y| {
+            std::array::from_fn(|x| colors[y * 6 + x])
+        })),
+        _ => Cfa::Pattern {
+            width: columns,
+            height: rows,
+            colors,
+        },
+    })
+}
+
+/// The opcode lists (0xC740/1/2) are read far enough to say what is in
+/// them and no further.
+///
+/// They are per-file image corrections — DNG 1.3's WarpRectilinear and
+/// FixVignetteRadial, DNG 1.4's GainMap — that a developer is supposed
+/// to run at the stage the list's number names (1 before
+/// linearization, 2 after, 3 after demosaic). This crate applies none
+/// of them. The one that matters in practice is GainMap, which several
+/// phone DNGs use to flatten lens shading: without it the corners of a
+/// Pixel or Samsung frame stay darker than the camera intended. The
+/// data is left in the file for a future developer stage rather than
+/// baked into the sensor samples, which would make them no longer the
+/// camera's own.
+fn note_opcodes(ifd: &Ifd) {
+    for (tag, list) in [
+        (tag::OPCODE_LIST_1, 1),
+        (tag::OPCODE_LIST_2, 2),
+        (tag::OPCODE_LIST_3, 3),
+    ] {
+        let Some(bytes) = ifd.get(tag).and_then(|e| e.bytes()) else {
+            continue;
+        };
+        // An opcode list is a big-endian count followed by, for each
+        // opcode, its id, the DNG version it needs, flags, and the
+        // length of its parameters. Walking that much is enough to
+        // name them in a log line.
+        let word = |at: usize| -> Option<u32> {
+            bytes
+                .get(at..at + 4)
+                .map(|b| u32::from_be_bytes([b[0], b[1], b[2], b[3]]))
+        };
+        let Some(count) = word(0) else { continue };
+        let mut ids = Vec::new();
+        let mut at = 4;
+        for _ in 0..count.min(64) {
+            let (Some(id), Some(size)) = (word(at), word(at + 12)) else {
+                break;
+            };
+            ids.push(id);
+            at += 16 + size as usize;
+        }
+        log::debug!("DNG OpcodeList{list} not applied: opcodes {ids:?}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    // ---------------------------------------------------------------
+    // A DNG written by hand, so the tests exercise exactly the bytes a
+    // camera writes rather than whatever a TIFF library feels like
+    // emitting. IFD0 carries the camera-wide tags and points at one
+    // SubIFD holding the sensor data.
+    // ---------------------------------------------------------------
+
+    #[derive(Clone)]
+    enum V {
+        Byte(Vec<u8>),
+        Ascii(&'static str),
+        Short(Vec<u16>),
+        Long(Vec<u32>),
+        Rational(Vec<(u32, u32)>),
+        SRational(Vec<(i32, i32)>),
+    }
+
+    impl V {
+        fn kind(&self) -> u16 {
+            match self {
+                V::Byte(_) => 1,
+                V::Ascii(_) => 2,
+                V::Short(_) => 3,
+                V::Long(_) => 4,
+                V::Rational(_) => 5,
+                V::SRational(_) => 10,
+            }
+        }
+        fn count(&self) -> usize {
+            match self {
+                V::Byte(v) => v.len(),
+                // TIFF ASCII counts the terminating NUL.
+                V::Ascii(s) => s.len() + 1,
+                V::Short(v) => v.len(),
+                V::Long(v) => v.len(),
+                V::Rational(v) => v.len(),
+                V::SRational(v) => v.len(),
+            }
+        }
+        fn bytes(&self, little_endian: bool) -> Vec<u8> {
+            let w16 = |v: u16| {
+                if little_endian {
+                    v.to_le_bytes()
+                } else {
+                    v.to_be_bytes()
+                }
+            };
+            let w32 = |v: u32| {
+                if little_endian {
+                    v.to_le_bytes()
+                } else {
+                    v.to_be_bytes()
+                }
+            };
+            match self {
+                V::Byte(v) => v.clone(),
+                V::Ascii(s) => {
+                    let mut out = s.as_bytes().to_vec();
+                    out.push(0);
+                    out
+                }
+                V::Short(v) => v.iter().flat_map(|s| w16(*s)).collect(),
+                V::Long(v) => v.iter().flat_map(|l| w32(*l)).collect(),
+                V::Rational(v) => v
+                    .iter()
+                    .flat_map(|(n, d)| [w32(*n), w32(*d)].concat())
+                    .collect(),
+                V::SRational(v) => v
+                    .iter()
+                    .flat_map(|(n, d)| [w32(*n as u32), w32(*d as u32)].concat())
+                    .collect(),
+            }
+        }
+    }
+
+    struct Build {
+        little_endian: bool,
+        root: Vec<(u16, V)>,
+        raw: Vec<(u16, V)>,
+        chunks: Vec<Vec<u8>>,
+        tiled: bool,
+        preview: Option<Vec<u8>>,
+    }
+
+    impl Build {
+        /// A 12-bit uncompressed RGGB DNG of `width` x `height`, one
+        /// strip, with the tags every DNG carries.
+        fn new(width: usize, height: usize) -> Build {
+            Build {
+                little_endian: true,
+                root: vec![
+                    (tags::MAKE, V::Ascii("Test")),
+                    (tags::MODEL, V::Ascii("Camera")),
+                    (tags::ORIENTATION, V::Short(vec![1])),
+                    (tags::DNG_VERSION, V::Byte(vec![1, 4, 0, 0])),
+                    (tag::UNIQUE_CAMERA_MODEL, V::Ascii("Test Camera")),
+                ],
+                raw: vec![
+                    (tags::NEW_SUBFILE_TYPE, V::Long(vec![0])),
+                    (tags::IMAGE_WIDTH, V::Long(vec![width as u32])),
+                    (tags::IMAGE_LENGTH, V::Long(vec![height as u32])),
+                    (tags::BITS_PER_SAMPLE, V::Short(vec![12])),
+                    (tags::COMPRESSION, V::Short(vec![1])),
+                    (tags::PHOTOMETRIC, V::Short(vec![32803])),
+                    (tags::SAMPLES_PER_PIXEL, V::Short(vec![1])),
+                    (tags::ROWS_PER_STRIP, V::Long(vec![height as u32])),
+                    (tags::CFA_REPEAT_PATTERN_DIM, V::Short(vec![2, 2])),
+                    (tags::CFA_PATTERN, V::Byte(vec![0, 1, 1, 2])),
+                    (tag::WHITE_LEVEL, V::Long(vec![4095])),
+                ],
+                chunks: Vec::new(),
+                tiled: false,
+                preview: None,
+            }
+        }
+        fn big_endian(mut self) -> Build {
+            self.little_endian = false;
+            self
+        }
+        fn root(mut self, tag: u16, value: V) -> Build {
+            self.root.retain(|(t, _)| *t != tag);
+            self.root.push((tag, value));
+            self
+        }
+        fn raw(mut self, tag: u16, value: V) -> Build {
+            self.raw.retain(|(t, _)| *t != tag);
+            self.raw.push((tag, value));
+            self
+        }
+        fn without(mut self, tag: u16) -> Build {
+            self.raw.retain(|(t, _)| *t != tag);
+            self.root.retain(|(t, _)| *t != tag);
+            self
+        }
+        fn strip(self, bytes: Vec<u8>) -> Build {
+            self.chunk_list(vec![bytes])
+        }
+        /// Several strips, in order down the frame.
+        fn chunk_list(mut self, chunks: Vec<Vec<u8>>) -> Build {
+            self.chunks = chunks;
+            self.tiled = false;
+            self
+        }
+        fn tiles(mut self, width: usize, height: usize, chunks: Vec<Vec<u8>>) -> Build {
+            self.chunks = chunks;
+            self.tiled = true;
+            self.raw.retain(|(t, _)| *t != tags::ROWS_PER_STRIP);
+            self = self.raw(tags::TILE_WIDTH, V::Long(vec![width as u32]));
+            self.raw(tags::TILE_LENGTH, V::Long(vec![height as u32]))
+        }
+        fn preview(mut self, jpeg: Vec<u8>) -> Build {
+            self.preview = Some(jpeg);
+            self
+        }
+
+        fn bytes(&self) -> Vec<u8> {
+            let le = self.little_endian;
+            let w16 = |v: u16| if le { v.to_le_bytes() } else { v.to_be_bytes() };
+            let w32 = |v: u32| if le { v.to_le_bytes() } else { v.to_be_bytes() };
+            let count = self.chunks.len().max(1);
+
+            // The layout is fixed once the entry counts are known, so
+            // the file is written twice: the first pass measures the
+            // heap, the second fills in the offsets that depend on it.
+            let mut chunk_offsets = vec![0u32; count];
+            let mut preview_offset = 0u32;
+            let mut out = Vec::new();
+            for _ in 0..2 {
+                let mut root = self.root.clone();
+                let mut raw = self.raw.clone();
+                let (offsets_tag, counts_tag) = if self.tiled {
+                    (tags::TILE_OFFSETS, tags::TILE_BYTE_COUNTS)
+                } else {
+                    (tags::STRIP_OFFSETS, tags::STRIP_BYTE_COUNTS)
+                };
+                raw.push((offsets_tag, V::Long(chunk_offsets.clone())));
+                raw.push((
+                    counts_tag,
+                    V::Long(self.chunks.iter().map(|c| c.len() as u32).collect()),
+                ));
+                root.push((tags::SUB_IFDS, V::Long(vec![0])));
+                if let Some(jpeg) = &self.preview {
+                    root.push((tags::JPEG_INTERCHANGE_FORMAT, V::Long(vec![preview_offset])));
+                    root.push((
+                        tags::JPEG_INTERCHANGE_FORMAT_LENGTH,
+                        V::Long(vec![jpeg.len() as u32]),
+                    ));
+                }
+                root.sort_by_key(|(t, _)| *t);
+                raw.sort_by_key(|(t, _)| *t);
+
+                let directory = |n: usize| 2 + 12 * n + 4;
+                let root_at = 8usize;
+                let raw_at = root_at + directory(root.len());
+                let heap_at = raw_at + directory(raw.len());
+                // IFD0 points at the SubIFD, which is written next.
+                for entry in root.iter_mut() {
+                    if entry.0 == tags::SUB_IFDS {
+                        entry.1 = V::Long(vec![raw_at as u32]);
+                    }
+                }
+
+                let mut heap: Vec<u8> = Vec::new();
+                let mut write = |entries: &[(u16, V)], next: u32| -> Vec<u8> {
+                    let mut ifd = w16(entries.len() as u16).to_vec();
+                    for (tag, value) in entries {
+                        ifd.extend_from_slice(&w16(*tag));
+                        ifd.extend_from_slice(&w16(value.kind()));
+                        ifd.extend_from_slice(&w32(value.count() as u32));
+                        let mut bytes = value.bytes(le);
+                        if bytes.len() <= 4 {
+                            bytes.resize(4, 0);
+                            ifd.extend_from_slice(&bytes);
+                        } else {
+                            // TIFF wants values on a word boundary.
+                            if heap.len() % 2 == 1 {
+                                heap.push(0);
+                            }
+                            ifd.extend_from_slice(&w32((heap_at + heap.len()) as u32));
+                            heap.extend_from_slice(&bytes);
+                        }
+                    }
+                    ifd.extend_from_slice(&w32(next));
+                    ifd
+                };
+                let root_ifd = write(&root, 0);
+                let raw_ifd = write(&raw, 0);
+
+                out = Vec::new();
+                out.extend_from_slice(if le { b"II*\0" } else { b"MM\0*" });
+                out.extend_from_slice(&w32(root_at as u32));
+                out.extend_from_slice(&root_ifd);
+                out.extend_from_slice(&raw_ifd);
+                out.extend_from_slice(&heap);
+                for (i, chunk) in self.chunks.iter().enumerate() {
+                    chunk_offsets[i] = out.len() as u32;
+                    out.extend_from_slice(chunk);
+                }
+                if let Some(jpeg) = &self.preview {
+                    preview_offset = out.len() as u32;
+                    out.extend_from_slice(jpeg);
+                }
+            }
+            out
+        }
+    }
+
+    /// Samples packed most-significant-bit first, each row starting on
+    /// a byte boundary — the way an uncompressed DNG stores them.
+    fn pack_msb(rows: &[Vec<u16>], bits: u32) -> Vec<u8> {
+        let mut out = Vec::new();
+        for row in rows {
+            let mut accumulator = 0u32;
+            let mut held = 0u32;
+            for sample in row {
+                accumulator = (accumulator << bits) | (*sample as u32 & ((1 << bits) - 1));
+                held += bits;
+                while held >= 8 {
+                    out.push((accumulator >> (held - 8)) as u8);
+                    held -= 8;
+                }
+            }
+            if held > 0 {
+                out.push((accumulator << (8 - held)) as u8);
+            }
+        }
+        out
+    }
+
+    fn samples(raw: &RawImage) -> &[u16] {
+        match &raw.data {
+            RawData::U16(v) => v,
+            RawData::F32(_) => panic!("expected integer samples"),
+        }
+    }
+
+    fn floats(raw: &RawImage) -> &[f32] {
+        match &raw.data {
+            RawData::F32(v) => v,
+            RawData::U16(_) => panic!("expected floating-point samples"),
+        }
+    }
+
+    #[test]
+    fn packed_samples_are_msb_first_whichever_way_the_tiff_runs() {
+        let rows = vec![vec![0u16, 1, 4094, 4095], vec![2048, 7, 100, 3000]];
+        let packed = pack_msb(&rows, 12);
+        // Four 12-bit samples are exactly six bytes, so no row padding
+        // is involved and the two byte orders must agree.
+        assert_eq!(packed.len(), 12);
+        for big in [false, true] {
+            let mut build = Build::new(4, 2).strip(packed.clone());
+            if big {
+                build = build.big_endian();
+            }
+            let raw = decode(&build.bytes()).expect("decode");
+            assert_eq!(samples(&raw), rows.concat().as_slice());
+            assert_eq!(raw.cfa, Cfa::RGGB);
+            assert_eq!(raw.white_level, 4095.0);
+        }
+    }
+
+    #[test]
+    fn packed_rows_restart_on_a_byte_boundary() {
+        // Three 12-bit samples are four and a half bytes, so each row
+        // is padded to five and the second row starts clean.
+        let rows = vec![vec![1u16, 2, 3], vec![4095, 2048, 17]];
+        let packed = pack_msb(&rows, 12);
+        assert_eq!(packed.len(), 10);
+        let build = Build::new(3, 2).strip(packed);
+        let raw = decode(&build.bytes()).expect("decode");
+        assert_eq!(samples(&raw), rows.concat().as_slice());
+    }
+
+    #[test]
+    fn sixteen_bit_samples_follow_the_file_byte_order() {
+        let values: Vec<u16> = vec![0, 1000, 40000, 65535];
+        for big in [false, true] {
+            let pixels: Vec<u8> = values
+                .iter()
+                .flat_map(|v| {
+                    if big {
+                        v.to_be_bytes()
+                    } else {
+                        v.to_le_bytes()
+                    }
+                })
+                .collect();
+            let mut build = Build::new(2, 2)
+                .raw(tags::BITS_PER_SAMPLE, V::Short(vec![16]))
+                .raw(tag::WHITE_LEVEL, V::Long(vec![65535]))
+                .strip(pixels);
+            if big {
+                build = build.big_endian();
+            }
+            let raw = decode(&build.bytes()).expect("decode");
+            assert_eq!(samples(&raw), values.as_slice());
+        }
+    }
+
+    #[test]
+    fn eight_ten_and_fourteen_bit_samples_round_trip() {
+        for bits in [8u32, 10, 14] {
+            let top = (1u16 << bits) - 1;
+            let rows = vec![vec![0u16, 1, top / 2, top], vec![top, 0, 3, 9]];
+            let build = Build::new(4, 2)
+                .raw(tags::BITS_PER_SAMPLE, V::Short(vec![bits as u16]))
+                .raw(tag::WHITE_LEVEL, V::Long(vec![top as u32]))
+                .strip(pack_msb(&rows, bits));
+            let raw = decode(&build.bytes()).expect("decode");
+            assert_eq!(samples(&raw), rows.concat().as_slice(), "{bits} bits");
+        }
+    }
+
+    #[test]
+    fn strips_and_tiles_land_in_the_right_place() {
+        // Six columns and three rows in 4x2 tiles: the right column of
+        // tiles is half wasted and the bottom row one row short, both
+        // of which the reader has to clip.
+        let tile = |base: u16| pack_msb(&[vec![base; 4], vec![base + 1; 4]], 12);
+        let build = Build::new(6, 3).tiles(4, 2, vec![tile(10), tile(20), tile(30), tile(40)]);
+        let raw = decode(&build.bytes()).expect("decode");
+        let got = samples(&raw);
+        assert_eq!(&got[0..6], &[10, 10, 10, 10, 20, 20]);
+        assert_eq!(&got[6..12], &[11, 11, 11, 11, 21, 21]);
+        assert_eq!(&got[12..18], &[30, 30, 30, 30, 40, 40]);
+
+        // The same frame as three one-row strips.
+        let strips = Build::new(6, 1)
+            .raw(tags::IMAGE_LENGTH, V::Long(vec![3]))
+            .raw(tags::ROWS_PER_STRIP, V::Long(vec![1]))
+            .chunk_list(vec![
+                pack_msb(&[vec![1u16; 6]], 12),
+                pack_msb(&[vec![2u16; 6]], 12),
+                pack_msb(&[vec![3u16; 6]], 12),
+            ]);
+        let raw = decode(&strips.bytes()).expect("decode");
+        assert_eq!(
+            samples(&raw),
+            [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3]
+        );
+    }
+
+    #[test]
+    fn black_level_folds_onto_the_two_by_two() {
+        let flat = Build::new(2, 2).strip(pack_msb(&vec![vec![0u16; 2]; 2], 12));
+        let decode_with = |build: Build| decode(&build.bytes()).expect("decode").black_levels;
+
+        // One value for the whole sensor.
+        assert_eq!(
+            decode_with(
+                Build::new(2, 2)
+                    .raw(tag::BLACK_LEVEL_REPEAT_DIM, V::Short(vec![1, 1]))
+                    .raw(tag::BLACK_LEVEL, V::Long(vec![64]))
+                    .strip(pack_msb(&vec![vec![0u16; 2]; 2], 12))
+            ),
+            [64.0; 4]
+        );
+        // The 2x2 the crate carries, straight through, row-major.
+        assert_eq!(
+            decode_with(
+                Build::new(2, 2)
+                    .raw(tag::BLACK_LEVEL_REPEAT_DIM, V::Short(vec![2, 2]))
+                    .raw(tag::BLACK_LEVEL, V::Long(vec![10, 20, 30, 40]))
+                    .strip(pack_msb(&vec![vec![0u16; 2]; 2], 12))
+            ),
+            [10.0, 20.0, 30.0, 40.0]
+        );
+        // Rationals: Sigma writes a fractional black level.
+        assert_eq!(
+            decode_with(
+                Build::new(2, 2)
+                    .raw(tag::BLACK_LEVEL_REPEAT_DIM, V::Short(vec![1, 1]))
+                    .raw(tag::BLACK_LEVEL, V::Rational(vec![(511, 2)]))
+                    .strip(pack_msb(&vec![vec![0u16; 2]; 2], 12))
+            ),
+            [255.5; 4]
+        );
+        // A 4x4 block still has a 2x2 phase, so each of the four
+        // positions averages the four cells that share it: position
+        // (0, 0) takes 0, 2, 8 and 10 out of a row-major 0..16.
+        let block: Vec<u32> = (0..16).collect();
+        assert_eq!(
+            decode_with(
+                Build::new(2, 2)
+                    .raw(tag::BLACK_LEVEL_REPEAT_DIM, V::Short(vec![4, 4]))
+                    .raw(tag::BLACK_LEVEL, V::Long(block))
+                    .strip(pack_msb(&vec![vec![0u16; 2]; 2], 12))
+            ),
+            [5.0, 6.0, 9.0, 10.0]
+        );
+        assert_eq!(decode_with(flat), [0.0; 4]);
+    }
+
+    #[test]
+    fn crop_is_the_default_crop_inside_the_active_area() {
+        let pixels = pack_msb(&vec![vec![0u16; 24]; 16], 12);
+        let build = Build::new(24, 16)
+            .raw(tag::ACTIVE_AREA, V::Long(vec![2, 4, 14, 20]))
+            .raw(tag::DEFAULT_CROP_ORIGIN, V::Long(vec![3, 1]))
+            .raw(tag::DEFAULT_CROP_SIZE, V::Long(vec![8, 6]))
+            .strip(pixels.clone());
+        let raw = decode(&build.bytes()).expect("decode");
+        assert_eq!(
+            raw.crop,
+            Rect {
+                x: 7,
+                y: 3,
+                width: 8,
+                height: 6
+            }
+        );
+
+        // ActiveArea alone crops to the unmasked sensor.
+        let raw = decode(
+            &Build::new(24, 16)
+                .raw(tag::ACTIVE_AREA, V::Long(vec![2, 4, 14, 20]))
+                .strip(pixels.clone())
+                .bytes(),
+        )
+        .expect("decode");
+        assert_eq!(
+            raw.crop,
+            Rect {
+                x: 4,
+                y: 2,
+                width: 16,
+                height: 12
+            }
+        );
+
+        // Neither tag: the whole frame.
+        let raw = decode(&Build::new(24, 16).strip(pixels.clone()).bytes()).expect("decode");
+        assert_eq!(
+            raw.crop,
+            Rect {
+                x: 0,
+                y: 0,
+                width: 24,
+                height: 16
+            }
+        );
+
+        // A crop that runs off the sensor is clamped rather than
+        // handed to the developer to trip over.
+        let raw = decode(
+            &Build::new(24, 16)
+                .raw(tag::DEFAULT_CROP_ORIGIN, V::Long(vec![20, 12]))
+                .raw(tag::DEFAULT_CROP_SIZE, V::Long(vec![900, 900]))
+                .strip(pixels)
+                .bytes(),
+        )
+        .expect("decode");
+        assert_eq!(raw.crop.x + raw.crop.width, 24);
+        assert_eq!(raw.crop.y + raw.crop.height, 16);
+    }
+
+    #[test]
+    fn cfa_pattern_entries_are_plane_indices() {
+        let pixels = pack_msb(&vec![vec![0u16; 6]; 6], 12);
+        // The default planes are red, green, blue in that order.
+        let raw = decode(&Build::new(6, 6).strip(pixels.clone()).bytes()).expect("decode");
+        assert_eq!(raw.cfa, Cfa::RGGB);
+
+        // Re-ordering the planes re-orders the pattern without the
+        // pattern itself changing.
+        let raw = decode(
+            &Build::new(6, 6)
+                .raw(tag::CFA_PLANE_COLOR, V::Byte(vec![2, 1, 0]))
+                .strip(pixels.clone())
+                .bytes(),
+        )
+        .expect("decode");
+        assert_eq!(raw.cfa, Cfa::BGGR);
+
+        // A 6x6 pattern is X-Trans.
+        let xtrans: Vec<u8> = (0..36).map(|i| [1u8, 1, 0, 1, 1, 2][i % 6]).collect();
+        let raw = decode(
+            &Build::new(6, 6)
+                .raw(tags::CFA_REPEAT_PATTERN_DIM, V::Short(vec![6, 6]))
+                .raw(tags::CFA_PATTERN, V::Byte(xtrans))
+                .strip(pixels.clone())
+                .bytes(),
+        )
+        .expect("decode");
+        assert!(matches!(raw.cfa, Cfa::XTrans(_)));
+        assert_eq!(raw.cfa.color_at(2, 0), Some(CfaColor::Red));
+
+        // Anything else is carried as a plain repeating block.
+        let raw = decode(
+            &Build::new(6, 6)
+                .raw(tags::CFA_REPEAT_PATTERN_DIM, V::Short(vec![2, 4]))
+                .raw(tags::CFA_PATTERN, V::Byte(vec![0, 1, 2, 3, 4, 5, 0, 1]))
+                .strip(pixels.clone())
+                .bytes(),
+        )
+        .expect("decode");
+        assert_eq!(
+            raw.cfa,
+            Cfa::Pattern {
+                width: 4,
+                height: 2,
+                colors: vec![
+                    CfaColor::Red,
+                    CfaColor::Green,
+                    CfaColor::Blue,
+                    CfaColor::Cyan,
+                    CfaColor::Magenta,
+                    CfaColor::Yellow,
+                    CfaColor::Red,
+                    CfaColor::Green,
+                ],
+            }
+        );
+
+        // A white photosite has no place in the develop pipeline.
+        let error = decode(
+            &Build::new(6, 6)
+                .raw(tag::CFA_PLANE_COLOR, V::Byte(vec![0, 1, 6]))
+                .strip(pixels)
+                .bytes(),
+        )
+        .expect_err("white plane");
+        assert!(matches!(error, Error::Unsupported(_)), "{error}");
+    }
+
+    #[test]
+    fn the_matrix_measured_nearest_daylight_wins() {
+        let pixels = pack_msb(&vec![vec![0u16; 2]; 2], 12);
+        let one = V::SRational((1..=9).map(|i| (i * 1000, 10000)).collect());
+        let two = V::SRational((1..=9).map(|i| (i * 2000, 10000)).collect());
+        let build = |a: u16, b: u16| {
+            Build::new(2, 2)
+                .root(tag::COLOR_MATRIX_1, one.clone())
+                .root(tag::COLOR_MATRIX_2, two.clone())
+                .root(tag::CALIBRATION_ILLUMINANT_1, V::Short(vec![a]))
+                .root(tag::CALIBRATION_ILLUMINANT_2, V::Short(vec![b]))
+                .strip(pixels.clone())
+        };
+        let first_of = |raw: &RawImage| raw.color_matrix.expect("a matrix")[0][0];
+        // Standard light A against D65: D65 by a mile.
+        assert_eq!(first_of(&decode(&build(17, 21).bytes()).unwrap()), 0.2);
+        assert_eq!(first_of(&decode(&build(21, 17).bytes()).unwrap()), 0.1);
+        // D50 still beats standard light A.
+        assert_eq!(first_of(&decode(&build(17, 23).bytes()).unwrap()), 0.2);
+        assert_eq!(first_of(&decode(&build(23, 17).bytes()).unwrap()), 0.1);
+        // One matrix on its own is the one, whatever it was measured
+        // under.
+        let only = Build::new(2, 2)
+            .root(tag::COLOR_MATRIX_1, one.clone())
+            .root(tag::CALIBRATION_ILLUMINANT_1, V::Short(vec![17]))
+            .strip(pixels.clone());
+        assert_eq!(first_of(&decode(&only.bytes()).unwrap()), 0.1);
+        // No matrix at all leaves the field for the camera table.
+        let raw = decode(&Build::new(2, 2).strip(pixels).bytes()).unwrap();
+        assert_eq!(raw.color_matrix, None);
+    }
+
+    #[test]
+    fn as_shot_neutral_inverts_into_multipliers() {
+        let pixels = pack_msb(&vec![vec![0u16; 2]; 2], 12);
+        let raw = decode(
+            &Build::new(2, 2)
+                .root(
+                    tag::AS_SHOT_NEUTRAL,
+                    V::Rational(vec![(1, 2), (1, 1), (1, 4)]),
+                )
+                .strip(pixels.clone())
+                .bytes(),
+        )
+        .expect("decode");
+        assert_eq!(raw.wb_coeffs, [2.0, 1.0, 4.0, 1.0]);
+
+        // A neutral that does not already have green at one is scaled.
+        let raw = decode(
+            &Build::new(2, 2)
+                .root(
+                    tag::AS_SHOT_NEUTRAL,
+                    V::Rational(vec![(1, 2), (2, 1), (1, 4)]),
+                )
+                .strip(pixels.clone())
+                .bytes(),
+        )
+        .expect("decode");
+        assert_eq!(raw.wb_coeffs, [4.0, 1.0, 8.0, 1.0]);
+
+        // AsShotWhiteXY is a chromaticity: without a matrix nothing can
+        // turn it into multipliers, so the balance stays at unity.
+        let raw = decode(
+            &Build::new(2, 2)
+                .root(
+                    tag::AS_SHOT_WHITE_XY,
+                    V::Rational(vec![(3127, 10000), (3290, 10000)]),
+                )
+                .strip(pixels.clone())
+                .bytes(),
+        )
+        .expect("decode");
+        assert_eq!(raw.wb_coeffs, [1.0; 4]);
+        // With a matrix, the white point's camera response inverts into
+        // the multipliers. The matrix here maps XYZ to (X, Y, Z)/2 for
+        // red, green, blue in turn, so D65's response is its XYZ halved
+        // and the multipliers are Y/X, 1, Y/Z of D65.
+        let raw = decode(
+            &Build::new(2, 2)
+                .root(
+                    tag::AS_SHOT_WHITE_XY,
+                    V::Rational(vec![(3127, 10000), (3290, 10000)]),
+                )
+                .root(
+                    tag::COLOR_MATRIX_1,
+                    V::SRational(vec![
+                        (5000, 10000),
+                        (0, 1),
+                        (0, 1),
+                        (0, 1),
+                        (5000, 10000),
+                        (0, 1),
+                        (0, 1),
+                        (0, 1),
+                        (5000, 10000),
+                    ]),
+                )
+                .strip(pixels)
+                .bytes(),
+        )
+        .expect("decode");
+        let (x, y) = (0.3127f32, 0.3290f32);
+        let (want_r, want_b) = (y / x, y / (1.0 - x - y));
+        assert!(
+            (raw.wb_coeffs[0] - want_r).abs() < 1e-3,
+            "{:?}",
+            raw.wb_coeffs
+        );
+        assert_eq!(raw.wb_coeffs[1], 1.0);
+        assert!(
+            (raw.wb_coeffs[2] - want_b).abs() < 1e-3,
+            "{:?}",
+            raw.wb_coeffs
+        );
+    }
+
+    #[test]
+    fn the_linearization_table_is_applied_and_sets_the_default_white() {
+        let rows = vec![vec![0u16, 1, 2, 9]];
+        let build = Build::new(4, 1)
+            .raw(tags::BITS_PER_SAMPLE, V::Short(vec![8]))
+            .raw(
+                tag::LINEARIZATION_TABLE,
+                V::Short(vec![0, 1000, 2000, 3000]),
+            )
+            .without(tag::WHITE_LEVEL)
+            .strip(pack_msb(&rows, 8));
+        let raw = decode(&build.bytes()).expect("decode");
+        // The last entry stands in for every index past the table.
+        assert_eq!(samples(&raw), [0, 1000, 2000, 3000]);
+        assert_eq!(raw.white_level, 3000.0);
+    }
+
+    #[test]
+    fn multi_image_dngs_take_the_largest_raw_plane() {
+        // A reduced-resolution CFA image beside the real one is
+        // ignored even though it has the raw photometric.
+        let big = pack_msb(&vec![vec![7u16; 8]; 4], 12);
+        let build = Build::new(8, 4).strip(big);
+        let raw = decode(&build.bytes()).expect("decode");
+        assert_eq!((raw.width, raw.height), (8, 4));
+        assert!(samples(&raw).iter().all(|s| *s == 7));
+    }
+
+    #[test]
+    fn deflated_integers_undo_the_horizontal_predictor() {
+        let values: Vec<u16> = vec![100, 120, 90, 4000, 30, 31, 32, 33];
+        // Predictor 2 differences each sample from the one before it
+        // in the row; the two rows are independent.
+        let mut encoded = Vec::new();
+        for row in values.chunks(4) {
+            let mut previous = 0u16;
+            for sample in row {
+                encoded.extend_from_slice(&sample.wrapping_sub(previous).to_le_bytes());
+                previous = *sample;
+            }
+        }
+        let build = Build::new(4, 2)
+            .raw(tags::BITS_PER_SAMPLE, V::Short(vec![16]))
+            .raw(tags::COMPRESSION, V::Short(vec![8]))
+            .raw(tag::PREDICTOR, V::Short(vec![2]))
+            .raw(tag::WHITE_LEVEL, V::Long(vec![65535]))
+            .strip(miniz_oxide::deflate::compress_to_vec_zlib(&encoded, 6));
+        let raw = decode(&build.bytes()).expect("decode");
+        assert_eq!(samples(&raw), values.as_slice());
+
+        // DNG's own 34892 widens the stride to two pixels, so a Bayer
+        // row differences red against red.
+        let mut encoded = Vec::new();
+        for row in values.chunks(4) {
+            for (i, sample) in row.iter().enumerate() {
+                let previous = if i >= 2 { row[i - 2] } else { 0 };
+                encoded.extend_from_slice(&sample.wrapping_sub(previous).to_le_bytes());
+            }
+        }
+        let build = Build::new(4, 2)
+            .raw(tags::BITS_PER_SAMPLE, V::Short(vec![16]))
+            .raw(tags::COMPRESSION, V::Short(vec![8]))
+            .raw(tag::PREDICTOR, V::Short(vec![34892]))
+            .raw(tag::WHITE_LEVEL, V::Long(vec![65535]))
+            .strip(miniz_oxide::deflate::compress_to_vec_zlib(&encoded, 6));
+        let raw = decode(&build.bytes()).expect("decode");
+        assert_eq!(samples(&raw), values.as_slice());
+    }
+
+    /// Split a row of samples into byte planes, most significant
+    /// first, then difference the bytes `stride` apart — the encoder
+    /// side of DNG's floating-point predictor.
+    fn shuffle(row: &[u32], width: usize, stride: usize) -> Vec<u8> {
+        let mut planes = vec![0u8; row.len() * width];
+        for (sample, value) in row.iter().enumerate() {
+            for plane in 0..width {
+                planes[plane * row.len() + sample] = (value >> (8 * (width - 1 - plane))) as u8;
+            }
+        }
+        for i in (stride..planes.len()).rev() {
+            planes[i] = planes[i].wrapping_sub(planes[i - stride]);
+        }
+        planes
+    }
+
+    #[test]
+    fn deflated_floats_come_back_through_the_byte_shuffle() {
+        let values: Vec<f32> = vec![0.0, 0.25, 1.0, 0.5, -1.5, 3.25, 0.125, 65504.0];
+        let mut encoded = Vec::new();
+        for row in values.chunks(4) {
+            let bits: Vec<u32> = row.iter().map(|v| v.to_bits()).collect();
+            // Predictor 34894: floating point, two pixels apart.
+            encoded.extend_from_slice(&shuffle(&bits, 4, 2));
+        }
+        let build = Build::new(4, 2)
+            .raw(tags::BITS_PER_SAMPLE, V::Short(vec![32]))
+            .raw(tag::SAMPLE_FORMAT, V::Short(vec![3]))
+            .raw(tags::COMPRESSION, V::Short(vec![8]))
+            .raw(tag::PREDICTOR, V::Short(vec![34894]))
+            .without(tag::WHITE_LEVEL)
+            .strip(miniz_oxide::deflate::compress_to_vec_zlib(&encoded, 6));
+        let raw = decode(&build.bytes()).expect("decode");
+        assert_eq!(floats(&raw), values.as_slice());
+        // A float DNG is already scaled: one is saturation.
+        assert_eq!(raw.white_level, 1.0);
+        assert_eq!(raw.black_levels, [0.0; 4]);
+    }
+
+    #[test]
+    fn twenty_four_bit_floats_are_a_shift() {
+        // DNG's 24-bit float is a single-precision one with the low
+        // sixteen mantissa bits dropped, so values that fit exactly
+        // survive the round trip.
+        let values: Vec<f32> = vec![1.0, 0.5, -2.0, 0.0];
+        let bits: Vec<u32> = values.iter().map(|v| v.to_bits() >> 8).collect();
+        let encoded = shuffle(&bits, 3, 1);
+        let build = Build::new(4, 1)
+            .raw(tags::BITS_PER_SAMPLE, V::Short(vec![24]))
+            .raw(tag::SAMPLE_FORMAT, V::Short(vec![3]))
+            .raw(tags::COMPRESSION, V::Short(vec![8]))
+            .raw(tag::PREDICTOR, V::Short(vec![3]))
+            .without(tag::WHITE_LEVEL)
+            .strip(miniz_oxide::deflate::compress_to_vec_zlib(&encoded, 6));
+        let raw = decode(&build.bytes()).expect("decode");
+        assert_eq!(floats(&raw), values.as_slice());
+    }
+
+    #[test]
+    fn half_precision_covers_zero_subnormals_and_infinity() {
+        assert_eq!(half_to_f32(0x0000), 0.0);
+        assert_eq!(half_to_f32(0x8000).to_bits(), (-0.0f32).to_bits());
+        assert_eq!(half_to_f32(0x3C00), 1.0);
+        assert_eq!(half_to_f32(0xBC00), -1.0);
+        assert_eq!(half_to_f32(0x3800), 0.5);
+        // The largest half, and the smallest normal one.
+        assert_eq!(half_to_f32(0x7BFF), 65504.0);
+        assert_eq!(half_to_f32(0x0400), 2.0f32.powi(-14));
+        // Subnormals: the smallest is 2^-24, and 0x0200 is 2^-15.
+        assert_eq!(half_to_f32(0x0001), 2.0f32.powi(-24));
+        assert_eq!(half_to_f32(0x0200), 2.0f32.powi(-15));
+        assert_eq!(half_to_f32(0x0003), 3.0 * 2.0f32.powi(-24));
+        assert!(half_to_f32(0x7C00).is_infinite());
+        assert!(half_to_f32(0xFC00).is_infinite() && half_to_f32(0xFC00) < 0.0);
+        assert!(half_to_f32(0x7E00).is_nan());
+    }
+
+    #[test]
+    fn half_precision_tiles_decode() {
+        let halves: Vec<u32> = vec![0x0000, 0x3C00, 0x3800, 0x7BFF];
+        let encoded = shuffle(&halves, 2, 1);
+        let build = Build::new(4, 1)
+            .raw(tags::BITS_PER_SAMPLE, V::Short(vec![16]))
+            .raw(tag::SAMPLE_FORMAT, V::Short(vec![3]))
+            .raw(tags::COMPRESSION, V::Short(vec![8]))
+            .raw(tag::PREDICTOR, V::Short(vec![3]))
+            .without(tag::WHITE_LEVEL)
+            .strip(miniz_oxide::deflate::compress_to_vec_zlib(&encoded, 6));
+        let raw = decode(&build.bytes()).expect("decode");
+        assert_eq!(floats(&raw), [0.0, 1.0, 0.5, 65504.0]);
+    }
+
+    #[test]
+    fn unshuffled_floats_use_the_file_byte_order() {
+        let values: Vec<f32> = vec![1.0, -0.5, 0.25, 3.0];
+        for big in [false, true] {
+            let encoded: Vec<u8> = values
+                .iter()
+                .flat_map(|v| {
+                    if big {
+                        v.to_bits().to_be_bytes()
+                    } else {
+                        v.to_bits().to_le_bytes()
+                    }
+                })
+                .collect();
+            let mut build = Build::new(4, 1)
+                .raw(tags::BITS_PER_SAMPLE, V::Short(vec![32]))
+                .raw(tag::SAMPLE_FORMAT, V::Short(vec![3]))
+                .raw(tags::COMPRESSION, V::Short(vec![8]))
+                .without(tag::PREDICTOR)
+                .without(tag::WHITE_LEVEL)
+                .strip(miniz_oxide::deflate::compress_to_vec_zlib(&encoded, 6));
+            if big {
+                build = build.big_endian();
+            }
+            let raw = decode(&build.bytes()).expect("decode");
+            assert_eq!(floats(&raw), values.as_slice());
+        }
+    }
+
+    #[test]
+    fn lossy_tiles_are_baseline_jpeg_widened_by_the_table() {
+        // A lossy DNG is linear raw: three eight-bit channels a pixel,
+        // one complete JPEG per tile, and a linearization table to put
+        // the samples back on the sensor's scale.
+        let jpeg = |red: u8, green: u8, blue: u8| {
+            let mut out = Vec::new();
+            let pixels: Vec<u8> = (0..8 * 8).flat_map(|_| [red, green, blue]).collect();
+            let encoder = image::codecs::jpeg::JpegEncoder::new_with_quality(&mut out, 100);
+            image::ImageEncoder::write_image(
+                encoder,
+                &pixels,
+                8,
+                8,
+                image::ExtendedColorType::Rgb8,
+            )
+            .expect("encode a tile");
+            out
+        };
+        let table: Vec<u16> = (0..256).map(|i| i as u16 * 257).collect();
+        let build = Build::new(16, 16)
+            .raw(tags::PHOTOMETRIC, V::Short(vec![34892]))
+            .raw(tags::SAMPLES_PER_PIXEL, V::Short(vec![3]))
+            .raw(tags::BITS_PER_SAMPLE, V::Short(vec![8, 8, 8]))
+            .raw(tags::COMPRESSION, V::Short(vec![34892]))
+            .raw(tag::LINEARIZATION_TABLE, V::Short(table))
+            .raw(tag::WHITE_LEVEL, V::Long(vec![65535]))
+            .without(tags::CFA_REPEAT_PATTERN_DIM)
+            .without(tags::CFA_PATTERN)
+            .tiles(
+                8,
+                8,
+                vec![
+                    jpeg(200, 100, 50),
+                    jpeg(10, 20, 30),
+                    jpeg(255, 255, 255),
+                    jpeg(0, 0, 0),
+                ],
+            );
+        let raw = decode(&build.bytes()).expect("decode");
+        assert_eq!(raw.cpp, 3);
+        assert_eq!(raw.cfa, Cfa::None);
+        let got = samples(&raw);
+        let at = |x: usize, y: usize| {
+            let i = (y * 16 + x) * 3;
+            [got[i], got[i + 1], got[i + 2]]
+        };
+        // JPEG is lossy even at quality 100, so a flat tile comes back
+        // within a code or two of what went in, times 257.
+        let close = |got: [u16; 3], want: [u16; 3]| {
+            got.iter()
+                .zip(want.iter())
+                .all(|(a, b)| (*a as i32 - *b as i32).abs() <= 3 * 257)
+        };
+        assert!(
+            close(at(2, 2), [200 * 257, 100 * 257, 50 * 257]),
+            "{:?}",
+            at(2, 2)
+        );
+        assert!(
+            close(at(12, 2), [10 * 257, 20 * 257, 30 * 257]),
+            "{:?}",
+            at(12, 2)
+        );
+        assert!(close(at(2, 12), [65535, 65535, 65535]), "{:?}", at(2, 12));
+        assert!(close(at(12, 12), [0, 0, 0]), "{:?}", at(12, 12));
+    }
+
+    #[test]
+    fn the_preview_is_the_largest_embedded_jpeg() {
+        let mut jpeg = Vec::new();
+        let pixels = vec![128u8; 16 * 16 * 3];
+        let encoder = image::codecs::jpeg::JpegEncoder::new(&mut jpeg);
+        image::ImageEncoder::write_image(encoder, &pixels, 16, 16, image::ExtendedColorType::Rgb8)
+            .expect("encode");
+        let build = Build::new(4, 2)
+            .strip(pack_msb(&vec![vec![0u16; 4]; 2], 12))
+            .preview(jpeg.clone());
+        let bytes = build.bytes();
+        assert_eq!(preview(&bytes).expect("preview"), Some(jpeg.clone()));
+        assert_eq!(decode(&bytes).expect("decode").preview, Some(jpeg));
+    }
+
+    #[test]
+    fn compressions_this_module_has_no_decoder_for_are_unsupported() {
+        let pixels = pack_msb(&vec![vec![0u16; 4]; 2], 12);
+        for (code, what) in [(52546u16, "JPEG XL"), (9, "VC-5"), (5, "LZW")] {
+            let build = Build::new(4, 2)
+                .raw(tags::COMPRESSION, V::Short(vec![code]))
+                .strip(pixels.clone());
+            let error = decode(&build.bytes()).expect_err(what);
+            assert!(matches!(error, Error::Unsupported(_)), "{what}: {error}");
+        }
+    }
+
+    #[test]
+    fn a_dng_from_the_future_is_refused_rather_than_guessed_at() {
+        let build = Build::new(4, 2)
+            .root(tags::DNG_VERSION, V::Byte(vec![2, 0, 0, 0]))
+            .root(tag::DNG_BACKWARD_VERSION, V::Byte(vec![2, 0, 0, 0]))
+            .strip(pack_msb(&vec![vec![0u16; 4]; 2], 12));
+        let error = decode(&build.bytes()).expect_err("a 2.0 DNG");
+        assert!(matches!(error, Error::Unsupported(_)), "{error}");
+
+        // A 1.7 file whose *backward* version is old still decodes.
+        let build = Build::new(4, 2)
+            .root(tags::DNG_VERSION, V::Byte(vec![1, 7, 0, 0]))
+            .root(tag::DNG_BACKWARD_VERSION, V::Byte(vec![1, 1, 0, 0]))
+            .strip(pack_msb(&vec![vec![0u16; 4]; 2], 12));
+        decode(&build.bytes()).expect("a 1.7 file with a 1.1 fallback");
+    }
+
+    #[test]
+    fn garbage_and_short_files_are_errors_not_panics() {
+        assert!(decode(&[]).is_err());
+        assert!(decode(b"II*\0").is_err());
+        assert!(decode(b"not a tiff at all").is_err());
+        // A DNG whose strip says it is far longer than the file.
+        let build = Build::new(4, 2).strip(vec![0; 12]);
+        let mut bytes = build.bytes();
+        bytes.truncate(bytes.len() - 6);
+        assert!(decode(&bytes).is_err());
+
+        let whole = Build::new(64, 64)
+            .strip(pack_msb(&vec![vec![0u16; 64]; 64], 12))
+            .bytes();
+        for cut in 0..whole.len() / 7 {
+            let _ = decode(&whole[..cut * 7]);
+            let _ = preview(&whole[..cut * 7]);
+        }
+    }
+
+    #[test]
+    fn a_frame_larger_than_its_data_is_corrupt() {
+        // The IFD claims 64 rows and the strip holds two.
+        let build = Build::new(4, 64)
+            .raw(tags::ROWS_PER_STRIP, V::Long(vec![64]))
+            .strip(pack_msb(&vec![vec![0u16; 4]; 2], 12));
+        let error = decode(&build.bytes()).expect_err("short strip");
+        assert!(matches!(error, Error::Corrupt(_)), "{error}");
+    }
+
+    // ---------------------------------------------------------------
+    // Corpus. `SCHIST_RAW_CORPUS` points at a tree of camera files
+    // with LibRaw's output beside each one: `<name>.tiff` is the
+    // sensor frame as `unprocessed_raw -T` unpacked it (black not
+    // subtracted) and `<name>.identify.txt` is `raw-identify -v -w`.
+    // ---------------------------------------------------------------
+
+    fn corpus() -> Option<PathBuf> {
+        let dir = PathBuf::from(std::env::var_os("SCHIST_RAW_CORPUS")?);
+        dir.is_dir().then_some(dir)
+    }
+
+    /// Every file this module claims, DNG and GoPro's GPR dialect.
+    fn corpus_files() -> Vec<PathBuf> {
+        let Some(dir) = corpus() else {
+            return Vec::new();
+        };
+        let mut found = Vec::new();
+        let mut stack = vec![dir];
+        while let Some(at) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&at) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| e.eq_ignore_ascii_case("dng") || e.eq_ignore_ascii_case("gpr"))
+                {
+                    found.push(path);
+                }
+            }
+        }
+        found.sort();
+        found
+    }
+
+    /// Files this module knowingly refuses, and why. A corpus file
+    /// that fails for any other reason fails the test.
+    fn unsupported_reason(path: &Path) -> Option<&'static str> {
+        let name = path.file_name()?.to_str()?;
+        name.to_ascii_lowercase()
+            .ends_with(".gpr")
+            .then_some("GoPro VC-5, not a DNG compression")
+    }
+
+    /// LibRaw's own view of a file, as far as this test compares it.
+    #[derive(Debug, Default)]
+    struct Identify {
+        full: Option<(usize, usize)>,
+        inset: Option<(usize, usize, usize, usize)>,
+        filter: Option<String>,
+        /// LibRaw splits a DNG's black level in two: a scalar for
+        /// the whole sensor and a four-entry `cblack[6..]` for the
+        /// per-CFA-position extra. The sum is the black level.
+        black_scalar: u32,
+        black: Option<Vec<u32>>,
+        white: Option<f32>,
+        flip: Option<u32>,
+        as_shot: Option<[f32; 3]>,
+    }
+
+    fn identify(path: &Path) -> Option<Identify> {
+        let sidecar = path.with_extension(format!(
+            "{}.identify.txt",
+            path.extension().and_then(|e| e.to_str()).unwrap_or("")
+        ));
+        // The sidecar is not valid UTF-8 for every camera: LibRaw
+        // prints RawDataUniqueID as raw bytes.
+        let text = String::from_utf8_lossy(&std::fs::read(sidecar).ok()?).into_owned();
+        let mut out = Identify::default();
+        for line in text.lines() {
+            let line = line.trim();
+            let numbers = |rest: &str| -> Vec<f32> {
+                rest.split(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
+                    .filter(|s| !s.is_empty())
+                    .filter_map(|s| s.parse::<f32>().ok())
+                    .collect()
+            };
+            if let Some(rest) = line.strip_prefix("Full size:") {
+                let n = numbers(rest);
+                if n.len() >= 2 {
+                    out.full = Some((n[0] as usize, n[1] as usize));
+                }
+            } else if let Some(rest) = line.strip_prefix("Raw inset, width x height:") {
+                let n = numbers(rest);
+                if n.len() >= 4 {
+                    out.inset = Some((n[2] as usize, n[3] as usize, n[0] as usize, n[1] as usize));
+                }
+            } else if let Some(rest) = line.strip_prefix("Filter pattern:") {
+                out.filter = Some(rest.trim().to_string());
+            } else if let Some(rest) = line.strip_prefix("Highlight linearity limits:") {
+                out.white = numbers(rest).first().copied();
+            } else if let Some(rest) = line.strip_prefix("Image flip:") {
+                out.flip = numbers(rest).first().map(|v| *v as u32);
+            } else if line.starts_with("cblack[") {
+                if let Some(rest) = line.split_once(':') {
+                    out.black = Some(numbers(rest.1).iter().map(|v| *v as u32).collect());
+                }
+            } else if let Some(rest) = line.strip_prefix("black:") {
+                out.black_scalar = numbers(rest).first().copied().unwrap_or(0.0) as u32;
+            } else if let Some(rest) = line.strip_prefix("As shot") {
+                let n = numbers(rest);
+                if n.len() >= 3 && out.as_shot.is_none() {
+                    out.as_shot = Some([n[0], n[1], n[2]]);
+                }
+            }
+        }
+        Some(out)
+    }
+
+    /// LibRaw's unpacked sensor frame, when it managed to unpack one.
+    fn oracle(path: &Path) -> Option<(usize, usize, Vec<u16>)> {
+        let sidecar = path.with_extension(format!(
+            "{}.tiff",
+            path.extension().and_then(|e| e.to_str()).unwrap_or("")
+        ));
+        let image = image::open(&sidecar).ok()?.into_luma16();
+        let (width, height) = (image.width() as usize, image.height() as usize);
+        Some((width, height, image.into_raw()))
+    }
+
+    /// Where LibRaw deliberately disagrees with the file's own tags.
+    ///
+    /// LibRaw carries per-body margin tables that override a DNG's
+    /// ActiveArea and DefaultCropOrigin for cameras it recognises, and
+    /// it rounds a rational default crop the other way. The tags are
+    /// what the file says, so this module follows them and the crop
+    /// comparison is skipped for these.
+    fn crop_deviates(path: &Path) -> bool {
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        ["645D-", "_MAR0543", "fp-A002_647"]
+            .iter()
+            .any(|stem| name.contains(stem))
+    }
+
+    fn color_letter(color: CfaColor) -> char {
+        match color {
+            CfaColor::Red => 'R',
+            CfaColor::Green | CfaColor::Green2 => 'G',
+            CfaColor::Blue => 'B',
+            CfaColor::Cyan => 'C',
+            CfaColor::Magenta => 'M',
+            CfaColor::Yellow => 'Y',
+            CfaColor::Emerald => 'E',
+        }
+    }
+
+    #[test]
+    fn corpus_matches_libraw() {
+        let files = corpus_files();
+        if files.is_empty() {
+            return;
+        }
+        let mut checked = 0;
+        let mut skipped = Vec::new();
+        for path in &files {
+            let bytes = std::fs::read(path).expect("read the sample");
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(Format::Dng),
+                "{} does not probe as a DNG",
+                path.display()
+            );
+            let started = std::time::Instant::now();
+            let raw = match decode(&bytes) {
+                Ok(raw) => raw,
+                Err(Error::Unsupported(why)) => {
+                    let reason = unsupported_reason(path).unwrap_or_else(|| {
+                        panic!(
+                            "{} is unsupported and not allow-listed: {why}",
+                            path.display()
+                        )
+                    });
+                    skipped.push(format!("{}: {reason}", path.display()));
+                    continue;
+                }
+                Err(other) => panic!("{}: {other}", path.display()),
+            };
+            let elapsed = started.elapsed();
+            raw.validate()
+                .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+            checked += 1;
+            println!(
+                "{}: {}x{}x{} in {:.3}s ({:.1} MP/s), {} {}",
+                path.display(),
+                raw.width,
+                raw.height,
+                raw.cpp,
+                elapsed.as_secs_f64(),
+                (raw.width * raw.height) as f64 / 1e6 / elapsed.as_secs_f64(),
+                raw.make,
+                raw.model,
+            );
+
+            // The preview must be a JPEG a viewer can open.
+            if let Some(preview) = &raw.preview {
+                image::load_from_memory(preview)
+                    .unwrap_or_else(|e| panic!("{}: preview does not decode: {e}", path.display()));
+            }
+            assert_eq!(
+                preview(&bytes).expect("preview"),
+                raw.preview,
+                "{}: the cheap preview path disagrees",
+                path.display()
+            );
+
+            match oracle(path) {
+                Some((width, height, want)) => {
+                    assert_eq!(
+                        (raw.width, raw.height, raw.cpp),
+                        (width, height, 1),
+                        "{}: frame differs from LibRaw's",
+                        path.display()
+                    );
+                    let RawData::U16(got) = &raw.data else {
+                        panic!("{}: float data with an integer oracle", path.display());
+                    };
+                    let mut bad = 0usize;
+                    let mut first = None;
+                    for (i, (got, want)) in got.iter().zip(want.iter()).enumerate() {
+                        if got != want {
+                            bad += 1;
+                            first.get_or_insert((i % width, i / width, *got, *want));
+                        }
+                    }
+                    assert_eq!(
+                        bad,
+                        0,
+                        "{}: {bad} samples differ, first (x, y, got, want) {:?}",
+                        path.display(),
+                        first
+                    );
+                }
+                None => {
+                    // LibRaw refuses Apple's linear ProRAW and some
+                    // Samsung phone DNGs outright, so there is nothing
+                    // to compare against: check the frame is at least
+                    // plausible.
+                    println!("  no oracle: LibRaw could not unpack this one");
+                    assert!(raw.width >= 16 && raw.height >= 16, "{}", path.display());
+                    assert_eq!(raw.data.len(), raw.width * raw.height * raw.cpp);
+                    if raw.cpp == 3 {
+                        assert_eq!(raw.cfa, Cfa::None, "{}", path.display());
+                    }
+                    let peak = (0..raw.data.len())
+                        .map(|i| raw.data.get(i))
+                        .fold(0.0, f32::max);
+                    assert!(
+                        peak > raw.white_level * 0.02 && peak <= raw.white_level,
+                        "{}: samples peak at {peak} against a white level of {}",
+                        path.display(),
+                        raw.white_level
+                    );
+                }
+            }
+
+            let Some(identify) = identify(path) else {
+                continue;
+            };
+            if let Some(full) = identify.full {
+                assert_eq!((raw.width, raw.height), full, "{}: size", path.display());
+            }
+            if let Some(filter) = &identify.filter {
+                let got: String = (0..4)
+                    .map(|i| color_letter(raw.cfa.color_at(i % 2, i / 2).expect("a CFA colour")))
+                    .collect();
+                assert!(
+                    filter.starts_with(&got),
+                    "{}: CFA {got} against LibRaw's {filter}",
+                    path.display()
+                );
+            }
+            // LibRaw prints a black level only for files it could
+            // unpack; the sum of its scalar and per-position parts is
+            // what the DNG's BlackLevel says, truncated to an integer.
+            if identify.black.is_some() || identify.black_scalar > 0 {
+                let per_position = identify.black.unwrap_or_default();
+                for position in 0..4 {
+                    let extra = per_position
+                        .get(position.min(per_position.len().saturating_sub(1)))
+                        .copied()
+                        .unwrap_or(0);
+                    assert_eq!(
+                        raw.black_levels[position].floor() as u32,
+                        identify.black_scalar + extra,
+                        "{}: black level {position} of {:?}",
+                        path.display(),
+                        raw.black_levels
+                    );
+                }
+            }
+            if let Some(white) = identify.white {
+                assert_eq!(raw.white_level, white, "{}: white level", path.display());
+            }
+            if let Some(flip) = identify.flip {
+                let want = match flip {
+                    3 => crate::Orientation::Rotate180,
+                    5 => crate::Orientation::Rotate270CW,
+                    6 => crate::Orientation::Rotate90CW,
+                    _ => crate::Orientation::Normal,
+                };
+                assert_eq!(raw.orientation, want, "{}: orientation", path.display());
+            }
+            if let (Some(inset), false) = (identify.inset, crop_deviates(path)) {
+                assert_eq!(
+                    (raw.crop.x, raw.crop.y, raw.crop.width, raw.crop.height),
+                    inset,
+                    "{}: crop",
+                    path.display()
+                );
+            }
+            // `cam_mul` carries the same ratios without normalising
+            // green, so scale it before comparing.
+            if let Some(as_shot) = identify.as_shot.filter(|v| v[1] > 0.0) {
+                let as_shot = [as_shot[0] / as_shot[1], 1.0, as_shot[2] / as_shot[1]];
+                for (got, want) in raw.wb_coeffs.iter().zip(as_shot.iter()) {
+                    assert!(
+                        (got - want).abs() <= want.abs() * 1e-4 + 1e-4,
+                        "{}: white balance {:?} against LibRaw's normalised {as_shot:?}",
+                        path.display(),
+                        raw.wb_coeffs
+                    );
+                }
+            }
+        }
+        println!("decoded {checked} of {} DNGs", files.len());
+        for line in &skipped {
+            println!("  unsupported: {line}");
+        }
+    }
+
+    /// A file cut short anywhere must give an error, never a panic and
+    /// never an unbounded allocation.
+    #[test]
+    fn corpus_truncation_never_panics() {
+        for path in corpus_files() {
+            let bytes = std::fs::read(&path).expect("read the sample");
+            // A deterministic spread of cut points: the header, the
+            // middle of the IFDs, and eight places through the data.
+            let mut seed = 0x2545_F491_4F6C_DD1Du64;
+            for i in 0..10 {
+                let cut = if i == 0 {
+                    bytes.len() / 2
+                } else {
+                    seed ^= seed << 13;
+                    seed ^= seed >> 7;
+                    seed ^= seed << 17;
+                    (seed % bytes.len() as u64) as usize
+                };
+                let _ = decode(&bytes[..cut]);
+                let _ = preview(&bytes[..cut]);
+            }
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/erf.rs
+++ b/crates/codec-raw/src/formats/erf.rs
@@ -1,0 +1,566 @@
+//! Epson ERF: the R-D1, R-D1s and R-D1x rangefinders.
+//!
+//! An ERF is an ordinary TIFF/EP file. IFD0 is a 160x120 uncompressed
+//! RGB thumbnail and its single SubIFD is the sensor: 3040x2024
+//! samples of 12 bits under an RGGB array, `PhotometricInterpretation`
+//! 32803 and `Compression` 32769.
+//!
+//! That compression number promises nothing — the samples are not
+//! compressed, only packed, and the packing has a quirk that no TIFF
+//! reader would guess. Twelve-bit samples are written most
+//! significant bits first, three bytes to two pixels, but after every
+//! *ten* pixels the camera writes one extra byte, so ten pixels
+//! occupy sixteen bytes rather than fifteen. That is where the
+//! declared strip length comes from: 3040 pixels a row is 304 groups,
+//! 4864 bytes a row, 9844736 bytes for the frame, and reading it as a
+//! plain 12-bit stream goes wrong at the eleventh pixel. The spare
+//! byte has been zero in every file examined.
+//!
+//! Epson bought the R-D1's firmware plumbing from Olympus, and it
+//! shows: the makernote is `EPSON\0` plus a two-byte version and then
+//! an Olympus-style IFD, with Olympus's tag numbers and offsets
+//! relative to the file rather than to the note. The ones that matter
+//! are 0x0280 (the full-size JPEG preview, its leading `FF` byte
+//! clobbered exactly as Minolta and Sony clobber theirs), 0x0400
+//! (the sensor rectangle), 0x0401 (black level, four values in
+//! R, G, B, G2 order rather than in filter-array order) and
+//! 0x020b/0x020c, the size of the picture inside the sensor frame.
+//!
+//! What the file does *not* record anywhere this decoder could find is
+//! the as-shot white balance; see [`decode`].
+
+use crate::formats::common;
+use crate::tiff::{tags, Ifd, Tiff};
+use crate::{Cfa, CfaColor, Error, Format, RawData, RawImage, Rect, Result};
+
+/// Epson's (Olympus's) makernote tags.
+const EPSON_IMAGE_WIDTH: u16 = 0x020b;
+const EPSON_IMAGE_HEIGHT: u16 = 0x020c;
+const EPSON_PREVIEW: u16 = 0x0280;
+const EPSON_SENSOR_AREA: u16 = 0x0400;
+const EPSON_BLACK_LEVEL: u16 = 0x0401;
+
+/// Epson's private "packed, not compressed" value for `Compression`.
+const COMPRESSION_PACKED: u32 = 32769;
+
+/// How many pixels share a packing group, and how many bytes the group
+/// takes. Fifteen bytes hold the ten 12-bit samples; the sixteenth is
+/// padding the camera writes and the decoder steps over.
+const GROUP_PIXELS: usize = 10;
+const GROUP_BYTES: usize = 16;
+
+/// The IFD holding sensor samples: the one that says so with
+/// `PhotometricInterpretation` 32803 (CFA).
+fn raw_ifd<'a>(tiff: &'a Tiff<'_>) -> Result<&'a Ifd> {
+    tiff.all()
+        .into_iter()
+        .find(|ifd| ifd.get(tags::PHOTOMETRIC).and_then(|e| e.u32(0)) == Some(32803))
+        .ok_or_else(|| Error::Unsupported("ERF with no CFA image directory".into()))
+}
+
+/// Unpack the ten-pixels-in-sixteen-bytes frame.
+fn unpack(data: &[u8], width: usize, height: usize) -> Result<Vec<u16>> {
+    let pixels = width
+        .checked_mul(height)
+        .ok_or_else(|| Error::Corrupt("ERF frame too large".into()))?;
+    let groups = pixels.div_ceil(GROUP_PIXELS);
+    let need = groups
+        .checked_mul(GROUP_BYTES)
+        .ok_or_else(|| Error::Corrupt("ERF frame too large".into()))?;
+    if data.len() < need {
+        return Err(Error::Corrupt(format!(
+            "ERF strip holds {} bytes, want {need} for {width}x{height}",
+            data.len()
+        )));
+    }
+    let mut out = vec![0u16; pixels];
+    for (group, chunk) in out
+        .chunks_mut(GROUP_PIXELS)
+        .zip(data.as_chunks::<GROUP_BYTES>().0)
+    {
+        for (pair, triple) in group.chunks_mut(2).zip(chunk.as_chunks::<3>().0) {
+            pair[0] = ((triple[0] as u16) << 4) | (triple[1] as u16 >> 4);
+            if let Some(second) = pair.get_mut(1) {
+                *second = ((triple[1] as u16 & 0x0f) << 8) | triple[2] as u16;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// The makernote as its own IFD: `EPSON\0` and a two-byte version,
+/// then a bare directory in the file's byte order whose offsets are
+/// relative to the file, not to the note.
+fn makernote<'a>(tiff: &Tiff<'a>) -> Option<Tiff<'a>> {
+    let entry = tiff.exif()?.get(tags::MAKER_NOTE)?;
+    let head = tiff.bytes().get(entry.offset..entry.offset + 8)?;
+    if !head.starts_with(b"EPSON\0") {
+        return None;
+    }
+    Tiff::parse_at(tiff.bytes(), entry.offset + 8, tiff.little_endian()).ok()
+}
+
+/// Black level per filter-array position from makernote 0x0401, whose
+/// four values are ordered R, G, B, G2 whatever the array is.
+fn black_levels(maker: &Ifd, cfa: &Cfa) -> Option<[f32; 4]> {
+    let entry = maker.get(EPSON_BLACK_LEVEL)?;
+    let values: Vec<u32> = (0..4).map_while(|i| entry.u32(i)).collect();
+    let [red, green, blue, green2] = values[..] else {
+        return None;
+    };
+    let mut levels = [0.0f32; 4];
+    for (position, level) in levels.iter_mut().enumerate() {
+        *level = match cfa.color_at(position % 2, position / 2)? {
+            CfaColor::Red => red,
+            CfaColor::Green => green,
+            CfaColor::Blue => blue,
+            CfaColor::Green2 => green2,
+            _ => return None,
+        } as f32;
+    }
+    // The two greens of an RGGB array are not the same number here
+    // (64 and 60 on the R-D1): the second green position takes the
+    // fourth value, which is why the mapping goes through the colour
+    // rather than straight down the list.
+    Some(levels)
+}
+
+/// The preview the makernote points at, its clobbered first byte put
+/// back. Verified to be a whole JPEG before it is handed out.
+fn makernote_preview(tiff: &Tiff<'_>, maker: &Ifd) -> Option<Vec<u8>> {
+    let entry = maker.get(EPSON_PREVIEW)?;
+    let stream = tiff
+        .bytes()
+        .get(entry.offset..entry.offset.checked_add(entry.count)?)?;
+    if stream.len() < 4 || stream[1] != 0xd8 || stream[stream.len() - 2..] != [0xff, 0xd9] {
+        return None;
+    }
+    let mut out = stream.to_vec();
+    out[0] = 0xff;
+    Some(out)
+}
+
+fn best_preview(tiff: &Tiff<'_>) -> Option<Vec<u8>> {
+    let maker = makernote(tiff);
+    let from_maker = maker
+        .as_ref()
+        .and_then(|m| makernote_preview(tiff, m.root()));
+    let embedded = common::largest_jpeg(tiff);
+    match (from_maker, embedded) {
+        (Some(a), Some(b)) => Some(if a.len() >= b.len() { a } else { b }),
+        (a, b) => a.or(b),
+    }
+}
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let tiff = Tiff::parse(bytes)?;
+    let ifd = raw_ifd(&tiff)?;
+    let layout = crate::tiff::ImageLayout::of(&tiff, ifd)?;
+    if layout.compression != COMPRESSION_PACKED {
+        return Err(Error::Unsupported(format!(
+            "ERF with Compression {} (only 32769, Epson's packed raw, is known)",
+            layout.compression
+        )));
+    }
+    if layout.bits_per_sample != 12 {
+        return Err(Error::Unsupported(format!(
+            "ERF with {}-bit samples",
+            layout.bits_per_sample
+        )));
+    }
+    let [(start, len)] = layout.chunks[..] else {
+        return Err(Error::Unsupported(format!(
+            "ERF sensor data in {} strips, want one",
+            layout.chunks.len()
+        )));
+    };
+    let data = unpack(&bytes[start..start + len], layout.width, layout.height)?;
+
+    // Every R-D1 body reads out RGGB, and the file says so in
+    // CFAPattern; there is no other layout to fall back to.
+    let cfa = Cfa::RGGB;
+    let mut raw = RawImage::new(
+        Format::Erf,
+        layout.width,
+        layout.height,
+        1,
+        RawData::U16(data),
+        cfa.clone(),
+    );
+    raw.white_level = 4095.0;
+
+    let (make, model) = tiff.make_model();
+    raw.set_camera(&make, &model);
+    raw.orientation = common::orientation(&tiff);
+    raw.metadata = common::metadata(&tiff);
+    raw.preview = best_preview(&tiff);
+
+    if let Some(maker) = makernote(&tiff) {
+        let root = maker.root();
+        if let Some(levels) = black_levels(root, &cfa) {
+            raw.black_levels = levels;
+        }
+        // The picture is centred in the sensor frame: the camera
+        // records only its size (0x020b/0x020c), and half the
+        // difference on each side is the margin LibRaw also reports
+        // (16 columns, 12 rows on the R-D1).
+        let inner = |tag| root.get(tag).and_then(|e| e.u32(0)).map(|v| v as usize);
+        if let (Some(width), Some(height)) = (inner(EPSON_IMAGE_WIDTH), inner(EPSON_IMAGE_HEIGHT)) {
+            if width <= layout.width && height <= layout.height && width > 0 && height > 0 {
+                raw.crop = Rect {
+                    x: (layout.width - width) / 2,
+                    y: (layout.height - height) / 2,
+                    width,
+                    height,
+                };
+            }
+        }
+        // 0x0400 is the sensor rectangle itself (0 0 3040 2024 on both
+        // bodies). It is read only to check the frame is the whole
+        // sensor; nothing here needs it otherwise.
+        if let Some(area) = root.get(EPSON_SENSOR_AREA) {
+            if let (Some(width), Some(height)) = (area.u32(2), area.u32(3)) {
+                if width as usize != layout.width || height as usize != layout.height {
+                    log::debug!(
+                        "ERF sensor area {}x{} disagrees with the frame {}x{}",
+                        width,
+                        height,
+                        layout.width,
+                        layout.height
+                    );
+                }
+            }
+        }
+    }
+
+    // The as-shot white balance is deliberately left at unity. The
+    // R-D1's makernote carries no pair of numbers anywhere in its
+    // 1508-byte header whose ratio is the multiplier LibRaw reports —
+    // an exhaustive search over every 1-, 2-, 3- and 4-byte integer
+    // and every IEEE float in the header, in both byte orders, finds
+    // nothing, and the same search across two bodies with very
+    // different balances finds nothing either. Whatever LibRaw does
+    // with the R-D1 is not reading a stored multiplier, and inventing
+    // one here would be worse than saying the file records none.
+    //
+    // Without a balance the colours cannot be right, so no colour
+    // matrix is offered either: a caller with another decoder (the
+    // plugin has LibRaw) treats a missing matrix as "let the other one
+    // render this", which is the right outcome until the balance is
+    // found. The sensor data itself is exact.
+    raw.apply_camera_table();
+    raw.color_matrix = None;
+    Ok(raw)
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    let tiff = Tiff::parse(bytes)?;
+    Ok(best_preview(&tiff))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    /// Every file under `$SCHIST_RAW_CORPUS` with one of `extensions`,
+    /// recursively. Empty when the variable is unset, which is how the
+    /// corpus tests skip on a machine without the samples.
+    fn corpus(extensions: &[&str]) -> Vec<PathBuf> {
+        let Ok(root) = std::env::var("SCHIST_RAW_CORPUS") else {
+            return Vec::new();
+        };
+        let mut found = Vec::new();
+        let mut stack = vec![PathBuf::from(root)];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| extensions.iter().any(|want| e.eq_ignore_ascii_case(want)))
+                {
+                    found.push(path);
+                }
+            }
+        }
+        found.sort();
+        found
+    }
+
+    /// LibRaw's `unprocessed_raw -T` output beside the sample.
+    fn oracle(path: &Path) -> Option<(usize, usize, Vec<u16>)> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".tiff");
+        let image = image::open(PathBuf::from(name)).ok()?.into_luma16();
+        let (width, height) = (image.width() as usize, image.height() as usize);
+        Some((width, height, image.into_raw()))
+    }
+
+    /// `raw-identify -v -w` output beside the sample.
+    fn identify(path: &Path) -> Option<String> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".identify.txt");
+        std::fs::read_to_string(PathBuf::from(name)).ok()
+    }
+
+    /// The text after `key:` on the line that starts with it.
+    fn field<'a>(text: &'a str, key: &str) -> Option<&'a str> {
+        text.lines()
+            .map(str::trim)
+            .find(|line| line.starts_with(key))
+            .map(|line| line[key.len()..].trim())
+    }
+
+    /// A "W x H" pair.
+    fn size(text: &str, key: &str) -> Option<(usize, usize)> {
+        let value = field(text, key)?;
+        let (w, h) = value.split_once('x')?;
+        Some((w.trim().parse().ok()?, h.trim().parse().ok()?))
+    }
+
+    /// What LibRaw's "Image flip" means as an [`Orientation`].
+    fn flip(text: &str) -> Option<crate::Orientation> {
+        Some(match field(text, "Image flip:")?.parse::<u32>().ok()? {
+            3 => crate::Orientation::Rotate180,
+            5 => crate::Orientation::Rotate270CW,
+            6 => crate::Orientation::Rotate90CW,
+            _ => crate::Orientation::Normal,
+        })
+    }
+
+    /// The first four letters of the "Filter pattern" line as a CFA.
+    fn filter_pattern(text: &str) -> Option<Cfa> {
+        let pattern = field(text, "Filter pattern:")?;
+        let mut colors = [CfaColor::Red; 4];
+        for (color, letter) in colors.iter_mut().zip(pattern.chars()) {
+            *color = match letter {
+                'R' => CfaColor::Red,
+                'G' => CfaColor::Green,
+                'B' => CfaColor::Blue,
+                _ => return None,
+            };
+        }
+        Some(Cfa::Bayer(colors))
+    }
+
+    /// The as-shot multipliers, normalised to green, from the
+    /// "As shot" row of the makernote white-balance table.
+    fn as_shot(text: &str) -> Option<[f32; 3]> {
+        let row = field(text, "As shot")?;
+        let numbers: Vec<f32> = row
+            .split_whitespace()
+            .take(4)
+            .map_while(|v| v.parse::<f32>().ok())
+            .collect();
+        let [red, green, blue, ..] = numbers[..] else {
+            return None;
+        };
+        (green > 0.0).then(|| [red / green, 1.0, blue / green])
+    }
+
+    /// Compare a decoded frame with the oracle sample for sample.
+    fn compare(path: &Path, raw: &RawImage) {
+        let Some((width, height, expect)) = oracle(path) else {
+            eprintln!("{}: no oracle TIFF, data not checked", path.display());
+            return;
+        };
+        assert_eq!(
+            (raw.width, raw.height),
+            (width, height),
+            "{}: frame is {}x{}, oracle {width}x{height}",
+            path.display(),
+            raw.width,
+            raw.height
+        );
+        let RawData::U16(got) = &raw.data else {
+            panic!("{}: expected integer samples", path.display())
+        };
+        let mut wrong = 0usize;
+        let mut first = Vec::new();
+        for (i, (a, b)) in got.iter().zip(expect.iter()).enumerate() {
+            if a != b {
+                wrong += 1;
+                if first.len() < 8 {
+                    first.push(format!("({}, {}): {a} not {b}", i % width, i / width));
+                }
+            }
+        }
+        assert_eq!(
+            wrong,
+            0,
+            "{}: {wrong} samples differ; {}",
+            path.display(),
+            first.join(", ")
+        );
+    }
+
+    /// Levels, balance, crop, orientation and CFA against
+    /// `raw-identify`.
+    fn compare_metadata(path: &Path, raw: &RawImage) {
+        let Some(text) = identify(path) else { return };
+        if let Some(cfa) = filter_pattern(&text) {
+            assert_eq!(raw.cfa, cfa, "{}: filter pattern", path.display());
+        }
+        if let Some(orientation) = flip(&text) {
+            assert_eq!(
+                raw.orientation,
+                orientation,
+                "{}: orientation",
+                path.display()
+            );
+        }
+        if let Some((width, height)) = size(&text, "Image size:") {
+            let (x, y) = match field(&text, "Raw inset, width x height:") {
+                Some(inset) => {
+                    let left = inset
+                        .split("left:")
+                        .nth(1)
+                        .and_then(|v| v.split_whitespace().next().and_then(|v| v.parse().ok()));
+                    let top = inset
+                        .split("top:")
+                        .nth(1)
+                        .and_then(|v| v.split_whitespace().next().and_then(|v| v.parse().ok()));
+                    (left.unwrap_or(0), top.unwrap_or(0))
+                }
+                None => (0, 0),
+            };
+            let inset = field(&text, "Raw inset, width x height:")
+                .and_then(|v| v.split_whitespace().next().map(str::to_string));
+            let expect = match inset.and_then(|w| w.parse::<usize>().ok()) {
+                Some(w) => {
+                    let h = field(&text, "Raw inset, width x height:")
+                        .and_then(|v| v.split_whitespace().nth(2))
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(height);
+                    Rect {
+                        x,
+                        y,
+                        width: w,
+                        height: h,
+                    }
+                }
+                None => Rect {
+                    x: 0,
+                    y: 0,
+                    width,
+                    height,
+                },
+            };
+            if raw.crop != expect {
+                eprintln!("{}: crop {:?}, LibRaw {expect:?}", path.display(), raw.crop);
+            }
+        }
+        if let Some(expect) = as_shot(&text) {
+            for (got, want) in raw.wb_coeffs.iter().zip(expect.iter()) {
+                if (got - want).abs() > want * 0.02 {
+                    eprintln!(
+                        "{}: white balance {:?}, LibRaw {expect:?}",
+                        path.display(),
+                        raw.wb_coeffs
+                    );
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Cutting a file short must never panic, whatever it does return.
+    fn truncations(path: &Path) {
+        let bytes = std::fs::read(path).expect("sample readable");
+        let mut seed = bytes.len() as u64;
+        for _ in 0..10 {
+            // A cheap deterministic spread of cut points.
+            seed = seed
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            let at = (seed >> 33) as usize % bytes.len().max(1);
+            let _ = crate::decode(&bytes[..at]);
+            let _ = crate::probe(&bytes[..at]);
+        }
+    }
+
+    #[test]
+    fn unpacks_ten_pixels_from_sixteen_bytes() {
+        // Fifteen bytes of 12-bit samples then the padding byte the
+        // camera writes; the eleventh pixel restarts in the next group.
+        let mut data = vec![0u8; 32];
+        data[0] = 0xab;
+        data[1] = 0xcd;
+        data[2] = 0xef;
+        data[15] = 0xff; // padding, must be stepped over
+        data[16] = 0x12;
+        data[17] = 0x34;
+        let out = unpack(&data, 10, 2).unwrap();
+        assert_eq!(out[0], 0xabc);
+        assert_eq!(out[1], 0xdef);
+        assert_eq!(out[10], 0x123);
+    }
+
+    #[test]
+    fn short_strips_are_corrupt_not_a_panic() {
+        assert!(matches!(
+            unpack(&[0; 16], 3040, 2024),
+            Err(Error::Corrupt(_))
+        ));
+    }
+
+    #[test]
+    fn garbage_is_rejected() {
+        assert!(decode(b"II*\0garbage").is_err());
+        assert!(decode(&[]).is_err());
+    }
+
+    #[test]
+    fn corpus_matches_the_oracle() {
+        for path in corpus(&["erf"]) {
+            let bytes = std::fs::read(&path).expect("sample readable");
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(crate::Format::Erf),
+                "{}: probed as something else",
+                path.display()
+            );
+            let raw = match crate::decode(&bytes) {
+                Ok(raw) => raw,
+                Err(Error::Unsupported(why)) => {
+                    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    let allowed: &[(&str, &str)] = &[];
+                    let reason = allowed
+                        .iter()
+                        .find(|(file, _)| name.contains(file))
+                        .unwrap_or_else(|| {
+                            panic!("{}: unexpected Unsupported: {why}", path.display())
+                        });
+                    eprintln!(
+                        "{}: unsupported as documented ({}): {why}",
+                        path.display(),
+                        reason.1
+                    );
+                    continue;
+                }
+                Err(other) => panic!("{}: {other}", path.display()),
+            };
+            raw.validate().expect("decoded frame is self-consistent");
+            compare(&path, &raw);
+            compare_metadata(&path, &raw);
+            if let Some(preview) = &raw.preview {
+                image::load_from_memory(preview)
+                    .unwrap_or_else(|e| panic!("{}: preview will not decode: {e}", path.display()));
+            }
+        }
+    }
+
+    #[test]
+    fn truncated_files_never_panic() {
+        for path in corpus(&["erf"]) {
+            truncations(&path);
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/hasselblad.rs
+++ b/crates/codec-raw/src/formats/hasselblad.rs
@@ -1,0 +1,881 @@
+//! Hasselblad 3FR and FFF: the raw files of the H, X and CFV backs,
+//! and of the Imacon Ixpress backs Hasselblad bought.
+//!
+//! Both extensions hold the same thing — an ordinary TIFF (little
+//! endian for 3FR, big endian for the FFF a Phocus session writes)
+//! whose sensor IFD is marked `PhotometricInterpretation = 32803`
+//! (CFA) and carries the DNG level and crop tags. Only the
+//! compression differs: `1` is a plain 16-bit raster, `7` (and the
+//! `9` a few writers use) is Hasselblad's own lossless JPEG.
+//!
+//! That JPEG is where the format earns its module. The stream is a
+//! real SOF3 frame — 16-bit precision, one component, the sensor's
+//! dimensions, a single 17-symbol Huffman table — but the scan under
+//! it is not T.81's:
+//!
+//!  * the entropy data is **not** byte-stuffed. `0xFF` bytes appear
+//!    raw, so a JPEG-aware bit reader would stop at the first one it
+//!    mistook for a marker.
+//!  * bits are read most-significant-first out of **32-bit
+//!    little-endian words**, not out of the byte stream
+//!    ([`BitPumpMsb32`]).
+//!  * pixels are coded in pairs sharing one code group: both
+//!    difference *lengths* first, then both difference *values*.
+//!  * the two pixels of a pair belong to two independent prediction
+//!    chains (even and odd columns), each reset to 32768 at the start
+//!    of every row. The scan itself runs on without a break, so rows
+//!    are not byte-aligned.
+//!  * a length of 16 is followed by sixteen value bits rather than
+//!    standing for 32768 on its own, and the value 65535 in those
+//!    bits is an escape for -32768 (the one difference the ordinary
+//!    sign rule cannot spell).
+//!
+//! `SOS`'s `Ss` byte, which would be T.81's predictor selector, is 8
+//! — outside the standard's 1..=7 — which is the format admitting it
+//! is not doing T.81 prediction. That is why this module decodes the
+//! scan itself instead of calling [`crate::ljpeg`].
+
+use crate::bits::{BitPump, BitPumpMsb32, HuffTable};
+use crate::formats::common;
+use crate::tiff::{tags, Ifd, Tiff};
+use crate::{Cfa, Error, Format, RawData, RawImage, Rect, Result};
+
+/// DNG tags Hasselblad writes in its sensor IFD and IFD0.
+mod hb_tags {
+    pub const BLACK_LEVEL: u16 = 0xC61A;
+    pub const WHITE_LEVEL: u16 = 0xC61D;
+    pub const DEFAULT_CROP_ORIGIN: u16 = 0xC61F;
+    pub const DEFAULT_CROP_SIZE: u16 = 0xC620;
+    pub const COLOR_MATRIX_1: u16 = 0xC621;
+    pub const COLOR_MATRIX_2: u16 = 0xC622;
+    pub const AS_SHOT_NEUTRAL: u16 = 0xC628;
+    pub const UNIQUE_CAMERA_MODEL: u16 = 0xC614;
+}
+
+/// The sensor IFD: the one that says it holds a colour filter array.
+fn raw_ifd<'a>(tiff: &'a Tiff<'_>) -> Result<&'a Ifd> {
+    tiff.all()
+        .into_iter()
+        .find(|ifd| {
+            matches!(
+                ifd.get(tags::PHOTOMETRIC).and_then(|e| e.u32(0)),
+                Some(32803 | 34892)
+            )
+        })
+        .ok_or_else(|| Error::Corrupt("no CFA IFD in this Hasselblad file".into()))
+}
+
+/// The sensor data's byte range.
+///
+/// Not [`crate::tiff::ImageLayout`], because Hasselblad's
+/// `StripByteCounts` cannot be trusted: the Ixpress CF132 sample
+/// stores the *uncompressed* size there, 44,695,552 bytes in a
+/// 33,503,232-byte file, and means "to the end". Clamping is the only
+/// reading that decodes it, and it costs nothing for the files whose
+/// count is right.
+fn strip(tiff: &Tiff<'_>, ifd: &Ifd) -> Result<(usize, usize)> {
+    let base = tiff.base();
+    let offset = ifd
+        .get(tags::STRIP_OFFSETS)
+        .and_then(|e| e.u64(0))
+        .and_then(|o| usize::try_from(o).ok())
+        .and_then(|o| o.checked_add(base))
+        .ok_or_else(|| Error::Corrupt("Hasselblad CFA IFD without StripOffsets".into()))?;
+    if offset >= tiff.bytes().len() {
+        return Err(Error::Corrupt(
+            "Hasselblad strip starts past the end of the file".into(),
+        ));
+    }
+    let available = tiff.bytes().len() - offset;
+    let count = ifd
+        .get(tags::STRIP_BYTE_COUNTS)
+        .and_then(|e| e.u64(0))
+        .and_then(|c| usize::try_from(c).ok())
+        .unwrap_or(available)
+        .min(available);
+    Ok((offset, count))
+}
+
+/// What the markers before the scan say.
+struct Frame {
+    width: usize,
+    height: usize,
+    huffman: HuffTable,
+    /// Offset of the first entropy-coded byte within the stream.
+    scan: usize,
+}
+
+/// Parse SOI/SOF3/DHT/SOS. Only the pieces this scan needs are kept:
+/// the frame size to cross-check the IFD with, and the single
+/// difference-length table. Unknown segments are skipped by length,
+/// and `0xFF` fill bytes between segments are allowed (Hasselblad
+/// writes one before its DHT).
+fn frame(stream: &[u8]) -> Result<Frame> {
+    if stream.get(0..2) != Some(&[0xFF, 0xD8]) {
+        return Err(Error::Corrupt("Hasselblad raw strip is not a JPEG".into()));
+    }
+    let (mut width, mut height, mut huffman) = (0usize, 0usize, None);
+    let mut at = 2;
+    loop {
+        // Fill bytes: any number of 0xFF may precede a marker.
+        while stream.get(at) == Some(&0xFF) && stream.get(at + 1) == Some(&0xFF) {
+            at += 1;
+        }
+        let (Some(0xFF), Some(&marker)) = (stream.get(at), stream.get(at + 1)) else {
+            return Err(Error::Corrupt(format!(
+                "Hasselblad JPEG: no marker at byte {at}"
+            )));
+        };
+        let length = stream
+            .get(at + 2..at + 4)
+            .map(|b| u16::from_be_bytes([b[0], b[1]]) as usize)
+            .filter(|l| *l >= 2)
+            .ok_or_else(|| Error::Corrupt("Hasselblad JPEG: truncated segment".into()))?;
+        let body = stream
+            .get(at + 4..at + 2 + length)
+            .ok_or_else(|| Error::Corrupt("Hasselblad JPEG: segment past the end".into()))?;
+        match marker {
+            // SOF3, lossless. Anything else that starts a frame is a
+            // stream this module has never seen and cannot check.
+            0xC3 => {
+                if body.len() < 6 {
+                    return Err(Error::Corrupt("Hasselblad JPEG: short SOF".into()));
+                }
+                height = u16::from_be_bytes([body[1], body[2]]) as usize;
+                width = u16::from_be_bytes([body[3], body[4]]) as usize;
+                if body[5] != 1 {
+                    return Err(Error::Unsupported(format!(
+                        "Hasselblad JPEG with {} components",
+                        body[5]
+                    )));
+                }
+            }
+            0xC4 => {
+                // One table, always id 0; the scan has a single
+                // component so there is nothing to select between.
+                let counts = body
+                    .get(1..17)
+                    .ok_or_else(|| Error::Corrupt("Hasselblad JPEG: short DHT".into()))?;
+                let symbols = &body[17..];
+                huffman = Some(HuffTable::new(counts, symbols)?);
+            }
+            0xDA => {
+                let huffman = huffman.ok_or_else(|| {
+                    Error::Corrupt("Hasselblad JPEG: scan with no Huffman table".into())
+                })?;
+                if width == 0 || height == 0 {
+                    return Err(Error::Corrupt("Hasselblad JPEG: scan with no frame".into()));
+                }
+                return Ok(Frame {
+                    width,
+                    height,
+                    huffman,
+                    scan: at + 2 + length,
+                });
+            }
+            0xD9 => {
+                return Err(Error::Corrupt(
+                    "Hasselblad JPEG ends before its scan".into(),
+                ))
+            }
+            _ => {}
+        }
+        at += 2 + length;
+    }
+}
+
+/// One difference: the length symbol has already been read, so this
+/// only takes the value bits.
+///
+/// The sign rule is T.81's — a leading zero bit means the negative
+/// half of the category — with Hasselblad's escape on top: sixteen
+/// value bits reading 65535 mean -32768. Under the ordinary rule
+/// those bits would mean +65535, which as a 16-bit wrap is -1, a
+/// difference the shorter categories already spell; -32768 has no
+/// other spelling, so the encoder borrows the redundant code for it.
+#[inline]
+fn difference(pump: &mut BitPumpMsb32<'_>, length: u32) -> i32 {
+    if length == 0 || length > 16 {
+        return 0;
+    }
+    let value = pump.get(length);
+    if length == 16 && value == 0xFFFF {
+        return -32768;
+    }
+    if value < 1 << (length - 1) {
+        value as i32 - (1 << length) + 1
+    } else {
+        value as i32
+    }
+}
+
+/// Decode the scan into `width * height` samples.
+fn decompress(stream: &[u8], width: usize, height: usize) -> Result<Vec<u16>> {
+    let frame = frame(stream)?;
+    if frame.width != width || frame.height != height {
+        return Err(Error::Corrupt(format!(
+            "Hasselblad JPEG is {}x{} but its IFD says {width}x{height}",
+            frame.width, frame.height
+        )));
+    }
+    // At least a bit a sample: bounds a forged frame by the data.
+    let samples = crate::frame_samples(width, height, 1)?;
+    if stream.len().saturating_mul(8) < samples {
+        return Err(Error::Corrupt(format!(
+            "Hasselblad frame of {samples} samples in {} bytes",
+            stream.len()
+        )));
+    }
+    let mut out = vec![0u16; samples];
+    let mut pump = BitPumpMsb32::new(&stream[frame.scan..]);
+    for row in out.chunks_exact_mut(width) {
+        // Both chains start at the middle of the range, as T.81 has
+        // the first sample of a frame do; here it is every row.
+        let mut pred = [0x8000i32; 2];
+        let mut col = 0;
+        while col < width {
+            let len0 = frame.huffman.decode(&mut pump) as u32;
+            let len1 = frame.huffman.decode(&mut pump) as u32;
+            let diff0 = difference(&mut pump, len0);
+            let diff1 = difference(&mut pump, len1);
+            pred[0] = pred[0].wrapping_add(diff0);
+            pred[1] = pred[1].wrapping_add(diff1);
+            row[col] = pred[0] as u16;
+            // An odd width would leave the second half of the last
+            // pair with nowhere to go; no Hasselblad has one, but the
+            // bits are still consumed above so the stream stays in
+            // step.
+            if col + 1 < width {
+                row[col + 1] = pred[1] as u16;
+            }
+            col += 2;
+        }
+    }
+    Ok(out)
+}
+
+/// The 16-bit raster of the uncompressed backs, in the file's byte
+/// order.
+fn unpack(data: &[u8], width: usize, height: usize, little_endian: bool) -> Result<Vec<u16>> {
+    let samples = crate::frame_samples(width, height, 1)?;
+    if data.len() / 2 < samples {
+        return Err(Error::Corrupt(format!(
+            "Hasselblad strip holds {} bytes for {samples} 16-bit samples",
+            data.len()
+        )));
+    }
+    Ok(data[..samples * 2]
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|b| {
+            if little_endian {
+                u16::from_le_bytes([b[0], b[1]])
+            } else {
+                u16::from_be_bytes([b[0], b[1]])
+            }
+        })
+        .collect())
+}
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let tiff = Tiff::parse(bytes)?;
+    let ifd = raw_ifd(&tiff)?;
+    let int = |tag: u16| ifd.get(tag).and_then(|e| e.u32(0));
+    let width = int(tags::IMAGE_WIDTH).unwrap_or(0) as usize;
+    let height = int(tags::IMAGE_LENGTH).unwrap_or(0) as usize;
+    if width == 0 || height == 0 {
+        return Err(Error::Corrupt("Hasselblad CFA IFD with no size".into()));
+    }
+    let bits = int(tags::BITS_PER_SAMPLE).unwrap_or(16);
+    if bits != 16 {
+        return Err(Error::Unsupported(format!(
+            "Hasselblad sensor data {bits} bits deep"
+        )));
+    }
+    let (offset, count) = strip(&tiff, ifd)?;
+    let data = &bytes[offset..offset + count];
+    let compression = int(tags::COMPRESSION).unwrap_or(1);
+    let samples = match compression {
+        1 => unpack(data, width, height, tiff.little_endian())?,
+        // 7 is TIFF's "new-style JPEG"; 9 is the private value some
+        // Phocus versions write for the very same stream.
+        7 | 9 => decompress(data, width, height)?,
+        other => {
+            return Err(Error::Unsupported(format!(
+                "Hasselblad compression {other}"
+            )))
+        }
+    };
+
+    let mut raw = RawImage::new(
+        Format::Hasselblad,
+        width,
+        height,
+        1,
+        RawData::U16(samples),
+        // Every Hasselblad back this decoder has met reads RGGB from
+        // the top-left of the full frame; none of them carry a
+        // CFAPattern tag to say otherwise.
+        Cfa::RGGB,
+    );
+
+    let root = tiff.root();
+    let (make, model) = tiff.make_model();
+    // Model carries the body on the modern backs ("X2D 100C",
+    // "Hasselblad H5D-50c") and the shutter mode on some others
+    // ("CFV 100C/Electronic Shutter", which the camera table splits).
+    // Where it is missing altogether, UniqueCameraModel names the back.
+    let model = if model.trim().is_empty() {
+        root.get(hb_tags::UNIQUE_CAMERA_MODEL)
+            .and_then(|e| e.str())
+            .unwrap_or("")
+            .to_string()
+    } else {
+        model
+    };
+    raw.set_camera(&make, &model);
+
+    if let Some(black) = ifd.get(hb_tags::BLACK_LEVEL).and_then(|e| e.f64(0)) {
+        raw.black_levels = [black as f32; 4];
+    }
+    if let Some(white) = ifd.get(hb_tags::WHITE_LEVEL).and_then(|e| e.f64(0)) {
+        if white > 0.0 {
+            raw.white_level = white as f32;
+        }
+    }
+    // AsShotNeutral is the camera-space colour of white, so the
+    // multipliers that make it grey are its reciprocals; green is
+    // already 1 in every Hasselblad file, but normalising costs
+    // nothing and keeps the promise `wb_coeffs` makes.
+    if let Some(neutral) = root.get(hb_tags::AS_SHOT_NEUTRAL) {
+        let value = |i: usize| neutral.f64(i).filter(|v| *v > 0.0).map(|v| 1.0 / v as f32);
+        if let (Some(r), Some(g), Some(b)) = (value(0), value(1), value(2)) {
+            raw.wb_coeffs = [r / g, 1.0, b / g, 1.0];
+        }
+    }
+    // ColorMatrix2 belongs to the second calibration illuminant,
+    // which is the daylight one where a file carries both.
+    for tag in [hb_tags::COLOR_MATRIX_2, hb_tags::COLOR_MATRIX_1] {
+        if let Some(entry) = root.get(tag) {
+            if let Some(matrix) = (0..9)
+                .map(|i| entry.f64(i).map(|v| v as f32))
+                .collect::<Option<Vec<f32>>>()
+            {
+                raw.color_matrix = Some([
+                    [matrix[0], matrix[1], matrix[2]],
+                    [matrix[3], matrix[4], matrix[5]],
+                    [matrix[6], matrix[7], matrix[8]],
+                ]);
+                break;
+            }
+        }
+    }
+
+    // DefaultCropOrigin/Size mark the frame's active area; the rest
+    // is the masked border the back uses for its own black reference.
+    let pair = |tag: u16| -> Option<(usize, usize)> {
+        let entry = ifd.get(tag)?;
+        Some((entry.f64(0)? as usize, entry.f64(1)? as usize))
+    };
+    if let (Some((x, y)), Some((w, h))) = (
+        pair(hb_tags::DEFAULT_CROP_ORIGIN),
+        pair(hb_tags::DEFAULT_CROP_SIZE),
+    ) {
+        let inside = x.checked_add(w).is_some_and(|r| r <= width)
+            && y.checked_add(h).is_some_and(|b| b <= height);
+        if inside && w > 0 && h > 0 {
+            raw.crop = Rect {
+                x,
+                y,
+                width: w,
+                height: h,
+            };
+        }
+    }
+    raw.orientation = common::orientation(&tiff);
+    raw.metadata = common::metadata(&tiff);
+    raw.preview = common::largest_jpeg(&tiff);
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    Ok(common::largest_jpeg(&Tiff::parse(bytes)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Hasselblad's fixed table: seventeen difference lengths, 0..=16.
+    const COUNTS: [u8; 16] = [0, 2, 1, 4, 2, 3, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0];
+    const SYMBOLS: [u8; 17] = [6, 7, 5, 4, 8, 9, 10, 3, 11, 1, 2, 12, 0, 13, 14, 15, 16];
+
+    /// Writes bits MSB-first into 32-bit little-endian words, the
+    /// mirror of what [`BitPumpMsb32`] reads.
+    #[derive(Default)]
+    struct Writer {
+        words: Vec<u32>,
+        acc: u64,
+        bits: u32,
+    }
+
+    impl Writer {
+        fn put(&mut self, value: u32, len: u32) {
+            self.acc = (self.acc << len) | (value & ((1u64 << len) - 1) as u32) as u64;
+            self.bits += len;
+            while self.bits >= 32 {
+                self.words.push((self.acc >> (self.bits - 32)) as u32);
+                self.bits -= 32;
+            }
+        }
+        fn finish(mut self) -> Vec<u8> {
+            if self.bits > 0 {
+                self.put(0, 32 - self.bits);
+            }
+            self.words.iter().flat_map(|w| w.to_le_bytes()).collect()
+        }
+    }
+
+    /// The canonical code for a symbol in the table above.
+    fn code(symbol: u8) -> (u32, u32) {
+        let (mut value, mut index) = (0u32, 0usize);
+        for len in 1..=16u32 {
+            for _ in 0..COUNTS[len as usize - 1] {
+                if SYMBOLS[index] == symbol {
+                    return (value, len);
+                }
+                value += 1;
+                index += 1;
+            }
+            value <<= 1;
+        }
+        panic!("symbol {symbol} is not in the table");
+    }
+
+    /// The category and value bits for a difference, T.81's rule.
+    fn encode_diff(diff: i32) -> (u8, u32, u32) {
+        if diff == 0 {
+            return (0, 0, 0);
+        }
+        let magnitude = diff.unsigned_abs();
+        let len = 32 - magnitude.leading_zeros();
+        let bits = if diff > 0 {
+            diff as u32
+        } else {
+            (diff + (1 << len) - 1) as u32
+        };
+        (len as u8, bits, len)
+    }
+
+    /// A whole Hasselblad stream around a frame of differences.
+    fn stream(width: usize, height: usize, diffs: &[(i32, i32)]) -> Vec<u8> {
+        let mut out = vec![0xFF, 0xD8, 0xFF, 0xC3, 0, 11, 16];
+        out.extend_from_slice(&(height as u16).to_be_bytes());
+        out.extend_from_slice(&(width as u16).to_be_bytes());
+        out.extend_from_slice(&[1, 0, 0x11, 0]);
+        // A fill byte before the DHT, exactly as the cameras write it.
+        out.push(0xFF);
+        out.extend_from_slice(&[0xFF, 0xC4, 0, 36, 0]);
+        out.extend_from_slice(&COUNTS);
+        out.extend_from_slice(&SYMBOLS);
+        out.extend_from_slice(&[0xFF, 0xDA, 0, 8, 1, 0, 0, 8, 0, 0]);
+        let mut writer = Writer::default();
+        for (a, b) in diffs {
+            let (sym_a, bits_a, len_a) = encode_diff(*a);
+            let (sym_b, bits_b, len_b) = encode_diff(*b);
+            for symbol in [sym_a, sym_b] {
+                let (value, len) = code(symbol);
+                writer.put(value, len);
+            }
+            writer.put(bits_a, len_a);
+            writer.put(bits_b, len_b);
+        }
+        out.extend_from_slice(&writer.finish());
+        out
+    }
+
+    #[test]
+    fn pairs_run_two_prediction_chains() {
+        // Two rows of four: the chains must restart at 32768 on the
+        // second row rather than carry the first row's values on.
+        let diffs = [(10, -20), (3, 4), (-8, 30), (0, 1)];
+        let bytes = stream(4, 2, &diffs);
+        let out = decompress(&bytes, 4, 2).unwrap();
+        assert_eq!(
+            out,
+            vec![
+                32778, 32748, 32781, 32752, // row 0
+                32760, 32798, 32760, 32799, // row 1
+            ]
+        );
+    }
+
+    #[test]
+    fn sixteen_bit_escape_is_minus_32768() {
+        // 65535 in sixteen value bits is Hasselblad's spelling of
+        // -32768, which the ordinary rule cannot reach.
+        let mut bytes = vec![0xFF, 0xD8, 0xFF, 0xC3, 0, 11, 16, 0, 1, 0, 2, 1, 0, 0x11, 0];
+        bytes.extend_from_slice(&[0xFF, 0xC4, 0, 36, 0]);
+        bytes.extend_from_slice(&COUNTS);
+        bytes.extend_from_slice(&SYMBOLS);
+        bytes.extend_from_slice(&[0xFF, 0xDA, 0, 8, 1, 0, 0, 8, 0, 0]);
+        let mut writer = Writer::default();
+        let (value, len) = code(16);
+        writer.put(value, len);
+        let (zero, zero_len) = code(0);
+        writer.put(zero, zero_len);
+        writer.put(0xFFFF, 16);
+        bytes.extend_from_slice(&writer.finish());
+        let out = decompress(&bytes, 2, 1).unwrap();
+        assert_eq!(out, vec![0x8000u16.wrapping_sub(32768), 0x8000]);
+    }
+
+    #[test]
+    fn a_scan_may_hold_ff_bytes() {
+        // 0xFF is ordinary data here: a stuffing-aware reader would
+        // stop dead at one. A run of large positive differences fills
+        // the value bits with ones and so writes 0xFF bytes.
+        let diffs = [(4095, 4095); 8];
+        let bytes = stream(4, 2, &diffs);
+        let scan = frame(&bytes).unwrap().scan;
+        assert!(
+            bytes[scan..].contains(&0xFF),
+            "test stream has no 0xFF byte"
+        );
+        let out = decompress(&bytes, 4, 2).unwrap();
+        assert_eq!(
+            out,
+            vec![36863, 36863, 40958, 40958, 36863, 36863, 40958, 40958]
+        );
+    }
+
+    #[test]
+    fn truncated_streams_do_not_panic() {
+        let bytes = stream(4, 2, &[(10, -20), (3, 4), (-8, 30), (0, 1)]);
+        for cut in 0..bytes.len() {
+            // Either an error or a short frame; never a panic.
+            let _ = decompress(&bytes[..cut], 4, 2);
+        }
+    }
+
+    #[test]
+    fn a_frame_smaller_than_its_ifd_is_corrupt() {
+        let bytes = stream(4, 2, &[(1, 1), (1, 1)]);
+        assert!(matches!(decompress(&bytes, 8, 2), Err(Error::Corrupt(_))));
+    }
+
+    #[test]
+    fn corpus_matches_the_oracle() {
+        let files = corpus::files(&["3fr", "fff"]);
+        for path in &files {
+            let bytes = std::fs::read(path).unwrap();
+            let name = corpus::name(path);
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(Format::Hasselblad),
+                "{name} did not probe as Hasselblad"
+            );
+            let raw = decode(&bytes).unwrap_or_else(|e| panic!("{name}: {e}"));
+            raw.validate().unwrap_or_else(|e| panic!("{name}: {e}"));
+            assert_eq!(raw.cfa, Cfa::RGGB, "{name}");
+            corpus::check_against_oracle(path, &raw);
+            corpus::check_against_identify(path, &raw, &["Image size"]);
+            corpus::check_preview(path, &raw);
+        }
+        eprintln!("hasselblad: {} corpus files checked", files.len());
+    }
+
+    #[test]
+    fn corpus_truncations_do_not_panic() {
+        for path in corpus::files(&["3fr", "fff"]) {
+            corpus::check_truncations(&path, decode);
+        }
+    }
+
+    #[test]
+    fn garbage_is_not_a_hasselblad() {
+        assert!(decode(&[0u8; 64]).is_err());
+        assert!(decode(b"II*\0\x08\0\0\0").is_err());
+    }
+}
+
+/// Shared support for the corpus tests of the medium-format and
+/// Foveon modules (this one, `iiq`, `mos` and `x3f`).
+///
+/// Every check is driven by the sidecars the fetch script leaves
+/// beside a sample: `<file>.tiff` is LibRaw's `unprocessed_raw -T`
+/// frame, `<file>.identify.txt` is `raw-identify -v -w`. A sample
+/// with no sidecar is still decoded and validated; only the
+/// comparisons are skipped.
+#[cfg(test)]
+pub(crate) mod corpus {
+    use crate::{Orientation, RawData, RawImage};
+    use std::path::{Path, PathBuf};
+
+    /// Every file under `SCHIST_RAW_CORPUS` with one of `extensions`
+    /// (compared case-insensitively). Empty when the variable is
+    /// unset, which is how these tests skip themselves.
+    pub fn files(extensions: &[&str]) -> Vec<PathBuf> {
+        let Ok(root) = std::env::var("SCHIST_RAW_CORPUS") else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        let mut stack = vec![PathBuf::from(root)];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| extensions.iter().any(|w| w.eq_ignore_ascii_case(e)))
+                {
+                    out.push(path);
+                }
+            }
+        }
+        out.sort();
+        out
+    }
+
+    pub fn name(path: &Path) -> String {
+        path.file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    /// `<file><suffix>`, appended to the whole name so the sample's
+    /// own extension stays in it.
+    fn sidecar(path: &Path, suffix: &str) -> PathBuf {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(suffix);
+        PathBuf::from(name)
+    }
+
+    /// LibRaw's unpacked frame: 16-bit grey, the full sensor,
+    /// black not subtracted.
+    ///
+    /// Read with this crate's own TIFF parser rather than the `image`
+    /// crate, whose default allocation limit refuses the 200 MB
+    /// frames a 100 MP back unpacks to.
+    pub fn oracle(path: &Path) -> Option<(usize, usize, Vec<u16>)> {
+        let file = sidecar(path, ".tiff");
+        let bytes = std::fs::read(&file).ok()?;
+        let read = || -> crate::Result<(usize, usize, Vec<u16>)> {
+            let tiff = crate::tiff::Tiff::parse(&bytes)?;
+            let layout = crate::tiff::ImageLayout::of(&tiff, tiff.root())?;
+            if layout.bits_per_sample != 16 || layout.samples_per_pixel != 1 {
+                return Err(crate::Error::Unsupported(format!(
+                    "oracle frame is {} bits x {} samples",
+                    layout.bits_per_sample, layout.samples_per_pixel
+                )));
+            }
+            let little_endian = tiff.little_endian();
+            let mut out = Vec::with_capacity(layout.width * layout.height);
+            for (start, len) in &layout.chunks {
+                out.extend(
+                    bytes[*start..*start + *len]
+                        .as_chunks::<2>()
+                        .0
+                        .iter()
+                        .map(|b| {
+                            if little_endian {
+                                u16::from_le_bytes([b[0], b[1]])
+                            } else {
+                                u16::from_be_bytes([b[0], b[1]])
+                            }
+                        }),
+                );
+            }
+            out.truncate(layout.width * layout.height);
+            Ok((layout.width, layout.height, out))
+        };
+        // A sidecar that exists but will not read is a broken oracle,
+        // not a missing one, and must not pass silently.
+        Some(read().unwrap_or_else(|e| panic!("{}: {e}", file.display())))
+    }
+
+    pub fn identify(path: &Path) -> Option<String> {
+        std::fs::read_to_string(sidecar(path, ".identify.txt")).ok()
+    }
+
+    /// Samples must equal the oracle exactly, at the oracle's size.
+    pub fn check_against_oracle(path: &Path, raw: &RawImage) {
+        let file = name(path);
+        let Some((width, height, want)) = oracle(path) else {
+            eprintln!("{file}: no oracle frame, decode only");
+            return;
+        };
+        assert_eq!(
+            (raw.width, raw.height),
+            (width, height),
+            "{file}: decoded {}x{} but LibRaw unpacked {width}x{height}",
+            raw.width,
+            raw.height
+        );
+        let RawData::U16(got) = &raw.data else {
+            panic!("{file}: float samples from an integer sensor");
+        };
+        let mut wrong = 0usize;
+        let mut first = Vec::new();
+        for (i, (a, b)) in got.iter().zip(want.iter()).enumerate() {
+            if a != b {
+                wrong += 1;
+                if first.len() < 8 {
+                    first.push(format!("({},{}) got {a} want {b}", i % width, i / width));
+                }
+            }
+        }
+        assert_eq!(
+            wrong,
+            0,
+            "{file}: {wrong} of {} samples differ from the oracle: {}",
+            got.len(),
+            first.join(", ")
+        );
+    }
+
+    /// Compare what `raw-identify -v -w` printed with what the
+    /// decoder produced. `allow` names the checks a caller knows
+    /// LibRaw and this decoder legitimately disagree on.
+    pub fn check_against_identify(path: &Path, raw: &RawImage, allow: &[&str]) {
+        let file = name(path);
+        let Some(text) = identify(path) else { return };
+        let field = |key: &str| -> Option<String> {
+            text.lines()
+                .find(|l| l.trim_start().starts_with(key))
+                .and_then(|l| l.split_once(':'))
+                .map(|(_, v)| v.trim().to_string())
+        };
+        let size = |key: &str| -> Option<(usize, usize)> {
+            let value = field(key)?;
+            let (w, h) = value.split_once('x')?;
+            Some((w.trim().parse().ok()?, h.trim().parse().ok()?))
+        };
+        if let Some((width, height)) = size("Full size") {
+            assert_eq!(
+                (raw.width, raw.height),
+                (width, height),
+                "{file}: full size"
+            );
+        }
+        if !allow.contains(&"Image size") {
+            if let Some((width, height)) = size("Image size") {
+                assert_eq!(
+                    (raw.crop.width, raw.crop.height),
+                    (width, height),
+                    "{file}: crop size"
+                );
+            }
+        }
+        if !allow.contains(&"Image flip") {
+            if let Some(flip) = field("Image flip").and_then(|v| v.parse::<u32>().ok()) {
+                // LibRaw's flip is the EXIF orientation in its own
+                // spelling: 0 none, 3 half turn, 5 and 6 the quarters.
+                let want = match flip {
+                    3 => Orientation::Rotate180,
+                    5 => Orientation::Rotate270CW,
+                    6 => Orientation::Rotate90CW,
+                    _ => Orientation::Normal,
+                };
+                assert_eq!(raw.orientation, want, "{file}: orientation");
+            }
+        }
+        if !allow.contains(&"As shot") {
+            if let Some(line) = text.lines().find(|l| l.trim_start().starts_with("As shot")) {
+                let numbers: Vec<f32> = line
+                    .split_whitespace()
+                    .skip(2)
+                    .filter_map(|t| t.parse().ok())
+                    .collect();
+                if numbers.len() >= 3 && numbers[1] > 0.0 {
+                    for (i, want) in numbers[..3].iter().enumerate() {
+                        let want = want / numbers[1];
+                        let got = raw.wb_coeffs[i];
+                        assert!(
+                            (got - want).abs() <= 1e-3 * want.max(1.0),
+                            "{file}: white balance {i}: got {got} want {want}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// LibRaw prints the filter array as sixteen letters, a 4x4
+    /// expansion of the pattern at the frame's origin.
+    pub fn check_cfa(path: &Path, raw: &RawImage) {
+        use crate::{Cfa, CfaColor};
+        let file = name(path);
+        let Some(text) = identify(path) else { return };
+        let Some(want) = text
+            .lines()
+            .find(|l| l.trim_start().starts_with("Filter pattern"))
+            .and_then(|l| l.split_once(':'))
+            .map(|(_, v)| v.trim().to_string())
+        else {
+            return;
+        };
+        if want.len() < 4 {
+            return;
+        }
+        let letter = |c: CfaColor| match c {
+            CfaColor::Red => 'R',
+            CfaColor::Green | CfaColor::Green2 => 'G',
+            CfaColor::Blue => 'B',
+            CfaColor::Cyan => 'C',
+            CfaColor::Magenta => 'M',
+            CfaColor::Yellow => 'Y',
+            CfaColor::Emerald => 'E',
+        };
+        let Cfa::Bayer(_) = &raw.cfa else { return };
+        let got: String = [(0, 0), (1, 0), (0, 1), (1, 1)]
+            .iter()
+            .map(|(x, y)| raw.cfa.color_at(*x, *y).map(letter).unwrap_or('?'))
+            .collect();
+        // LibRaw prints the 2x2 four times over, in the same
+        // top-left, top-right, bottom-left, bottom-right order
+        // [`Cfa::Bayer`] uses, so the first four letters are it.
+        assert_eq!(got, want[..4], "{file}: filter pattern");
+    }
+
+    /// The preview must be a JPEG a viewer can actually show.
+    pub fn check_preview(path: &Path, raw: &RawImage) {
+        let file = name(path);
+        match &raw.preview {
+            Some(jpeg) => {
+                let decoded = image::load_from_memory(jpeg)
+                    .unwrap_or_else(|e| panic!("{file}: preview will not decode: {e}"));
+                assert!(decoded.width() > 0 && decoded.height() > 0, "{file}");
+            }
+            None => eprintln!("{file}: no embedded preview"),
+        }
+    }
+
+    /// A truncated file must be an error, never a panic. The cuts are
+    /// spread over the file with a fixed sequence so a failure is
+    /// reproducible.
+    pub fn check_truncations(path: &Path, decode: fn(&[u8]) -> crate::Result<RawImage>) {
+        let Ok(bytes) = std::fs::read(path) else {
+            return;
+        };
+        let mut state = 0x2545_F491_4F6C_DD1Du64;
+        for _ in 0..10 {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            let cut = (state % bytes.len() as u64) as usize;
+            let _ = decode(&bytes[..cut]);
+        }
+        // The empty file and a bare header, too.
+        let _ = decode(&[]);
+        let _ = decode(&bytes[..bytes.len().min(64)]);
+    }
+}

--- a/crates/codec-raw/src/formats/iiq.rs
+++ b/crates/codec-raw/src/formats/iiq.rs
@@ -1,0 +1,630 @@
+//! Phase One IIQ, the raw of the P, IQ and iXU backs.
+//!
+//! The container is a little-endian TIFF whose IFD0 is only the RGB
+//! thumbnail; everything that matters hangs off a private structure
+//! that starts at byte 8 with the signature `IIIICwaR`. Byte 16 holds
+//! the offset of a tag directory, and **every offset inside that
+//! structure — the directory's own, and each entry's — is relative to
+//! byte 8**, not to the file. (Files with the extension `.IIQ` and
+//! files a capture session writes as `.TIF` are the same format; the
+//! extension says nothing.)
+//!
+//! The directory is a count, a reserved word, then 16-byte entries of
+//! four little-endian `u32`s: tag, type, length in bytes, and either
+//! the value itself when it fits in four bytes or the offset of the
+//! value when it does not. Tag 0x010F is the sensor data: its length
+//! field is the byte count and its value field the offset.
+//!
+//! Four compressions live under tag 0x010E:
+//!
+//!  * **0** — a plain 16-bit raster.
+//!  * **3** — "IIQ L", lossless: 14-bit samples, one bit stream a
+//!    row, addressed through the row-offset table in tag 0x021C.
+//!    Every group of eight columns opens with two length selectors,
+//!    one for the even columns and one for the odd, and each pixel is
+//!    then a difference against the previous pixel of its own parity.
+//!    The bits are read most-significant-first out of 32-bit
+//!    little-endian words — the same reader Hasselblad's lossless
+//!    JPEG needs, which is no coincidence: the two formats share an
+//!    ancestor.
+//!  * **5** and **6** — "IIQ S", lossy. Neither is a
+//!    predictor-plus-residual code (the samples land on a coarse,
+//!    non-linear grid that no arrangement of the format-3 machinery
+//!    reproduces), and this module does not decode them.
+//!
+//! The 14-bit formats are shifted up by two on the way out, so that
+//! every Phase One frame — 16-bit raster or compressed — shares one
+//! scale and one white level. That is also what LibRaw does, so the
+//! oracle frames compare directly.
+
+use crate::bits::{BitPump, BitPumpMsb32};
+use crate::formats::common;
+use crate::tiff::Tiff;
+use crate::{Cfa, Error, Format, RawData, RawImage, Rect, Result};
+use rayon::prelude::*;
+
+/// Everything in the Phase One structure is addressed from byte 8,
+/// where its signature sits.
+const BASE: usize = 8;
+const SIGNATURE: &[u8; 8] = b"IIIICwaR";
+
+/// Tags of the Phase One directory that this decoder reads.
+mod p1 {
+    /// Three floats: the as-shot R, G and B multipliers, green 1.0.
+    /// (Tag 0x0106 beside it holds nine floats, but they are Phase
+    /// One's own camera matrix, not DNG's XYZ-to-camera one, so the
+    /// colour matrix is left to the camera table.)
+    pub const WHITE_BALANCE: u32 = 0x0107;
+    pub const RAW_WIDTH: u32 = 0x0108;
+    pub const RAW_HEIGHT: u32 = 0x0109;
+    pub const CROP_LEFT: u32 = 0x010A;
+    pub const CROP_TOP: u32 = 0x010B;
+    pub const CROP_WIDTH: u32 = 0x010C;
+    pub const CROP_HEIGHT: u32 = 0x010D;
+    pub const FORMAT: u32 = 0x010E;
+    /// The sensor data: length in the length field, offset in the
+    /// value field.
+    pub const RAW_DATA: u32 = 0x010F;
+    /// One `u32` a row: where that row's bits start, counted from the
+    /// beginning of the sensor data.
+    pub const ROW_OFFSETS: u32 = 0x021C;
+    /// The back's name and firmware, ASCII.
+    pub const MODEL_FIRMWARE: u32 = 0x0301;
+}
+
+/// The difference lengths a selector can choose between.
+///
+/// The selector is unary: up to five zero bits, then (unless five
+/// were read) a one, and finally a single bit that picks between the
+/// pair the run length reached. A run of zero — a leading one bit —
+/// means "keep the length in force", which is what a flat row spends
+/// most of its selectors on and why the format costs so little more
+/// than its samples. Entry 14 is not a length but the escape: the
+/// sample is sixteen raw bits, absolute rather than a difference.
+const LENGTHS: [u32; 10] = [8, 7, 6, 9, 11, 10, 5, 12, 14, 13];
+const ESCAPE: u32 = 14;
+
+/// One entry of the Phase One directory.
+#[derive(Debug, Clone, Copy)]
+struct Entry {
+    tag: u32,
+    /// Bytes of value, whether inline or out of line.
+    length: u32,
+    /// The value itself when `length <= 4`, else its offset from
+    /// [`BASE`].
+    value: u32,
+}
+
+/// The Phase One tag directory, and the file it points into.
+struct Directory<'a> {
+    bytes: &'a [u8],
+    entries: Vec<Entry>,
+}
+
+fn u32_at(bytes: &[u8], at: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(bytes.get(at..at + 4)?.try_into().ok()?))
+}
+
+impl<'a> Directory<'a> {
+    fn parse(bytes: &'a [u8]) -> Result<Directory<'a>> {
+        if bytes.get(BASE..BASE + 8) != Some(SIGNATURE) {
+            return Err(Error::Corrupt(
+                "no IIIICwaR signature at byte 8: not a Phase One raw".into(),
+            ));
+        }
+        let start = u32_at(bytes, 16)
+            .and_then(|o| (o as usize).checked_add(BASE))
+            .ok_or_else(|| Error::Corrupt("truncated Phase One header".into()))?;
+        let count = u32_at(bytes, start)
+            .ok_or_else(|| Error::Corrupt("Phase One directory outside the file".into()))?;
+        // A directory is sixteen bytes an entry; anything claiming
+        // more entries than the file could hold is corrupt, and
+        // capping keeps the allocation honest.
+        let count = count.min((bytes.len() / 16) as u32) as usize;
+        let mut entries = Vec::with_capacity(count);
+        for i in 0..count {
+            let at = start + 8 + i * 16;
+            let (Some(tag), Some(length), Some(value)) = (
+                u32_at(bytes, at),
+                u32_at(bytes, at + 8),
+                u32_at(bytes, at + 12),
+            ) else {
+                break;
+            };
+            entries.push(Entry { tag, length, value });
+        }
+        if entries.is_empty() {
+            return Err(Error::Corrupt("empty Phase One directory".into()));
+        }
+        Ok(Directory { bytes, entries })
+    }
+
+    fn entry(&self, tag: u32) -> Option<Entry> {
+        self.entries.iter().find(|e| e.tag == tag).copied()
+    }
+
+    /// A tag whose value fits in the entry.
+    fn int(&self, tag: u32) -> Option<u32> {
+        self.entry(tag).filter(|e| e.length <= 4).map(|e| e.value)
+    }
+
+    /// The bytes a tag points at, `None` when they are inline or fall
+    /// outside the file.
+    fn blob(&self, tag: u32) -> Option<&'a [u8]> {
+        let entry = self.entry(tag).filter(|e| e.length > 4)?;
+        let start = (entry.value as usize).checked_add(BASE)?;
+        let end = start.checked_add(entry.length as usize)?;
+        self.bytes.get(start..end)
+    }
+
+    fn floats(&self, tag: u32, count: usize) -> Option<Vec<f32>> {
+        let blob = self.blob(tag)?;
+        (blob.len() >= count * 4).then(|| {
+            blob[..count * 4]
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .map(|b| f32::from_le_bytes(*b))
+                .collect()
+        })
+    }
+
+    fn text(&self, tag: u32) -> Option<String> {
+        let blob = self.blob(tag)?;
+        let end = blob.iter().position(|b| *b == 0).unwrap_or(blob.len());
+        let text = String::from_utf8_lossy(&blob[..end]).trim().to_string();
+        (!text.is_empty()).then_some(text)
+    }
+}
+
+/// One row of an IIQ L stream.
+///
+/// `pred` holds the previous sample of each column parity and `len`
+/// the difference length in force for each; both are per row, because
+/// every row starts at its own offset in the table and its own bit
+/// boundary.
+fn decode_row(bytes: &[u8], out: &mut [u16]) {
+    let width = out.len();
+    let mut pump = BitPumpMsb32::new(bytes);
+    let mut pred = [0i32; 2];
+    // The escape until a selector says otherwise: a row whose first
+    // group declines to choose a length then reads whole samples
+    // rather than an arbitrary number of bits.
+    let mut len = [ESCAPE; 2];
+    // The columns past the last whole group of eight are always
+    // escapes; the encoder has no group header left to describe them.
+    let tail = width & !7;
+    for (col, sample) in out.iter_mut().enumerate() {
+        if col >= tail {
+            len = [ESCAPE; 2];
+        } else if col % 8 == 0 {
+            for side in &mut len {
+                let mut zeros = 0;
+                while zeros < 5 && pump.get(1) == 0 {
+                    zeros += 1;
+                }
+                if zeros > 0 {
+                    let index = (zeros - 1) * 2 + pump.get(1) as usize;
+                    *side = LENGTHS[index.min(LENGTHS.len() - 1)];
+                }
+            }
+        }
+        let parity = col & 1;
+        let bits = len[parity];
+        if bits == ESCAPE {
+            pred[parity] = pump.get(16) as i32;
+        } else {
+            // The value bits are the difference biased into the
+            // unsigned range: the low half of the range is negative.
+            let value = pump.get(bits) as i32;
+            pred[parity] += value + 1 - (1 << (bits - 1));
+        }
+        // 14-bit samples, shifted to share the 16-bit raster's scale.
+        *sample = (pred[parity].clamp(0, 0x3FFF) as u16) << 2;
+    }
+}
+
+/// IIQ L: one independent bit stream a row, found through the
+/// row-offset table.
+fn decompress(data: &[u8], offsets: &[u8], width: usize, height: usize) -> Result<Vec<u16>> {
+    if offsets.len() < height * 4 {
+        return Err(Error::Corrupt(format!(
+            "Phase One row table holds {} bytes for {height} rows",
+            offsets.len()
+        )));
+    }
+    // A compressed row cannot be shorter than a bit a sample, so the
+    // data length bounds the frame a forged header may claim.
+    let samples = crate::frame_samples(width, height, 1)?;
+    if data.len().saturating_mul(8) < samples {
+        return Err(Error::Corrupt(format!(
+            "Phase One frame of {samples} samples in {} bytes",
+            data.len()
+        )));
+    }
+    let mut out = vec![0u16; samples];
+    out.par_chunks_exact_mut(width)
+        .enumerate()
+        .for_each(|(row, line)| {
+            let start = u32::from_le_bytes([
+                offsets[row * 4],
+                offsets[row * 4 + 1],
+                offsets[row * 4 + 2],
+                offsets[row * 4 + 3],
+            ]) as usize;
+            // A row pointing outside the data is left black rather
+            // than failing the whole frame: the rest of the file is
+            // still worth having, and the bit reader would only see
+            // zeros anyway.
+            if let Some(bits) = data.get(start..) {
+                decode_row(bits, line);
+            }
+        });
+    Ok(out)
+}
+
+/// The uncompressed format: little-endian 16-bit, no padding.
+fn unpack(data: &[u8], width: usize, height: usize) -> Result<Vec<u16>> {
+    let samples = width * height;
+    if data.len() < samples * 2 {
+        return Err(Error::Corrupt(format!(
+            "Phase One raster holds {} bytes for {samples} samples",
+            data.len()
+        )));
+    }
+    Ok(data[..samples * 2]
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|b| u16::from_le_bytes(*b))
+        .collect())
+}
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let dir = Directory::parse(bytes)?;
+    let width = dir.int(p1::RAW_WIDTH).unwrap_or(0) as usize;
+    let height = dir.int(p1::RAW_HEIGHT).unwrap_or(0) as usize;
+    if width == 0 || height == 0 || width > 1 << 16 || height > 1 << 16 {
+        return Err(Error::Corrupt(format!(
+            "Phase One frame of {width}x{height}"
+        )));
+    }
+    let raw = dir
+        .entry(p1::RAW_DATA)
+        .ok_or_else(|| Error::Corrupt("Phase One file with no sensor data".into()))?;
+    let start = (raw.value as usize)
+        .checked_add(BASE)
+        .ok_or_else(|| Error::Corrupt("Phase One data offset out of range".into()))?;
+    let data = bytes
+        .get(start..)
+        .ok_or_else(|| Error::Corrupt("Phase One data starts past the end of the file".into()))?;
+    let data = &data[..(raw.length as usize).min(data.len())];
+
+    let format = dir.int(p1::FORMAT).unwrap_or(0);
+    let (samples, white) = match format {
+        0 => (unpack(data, width, height)?, 65535.0),
+        3 => {
+            let offsets = dir
+                .blob(p1::ROW_OFFSETS)
+                .ok_or_else(|| Error::Corrupt("IIQ L with no row-offset table".into()))?;
+            // 14 bits shifted up by two: the largest sample a row can
+            // carry is 0x3FFF, so saturation lands here.
+            (decompress(data, offsets, width, height)?, 65532.0)
+        }
+        5 | 6 => {
+            return Err(Error::Unsupported(
+                "Phase One IIQ S (compression 5 and 6): a lossy code this decoder cannot read"
+                    .into(),
+            ))
+        }
+        other => return Err(Error::Unsupported(format!("Phase One compression {other}"))),
+    };
+
+    // The crop's top-left is where the sensor's active area begins,
+    // and that area always reads RGGB; the masked border in front of
+    // it moves the pattern's phase for the full frame.
+    let left = dir.int(p1::CROP_LEFT).unwrap_or(0) as usize;
+    let top = dir.int(p1::CROP_TOP).unwrap_or(0) as usize;
+    let cfa = Cfa::RGGB.shifted(left % 2, top % 2);
+    let mut image = RawImage::new(Format::Iiq, width, height, 1, RawData::U16(samples), cfa);
+    image.white_level = white;
+
+    let crop_width = dir.int(p1::CROP_WIDTH).unwrap_or(0) as usize;
+    let crop_height = dir.int(p1::CROP_HEIGHT).unwrap_or(0) as usize;
+    if crop_width > 0
+        && crop_height > 0
+        && left + crop_width <= width
+        && top + crop_height <= height
+    {
+        image.crop = Rect {
+            x: left,
+            y: top,
+            width: crop_width,
+            height: crop_height,
+        };
+    }
+    if let Some(wb) = dir.floats(p1::WHITE_BALANCE, 3) {
+        if wb.iter().all(|v| v.is_finite() && *v > 0.0) {
+            image.wb_coeffs = [wb[0] / wb[1], 1.0, wb[2] / wb[1], 1.0];
+        }
+    }
+
+    // The TIFF around the private structure carries the maker, the
+    // model, the Exif IFD and the thumbnail. It is an ordinary TIFF,
+    // so a failure to parse it costs only the metadata.
+    if let Ok(tiff) = Tiff::parse(bytes) {
+        let (make, model) = tiff.make_model();
+        image.set_camera(&make, &model);
+        image.metadata = common::metadata(&tiff);
+        image.orientation = common::orientation(&tiff);
+        // Phase One thumbnails are uncompressed RGB, so this is
+        // almost always None; it costs nothing to look.
+        image.preview = common::largest_jpeg(&tiff);
+    }
+    if image.model.is_empty() {
+        // The back names itself in the private structure too, ahead
+        // of its firmware versions: "IQ140, User Firmware: 8.00.30".
+        if let Some(text) = dir.text(p1::MODEL_FIRMWARE) {
+            let model = text.split(',').next().unwrap_or(&text).trim().to_string();
+            image.set_camera("Phase One", &model);
+        }
+    }
+    image.apply_camera_table();
+    Ok(image)
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    Ok(common::largest_jpeg(&Tiff::parse(bytes)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::formats::hasselblad::corpus;
+
+    /// Files whose compression this module knowingly declines, with
+    /// the reason. Everything else in the corpus must decode.
+    const UNSUPPORTED: &[(&str, &str)] = &[
+        ("H_25-H25_Outdoor_.IIQ", "IIQ S, compression 5"),
+        ("P25+-CF028662.IIQ", "IIQ S, compression 5"),
+        ("P45-230215_3810.TIF", "IIQ S, compression 5"),
+        (
+            "IQ140-Phase_One_IQ140_sample_files_04_Diciembre_2017_005_IIQ_S.TIF",
+            "IIQ S, compression 6",
+        ),
+        (
+            "IQ140-Phase_One_IQ140_sample_files_04_Diciembre_2017_011_Sensor+_IIQ_S.TIF",
+            "IIQ S, compression 6",
+        ),
+        ("iXU180-cap_22908.IIQ", "IIQ S, compression 6"),
+    ];
+
+    /// A Phase One structure around one directory, for the tests that
+    /// do not need a whole file.
+    fn build(entries: &[(u32, u32, u32)], trailer: &[u8]) -> Vec<u8> {
+        let mut out = b"II*\0".to_vec();
+        out.extend_from_slice(&0u32.to_le_bytes()); // no IFD0
+        out.extend_from_slice(SIGNATURE);
+        let directory = 4096u32;
+        out.extend_from_slice(&directory.to_le_bytes());
+        out.resize(BASE + directory as usize, 0);
+        out.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+        out.extend_from_slice(&0u32.to_le_bytes());
+        for (tag, length, value) in entries {
+            out.extend_from_slice(&tag.to_le_bytes());
+            out.extend_from_slice(&4u32.to_le_bytes());
+            out.extend_from_slice(&length.to_le_bytes());
+            out.extend_from_slice(&value.to_le_bytes());
+        }
+        out.extend_from_slice(trailer);
+        out
+    }
+
+    #[test]
+    fn offsets_are_relative_to_the_signature() {
+        // The blob's value field is 0, which is byte 8 of the file:
+        // the signature itself. Reading it from byte 0 would give
+        // "II*\0".
+        let bytes = build(&[(p1::MODEL_FIRMWARE, 8, 0)], &[]);
+        assert_eq!(
+            Directory::parse(&bytes)
+                .unwrap()
+                .text(p1::MODEL_FIRMWARE)
+                .as_deref(),
+            Some("IIIICwaR")
+        );
+    }
+
+    #[test]
+    fn short_values_live_in_the_entry() {
+        let bytes = build(&[(p1::RAW_WIDTH, 4, 4134), (p1::FORMAT, 4, 3)], &[]);
+        let dir = Directory::parse(&bytes).unwrap();
+        assert_eq!(dir.int(p1::RAW_WIDTH), Some(4134));
+        assert_eq!(dir.int(p1::FORMAT), Some(3));
+        assert_eq!(dir.blob(p1::RAW_WIDTH), None);
+    }
+
+    /// Writes bits MSB-first into 32-bit little-endian words.
+    #[derive(Default)]
+    struct Writer {
+        words: Vec<u32>,
+        acc: u64,
+        bits: u32,
+    }
+
+    impl Writer {
+        fn put(&mut self, value: u32, len: u32) {
+            self.acc = (self.acc << len) | (value & ((1u64 << len) - 1) as u32) as u64;
+            self.bits += len;
+            while self.bits >= 32 {
+                self.words.push((self.acc >> (self.bits - 32)) as u32);
+                self.bits -= 32;
+            }
+        }
+        /// The unary selector for a length, or a bare 1 for "keep".
+        fn selector(&mut self, length: Option<u32>) {
+            match length {
+                None => self.put(1, 1),
+                Some(length) => {
+                    let index = LENGTHS.iter().position(|l| *l == length).expect("a length");
+                    let zeros = index as u32 / 2 + 1;
+                    // Five zeros need no terminating one: the run is
+                    // already as long as the code allows.
+                    if zeros < 5 {
+                        self.put(1, zeros + 1);
+                    } else {
+                        self.put(0, zeros);
+                    }
+                    self.put(index as u32 % 2, 1);
+                }
+            }
+        }
+        fn finish(mut self) -> Vec<u8> {
+            if self.bits > 0 {
+                self.put(0, 32 - self.bits);
+            }
+            self.words.iter().flat_map(|w| w.to_le_bytes()).collect()
+        }
+    }
+
+    #[test]
+    fn a_group_of_eight_carries_two_selectors() {
+        let mut writer = Writer::default();
+        // Even columns escape to whole samples, odd columns use
+        // six-bit differences from zero.
+        writer.selector(Some(ESCAPE));
+        writer.selector(Some(6));
+        for i in 0..4 {
+            writer.put(1000 + i, 16);
+            // 6-bit differences of +1: value 1 - 1 + 32 = 32.
+            writer.put(32, 6);
+        }
+        let bytes = writer.finish();
+        let mut out = vec![0u16; 8];
+        decode_row(&bytes, &mut out);
+        assert_eq!(
+            out,
+            vec![
+                1000 << 2,
+                1 << 2,
+                1001 << 2,
+                2 << 2,
+                1002 << 2,
+                3 << 2,
+                1003 << 2,
+                4 << 2
+            ]
+        );
+    }
+
+    #[test]
+    fn a_leading_one_keeps_the_length_in_force() {
+        let mut writer = Writer::default();
+        writer.selector(Some(5));
+        writer.selector(Some(5));
+        for _ in 0..8 {
+            // 5 bits: value 16 is the difference 16 + 1 - 16 = +1.
+            writer.put(16, 5);
+        }
+        writer.selector(None);
+        writer.selector(None);
+        for _ in 0..8 {
+            writer.put(16, 5);
+        }
+        let bytes = writer.finish();
+        let mut out = vec![0u16; 16];
+        decode_row(&bytes, &mut out);
+        // Each parity climbs by one a step, right through the second
+        // group's "keep" selectors.
+        let want: Vec<u16> = (0..16).map(|i| ((i / 2 + 1) << 2) as u16).collect();
+        assert_eq!(out, want);
+    }
+
+    #[test]
+    fn the_tail_past_the_last_whole_group_is_absolute() {
+        let mut writer = Writer::default();
+        writer.selector(Some(5));
+        writer.selector(Some(5));
+        for _ in 0..8 {
+            writer.put(16, 5);
+        }
+        // Ten columns: the last two have no group header and are
+        // whole samples.
+        writer.put(4000, 16);
+        writer.put(4001, 16);
+        let bytes = writer.finish();
+        let mut out = vec![0u16; 10];
+        decode_row(&bytes, &mut out);
+        assert_eq!(&out[8..], &[4000 << 2, 4001 << 2]);
+    }
+
+    #[test]
+    fn a_short_row_table_is_corrupt() {
+        assert!(matches!(
+            decompress(&[0; 64], &[0; 4], 8, 4),
+            Err(Error::Corrupt(_))
+        ));
+    }
+
+    #[test]
+    fn rows_pointing_outside_the_data_stay_black() {
+        // Two rows, the second addressed past the end.
+        let mut offsets = Vec::new();
+        offsets.extend_from_slice(&0u32.to_le_bytes());
+        offsets.extend_from_slice(&u32::MAX.to_le_bytes());
+        let out = decompress(&[0; 64], &offsets, 8, 2).unwrap();
+        assert_eq!(&out[8..], &[0; 8]);
+    }
+
+    #[test]
+    fn garbage_is_not_a_phase_one() {
+        assert!(decode(&[0u8; 64]).is_err());
+        assert!(decode(b"II*\0\x08\0\0\0IIIICwaR").is_err());
+        for cut in 0..200 {
+            let bytes = build(&[(p1::RAW_WIDTH, 4, 8), (p1::RAW_HEIGHT, 4, 8)], &[]);
+            let _ = decode(&bytes[..cut.min(bytes.len())]);
+        }
+    }
+
+    #[test]
+    fn corpus_matches_the_oracle() {
+        let files = corpus::files(&["iiq", "tif"]);
+        let mut checked = 0;
+        for path in &files {
+            let bytes = std::fs::read(path).unwrap();
+            let name = corpus::name(path);
+            // The corpus holds converters' TIFFs too; only the Phase
+            // One ones are this module's.
+            if crate::probe(&bytes) != Some(Format::Iiq) {
+                continue;
+            }
+            checked += 1;
+            if let Some((_, reason)) = UNSUPPORTED.iter().find(|(f, _)| *f == name) {
+                match decode(&bytes) {
+                    Err(Error::Unsupported(_)) => eprintln!("{name}: unsupported ({reason})"),
+                    other => panic!("{name}: expected Unsupported for {reason}, got {other:?}"),
+                }
+                continue;
+            }
+            let raw = decode(&bytes).unwrap_or_else(|e| panic!("{name}: {e}"));
+            raw.validate().unwrap_or_else(|e| panic!("{name}: {e}"));
+            corpus::check_against_oracle(path, &raw);
+            // LibRaw shaves a pixel off some Phase One crops and
+            // rotates portrait backs itself, neither of which the
+            // file says to do; the CFA check below covers what the
+            // crop is really for.
+            corpus::check_against_identify(path, &raw, &["Image size", "Image flip"]);
+            corpus::check_cfa(path, &raw);
+            corpus::check_preview(path, &raw);
+        }
+        eprintln!("iiq: {checked} corpus files checked");
+        assert!(files.is_empty() || checked > 0);
+    }
+
+    #[test]
+    fn corpus_truncations_do_not_panic() {
+        for path in corpus::files(&["iiq", "tif"]) {
+            corpus::check_truncations(&path, decode);
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/kodak.rs
+++ b/crates/codec-raw/src/formats/kodak.rs
@@ -1,0 +1,1014 @@
+//! Kodak DCR, KDC and the DCS-series TIFFs.
+//!
+//! Kodak's raws are all TIFF containers and share almost nothing else.
+//! Three generations of professional back, two of consumer compact and
+//! four compression schemes wear the same two file extensions, so this
+//! module works out what it is holding from the directories rather
+//! than from the name.
+//!
+//! Two private directories carry everything the TIFF tags do not, and
+//! neither is a SubIFD, so the shared parser does not reach them:
+//!
+//! * `KodakIFD`, tag 0x8290 of IFD0 — the DCS bodies' calibration.
+//!   Tags 0x03EB..0x03EE are the crop (left, top, width, height),
+//!   0x0848..0x084D six white-balance presets, 0x03FC which of them
+//!   was shot, 0x0960/0x0961 the sensor size and 0x090D the
+//!   linearisation curve.
+//! * The KDC directory, tag 0xFE00 of IFD0 — the EasyShare compacts'.
+//!   Its tags run 0xFA00..0xFB8D: 0xFA13/0xFA14 the frame, 0xFA18 the
+//!   depth and 0xFA25 the as-shot white balance.
+//!
+//! # White balance, two conventions
+//!
+//! The DCS presets are *divisors*: a stored triple (r, g, b) means
+//! multipliers proportional to (1/r, 1/g, 1/b), which is why LibRaw
+//! prints g²/r, g, g²/b for them. The KDC triples are multipliers
+//! already, scaled by 65536. Both are normalised to green here.
+//!
+//! # Compression
+//!
+//! * 7 — lossless JPEG (SOF3), on the DCS 460/560 backs. The frame is
+//!   one stream half the sensor's width with two components, so the
+//!   samples come out interleaved in exactly the order the sensor rows
+//!   want them.
+//! * 65000 — Kodak's own scheme, on the DCR bodies. See
+//!   [`decode_65000_segment`].
+//! * 32867 — the DC40/DC50's much older scheme. `Unsupported`.
+//! * 1 — uncompressed, packed at the stated depth.
+//!
+//! Whichever codec wrote it, a DCS frame decodes to *indices* into a
+//! linearisation curve rather than to samples — KodakIFD 0x090D where
+//! there is a KodakIFD, IFD0's GrayResponseCurve on the 460 — and the
+//! curve's last entry is the saturation point.
+
+use crate::formats::common;
+use crate::tiff::{tags, Entry, Ifd, ImageLayout, Tiff};
+use crate::{Cfa, CfaColor, Error, Format, RawData, RawImage, Rect, Result};
+use rayon::prelude::*;
+
+/// IFD0's pointer to the DCS calibration directory.
+const KODAK_IFD: u16 = 0x8290;
+/// IFD0's pointer to the EasyShare (KDC) directory.
+const KDC_IFD: u16 = 0xFE00;
+
+// KodakIFD tags.
+const KODAK_CROP_LEFT: u16 = 0x03EB;
+const KODAK_CROP_TOP: u16 = 0x03EC;
+const KODAK_CROP_WIDTH: u16 = 0x03ED;
+const KODAK_CROP_HEIGHT: u16 = 0x03EE;
+const KODAK_WB_INDEX: u16 = 0x03FC;
+const KODAK_WB_FIRST: u16 = 0x0848;
+const KODAK_CURVE: u16 = 0x090D;
+
+// KDC directory tags.
+const KDC_WIDTH: u16 = 0xFA13;
+const KDC_HEIGHT: u16 = 0xFA14;
+const KDC_CFA: u16 = 0xFA15;
+const KDC_DEPTH: u16 = 0xFA18;
+const KDC_WB_ASSHOT: u16 = 0xFA25;
+const KDC_IMAGE_WIDTH: u16 = 0xFA31;
+const KDC_IMAGE_HEIGHT: u16 = 0xFA32;
+const KDC_CROP_LEFT: u16 = 0xFA3E;
+const KDC_CROP_TOP: u16 = 0xFA3F;
+
+// Tags of the SubIFD the EasyShare bodies write beside the KDC one.
+const KDC_SUB_CFA_PATTERN: u16 = 0xFD09;
+const KDC_SUB_OFFSETS: u16 = 0xFD04;
+const KDC_SUB_OFFSET_BIAS: u16 = 0xFD14;
+
+/// TIFF's GrayResponseCurve, the 460's linearisation table.
+const GRAY_RESPONSE_CURVE: u16 = 0x0123;
+
+// Tags of a 65000-compressed image IFD.
+const K65000_SEGMENT: u16 = 0xFDE8;
+const K65000_OFFSETS: u16 = 0xFDE9;
+
+/// A private directory Kodak points at with a plain LONG offset: not a
+/// SubIFD, so the shared parser never followed it, but an ordinary IFD
+/// in the file's byte order once you go there.
+fn private_ifd<'a>(tiff: &Tiff<'a>, tag: u16) -> Option<Tiff<'a>> {
+    let offset = tiff.find(tag)?.u32(0)? as usize + tiff.base();
+    Tiff::parse_at(tiff.bytes(), offset, tiff.little_endian()).ok()
+}
+
+/// The IFD holding sensor samples, if the file has one at all.
+///
+/// The DCR bodies and the 560 back mark it with
+/// `PhotometricInterpretation` 32803 (CFA). The older DCS 460 predates
+/// that value and calls its sensor plain greyscale, so the fallback is
+/// the largest single-sample strip image in the file — every other
+/// directory in one of these is either an RGB preview or a thumbnail
+/// smaller than the frame. The EasyShare KDCs have no image directory
+/// at all and describe their frame only in the private one.
+fn raw_ifd<'a>(tiff: &'a Tiff<'_>) -> Option<&'a Ifd> {
+    let ifds = tiff.all();
+    if let Some(cfa) = ifds
+        .iter()
+        .find(|ifd| ifd.get(tags::PHOTOMETRIC).and_then(|e| e.u32(0)) == Some(32803))
+    {
+        return Some(cfa);
+    }
+    ifds.into_iter()
+        .filter(|ifd| {
+            ifd.has(tags::STRIP_OFFSETS)
+                && ifd
+                    .get(tags::SAMPLES_PER_PIXEL)
+                    .and_then(|e| e.u32(0))
+                    .unwrap_or(1)
+                    == 1
+        })
+        .max_by_key(|ifd| {
+            let side = |tag| ifd.get(tag).and_then(|e| e.u64(0)).unwrap_or(0);
+            side(tags::IMAGE_WIDTH).saturating_mul(side(tags::IMAGE_LENGTH))
+        })
+        .filter(|ifd| ifd.has(tags::IMAGE_WIDTH) && ifd.has(tags::IMAGE_LENGTH))
+}
+
+/// A 2x2 filter array from a CFAPattern-shaped entry (0 red, 1 green,
+/// 2 blue, row-major).
+fn cfa_from_pattern(entry: &Entry) -> Option<Cfa> {
+    let mut colors = [CfaColor::Red; 4];
+    for (i, color) in colors.iter_mut().enumerate() {
+        *color = match entry.u32(i)? {
+            0 => CfaColor::Red,
+            1 => CfaColor::Green,
+            2 => CfaColor::Blue,
+            _ => return None,
+        };
+    }
+    Some(Cfa::Bayer(colors))
+}
+
+/// The linearisation curve every DCS body decodes indices into.
+///
+/// KodakIFD 0x090D holds it where the file has a KodakIFD: 1024
+/// entries on the DCR bodies, 4096 on the 560 back, the last entry
+/// being where the sensor saturates. The 460 has no KodakIFD and uses
+/// the standard GrayResponseCurve instead, 256 entries for its 8-bit
+/// samples. Note that 0x090D wins where both exist: the 560's own
+/// GrayResponseCurve is a display curve and applying it would brighten
+/// every sample by a quarter.
+fn curve(tiff: &Tiff<'_>, kodak: Option<&Tiff<'_>>) -> Option<Vec<u16>> {
+    let entry = kodak
+        .and_then(|k| k.root().get(KODAK_CURVE))
+        // The DCS 460 has no KodakIFD; its 8-bit samples are indices
+        // into IFD0's 256-entry GrayResponseCurve instead, which is
+        // what that tag is for on a greyscale TIFF.
+        .or_else(|| tiff.find(GRAY_RESPONSE_CURVE))?;
+    let table: Vec<u16> = (0..entry.count)
+        .map_while(|i| entry.u32(i))
+        .map(|v| v.min(u16::MAX as u32) as u16)
+        .collect();
+    (table.len() >= 256).then_some(table)
+}
+
+/// Apply a linearisation curve in place, clamping indices that ran
+/// past its end (a corrupt segment can predict its way out of range).
+fn linearize(samples: &mut [u16], table: &[u16]) {
+    let last = table[table.len() - 1];
+    for sample in samples {
+        *sample = table.get(*sample as usize).copied().unwrap_or(last);
+    }
+}
+
+// ---------------------------------------------------------- 65000
+
+/// Kodak's "65000" compression, one 256-pixel segment at a time.
+///
+/// The scheme was read off the files themselves, and it is simple once
+/// seen. A segment of `n` pixels opens with `ceil(n/2)` bytes of
+/// lengths, one 4-bit field a pixel, **low nibble first** — so byte 0
+/// holds pixel 0's length in its low half and pixel 1's in its high
+/// half. The differences follow, `length` bits each, in a bitstream
+/// that is neither of the usual two: the bytes pair up into 16-bit
+/// **big-endian** words and the bits come out of each word from its
+/// **least** significant end. A field's value is extended the way
+/// JPEG extends a magnitude category — a value below half the range is
+/// negative, `v - 2^len + 1` — so a length of `k` covers exactly the
+/// differences whose magnitude needs `k` bits.
+///
+/// Each difference adds to the last pixel of the same filter column,
+/// two back, and both predictors restart at zero every segment; that
+/// is what lets a decoder start at any segment the offset table names.
+/// The result is an index into the linearisation curve, not a sample.
+fn decode_65000_segment(data: &[u8], out: &mut [u16]) -> Result<()> {
+    let n = out.len();
+    let table = n.div_ceil(2);
+    if data.len() < table {
+        return Err(Error::Corrupt(
+            "Kodak 65000 segment shorter than its length table".into(),
+        ));
+    }
+    // Read the bitstream from 16-bit big-endian words, least
+    // significant bit first. Past the end it yields zeros, so a
+    // truncated segment decodes to a flat run rather than failing.
+    let bits = &data[table..];
+    let mut accumulator: u64 = 0;
+    let mut have = 0u32;
+    let mut at = 0usize;
+    let mut predictor = [0i32; 2];
+
+    for i in 0..n {
+        let byte = data[i / 2];
+        let length = (if i % 2 == 0 { byte & 0x0f } else { byte >> 4 }) as u32;
+        if length > 12 {
+            return Err(Error::Corrupt(format!(
+                "Kodak 65000 difference length {length} (the field is at most 12 bits)"
+            )));
+        }
+        while have < length {
+            let high = bits.get(at).copied().unwrap_or(0) as u64;
+            let low = bits.get(at + 1).copied().unwrap_or(0) as u64;
+            accumulator |= ((high << 8) | low) << have;
+            have += 16;
+            at += 2;
+        }
+        let mut difference = 0i32;
+        if length > 0 {
+            let value = (accumulator & ((1u64 << length) - 1)) as i32;
+            accumulator >>= length;
+            have -= length;
+            difference = if value < (1 << (length - 1)) {
+                value - (1 << length) + 1
+            } else {
+                value
+            };
+        }
+        let slot = &mut predictor[i & 1];
+        *slot = slot.saturating_add(difference);
+        out[i] = (*slot).clamp(0, u16::MAX as i32) as u16;
+    }
+    Ok(())
+}
+
+/// A whole 65000 frame: the image IFD names the segment width
+/// (0xFDE8) and carries a table of segment *end* offsets (0xFDE9)
+/// relative to the strip, the first segment starting at zero.
+fn decode_65000(strip: &[u8], ifd: &Ifd, width: usize, height: usize) -> Result<Vec<u16>> {
+    let segment = ifd
+        .get(K65000_SEGMENT)
+        .and_then(|e| e.u32(0))
+        .filter(|v| *v > 0)
+        .ok_or_else(|| Error::Corrupt("Kodak 65000 image without a segment width".into()))?
+        as usize;
+    let offsets: Vec<u32> = ifd
+        .get(K65000_OFFSETS)
+        .map(|e| e.u32s())
+        .ok_or_else(|| Error::Corrupt("Kodak 65000 image without a segment offset table".into()))?;
+    let per_row = width.div_ceil(segment);
+    if offsets.len() < per_row * height {
+        return Err(Error::Corrupt(format!(
+            "Kodak 65000 offset table holds {} entries, want {}",
+            offsets.len(),
+            per_row * height
+        )));
+    }
+
+    let mut out = vec![0u16; width * height];
+    // Segments are independent by construction, so rows are too.
+    out.par_chunks_mut(width)
+        .enumerate()
+        .try_for_each(|(row, samples)| -> Result<()> {
+            for s in 0..per_row {
+                let index = row * per_row + s;
+                let start = if index == 0 {
+                    0
+                } else {
+                    offsets[index - 1] as usize
+                };
+                let end = offsets[index] as usize;
+                if end < start || end > strip.len() {
+                    return Err(Error::Corrupt(format!(
+                        "Kodak 65000 segment {index} spans {start}..{end} of a {}-byte strip",
+                        strip.len()
+                    )));
+                }
+                let first = s * segment;
+                let last = (first + segment).min(width);
+                decode_65000_segment(&strip[start..end], &mut samples[first..last])?;
+            }
+            Ok(())
+        })?;
+    Ok(out)
+}
+
+// ---------------------------------------------------------- packing
+
+/// Unpack samples stored without compression at `bits` a piece, most
+/// significant bits first.
+fn unpack(data: &[u8], pixels: usize, bits: u32, little_endian: bool) -> Result<Vec<u16>> {
+    match bits {
+        8 => {
+            if data.len() < pixels {
+                return Err(Error::Corrupt(
+                    "Kodak frame shorter than its 8-bit samples".into(),
+                ));
+            }
+            Ok(data[..pixels].iter().map(|b| *b as u16).collect())
+        }
+        12 => {
+            let need = pixels
+                .div_ceil(2)
+                .checked_mul(3)
+                .ok_or_else(|| Error::Corrupt("Kodak frame too large".into()))?;
+            if data.len() < need {
+                return Err(Error::Corrupt(format!(
+                    "Kodak frame holds {} bytes of 12-bit samples, want {need}",
+                    data.len()
+                )));
+            }
+            let mut out = vec![0u16; pixels];
+            for (pair, triple) in out.chunks_mut(2).zip(data.as_chunks::<3>().0) {
+                pair[0] = ((triple[0] as u16) << 4) | (triple[1] as u16 >> 4);
+                if let Some(second) = pair.get_mut(1) {
+                    *second = ((triple[1] as u16 & 0x0f) << 8) | triple[2] as u16;
+                }
+            }
+            Ok(out)
+        }
+        16 => {
+            if data.len() / 2 < pixels {
+                return Err(Error::Corrupt(
+                    "Kodak frame shorter than its 16-bit samples".into(),
+                ));
+            }
+            Ok(data[..pixels * 2]
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|w| {
+                    if little_endian {
+                        u16::from_le_bytes([w[0], w[1]])
+                    } else {
+                        u16::from_be_bytes([w[0], w[1]])
+                    }
+                })
+                .collect())
+        }
+        other => Err(Error::Unsupported(format!(
+            "Kodak frame with {other}-bit samples"
+        ))),
+    }
+}
+
+// ------------------------------------------------------ white balance
+
+/// The as-shot balance from the DCS presets. The six entries at
+/// 0x0848 are Daylight, Tungsten, Fluorescent, Flash, Custom and
+/// Camera Auto, and 0x03FC says which the shot used; the numbers are
+/// divisors, so a multiplier is green over the channel.
+fn dcs_white_balance(kodak: &Ifd) -> Option<[f32; 4]> {
+    let index = kodak
+        .get(KODAK_WB_INDEX)
+        .and_then(|e| e.u32(0))
+        .unwrap_or(0);
+    let entry = kodak.get(KODAK_WB_FIRST + index.min(5) as u16)?;
+    let (red, green, blue) = (entry.f64(0)?, entry.f64(1)?, entry.f64(2)?);
+    if !(red > 0.0 && green > 0.0 && blue > 0.0) {
+        return None;
+    }
+    Some([(green / red) as f32, 1.0, (green / blue) as f32, 1.0])
+}
+
+/// The as-shot balance from the KDC directory: multipliers scaled by
+/// whatever the green entry is (65536 on every file seen).
+fn kdc_white_balance(kdc: &Ifd) -> Option<[f32; 4]> {
+    let entry = kdc.get(KDC_WB_ASSHOT)?;
+    let (red, green, blue) = (entry.f64(0)?, entry.f64(1)?, entry.f64(2)?);
+    if !(red > 0.0 && green > 0.0 && blue > 0.0) {
+        return None;
+    }
+    Some([(red / green) as f32, 1.0, (blue / green) as f32, 1.0])
+}
+
+/// A crop rectangle, kept only when it actually lies inside the frame.
+/// The EasyShare Z981's does not — its own tags put a 4288-wide
+/// picture 52 columns into a 4304-wide sensor — so those files come
+/// out uncropped, which is what LibRaw reports for them too.
+fn crop_within(
+    x: usize,
+    y: usize,
+    width: usize,
+    height: usize,
+    frame: (usize, usize),
+) -> Option<Rect> {
+    (width > 0 && height > 0 && x + width <= frame.0 && y + height <= frame.1).then_some(Rect {
+        x,
+        y,
+        width,
+        height,
+    })
+}
+
+// ---------------------------------------------------------- decoding
+
+/// The DCS/DCR path: a real image IFD with strips.
+fn decode_tiff_raw(
+    bytes: &[u8],
+    tiff: &Tiff<'_>,
+    ifd: &Ifd,
+    kodak: Option<&Tiff<'_>>,
+) -> Result<RawImage> {
+    let layout = ImageLayout::of(tiff, ifd)?;
+    let [(start, len)] = layout.chunks[..] else {
+        return Err(Error::Unsupported(format!(
+            "Kodak sensor data in {} strips, want one",
+            layout.chunks.len()
+        )));
+    };
+    let strip = &bytes[start..start + len];
+    let pixels = layout
+        .width
+        .checked_mul(layout.height)
+        .ok_or_else(|| Error::Corrupt("Kodak frame too large".into()))?;
+
+    let curve_table = curve(tiff, kodak);
+    let mut samples = match layout.compression {
+        1 => unpack(strip, pixels, layout.bits_per_sample, tiff.little_endian())?,
+        7 => {
+            let image = crate::ljpeg::decode(strip)?;
+            // The DCS backs halve the width and use two components, so
+            // the stream's samples already alternate the way the row
+            // does; anything else would need a layout this has never
+            // seen.
+            if image.width * image.components != layout.width || image.height != layout.height {
+                return Err(Error::Corrupt(format!(
+                    "Kodak lossless JPEG is {}x{}x{}, want {}x{}",
+                    image.width, image.height, image.components, layout.width, layout.height
+                )));
+            }
+            image.data
+        }
+        65000 => decode_65000(strip, ifd, layout.width, layout.height)?,
+        32867 => {
+            return Err(Error::Unsupported(
+                "Kodak Compression 32867, the DC40/DC50 scheme".into(),
+            ))
+        }
+        other => return Err(Error::Unsupported(format!("Kodak Compression {other}"))),
+    };
+    if samples.len() != pixels {
+        return Err(Error::Corrupt(format!(
+            "Kodak decoder produced {} samples for {}x{}",
+            samples.len(),
+            layout.width,
+            layout.height
+        )));
+    }
+
+    let mut white = ((1u32 << layout.bits_per_sample.clamp(8, 16)) - 1) as f32;
+    if let Some(table) = &curve_table {
+        linearize(&mut samples, table);
+        // 3700 of a nominal 4095 on the DCS Pro bodies, the full
+        // 4095 on the 460/560 backs.
+        white = table[table.len() - 1] as f32;
+    }
+
+    let cfa = ifd
+        .get(tags::CFA_PATTERN)
+        .and_then(cfa_from_pattern)
+        .unwrap_or(Cfa::GRBG);
+    let mut raw = RawImage::new(
+        Format::Kodak,
+        layout.width,
+        layout.height,
+        1,
+        RawData::U16(samples),
+        cfa,
+    );
+    raw.white_level = white;
+
+    if let Some(kodak) = kodak {
+        let root = kodak.root();
+        if let Some(coeffs) = dcs_white_balance(root) {
+            raw.wb_coeffs = coeffs;
+        }
+        let number = |tag| root.get(tag).and_then(|e| e.u32(0)).map(|v| v as usize);
+        if let (Some(x), Some(y), Some(width), Some(height)) = (
+            number(KODAK_CROP_LEFT),
+            number(KODAK_CROP_TOP),
+            number(KODAK_CROP_WIDTH),
+            number(KODAK_CROP_HEIGHT),
+        ) {
+            if let Some(crop) = crop_within(x, y, width, height, (layout.width, layout.height)) {
+                raw.crop = crop;
+            }
+        }
+    }
+    Ok(raw)
+}
+
+/// The EasyShare path: no image IFD at all, only the private
+/// directories, and the samples packed somewhere the file names very
+/// indirectly.
+fn decode_kdc(bytes: &[u8], tiff: &Tiff<'_>, kdc: &Tiff<'_>) -> Result<RawImage> {
+    let root = kdc.root();
+    let number = |tag| root.get(tag).and_then(|e| e.u32(0)).map(|v| v as usize);
+    let width =
+        number(KDC_WIDTH).ok_or_else(|| Error::Corrupt("KDC without a frame width".into()))?;
+    // The stated height is one short of the frame LibRaw reads and is
+    // odd, which a Bayer frame cannot be; rounding it up to the next
+    // even row gives the frame the data actually holds.
+    let height = number(KDC_HEIGHT)
+        .map(|h| h + (h & 1))
+        .ok_or_else(|| Error::Corrupt("KDC without a frame height".into()))?;
+    // 0xFA18 is the sample depth on the Z981 and nonsense (65532) on
+    // the P880, so it is believed only when it could be one.
+    let bits = number(KDC_DEPTH)
+        .filter(|b| (8..=16).contains(b))
+        .unwrap_or(12) as u32;
+    if width == 0 || height == 0 {
+        return Err(Error::Corrupt("KDC with an empty frame".into()));
+    }
+
+    // Where the samples start is the one thing these files never say
+    // plainly. The SubIFD's 0xFD04 is a mixed bag of values that ends
+    // in a long arithmetic run — one entry per band of rows, spaced by
+    // exactly a band's worth of packed bytes — and 0xFD14 is a bias
+    // (-64) that has to come off the first of them. Both were read off
+    // the file against LibRaw's own frame; a KDC that has neither is
+    // rejected rather than guessed at.
+    let sub = tiff
+        .all()
+        .into_iter()
+        .find(|ifd| ifd.has(KDC_SUB_OFFSETS))
+        .ok_or_else(|| Error::Unsupported("KDC without the 0xFD04 band table".into()))?;
+    let bands = sub
+        .get(KDC_SUB_OFFSETS)
+        .map(|e| e.u32s())
+        .unwrap_or_default();
+    let bias = sub
+        .get(KDC_SUB_OFFSET_BIAS)
+        .and_then(|e| e.f64(0))
+        .unwrap_or(0.0) as i64;
+    let first = longest_ramp(&bands)
+        .ok_or_else(|| Error::Unsupported("KDC band table with no run of band offsets".into()))?;
+    let start = usize::try_from(first as i64 - bias)
+        .map_err(|_| Error::Corrupt("KDC sample offset out of range".into()))?;
+    if start >= bytes.len() {
+        return Err(Error::Corrupt(
+            "KDC sample offset past the end of the file".into(),
+        ));
+    }
+
+    let samples = unpack(&bytes[start..], width * height, bits, tiff.little_endian())?;
+    // The filter array is spelled out twice and the two disagree: the
+    // KDC directory's 0xFA15 names the array of the *cropped* picture
+    // ("RGGB"), the SubIFD's CFAPattern the array of the frame this
+    // decoder hands out. The frame's is the one that belongs here.
+    let cfa = sub
+        .get(KDC_SUB_CFA_PATTERN)
+        .and_then(cfa_from_pattern)
+        .unwrap_or(Cfa::GRBG);
+    let mut raw = RawImage::new(Format::Kodak, width, height, 1, RawData::U16(samples), cfa);
+    raw.white_level = ((1u32 << bits.clamp(8, 16)) - 1) as f32;
+    if let Some(coeffs) = kdc_white_balance(root) {
+        raw.wb_coeffs = coeffs;
+    }
+    if let (Some(x), Some(y), Some(w), Some(h)) = (
+        number(KDC_CROP_LEFT),
+        number(KDC_CROP_TOP),
+        number(KDC_IMAGE_WIDTH),
+        number(KDC_IMAGE_HEIGHT),
+    ) {
+        // The margins are a pixel out on the row axis: taking the
+        // P880's 3264x2448 picture at its stated (8, 1) would give the
+        // cropped image a GRBG array, and the same directory says in
+        // 0xFA15 that the picture is BGGR. The filter array is the
+        // camera's own statement about the crop, so the origin is
+        // nudged by up to one pixel to agree with it.
+        let (x, y) = match kdc_named_cfa(root) {
+            Some(named) => [(0, 0), (1, 0), (0, 1), (1, 1)]
+                .into_iter()
+                .map(|(dx, dy)| (x + dx, y + dy))
+                .find(|(x, y)| raw.cfa.shifted(*x, *y) == named)
+                .unwrap_or((x, y)),
+            None => (x, y),
+        };
+        if let Some(crop) = crop_within(x, y, w, h, (width, height)) {
+            raw.crop = crop;
+        }
+    }
+    Ok(raw)
+}
+
+/// The filter array of the *cropped* picture, spelled out in ASCII in
+/// the KDC directory ("RGGB", "BGGR").
+fn kdc_named_cfa(kdc: &Ifd) -> Option<Cfa> {
+    let name = kdc.get(KDC_CFA)?.str()?;
+    if name.len() != 4 {
+        return None;
+    }
+    let mut colors = [CfaColor::Red; 4];
+    for (color, letter) in colors.iter_mut().zip(name.chars()) {
+        *color = match letter {
+            'R' => CfaColor::Red,
+            'G' => CfaColor::Green,
+            'B' => CfaColor::Blue,
+            _ => return None,
+        };
+    }
+    Some(Cfa::Bayer(colors))
+}
+
+/// The first value of the longest run of equal, positive differences
+/// in `values`, which is how the band table hides its offsets among
+/// its other numbers. At least four bands are wanted so a chance pair
+/// cannot win.
+fn longest_ramp(values: &[u32]) -> Option<u32> {
+    let (mut best_start, mut best_len) = (0usize, 0usize);
+    let mut i = 0;
+    while i + 1 < values.len() {
+        let step = values[i + 1].checked_sub(values[i]).filter(|s| *s > 0);
+        let Some(step) = step else {
+            i += 1;
+            continue;
+        };
+        let mut j = i + 1;
+        while j + 1 < values.len() && values[j + 1].checked_sub(values[j]) == Some(step) {
+            j += 1;
+        }
+        if j - i + 1 > best_len {
+            best_len = j - i + 1;
+            best_start = i;
+        }
+        i = j.max(i + 1);
+    }
+    (best_len >= 4).then(|| values[best_start])
+}
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let tiff = Tiff::parse(bytes)?;
+    let kodak = private_ifd(&tiff, KODAK_IFD);
+    let kdc = private_ifd(&tiff, KDC_IFD);
+
+    let mut raw = match raw_ifd(&tiff) {
+        Some(ifd) => decode_tiff_raw(bytes, &tiff, ifd, kodak.as_ref())?,
+        None => {
+            let kdc = kdc.as_ref().ok_or_else(|| {
+                Error::Unsupported(
+                    "Kodak TIFF with neither a CFA image IFD nor a KDC directory".into(),
+                )
+            })?;
+            decode_kdc(bytes, &tiff, kdc)?
+        }
+    };
+
+    let (make, model) = tiff.make_model();
+    raw.set_camera(&make, &model);
+    raw.orientation = common::orientation(&tiff);
+    raw.metadata = common::metadata(&tiff);
+    // The DCS bodies keep every preview in Kodak's own compression, so
+    // there is frequently no JPEG to hand out at all; the EasyShare
+    // compacts point at a full-size one with JPEGInterchangeFormat.
+    raw.preview = common::largest_jpeg(&tiff);
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    let tiff = Tiff::parse(bytes)?;
+    Ok(common::largest_jpeg(&tiff))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    /// Every file under `$SCHIST_RAW_CORPUS` with one of `extensions`,
+    /// recursively. Empty when the variable is unset, which is how the
+    /// corpus tests skip on a machine without the samples.
+    fn corpus(extensions: &[&str]) -> Vec<PathBuf> {
+        let Ok(root) = std::env::var("SCHIST_RAW_CORPUS") else {
+            return Vec::new();
+        };
+        let mut found = Vec::new();
+        let mut stack = vec![PathBuf::from(root)];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| extensions.iter().any(|want| e.eq_ignore_ascii_case(want)))
+                {
+                    found.push(path);
+                }
+            }
+        }
+        found.sort();
+        found
+    }
+
+    /// LibRaw's `unprocessed_raw -T` output beside the sample.
+    fn oracle(path: &Path) -> Option<(usize, usize, Vec<u16>)> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".tiff");
+        let image = image::open(PathBuf::from(name)).ok()?.into_luma16();
+        let (width, height) = (image.width() as usize, image.height() as usize);
+        Some((width, height, image.into_raw()))
+    }
+
+    /// `raw-identify -v -w` output beside the sample.
+    fn identify(path: &Path) -> Option<String> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".identify.txt");
+        std::fs::read_to_string(PathBuf::from(name)).ok()
+    }
+
+    /// The text after `key:` on the line that starts with it.
+    fn field<'a>(text: &'a str, key: &str) -> Option<&'a str> {
+        text.lines()
+            .map(str::trim)
+            .find(|line| line.starts_with(key))
+            .map(|line| line[key.len()..].trim())
+    }
+
+    /// A "W x H" pair.
+    fn size(text: &str, key: &str) -> Option<(usize, usize)> {
+        let value = field(text, key)?;
+        let (w, h) = value.split_once('x')?;
+        Some((w.trim().parse().ok()?, h.trim().parse().ok()?))
+    }
+
+    /// What LibRaw's "Image flip" means as an [`Orientation`].
+    fn flip(text: &str) -> Option<crate::Orientation> {
+        Some(match field(text, "Image flip:")?.parse::<u32>().ok()? {
+            3 => crate::Orientation::Rotate180,
+            5 => crate::Orientation::Rotate270CW,
+            6 => crate::Orientation::Rotate90CW,
+            _ => crate::Orientation::Normal,
+        })
+    }
+
+    /// The first four letters of the "Filter pattern" line as a CFA.
+    fn filter_pattern(text: &str) -> Option<Cfa> {
+        let pattern = field(text, "Filter pattern:")?;
+        let mut colors = [CfaColor::Red; 4];
+        for (color, letter) in colors.iter_mut().zip(pattern.chars()) {
+            *color = match letter {
+                'R' => CfaColor::Red,
+                'G' => CfaColor::Green,
+                'B' => CfaColor::Blue,
+                _ => return None,
+            };
+        }
+        Some(Cfa::Bayer(colors))
+    }
+
+    /// The as-shot multipliers, normalised to green, from the
+    /// "As shot" row of the makernote white-balance table.
+    fn as_shot(text: &str) -> Option<[f32; 3]> {
+        let row = field(text, "As shot")?;
+        let numbers: Vec<f32> = row
+            .split_whitespace()
+            .take(4)
+            .map_while(|v| v.parse::<f32>().ok())
+            .collect();
+        let [red, green, blue, ..] = numbers[..] else {
+            return None;
+        };
+        (green > 0.0).then(|| [red / green, 1.0, blue / green])
+    }
+
+    /// Compare a decoded frame with the oracle sample for sample.
+    fn compare(path: &Path, raw: &RawImage) {
+        let Some((width, height, expect)) = oracle(path) else {
+            eprintln!("{}: no oracle TIFF, data not checked", path.display());
+            return;
+        };
+        assert_eq!(
+            (raw.width, raw.height),
+            (width, height),
+            "{}: frame is {}x{}, oracle {width}x{height}",
+            path.display(),
+            raw.width,
+            raw.height
+        );
+        let RawData::U16(got) = &raw.data else {
+            panic!("{}: expected integer samples", path.display())
+        };
+        let mut wrong = 0usize;
+        let mut first = Vec::new();
+        for (i, (a, b)) in got.iter().zip(expect.iter()).enumerate() {
+            if a != b {
+                wrong += 1;
+                if first.len() < 8 {
+                    first.push(format!("({}, {}): {a} not {b}", i % width, i / width));
+                }
+            }
+        }
+        assert_eq!(
+            wrong,
+            0,
+            "{}: {wrong} samples differ; {}",
+            path.display(),
+            first.join(", ")
+        );
+    }
+
+    /// Levels, balance, crop, orientation and CFA against
+    /// `raw-identify`.
+    fn compare_metadata(path: &Path, raw: &RawImage) {
+        let Some(text) = identify(path) else { return };
+        if let Some(cfa) = filter_pattern(&text) {
+            assert_eq!(raw.cfa, cfa, "{}: filter pattern", path.display());
+        }
+        if let Some(orientation) = flip(&text) {
+            assert_eq!(
+                raw.orientation,
+                orientation,
+                "{}: orientation",
+                path.display()
+            );
+        }
+        if let Some((width, height)) = size(&text, "Image size:") {
+            let (x, y) = match field(&text, "Raw inset, width x height:") {
+                Some(inset) => {
+                    let left = inset
+                        .split("left:")
+                        .nth(1)
+                        .and_then(|v| v.split_whitespace().next().and_then(|v| v.parse().ok()));
+                    let top = inset
+                        .split("top:")
+                        .nth(1)
+                        .and_then(|v| v.split_whitespace().next().and_then(|v| v.parse().ok()));
+                    (left.unwrap_or(0), top.unwrap_or(0))
+                }
+                None => (0, 0),
+            };
+            let inset = field(&text, "Raw inset, width x height:")
+                .and_then(|v| v.split_whitespace().next().map(str::to_string));
+            let expect = match inset.and_then(|w| w.parse::<usize>().ok()) {
+                Some(w) => {
+                    let h = field(&text, "Raw inset, width x height:")
+                        .and_then(|v| v.split_whitespace().nth(2))
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(height);
+                    Rect {
+                        x,
+                        y,
+                        width: w,
+                        height: h,
+                    }
+                }
+                None => Rect {
+                    x: 0,
+                    y: 0,
+                    width,
+                    height,
+                },
+            };
+            if raw.crop != expect {
+                eprintln!("{}: crop {:?}, LibRaw {expect:?}", path.display(), raw.crop);
+            }
+        }
+        if let Some(expect) = as_shot(&text) {
+            for (got, want) in raw.wb_coeffs.iter().zip(expect.iter()) {
+                if (got - want).abs() > want * 0.02 {
+                    eprintln!(
+                        "{}: white balance {:?}, LibRaw {expect:?}",
+                        path.display(),
+                        raw.wb_coeffs
+                    );
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Cutting a file short must never panic, whatever it does return.
+    fn truncations(path: &Path) {
+        let bytes = std::fs::read(path).expect("sample readable");
+        let mut seed = bytes.len() as u64;
+        for _ in 0..10 {
+            // A cheap deterministic spread of cut points.
+            seed = seed
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            let at = (seed >> 33) as usize % bytes.len().max(1);
+            let _ = crate::decode(&bytes[..at]);
+            let _ = crate::probe(&bytes[..at]);
+        }
+    }
+
+    #[test]
+    fn decodes_a_hand_built_65000_segment() {
+        // Four pixels, lengths 3, 3, 2, 1 (low nibble first), then the
+        // differences 5, 6, 2, 1 packed into one big-endian word from
+        // its least significant bit up.
+        let data = [0x33, 0x12, 0x01, 0xb5];
+        let mut out = [0u16; 4];
+        decode_65000_segment(&data, &mut out).expect("segment decodes");
+        assert_eq!(out, [5, 6, 7, 7]);
+    }
+
+    #[test]
+    fn a_65000_length_over_twelve_bits_is_corrupt() {
+        let data = [0xff, 0x00, 0x00, 0x00];
+        let mut out = [0u16; 2];
+        assert!(matches!(
+            decode_65000_segment(&data, &mut out),
+            Err(Error::Corrupt(_))
+        ));
+    }
+
+    #[test]
+    fn a_truncated_65000_segment_runs_out_in_zeros() {
+        // Lengths present, bitstream missing: the pump reads zeros, so
+        // the differences are the most negative the lengths allow and
+        // nothing panics.
+        let data = [0x33, 0x12];
+        let mut out = [0u16; 4];
+        decode_65000_segment(&data, &mut out).expect("no bitstream is still decodable");
+    }
+
+    #[test]
+    fn finds_the_band_offsets_among_the_other_numbers() {
+        let values = [
+            1, 3158, 654611, 2, 74722, 480, 1, 85952, 189248, 292544, 395840, 499136,
+        ];
+        assert_eq!(longest_ramp(&values), Some(85952));
+        assert_eq!(longest_ramp(&[1, 2, 3]), None);
+        assert_eq!(longest_ramp(&[]), None);
+    }
+
+    #[test]
+    fn unpacks_twelve_bit_samples() {
+        let data = [0xab, 0xcd, 0xef, 0x12, 0x34, 0x56];
+        assert_eq!(
+            unpack(&data, 4, 12, false).unwrap(),
+            vec![0xabc, 0xdef, 0x123, 0x456]
+        );
+    }
+
+    #[test]
+    fn a_linearisation_curve_is_a_lookup_with_a_clamp() {
+        let table = [0u16, 10, 20, 30];
+        let mut samples = [0, 2, 9];
+        linearize(&mut samples, &table);
+        assert_eq!(samples, [0, 20, 30]);
+    }
+
+    #[test]
+    fn garbage_is_rejected() {
+        assert!(decode(b"MM\0*nonsense").is_err());
+        assert!(decode(&[]).is_err());
+    }
+
+    #[test]
+    fn corpus_matches_the_oracle() {
+        for path in corpus(&["dcr", "kdc", "tif"]) {
+            let bytes = std::fs::read(&path).expect("sample readable");
+            if crate::probe(&bytes) != Some(crate::Format::Kodak) {
+                // The corpus mixes vendors under one extension: a TIFF
+                // some other camera wrote is not this module's to read.
+                continue;
+            }
+            let raw = match crate::decode(&bytes) {
+                Ok(raw) => raw,
+                Err(Error::Unsupported(why)) => {
+                    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    let allowed: &[(&str, &str)] = &[(
+                        "DC50",
+                        "Compression 32867, the DC40/DC50 scheme, is not implemented",
+                    )];
+                    let reason = allowed
+                        .iter()
+                        .find(|(file, _)| name.contains(file))
+                        .unwrap_or_else(|| {
+                            panic!("{}: unexpected Unsupported: {why}", path.display())
+                        });
+                    eprintln!(
+                        "{}: unsupported as documented ({}): {why}",
+                        path.display(),
+                        reason.1
+                    );
+                    continue;
+                }
+                Err(other) => panic!("{}: {other}", path.display()),
+            };
+            raw.validate().expect("decoded frame is self-consistent");
+            compare(&path, &raw);
+            compare_metadata(&path, &raw);
+            if let Some(preview) = &raw.preview {
+                image::load_from_memory(preview)
+                    .unwrap_or_else(|e| panic!("{}: preview will not decode: {e}", path.display()));
+            }
+        }
+    }
+
+    #[test]
+    fn truncated_files_never_panic() {
+        for path in corpus(&["dcr", "kdc", "tif"]) {
+            truncations(&path);
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/mef.rs
+++ b/crates/codec-raw/src/formats/mef.rs
@@ -1,0 +1,458 @@
+//! Mamiya MEF: the ZD, the only body that ever wrote one.
+//!
+//! A MEF is a plain big-endian TIFF/EP file with nothing private in
+//! it at all. IFD0 is a 144x192 uncompressed RGB thumbnail carrying
+//! the Exif and the orientation, and it points at three SubIFDs: the
+//! sensor (4016x5344 samples of 12 bits, `PhotometricInterpretation`
+//! 32803, `Compression` 1) and two more uncompressed RGB previews,
+//! 992x1328 and 240x320. There is no JPEG anywhere in the file, so
+//! [`RawImage::preview`](crate::RawImage::preview) comes out `None`:
+//! the ZD stores every preview as raw interleaved bytes.
+//!
+//! The samples are packed twelve bits at a time, most significant
+//! first, three bytes to two pixels, running straight through the
+//! frame with no row padding. One thing has to be worked around: the
+//! camera's `StripByteCounts` is 1024 bytes short of the frame it
+//! describes — 32191232 where 4016x5344 twelve-bit samples need
+//! 32192256 — and the missing kilobyte really is in the file, past the
+//! declared end of the strip. The strip length is therefore treated as
+//! a lower bound and the frame read to the length the dimensions ask
+//! for, still inside the file.
+//!
+//! Nothing in the file records black level, saturation or an as-shot
+//! white balance, and LibRaw reports none for it either; the levels
+//! come from the sample depth.
+
+use crate::formats::common;
+use crate::tiff::{tags, Ifd, ImageLayout, Tiff};
+use crate::{Cfa, CfaColor, Error, Format, RawData, RawImage, Result};
+
+/// The IFD holding sensor samples.
+fn raw_ifd<'a>(tiff: &'a Tiff<'_>) -> Result<&'a Ifd> {
+    tiff.all()
+        .into_iter()
+        .find(|ifd| ifd.get(tags::PHOTOMETRIC).and_then(|e| e.u32(0)) == Some(32803))
+        .ok_or_else(|| Error::Unsupported("MEF with no CFA image directory".into()))
+}
+
+/// The 2x2 filter array from CFAPattern (0x828E), whose bytes are
+/// 0 red, 1 green, 2 blue in row-major order. `None` when the tag is
+/// missing or is not the 2x2 the ZD writes.
+fn cfa_from_tag(ifd: &Ifd) -> Option<Cfa> {
+    let dim = ifd.get(tags::CFA_REPEAT_PATTERN_DIM)?;
+    if (dim.u32(0), dim.u32(1)) != (Some(2), Some(2)) {
+        return None;
+    }
+    let pattern = ifd.get(tags::CFA_PATTERN)?;
+    let mut colors = [CfaColor::Red; 4];
+    for (i, color) in colors.iter_mut().enumerate() {
+        *color = match pattern.u32(i)? {
+            0 => CfaColor::Red,
+            1 => CfaColor::Green,
+            2 => CfaColor::Blue,
+            _ => return None,
+        };
+    }
+    Some(Cfa::Bayer(colors))
+}
+
+/// Unpack 12-bit big-endian samples, three bytes to two pixels.
+fn unpack(data: &[u8], width: usize, height: usize) -> Result<Vec<u16>> {
+    let pixels = width
+        .checked_mul(height)
+        .ok_or_else(|| Error::Corrupt("MEF frame too large".into()))?;
+    let need = pixels
+        .div_ceil(2)
+        .checked_mul(3)
+        .ok_or_else(|| Error::Corrupt("MEF frame too large".into()))?;
+    if data.len() < need {
+        return Err(Error::Corrupt(format!(
+            "MEF holds {} bytes of samples, want {need} for {width}x{height}",
+            data.len()
+        )));
+    }
+    let mut out = vec![0u16; pixels];
+    for (pair, triple) in out.chunks_mut(2).zip(data.as_chunks::<3>().0) {
+        pair[0] = ((triple[0] as u16) << 4) | (triple[1] as u16 >> 4);
+        if let Some(second) = pair.get_mut(1) {
+            *second = ((triple[1] as u16 & 0x0f) << 8) | triple[2] as u16;
+        }
+    }
+    Ok(out)
+}
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let tiff = Tiff::parse(bytes)?;
+    let ifd = raw_ifd(&tiff)?;
+    let layout = ImageLayout::of(&tiff, ifd)?;
+    if layout.compression != 1 {
+        return Err(Error::Unsupported(format!(
+            "MEF with Compression {} (the ZD writes uncompressed packed samples)",
+            layout.compression
+        )));
+    }
+    if layout.bits_per_sample != 12 {
+        return Err(Error::Unsupported(format!(
+            "MEF with {}-bit samples",
+            layout.bits_per_sample
+        )));
+    }
+    let [(start, len)] = layout.chunks[..] else {
+        return Err(Error::Unsupported(format!(
+            "MEF sensor data in {} strips, want one",
+            layout.chunks.len()
+        )));
+    };
+    // See the module note: the declared strip is a kilobyte shorter
+    // than the frame it describes, so the strip length is a lower
+    // bound. The frame is read from the strip's start to whatever the
+    // dimensions need, which `unpack` checks is inside the file.
+    if len
+        < layout
+            .width
+            .saturating_mul(layout.height)
+            .div_ceil(2)
+            .saturating_mul(3)
+    {
+        log::debug!(
+            "MEF StripByteCounts {len} is short of the frame; reading to the end of the file"
+        );
+    }
+    let data = unpack(&bytes[start..], layout.width, layout.height)?;
+
+    let cfa = cfa_from_tag(ifd).unwrap_or(Cfa::RGGB);
+    let mut raw = RawImage::new(
+        Format::Mef,
+        layout.width,
+        layout.height,
+        1,
+        RawData::U16(data),
+        cfa,
+    );
+    // Twelve bits, and the frame really does reach 4095.
+    raw.white_level = 4095.0;
+
+    let (make, model) = tiff.make_model();
+    raw.set_camera(&make, &model);
+    // The ZD is a portrait-shaped sensor read out sideways: IFD0's
+    // Orientation is 6 on the sample here, and the crop is the whole
+    // frame — there are no masked borders to trim.
+    raw.orientation = common::orientation(&tiff);
+    raw.metadata = common::metadata(&tiff);
+    raw.preview = common::largest_jpeg(&tiff);
+
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    let tiff = Tiff::parse(bytes)?;
+    Ok(common::largest_jpeg(&tiff))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::Rect;
+    use std::path::{Path, PathBuf};
+
+    /// Every file under `$SCHIST_RAW_CORPUS` with one of `extensions`,
+    /// recursively. Empty when the variable is unset, which is how the
+    /// corpus tests skip on a machine without the samples.
+    fn corpus(extensions: &[&str]) -> Vec<PathBuf> {
+        let Ok(root) = std::env::var("SCHIST_RAW_CORPUS") else {
+            return Vec::new();
+        };
+        let mut found = Vec::new();
+        let mut stack = vec![PathBuf::from(root)];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| extensions.iter().any(|want| e.eq_ignore_ascii_case(want)))
+                {
+                    found.push(path);
+                }
+            }
+        }
+        found.sort();
+        found
+    }
+
+    /// LibRaw's `unprocessed_raw -T` output beside the sample.
+    fn oracle(path: &Path) -> Option<(usize, usize, Vec<u16>)> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".tiff");
+        let image = image::open(PathBuf::from(name)).ok()?.into_luma16();
+        let (width, height) = (image.width() as usize, image.height() as usize);
+        Some((width, height, image.into_raw()))
+    }
+
+    /// `raw-identify -v -w` output beside the sample.
+    fn identify(path: &Path) -> Option<String> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".identify.txt");
+        std::fs::read_to_string(PathBuf::from(name)).ok()
+    }
+
+    /// The text after `key:` on the line that starts with it.
+    fn field<'a>(text: &'a str, key: &str) -> Option<&'a str> {
+        text.lines()
+            .map(str::trim)
+            .find(|line| line.starts_with(key))
+            .map(|line| line[key.len()..].trim())
+    }
+
+    /// A "W x H" pair.
+    fn size(text: &str, key: &str) -> Option<(usize, usize)> {
+        let value = field(text, key)?;
+        let (w, h) = value.split_once('x')?;
+        Some((w.trim().parse().ok()?, h.trim().parse().ok()?))
+    }
+
+    /// What LibRaw's "Image flip" means as an [`Orientation`].
+    fn flip(text: &str) -> Option<crate::Orientation> {
+        Some(match field(text, "Image flip:")?.parse::<u32>().ok()? {
+            3 => crate::Orientation::Rotate180,
+            5 => crate::Orientation::Rotate270CW,
+            6 => crate::Orientation::Rotate90CW,
+            _ => crate::Orientation::Normal,
+        })
+    }
+
+    /// The first four letters of the "Filter pattern" line as a CFA.
+    fn filter_pattern(text: &str) -> Option<Cfa> {
+        let pattern = field(text, "Filter pattern:")?;
+        let mut colors = [CfaColor::Red; 4];
+        for (color, letter) in colors.iter_mut().zip(pattern.chars()) {
+            *color = match letter {
+                'R' => CfaColor::Red,
+                'G' => CfaColor::Green,
+                'B' => CfaColor::Blue,
+                _ => return None,
+            };
+        }
+        Some(Cfa::Bayer(colors))
+    }
+
+    /// The as-shot multipliers, normalised to green, from the
+    /// "As shot" row of the makernote white-balance table.
+    fn as_shot(text: &str) -> Option<[f32; 3]> {
+        let row = field(text, "As shot")?;
+        let numbers: Vec<f32> = row
+            .split_whitespace()
+            .take(4)
+            .map_while(|v| v.parse::<f32>().ok())
+            .collect();
+        let [red, green, blue, ..] = numbers[..] else {
+            return None;
+        };
+        (green > 0.0).then(|| [red / green, 1.0, blue / green])
+    }
+
+    /// Compare a decoded frame with the oracle sample for sample.
+    fn compare(path: &Path, raw: &RawImage) {
+        let Some((width, height, expect)) = oracle(path) else {
+            eprintln!("{}: no oracle TIFF, data not checked", path.display());
+            return;
+        };
+        assert_eq!(
+            (raw.width, raw.height),
+            (width, height),
+            "{}: frame is {}x{}, oracle {width}x{height}",
+            path.display(),
+            raw.width,
+            raw.height
+        );
+        let RawData::U16(got) = &raw.data else {
+            panic!("{}: expected integer samples", path.display())
+        };
+        let mut wrong = 0usize;
+        let mut first = Vec::new();
+        for (i, (a, b)) in got.iter().zip(expect.iter()).enumerate() {
+            if a != b {
+                wrong += 1;
+                if first.len() < 8 {
+                    first.push(format!("({}, {}): {a} not {b}", i % width, i / width));
+                }
+            }
+        }
+        assert_eq!(
+            wrong,
+            0,
+            "{}: {wrong} samples differ; {}",
+            path.display(),
+            first.join(", ")
+        );
+    }
+
+    /// Levels, balance, crop, orientation and CFA against
+    /// `raw-identify`.
+    fn compare_metadata(path: &Path, raw: &RawImage) {
+        let Some(text) = identify(path) else { return };
+        if let Some(cfa) = filter_pattern(&text) {
+            assert_eq!(raw.cfa, cfa, "{}: filter pattern", path.display());
+        }
+        if let Some(orientation) = flip(&text) {
+            assert_eq!(
+                raw.orientation,
+                orientation,
+                "{}: orientation",
+                path.display()
+            );
+        }
+        if let Some((width, height)) = size(&text, "Image size:") {
+            let (x, y) = match field(&text, "Raw inset, width x height:") {
+                Some(inset) => {
+                    let left = inset
+                        .split("left:")
+                        .nth(1)
+                        .and_then(|v| v.split_whitespace().next().and_then(|v| v.parse().ok()));
+                    let top = inset
+                        .split("top:")
+                        .nth(1)
+                        .and_then(|v| v.split_whitespace().next().and_then(|v| v.parse().ok()));
+                    (left.unwrap_or(0), top.unwrap_or(0))
+                }
+                None => (0, 0),
+            };
+            let inset = field(&text, "Raw inset, width x height:")
+                .and_then(|v| v.split_whitespace().next().map(str::to_string));
+            let expect = match inset.and_then(|w| w.parse::<usize>().ok()) {
+                Some(w) => {
+                    let h = field(&text, "Raw inset, width x height:")
+                        .and_then(|v| v.split_whitespace().nth(2))
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(height);
+                    Rect {
+                        x,
+                        y,
+                        width: w,
+                        height: h,
+                    }
+                }
+                None => Rect {
+                    x: 0,
+                    y: 0,
+                    width,
+                    height,
+                },
+            };
+            if raw.crop != expect {
+                eprintln!("{}: crop {:?}, LibRaw {expect:?}", path.display(), raw.crop);
+            }
+        }
+        if let Some(expect) = as_shot(&text) {
+            for (got, want) in raw.wb_coeffs.iter().zip(expect.iter()) {
+                if (got - want).abs() > want * 0.02 {
+                    eprintln!(
+                        "{}: white balance {:?}, LibRaw {expect:?}",
+                        path.display(),
+                        raw.wb_coeffs
+                    );
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Cutting a file short must never panic, whatever it does return.
+    fn truncations(path: &Path) {
+        let bytes = std::fs::read(path).expect("sample readable");
+        let mut seed = bytes.len() as u64;
+        for _ in 0..10 {
+            // A cheap deterministic spread of cut points.
+            seed = seed
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            let at = (seed >> 33) as usize % bytes.len().max(1);
+            let _ = crate::decode(&bytes[..at]);
+            let _ = crate::probe(&bytes[..at]);
+        }
+    }
+
+    #[test]
+    fn unpacks_twelve_bit_samples() {
+        let data = [0xab, 0xcd, 0xef, 0x12, 0x34, 0x56];
+        assert_eq!(
+            unpack(&data, 4, 1).unwrap(),
+            vec![0xabc, 0xdef, 0x123, 0x456]
+        );
+    }
+
+    #[test]
+    fn an_odd_pixel_count_takes_the_first_of_a_pair() {
+        // Three pixels still occupy two whole three-byte groups.
+        let data = [0xab, 0xcd, 0xef, 0x12, 0x30, 0x00];
+        assert_eq!(unpack(&data, 3, 1).unwrap(), vec![0xabc, 0xdef, 0x123]);
+    }
+
+    #[test]
+    fn short_data_is_corrupt_not_a_panic() {
+        assert!(matches!(
+            unpack(&[0; 8], 4016, 5344),
+            Err(Error::Corrupt(_))
+        ));
+    }
+
+    #[test]
+    fn garbage_is_rejected() {
+        assert!(decode(b"MM\0*nonsense").is_err());
+        assert!(decode(&[]).is_err());
+    }
+
+    #[test]
+    fn corpus_matches_the_oracle() {
+        for path in corpus(&["mef"]) {
+            let bytes = std::fs::read(&path).expect("sample readable");
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(crate::Format::Mef),
+                "{}: probed as something else",
+                path.display()
+            );
+            let raw = match crate::decode(&bytes) {
+                Ok(raw) => raw,
+                Err(Error::Unsupported(why)) => {
+                    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    let allowed: &[(&str, &str)] = &[];
+                    let reason = allowed
+                        .iter()
+                        .find(|(file, _)| name.contains(file))
+                        .unwrap_or_else(|| {
+                            panic!("{}: unexpected Unsupported: {why}", path.display())
+                        });
+                    eprintln!(
+                        "{}: unsupported as documented ({}): {why}",
+                        path.display(),
+                        reason.1
+                    );
+                    continue;
+                }
+                Err(other) => panic!("{}: {other}", path.display()),
+            };
+            raw.validate().expect("decoded frame is self-consistent");
+            compare(&path, &raw);
+            compare_metadata(&path, &raw);
+            if let Some(preview) = &raw.preview {
+                image::load_from_memory(preview)
+                    .unwrap_or_else(|e| panic!("{}: preview will not decode: {e}", path.display()));
+            }
+        }
+    }
+
+    #[test]
+    fn truncated_files_never_panic() {
+        for path in corpus(&["mef"]) {
+            truncations(&path);
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/mod.rs
+++ b/crates/codec-raw/src/formats/mod.rs
@@ -1,0 +1,210 @@
+//! One module per container. Each exposes
+//!
+//! ```text
+//! pub fn decode(bytes: &[u8]) -> Result<RawImage>;
+//! pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>>;
+//! ```
+//!
+//! `decode` fills a [`crate::RawImage`] completely — data, CFA, levels,
+//! white balance, crop, orientation, make/model via `set_camera`,
+//! preview, metadata — and calls `apply_camera_table` last. `preview`
+//! finds the largest embedded JPEG without decoding sensor data.
+
+pub mod arw;
+pub mod cr2;
+pub mod cr3;
+pub mod crw;
+pub mod crx;
+pub mod dng;
+pub mod erf;
+pub mod hasselblad;
+pub mod iiq;
+pub mod kodak;
+pub mod mef;
+pub mod mos;
+pub mod mrw;
+pub mod nef;
+pub mod orf;
+pub mod pef;
+pub mod raf;
+pub mod raf_compressed;
+pub mod rw2;
+pub mod srw;
+pub mod x3f;
+
+/// Shared helpers for the TIFF-shaped formats.
+pub mod common {
+    use crate::tiff::{tags, Tiff};
+    use crate::{Metadata, Orientation};
+
+    /// The largest JPEG referenced by JPEGInterchangeFormat/Length or
+    /// stored as a JPEG-compressed (6/7) strip in any IFD.
+    ///
+    /// Vendors disagree about where the preview goes: Canon and Nikon
+    /// point at it with JPEGInterchangeFormat (0x0201) and its length
+    /// (0x0202), Sony and Pentax store it as the single strip of an
+    /// IFD whose Compression says JPEG, Olympus marks the preview IFD
+    /// only with NewSubfileType 1. All three are checked, in every IFD
+    /// of the file, and the biggest JPEG wins — that is the full-size
+    /// preview rather than the 160x120 thumbnail.
+    pub fn largest_jpeg(tiff: &Tiff<'_>) -> Option<Vec<u8>> {
+        let bytes = tiff.bytes();
+        let base = tiff.base();
+        let mut best: Option<(usize, usize)> = None;
+        let mut consider = |offset: u64, len: u64| {
+            let (Ok(offset), Ok(len)) = (usize::try_from(offset), usize::try_from(len)) else {
+                return;
+            };
+            let Some(start) = offset.checked_add(base) else {
+                return;
+            };
+            let Some(end) = start.checked_add(len) else {
+                return;
+            };
+            // Only a real, showable JPEG counts: several formats leave
+            // a stale 0x0201 pointing into the raw data, and the raw
+            // data itself is frequently a lossless-JPEG stream that
+            // begins with the same two bytes.
+            let Some(stream) = bytes.get(start..end) else {
+                return;
+            };
+            if !stream.starts_with(&[0xff, 0xd8]) || !is_displayable_jpeg(stream) {
+                return;
+            }
+            if best.is_none_or(|(_, best)| len > best) {
+                best = Some((start, len));
+            }
+        };
+        for ifd in tiff.all() {
+            if let (Some(offset), Some(len)) = (
+                ifd.get(tags::JPEG_INTERCHANGE_FORMAT)
+                    .and_then(|e| e.u64(0)),
+                ifd.get(tags::JPEG_INTERCHANGE_FORMAT_LENGTH)
+                    .and_then(|e| e.u64(0)),
+            ) {
+                consider(offset, len);
+            }
+            let compression = ifd
+                .get(tags::COMPRESSION)
+                .and_then(|e| e.u32(0))
+                .unwrap_or(0);
+            let preview_ifd = ifd.get(tags::NEW_SUBFILE_TYPE).and_then(|e| e.u32(0)) == Some(1);
+            // An IFD that says it holds sensor samples holds sensor
+            // samples, however JPEG-shaped they are: 32803 is CFA,
+            // 34892 LinearRaw.
+            if matches!(
+                ifd.get(tags::PHOTOMETRIC).and_then(|e| e.u32(0)),
+                Some(32803 | 34892)
+            ) {
+                continue;
+            }
+            // 6 is TIFF 6.0's old-style JPEG, 7 the "new" one; both
+            // hold a complete JFIF stream when there is one strip.
+            if compression == 6 || compression == 7 || preview_ifd {
+                let offsets = ifd
+                    .get(tags::STRIP_OFFSETS)
+                    .map(|e| e.u64s())
+                    .unwrap_or_default();
+                let lengths = ifd
+                    .get(tags::STRIP_BYTE_COUNTS)
+                    .map(|e| e.u64s())
+                    .unwrap_or_default();
+                // A JPEG split over several strips is not a JPEG we can
+                // hand out whole, and nobody stores previews that way.
+                if let ([offset], [len]) = (&offsets[..], &lengths[..]) {
+                    consider(*offset, *len);
+                }
+            }
+        }
+        best.and_then(|(start, len)| bytes.get(start..start + len).map(|s| s.to_vec()))
+    }
+
+    /// Whether a JPEG stream is one a viewer could show.
+    ///
+    /// Raw data is very often *also* a JPEG: Canon's CR2 keeps the
+    /// sensor in a lossless (SOF3) stream, as do lossless DNG,
+    /// Hasselblad and Pentax, and all of them start with the same
+    /// FFD8. A preview is a picture — baseline, extended sequential or
+    /// progressive — so the first frame header decides it. The scan
+    /// walks marker segments only, never entropy-coded data, and stops
+    /// at the first SOF or at anything malformed.
+    fn is_displayable_jpeg(stream: &[u8]) -> bool {
+        let mut at = 2;
+        while at + 4 <= stream.len() {
+            if stream[at] != 0xff {
+                return false;
+            }
+            let marker = stream[at + 1];
+            match marker {
+                // Padding, and the standalone markers with no length.
+                0xff => {
+                    at += 1;
+                    continue;
+                }
+                0x01 | 0xd0..=0xd8 => {
+                    at += 2;
+                    continue;
+                }
+                // SOF0/1/2 and their arithmetic-coded twins SOF9/10.
+                0xc0 | 0xc1 | 0xc2 | 0xc9 | 0xca => return true,
+                // SOF3 and the rest of the lossless and hierarchical
+                // family: raw data, not a picture.
+                0xc3 | 0xc5..=0xc7 | 0xcb | 0xcd..=0xcf => return false,
+                // A scan before any frame header is not a JPEG we
+                // understand well enough to hand out.
+                0xda | 0xd9 => return false,
+                _ => {}
+            }
+            let len = u16::from_be_bytes([stream[at + 2], stream[at + 3]]) as usize;
+            if len < 2 {
+                return false;
+            }
+            at += 2 + len;
+        }
+        false
+    }
+
+    /// ISO, exposure, aperture, focal length, lens and date from the
+    /// Exif IFD (and IFD0's DateTime as a fallback).
+    pub fn metadata(tiff: &Tiff<'_>) -> Metadata {
+        let exif = tiff.exif();
+        // The Exif IFD is where these belong, but a few raws (Panasonic
+        // RW2, some Olympus) put the same tags straight in IFD0 and
+        // have no Exif IFD at all, so fall back to a search of the
+        // whole file before giving up on a tag.
+        let entry = |tag: u16| exif.and_then(|ifd| ifd.get(tag)).or_else(|| tiff.find(tag));
+        let number = |tag: u16| entry(tag).and_then(|e| e.f64(0)).map(|v| v as f32);
+        let text = |tag: u16| {
+            entry(tag)
+                .and_then(|e| e.str())
+                .map(str::to_string)
+                .filter(|s| !s.is_empty())
+        };
+        Metadata {
+            iso: number(tags::ISO),
+            exposure_time: number(tags::EXPOSURE_TIME),
+            f_number: number(tags::F_NUMBER),
+            focal_length: number(tags::FOCAL_LENGTH),
+            lens: text(tags::LENS_MODEL),
+            // DateTimeOriginal is when the shutter fired; IFD0's
+            // DateTime is when the file was written, which for a raw
+            // straight out of a camera is the same moment.
+            date_time: text(tags::DATE_TIME_ORIGINAL).or_else(|| {
+                tiff.root()
+                    .get(tags::DATE_TIME)
+                    .and_then(|e| e.str())
+                    .map(str::to_string)
+                    .filter(|s| !s.is_empty())
+            }),
+        }
+    }
+
+    /// IFD0's Orientation tag.
+    pub fn orientation(tiff: &Tiff<'_>) -> Orientation {
+        tiff.root()
+            .get(tags::ORIENTATION)
+            .and_then(|e| e.u32(0))
+            .map(Orientation::from_exif)
+            .unwrap_or_default()
+    }
+}

--- a/crates/codec-raw/src/formats/mos.rs
+++ b/crates/codec-raw/src/formats/mos.rs
@@ -1,0 +1,655 @@
+//! Leaf MOS: the raw of the Leaf Valeo, Aptus and AFi backs (and of
+//! the Aptus-II backs Phase One sold after buying Leaf).
+//!
+//! An ordinary TIFF, but one that says almost nothing about itself in
+//! TIFF terms: IFD0 *is* the sensor image, marked BlackIsZero rather
+//! than CFA, with no Make, no Model, no Exif IFD and no DNG tags. The
+//! camera's own name arrives in the XMP packet (tag 0x02BC) and
+//! everything else in a private blob under tag 0x8606, "LeafData".
+//!
+//! LeafData is a tree of records, each
+//!
+//! ```text
+//! "PKTS" | u32 version | 40-byte NUL-padded name | u32 big-endian length | data
+//! ```
+//!
+//! and a record whose data begins with `PKTS` is a container of more
+//! of them — `camera_profile` holds `CamProf_capture_profile`, which
+//! holds `CaptProf_*`, and so on. Leaf values are ASCII with
+//! newline-separated fields, so `NeutObj_neutrals` reads
+//! `"2096\n1659\n2096\n1507"`.
+//!
+//! The sensor data is either a plain 16-bit raster or, under TIFF
+//! compression 99, a lossless JPEG with two components: each row of
+//! the frame is one row of a half-width two-component scan, which is
+//! the same as a plain raster of the row once the components are
+//! interleaved — exactly what [`crate::ljpeg`] hands back.
+
+use crate::formats::common;
+use crate::tiff::{tags, Ifd, ImageLayout, Tiff};
+use crate::{Cfa, CfaColor, Error, Format, Orientation, RawData, RawImage, Result};
+
+/// The LeafData blob.
+const LEAF_DATA: u16 = 0x8606;
+/// The XMP packet, where the camera names itself.
+const XMP: u16 = 0x02BC;
+
+/// One record of the LeafData tree: its name and the bytes of its
+/// value. Containers are flattened away — a caller wants
+/// `NeutObj_neutrals`, not the four levels of profile above it — and
+/// names are unique enough across the tree for that to be safe.
+struct Leaf<'a> {
+    records: Vec<(&'a str, &'a [u8])>,
+}
+
+impl<'a> Leaf<'a> {
+    /// Walk the record tree depth-first. Bounded by the blob and by a
+    /// nesting limit, so a file that claims a record contains itself
+    /// cannot recurse without end.
+    fn parse(blob: &'a [u8]) -> Leaf<'a> {
+        let mut records = Vec::new();
+        Leaf::walk(blob, 0, &mut records);
+        Leaf { records }
+    }
+
+    fn walk(blob: &'a [u8], depth: usize, out: &mut Vec<(&'a str, &'a [u8])>) {
+        if depth > 8 {
+            return;
+        }
+        let mut at = 0usize;
+        // 4 magic + 4 version + 40 name + 4 length.
+        while at + 52 <= blob.len() {
+            if &blob[at..at + 4] != b"PKTS" {
+                break;
+            }
+            let name = &blob[at + 8..at + 48];
+            let name = &name[..name.iter().position(|b| *b == 0).unwrap_or(name.len())];
+            let length =
+                u32::from_be_bytes([blob[at + 48], blob[at + 49], blob[at + 50], blob[at + 51]])
+                    as usize;
+            let start = at + 52;
+            let end = start.saturating_add(length).min(blob.len());
+            let data = &blob[start..end];
+            if let Ok(name) = std::str::from_utf8(name) {
+                out.push((name, data));
+            }
+            if data.starts_with(b"PKTS") {
+                Leaf::walk(data, depth + 1, out);
+            }
+            // A zero-length record would spin forever otherwise.
+            at = end.max(at + 52);
+        }
+    }
+
+    fn get(&self, name: &str) -> Option<&'a [u8]> {
+        self.records
+            .iter()
+            .find(|(key, _)| *key == name)
+            .map(|(_, value)| *value)
+    }
+
+    /// A value's newline-separated fields, NUL trimmed.
+    fn fields(&self, name: &str) -> Vec<&'a str> {
+        let Some(value) = self.get(name) else {
+            return Vec::new();
+        };
+        let end = value.iter().position(|b| *b == 0).unwrap_or(value.len());
+        match std::str::from_utf8(&value[..end]) {
+            Ok(text) => text
+                .split('\n')
+                .map(str::trim)
+                .filter(|f| !f.is_empty())
+                .collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn numbers(&self, name: &str) -> Vec<f64> {
+        self.fields(name)
+            .iter()
+            .filter_map(|f| f.parse().ok())
+            .collect()
+    }
+}
+
+/// The raw bytes an entry points at.
+///
+/// Not [`crate::tiff::Entry::bytes`]: Leaf types both of the blobs
+/// this module wants — LeafData and the XMP packet — as ASCII, and an
+/// ASCII value stops at its first NUL, which LeafData reaches four
+/// bytes in. The entry's own offset and count are the whole thing.
+fn blob<'a>(tiff: &Tiff<'a>, entry: &crate::tiff::Entry) -> Option<&'a [u8]> {
+    let length = entry.count.checked_mul(entry.kind.size())?;
+    tiff.bytes()
+        .get(entry.offset..entry.offset.checked_add(length)?)
+}
+
+/// `tiff:Make` / `tiff:Model` out of the XMP packet, which Leaf
+/// writes either as elements or as attributes depending on the
+/// firmware.
+fn xmp_value(xmp: &str, key: &str) -> Option<String> {
+    for (open, close) in [(format!("<{key}>"), '<'), (format!("{key}=\""), '"')] {
+        if let Some(start) = xmp.find(&open) {
+            let rest = &xmp[start + open.len()..];
+            if let Some(end) = rest.find(close) {
+                let value = rest[..end].trim();
+                if !value.is_empty() {
+                    return Some(value.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Leaf's lossless-JPEG encoder numbers the scan's components one
+/// higher than the frame's: SOF3 declares components 0 and 1, SOS
+/// then asks for 1 and 2. T.81 says a scan may only name components
+/// the frame declared, and [`crate::ljpeg`] is right to refuse, so
+/// the header is corrected here before the stream is handed over.
+///
+/// Returns `None` when the stream is already consistent, so the
+/// ordinary case costs no copy.
+fn fix_scan_component_ids(stream: &[u8]) -> Option<Vec<u8>> {
+    if stream.get(0..2) != Some(&[0xFF, 0xD8]) {
+        return None;
+    }
+    let mut frame: Vec<u8> = Vec::new();
+    let mut at = 2usize;
+    loop {
+        while stream.get(at) == Some(&0xFF) && stream.get(at + 1) == Some(&0xFF) {
+            at += 1;
+        }
+        if stream.get(at) != Some(&0xFF) {
+            return None;
+        }
+        let marker = *stream.get(at + 1)?;
+        let length = stream
+            .get(at + 2..at + 4)
+            .map(|b| u16::from_be_bytes([b[0], b[1]]) as usize)
+            .filter(|l| *l >= 2)?;
+        let body = stream.get(at + 4..at + 2 + length)?;
+        match marker {
+            // Any SOF: precision, height, width, then the component
+            // count and three bytes each.
+            0xC0..=0xCF if !matches!(marker, 0xC4 | 0xC8 | 0xCC) => {
+                let count = *body.get(5)? as usize;
+                frame = (0..count)
+                    .map(|i| body.get(6 + i * 3).copied())
+                    .collect::<Option<Vec<u8>>>()?;
+            }
+            0xDA => {
+                let count = *body.first()? as usize;
+                let ids: Vec<u8> = (0..count)
+                    .map(|i| body.get(1 + i * 2).copied())
+                    .collect::<Option<Vec<u8>>>()?;
+                if frame.is_empty() || ids.iter().all(|id| frame.contains(id)) {
+                    return None;
+                }
+                // Only the uniform off-by-one is worth correcting; a
+                // stream wrong in some other way is not this bug.
+                if !ids
+                    .iter()
+                    .all(|id| id.checked_sub(1).is_some_and(|c| frame.contains(&c)))
+                {
+                    return None;
+                }
+                let mut fixed = stream.to_vec();
+                for i in 0..count {
+                    fixed[at + 5 + i * 2] -= 1;
+                }
+                return Some(fixed);
+            }
+            0xD9 => return None,
+            _ => {}
+        }
+        at += 2 + length;
+    }
+}
+
+/// Whether the scan's rows are the frame's rows, or two halves read
+/// from opposite edges of the sensor inward.
+///
+/// The AFi-II 12 reads its sensor from the top and the bottom at the
+/// same time: scan row 0 is the frame's first row, scan row 1 its
+/// last, scan row 2 its second, and so on. The Aptus 22 and Aptus 75
+/// do not. Nothing in their LeafData says which — the two profiles
+/// differ in a dozen fields (version, back type, dark-correction
+/// type, an extra calibration block) and none of them names a
+/// readout order — so the frame itself has to answer.
+///
+/// The test costs one pass over a few dozen rows and is not a close
+/// call. Under a plain readout, scan rows two apart are the same two
+/// CFA colours two rows apart on the sensor: nearly identical. Under
+/// a split readout they are *adjacent* rows, so they carry the other
+/// two colours and differ enormously, while rows four apart are the
+/// same colours. The margin between the two on real frames is more
+/// than twenty-fold, and a frame flat enough to score near the
+/// threshold has no vertical structure for the choice to damage.
+fn is_split_readout(scan: &[u16], width: usize, height: usize) -> bool {
+    if height < 16 || !height.is_multiple_of(2) {
+        return false;
+    }
+    let row = |r: usize| &scan[r * width..(r + 1) * width];
+    let distance = |a: usize, b: usize| -> u64 {
+        row(a)
+            .iter()
+            .zip(row(b))
+            .step_by(width / 512 + 1)
+            .map(|(x, y)| x.abs_diff(*y) as u64)
+            .sum()
+    };
+    // Sample from the middle of the top half, where a real frame has
+    // picture rather than masked border.
+    let first = (height / 4) & !1;
+    let count = 32.min((height / 2 - 4).saturating_sub(first) / 2);
+    if count == 0 {
+        return false;
+    }
+    let (mut two, mut four) = (0u64, 0u64);
+    for i in 0..count {
+        let r = first + i * 2;
+        two += distance(r, r + 2);
+        four += distance(r, r + 4);
+    }
+    two > four.saturating_mul(4)
+}
+
+/// The IFD holding the sensor: the largest 16-bit single-sample image
+/// in the file. Leaf marks it BlackIsZero, so the CFA photometric
+/// cannot be the test.
+fn raw_ifd<'a>(tiff: &'a Tiff<'_>) -> Result<&'a Ifd> {
+    tiff.all()
+        .into_iter()
+        .filter(|ifd| {
+            ifd.get(tags::BITS_PER_SAMPLE).and_then(|e| e.u32(0)) == Some(16)
+                && ifd
+                    .get(tags::SAMPLES_PER_PIXEL)
+                    .and_then(|e| e.u32(0))
+                    .unwrap_or(1)
+                    == 1
+        })
+        .max_by_key(|ifd| {
+            let side = |tag| ifd.get(tag).and_then(|e| e.u64(0)).unwrap_or(0);
+            side(tags::IMAGE_WIDTH).saturating_mul(side(tags::IMAGE_LENGTH))
+        })
+        .ok_or_else(|| Error::Corrupt("no 16-bit image IFD in this Leaf file".into()))
+}
+
+/// Leaf's colour codes, as `CaptProf_mosaic_pattern` lists them for
+/// the four positions of the 2x2, reading across then down.
+///
+/// Two backs pin the mapping down: the Aptus 75 writes `2 0 1 3` for
+/// a frame LibRaw calls GBRG and the AFi-II 12 writes `1 3 2 0` for
+/// one it calls RGGB, and only 0=blue, 1=red, 2 and 3 = the two
+/// greens satisfies both. The greens are reported as plain green
+/// rather than as green and [`CfaColor::Green2`], because a Leaf
+/// sensor balances them together.
+fn color(code: u32) -> Option<CfaColor> {
+    Some(match code {
+        0 => CfaColor::Blue,
+        1 => CfaColor::Red,
+        2 | 3 => CfaColor::Green,
+        _ => return None,
+    })
+}
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let tiff = Tiff::parse(bytes)?;
+    let ifd = raw_ifd(&tiff)?;
+    let layout = ImageLayout::of(&tiff, ifd)?;
+    let (width, height) = (layout.width, layout.height);
+    if width == 0 || height == 0 {
+        return Err(Error::Corrupt("Leaf frame with no size".into()));
+    }
+
+    let leaf = ifd
+        .get(LEAF_DATA)
+        .or_else(|| tiff.find(LEAF_DATA))
+        .and_then(|e| blob(&tiff, e))
+        .map(Leaf::parse);
+    // A Leaf frame is one plane of CFA samples; the backs can also
+    // write three-plane files, which are a developed image rather
+    // than a raw and have no business here.
+    if let Some(planes) = leaf
+        .as_ref()
+        .map(|l| l.numbers("CaptProf_number_of_planes"))
+    {
+        if planes.first().is_some_and(|p| *p != 1.0) {
+            return Err(Error::Unsupported(format!(
+                "Leaf file with {} planes",
+                planes[0]
+            )));
+        }
+    }
+
+    let samples = match layout.compression {
+        1 => {
+            // Reserve no more than the strips could hold: a forged
+            // frame size must not turn into a gigabyte request.
+            let stored: usize = layout.chunks.iter().map(|(_, len)| *len).sum();
+            let mut out =
+                Vec::with_capacity(crate::frame_samples(width, height, 1)?.min(stored / 2 + 1));
+            let little_endian = tiff.little_endian();
+            for (start, len) in &layout.chunks {
+                out.extend(
+                    bytes[*start..*start + *len]
+                        .as_chunks::<2>()
+                        .0
+                        .iter()
+                        .map(|b| {
+                            if little_endian {
+                                u16::from_le_bytes([b[0], b[1]])
+                            } else {
+                                u16::from_be_bytes([b[0], b[1]])
+                            }
+                        }),
+                );
+            }
+            if out.len() < width * height {
+                return Err(Error::Corrupt(format!(
+                    "Leaf raster holds {} of {} samples",
+                    out.len(),
+                    width * height
+                )));
+            }
+            out.truncate(width * height);
+            out
+        }
+        // 99 is Leaf's private number for lossless JPEG. The scan is
+        // two components over half the frame's width, which comes
+        // back interleaved — that is, as the frame's own rows.
+        99 => {
+            let stored: usize = layout.chunks.iter().map(|(_, len)| *len).sum();
+            let mut out =
+                Vec::with_capacity(crate::frame_samples(width, height, 1)?.min(stored * 4 + 1));
+            for (start, len) in &layout.chunks {
+                let stream = &bytes[*start..*start + *len];
+                let fixed = fix_scan_component_ids(stream);
+                let frame = crate::ljpeg::decode(fixed.as_deref().unwrap_or(stream))?;
+                if frame.width * frame.components != width {
+                    return Err(Error::Corrupt(format!(
+                        "Leaf scan is {}x{} of {} components for a {width}-wide frame",
+                        frame.width, frame.height, frame.components
+                    )));
+                }
+                out.extend_from_slice(&frame.data);
+            }
+            if out.len() < width * height {
+                return Err(Error::Corrupt(format!(
+                    "Leaf scans hold {} of {} samples",
+                    out.len(),
+                    width * height
+                )));
+            }
+            out.truncate(width * height);
+            out
+        }
+        other => return Err(Error::Unsupported(format!("Leaf compression {other}"))),
+    };
+
+    // Put the two halves back in order when the back read them from
+    // opposite edges.
+    let samples = if is_split_readout(&samples, width, height) {
+        let mut ordered = vec![0u16; samples.len()];
+        for k in 0..height / 2 {
+            let (top, bottom) = (k, height - 1 - k);
+            ordered[top * width..(top + 1) * width]
+                .copy_from_slice(&samples[2 * k * width..(2 * k + 1) * width]);
+            ordered[bottom * width..(bottom + 1) * width]
+                .copy_from_slice(&samples[(2 * k + 1) * width..(2 * k + 2) * width]);
+        }
+        ordered
+    } else {
+        samples
+    };
+
+    let cfa = leaf
+        .as_ref()
+        .map(|l| l.numbers("CaptProf_mosaic_pattern"))
+        .filter(|pattern| pattern.len() == 4)
+        .and_then(|pattern| {
+            let colors: Option<Vec<CfaColor>> = pattern.iter().map(|c| color(*c as u32)).collect();
+            colors.map(|c| Cfa::Bayer([c[0], c[1], c[2], c[3]]))
+        })
+        // Every Leaf back seen so far says which pattern it has; RGGB
+        // is the family's usual one for a file that does not.
+        .unwrap_or(Cfa::RGGB);
+
+    let mut raw = RawImage::new(Format::Mos, width, height, 1, RawData::U16(samples), cfa);
+    // Leaf backs are 14-bit sensors written into a 16-bit container:
+    // both corpus frames saturate at exactly 16383 and neither the
+    // TIFF nor LeafData records a level.
+    raw.white_level = 16383.0;
+
+    if let Some(leaf) = &leaf {
+        // NeutObj_neutrals is four integers: a reference value and
+        // then the neutral point of red, green and blue. The
+        // multiplier that makes a channel neutral is the reference
+        // over it.
+        let neutrals = leaf.numbers("NeutObj_neutrals");
+        if neutrals.len() >= 4 && neutrals.iter().all(|v| *v > 0.0) {
+            let (value, green) = (neutrals[0], neutrals[2]);
+            let mul = |n: f64| (value / n) as f32;
+            let green = mul(green);
+            if green > 0.0 {
+                raw.wb_coeffs = [mul(neutrals[1]) / green, 1.0, mul(neutrals[3]) / green, 1.0];
+            }
+        }
+        // The back records how far the frame is turned rather than an
+        // EXIF orientation; a Leaf shot on a portrait-mounted back
+        // says 90.
+        if let Some(angle) = leaf.numbers("ImgProf_rotation_angle").first() {
+            raw.orientation = match *angle as i32 {
+                90 => Orientation::Rotate90CW,
+                180 => Orientation::Rotate180,
+                270 => Orientation::Rotate270CW,
+                _ => Orientation::Normal,
+            };
+        }
+        if let Some(jpeg) = leaf.get("JPEG_preview_data") {
+            if jpeg.starts_with(&[0xFF, 0xD8]) {
+                raw.preview = Some(jpeg.to_vec());
+            }
+        }
+    }
+    if raw.preview.is_none() {
+        raw.preview = common::largest_jpeg(&tiff);
+    }
+
+    // The TIFF has no Make or Model; the XMP packet does.
+    let xmp = tiff
+        .root()
+        .get(XMP)
+        .and_then(|e| blob(&tiff, e))
+        .map(String::from_utf8_lossy);
+    match xmp.as_deref() {
+        Some(xmp) => raw.set_camera(
+            xmp_value(xmp, "tiff:Make").as_deref().unwrap_or("Leaf"),
+            xmp_value(xmp, "tiff:Model").as_deref().unwrap_or(""),
+        ),
+        None => raw.set_camera("Leaf", ""),
+    }
+    raw.metadata = common::metadata(&tiff);
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    let tiff = Tiff::parse(bytes)?;
+    if let Some(data) = tiff.find(LEAF_DATA).and_then(|e| blob(&tiff, e)) {
+        if let Some(jpeg) = Leaf::parse(data).get("JPEG_preview_data") {
+            if jpeg.starts_with(&[0xFF, 0xD8]) {
+                return Ok(Some(jpeg.to_vec()));
+            }
+        }
+    }
+    Ok(common::largest_jpeg(&tiff))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::formats::hasselblad::corpus;
+
+    /// One PKTS record around a value.
+    fn record(name: &str, value: &[u8]) -> Vec<u8> {
+        let mut out = b"PKTS".to_vec();
+        out.extend_from_slice(&1u32.to_be_bytes());
+        let mut padded = name.as_bytes().to_vec();
+        padded.resize(40, 0);
+        out.extend_from_slice(&padded);
+        out.extend_from_slice(&(value.len() as u32).to_be_bytes());
+        out.extend_from_slice(value);
+        out
+    }
+
+    #[test]
+    fn records_nest_and_flatten() {
+        let inner = [
+            record("NeutObj_neutrals", b"2096\n1659\n2096\n1507\0"),
+            record("ImgProf_rotation_angle", b"90\0"),
+        ]
+        .concat();
+        let blob = [record("camera_profile", &inner), record("tail", b"x\0")].concat();
+        let leaf = Leaf::parse(&blob);
+        assert_eq!(
+            leaf.numbers("NeutObj_neutrals"),
+            vec![2096.0, 1659.0, 2096.0, 1507.0]
+        );
+        assert_eq!(leaf.numbers("ImgProf_rotation_angle"), vec![90.0]);
+        assert_eq!(leaf.fields("tail"), vec!["x"]);
+        // The container itself is kept, so nothing is lost.
+        assert!(leaf.get("camera_profile").is_some());
+    }
+
+    #[test]
+    fn a_lying_length_does_not_run_away() {
+        let mut blob = record("thing", b"value\0");
+        // Claim far more data than the blob holds.
+        let at = blob.len() - 6 - 4;
+        blob[at..at + 4].copy_from_slice(&u32::MAX.to_be_bytes());
+        let leaf = Leaf::parse(&blob);
+        assert_eq!(leaf.records.len(), 1);
+    }
+
+    #[test]
+    fn zero_length_records_terminate() {
+        let blob = [record("a", b""), record("b", b""), record("c", b"z")].concat();
+        assert_eq!(Leaf::parse(&blob).records.len(), 3);
+    }
+
+    #[test]
+    fn deep_nesting_is_bounded() {
+        // A record whose data is a copy of itself, sixteen deep.
+        let mut blob = record("leaf", b"x\0");
+        for _ in 0..16 {
+            blob = record("nest", &blob);
+        }
+        // Terminates, and the limit is what stops it.
+        assert!(Leaf::parse(&blob).records.len() <= 10);
+    }
+
+    #[test]
+    fn the_mosaic_codes_match_the_two_known_backs() {
+        let bayer = |codes: [u32; 4]| {
+            let c: Vec<CfaColor> = codes.iter().map(|c| color(*c).unwrap()).collect();
+            Cfa::Bayer([c[0], c[1], c[2], c[3]])
+        };
+        // Aptus 75: LibRaw calls this GBRG.
+        assert_eq!(bayer([2, 0, 1, 3]), Cfa::GBRG);
+        // AFi-II 12: RGGB.
+        assert_eq!(bayer([1, 3, 2, 0]), Cfa::RGGB);
+        assert_eq!(color(7), None);
+    }
+
+    #[test]
+    fn xmp_is_read_as_element_or_attribute() {
+        assert_eq!(
+            xmp_value("<tiff:Make>Leaf</tiff:Make>", "tiff:Make").as_deref(),
+            Some("Leaf")
+        );
+        assert_eq!(
+            xmp_value(
+                r#"<rdf:Description tiff:Model="Leaf Aptus 75"/>"#,
+                "tiff:Model"
+            )
+            .as_deref(),
+            Some("Leaf Aptus 75")
+        );
+        assert_eq!(xmp_value("<x/>", "tiff:Make"), None);
+    }
+
+    #[test]
+    fn the_scan_component_off_by_one_is_corrected() {
+        // SOI, SOF3 with components 0 and 1, SOS asking for 1 and 2.
+        let mut stream = vec![0xFF, 0xD8, 0xFF, 0xC3, 0, 14, 16, 0, 2, 0, 4, 2];
+        stream.extend_from_slice(&[0, 0x11, 0, 1, 0x11, 1]);
+        stream.extend_from_slice(&[0xFF, 0xDA, 0, 10, 2, 1, 0x00, 2, 0x10, 1, 0, 0]);
+        let fixed = fix_scan_component_ids(&stream).expect("a correction");
+        assert_eq!(fixed[stream.len() - 7], 0);
+        assert_eq!(fixed[stream.len() - 5], 1);
+        // Corrected once, it needs no second pass.
+        assert!(fix_scan_component_ids(&fixed).is_none());
+    }
+
+    #[test]
+    fn a_split_readout_is_told_from_a_plain_one() {
+        // A frame whose rows alternate between two levels, as a CFA
+        // frame's do, laid out plainly.
+        let (width, height) = (64, 64);
+        let plain: Vec<u16> = (0..width * height)
+            .map(|i| if (i / width) % 2 == 0 { 1000 } else { 4000 })
+            .collect();
+        assert!(!is_split_readout(&plain, width, height));
+        // The same frame as the sensor's two halves would arrive.
+        let mut split = vec![0u16; plain.len()];
+        for k in 0..height / 2 {
+            split[2 * k * width..(2 * k + 1) * width]
+                .copy_from_slice(&plain[k * width..(k + 1) * width]);
+            let bottom = height - 1 - k;
+            split[(2 * k + 1) * width..(2 * k + 2) * width]
+                .copy_from_slice(&plain[bottom * width..(bottom + 1) * width]);
+        }
+        assert!(is_split_readout(&split, width, height));
+        // A frame with no vertical structure at all must not be
+        // reordered: there is nothing to gain and the test would be
+        // guessing.
+        let flat = vec![2000u16; width * height];
+        assert!(!is_split_readout(&flat, width, height));
+    }
+
+    #[test]
+    fn garbage_is_not_a_leaf() {
+        assert!(decode(&[0u8; 64]).is_err());
+        assert!(decode(b"II*\0\x08\0\0\0").is_err());
+    }
+
+    #[test]
+    fn corpus_matches_the_oracle() {
+        let files = corpus::files(&["mos"]);
+        for path in &files {
+            let bytes = std::fs::read(path).unwrap();
+            let name = corpus::name(path);
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(Format::Mos),
+                "{name} did not probe as Leaf MOS"
+            );
+            let raw = decode(&bytes).unwrap_or_else(|e| panic!("{name}: {e}"));
+            raw.validate().unwrap_or_else(|e| panic!("{name}: {e}"));
+            corpus::check_against_oracle(path, &raw);
+            corpus::check_against_identify(path, &raw, &[]);
+            corpus::check_cfa(path, &raw);
+            corpus::check_preview(path, &raw);
+        }
+        eprintln!("mos: {} corpus files checked", files.len());
+    }
+
+    #[test]
+    fn corpus_truncations_do_not_panic() {
+        for path in corpus::files(&["mos"]) {
+            corpus::check_truncations(&path, decode);
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/mrw.rs
+++ b/crates/codec-raw/src/formats/mrw.rs
@@ -1,0 +1,759 @@
+//! Minolta MRW: the DiMAGE compacts and the Dynax/Maxxum/Alpha DSLRs.
+//!
+//! An MRW is not a TIFF. It opens with the four bytes `\0MRM` and a
+//! 32-bit big-endian length, and everything up to `8 + length` is a
+//! chain of blocks with the same shape: a four-byte tag whose first
+//! byte is NUL (`\0PRD`, `\0WBG`, `\0RIF`, `\0TTW`, `\0PAD`), a 32-bit
+//! big-endian length, then that many bytes of body. The sensor data
+//! begins immediately after the last block and runs to the end of the
+//! file. Every number in the container is big-endian, on every body.
+//!
+//! Only three blocks matter here:
+//!
+//! * `PRD` — the sensor: its dimensions, how many bits a stored sample
+//!   takes, and which of the four Bayer phases the frame starts on.
+//! * `WBG` — the as-shot white balance, four numerators with a scale
+//!   exponent each, *in filter-array order* rather than in a fixed
+//!   R,G,G,B order: a body whose array is GBRG writes G,B,R,G. The
+//!   camera's own tag name says so — ExifTool reads the same twelve
+//!   bytes as `WB_RGGBLevels` on an RGGB body and `WB_GBRGLevels` on
+//!   the DiMAGE A200.
+//! * `TTW` — a complete big-endian TIFF, header and all, holding the
+//!   ordinary Exif of the shot plus Minolta's makernote. Its offsets
+//!   are relative to the block body, which is exactly what
+//!   [`Tiff::parse_embedded`] wants.
+//!
+//! The full-size JPEG preview is not in the TIFF's own thumbnail slot
+//! but in the makernote, at `PreviewImageStart`/`PreviewImageLength`
+//! (0x0088/0x0089) — and on every body but the A200 its first byte has
+//! been overwritten, so the stream starts `02 D8` or `00 D8` where a
+//! JPEG must start `FF D8`. Restoring that byte is enough to make the
+//! preview decodable, which is what `dcraw`-era readers have always
+//! done with Minolta and Sony previews.
+
+use crate::formats::common;
+use crate::tiff::{tags, Tiff};
+use crate::{Cfa, CfaColor, Error, Format, RawData, RawImage, Rect, Result};
+
+/// Minolta's makernote tags for the embedded preview.
+const PREVIEW_START: u16 = 0x0088;
+const PREVIEW_LENGTH: u16 = 0x0089;
+
+/// One block of the header chain.
+struct Block<'a> {
+    /// The four tag bytes as stored, NUL included.
+    tag: &'a [u8],
+    /// Where the body starts in the file, for the blocks (`TTW`) whose
+    /// contents carry offsets of their own.
+    start: usize,
+    body: &'a [u8],
+}
+
+/// The blocks of the header, and where the sensor data starts.
+struct Header<'a> {
+    blocks: Vec<Block<'a>>,
+    data_offset: usize,
+}
+
+impl<'a> Header<'a> {
+    fn parse(bytes: &'a [u8]) -> Result<Header<'a>> {
+        if bytes.len() < 8 || &bytes[0..4] != b"\0MRM" {
+            return Err(Error::Corrupt("not an MRW: no \\0MRM signature".into()));
+        }
+        let length = u32::from_be_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]) as usize;
+        let data_offset = length
+            .checked_add(8)
+            .filter(|end| *end <= bytes.len())
+            .ok_or_else(|| Error::Corrupt("MRW header runs past the end of the file".into()))?;
+
+        let mut blocks = Vec::new();
+        let mut at = 8;
+        // A malformed length could otherwise leave `at` standing still;
+        // every block costs at least its eight-byte head, so the walk
+        // terminates on its own, but the bounds are checked anyway.
+        while at + 8 <= data_offset {
+            let tag = &bytes[at..at + 4];
+            let len =
+                u32::from_be_bytes([bytes[at + 4], bytes[at + 5], bytes[at + 6], bytes[at + 7]])
+                    as usize;
+            let start = at + 8;
+            let end = start
+                .checked_add(len)
+                .filter(|end| *end <= data_offset)
+                .ok_or_else(|| {
+                    Error::Corrupt(format!("MRW block {tag:02x?} overruns the header"))
+                })?;
+            blocks.push(Block {
+                tag,
+                start,
+                body: &bytes[start..end],
+            });
+            at = end;
+        }
+        Ok(Header {
+            blocks,
+            data_offset,
+        })
+    }
+
+    fn get(&self, tag: &[u8; 4]) -> Option<&Block<'a>> {
+        self.blocks.iter().find(|b| b.tag == tag)
+    }
+}
+
+/// What `PRD` says about the sensor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Sensor {
+    width: usize,
+    height: usize,
+    /// The vendor's "image" size: always a few pixels smaller than the
+    /// sensor, with no statement of where inside it those pixels lie.
+    image_width: usize,
+    image_height: usize,
+    /// Bits a stored sample takes: 12 (three bytes to two pixels) or
+    /// 16 (one big-endian word a pixel, the low twelve bits used).
+    storage_bits: u32,
+    /// Bits the converter actually filled, always 12 so far.
+    data_bits: u32,
+    /// The filter-array phase, PRD's last byte.
+    pattern: u8,
+}
+
+impl Sensor {
+    /// `PRD` is a fixed 24-byte record: eight bytes of firmware
+    /// version, then the sensor's height and width and the image's
+    /// height and width as 16-bit counts (height first, which is the
+    /// opposite of every other field in this crate), then the storage
+    /// and data depths, then a storage-method byte, four unused bytes
+    /// and the Bayer phase.
+    fn parse(body: &[u8]) -> Result<Sensor> {
+        if body.len() < 24 {
+            return Err(Error::Corrupt(format!(
+                "MRW PRD block is {} bytes, want 24",
+                body.len()
+            )));
+        }
+        let u16_at = |i: usize| u16::from_be_bytes([body[i], body[i + 1]]) as usize;
+        let sensor = Sensor {
+            height: u16_at(8),
+            width: u16_at(10),
+            image_height: u16_at(12),
+            image_width: u16_at(14),
+            storage_bits: body[16] as u32,
+            data_bits: body[17] as u32,
+            pattern: body[23],
+        };
+        if sensor.width == 0 || sensor.height == 0 {
+            return Err(Error::Corrupt("MRW PRD gives an empty sensor".into()));
+        }
+        Ok(sensor)
+    }
+
+    /// The filter array anchored at the frame origin. Only two phases
+    /// have ever been seen: 1 on every Dynax/Maxxum/Alpha body and the
+    /// DiMAGE 5/7 family, 4 on the DiMAGE A200, which reads its sensor
+    /// out half a line further along.
+    fn cfa(&self) -> Result<Cfa> {
+        match self.pattern {
+            1 => Ok(Cfa::RGGB),
+            4 => Ok(Cfa::GBRG),
+            other => Err(Error::Unsupported(format!("MRW Bayer pattern {other}"))),
+        }
+    }
+}
+
+/// White balance from `WBG`: four scale exponents then four 16-bit
+/// numerators, in the order the filter array puts the colours in.
+///
+/// The value of a coefficient is `numerator >> exponent`; the
+/// exponents have been 2,2,2,2 on every file seen, so what survives
+/// normalisation is the ratio of the numerators, but a body that used
+/// different scales per channel would still come out right.
+fn white_balance(body: &[u8], cfa: &Cfa) -> Option<[f32; 4]> {
+    if body.len() < 12 {
+        return None;
+    }
+    let mut coeffs = [0.0f32; 4];
+    for i in 0..4 {
+        let scale = body[i].min(31) as i32;
+        let numerator = u16::from_be_bytes([body[4 + i * 2], body[5 + i * 2]]) as f32;
+        // Position i of the 2x2 pattern, row-major, names the colour
+        // this numerator balances.
+        let color = cfa.color_at(i % 2, i / 2)?;
+        let value = numerator / (1i64 << scale) as f32;
+        let slot = match color {
+            CfaColor::Red => 0,
+            CfaColor::Green => 1,
+            CfaColor::Blue => 2,
+            CfaColor::Green2 => 3,
+            _ => return None,
+        };
+        // Two positions carry green; the second fills G2 as well so a
+        // developer that separates them has both.
+        if slot == 1 && coeffs[1] != 0.0 {
+            coeffs[3] = value;
+        } else {
+            coeffs[slot] = value;
+        }
+    }
+    let green = coeffs[1];
+    // A missing numerator (or a NaN out of a mangled scale) leaves the
+    // balance unusable; unity is a better answer than a division.
+    if !green.is_finite() || green <= 0.0 || coeffs[0] <= 0.0 || coeffs[2] <= 0.0 {
+        return None;
+    }
+    if coeffs[3] <= 0.0 {
+        coeffs[3] = green;
+    }
+    Some([coeffs[0] / green, 1.0, coeffs[2] / green, coeffs[3] / green])
+}
+
+/// Unpack the sensor frame. 12-bit samples are packed most
+/// significant bits first, three bytes to two pixels, with no padding
+/// at all — not even at the end of a row, which is why the whole frame
+/// is unpacked as one run. 16-bit samples are plain big-endian words.
+fn unpack(data: &[u8], sensor: &Sensor) -> Result<Vec<u16>> {
+    let pixels = sensor
+        .width
+        .checked_mul(sensor.height)
+        .ok_or_else(|| Error::Corrupt("MRW frame too large".into()))?;
+    match sensor.storage_bits {
+        12 => {
+            let need = pixels.div_ceil(2) * 3;
+            if data.len() < need {
+                return Err(Error::Corrupt(format!(
+                    "MRW holds {} bytes of 12-bit samples, want {need}",
+                    data.len()
+                )));
+            }
+            let mut out = vec![0u16; pixels];
+            for (pair, chunk) in out.chunks_mut(2).zip(data.as_chunks::<3>().0) {
+                pair[0] = ((chunk[0] as u16) << 4) | (chunk[1] as u16 >> 4);
+                if let Some(second) = pair.get_mut(1) {
+                    *second = ((chunk[1] as u16 & 0x0f) << 8) | chunk[2] as u16;
+                }
+            }
+            Ok(out)
+        }
+        16 => {
+            let need = pixels * 2;
+            if data.len() < need {
+                return Err(Error::Corrupt(format!(
+                    "MRW holds {} bytes of 16-bit samples, want {need}",
+                    data.len()
+                )));
+            }
+            Ok(data[..need]
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|w| u16::from_be_bytes([w[0], w[1]]))
+                .collect())
+        }
+        other => Err(Error::Unsupported(format!(
+            "MRW with {other}-bit sample storage"
+        ))),
+    }
+}
+
+/// The makernote as its own IFD chain: Minolta writes a bare IFD with
+/// no header of its own, in the TTW TIFF's byte order, with offsets
+/// relative to the TTW TIFF rather than to the makernote.
+fn makernote<'a>(tiff: &Tiff<'a>) -> Option<Tiff<'a>> {
+    let entry = tiff.exif()?.get(tags::MAKER_NOTE)?;
+    Tiff::parse_at_relative(
+        tiff.bytes(),
+        entry.offset,
+        tiff.base(),
+        tiff.little_endian(),
+    )
+    .ok()
+}
+
+/// The preview the makernote points at, with its clobbered first byte
+/// put back. `None` unless the stream really does end `FF D9`, so a
+/// stale pointer cannot hand a caller a lump of sensor data.
+fn makernote_preview(tiff: &Tiff<'_>) -> Option<Vec<u8>> {
+    let maker = makernote(tiff)?;
+    let root = maker.root();
+    let start = root.get(PREVIEW_START)?.u32(0)? as usize + tiff.base();
+    let length = root.get(PREVIEW_LENGTH)?.u32(0)? as usize;
+    let stream = tiff.bytes().get(start..start.checked_add(length)?)?;
+    if stream.len() < 4 || stream[1] != 0xd8 || stream[stream.len() - 2..] != [0xff, 0xd9] {
+        return None;
+    }
+    let mut out = stream.to_vec();
+    out[0] = 0xff;
+    Some(out)
+}
+
+/// The largest showable JPEG in the file: the makernote's full-size
+/// preview when it is there, else whatever the TTW TIFF's own tags
+/// point at (the A200 keeps a small thumbnail there too).
+fn best_preview(tiff: &Tiff<'_>) -> Option<Vec<u8>> {
+    let maker = makernote_preview(tiff);
+    let embedded = common::largest_jpeg(tiff);
+    match (maker, embedded) {
+        (Some(a), Some(b)) => Some(if a.len() >= b.len() { a } else { b }),
+        (a, b) => a.or(b),
+    }
+}
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let header = Header::parse(bytes)?;
+    let prd = header
+        .get(b"\0PRD")
+        .ok_or_else(|| Error::Corrupt("MRW without a PRD block".into()))?;
+    let sensor = Sensor::parse(prd.body)?;
+    let cfa = sensor.cfa()?;
+
+    let data = unpack(&bytes[header.data_offset..], &sensor)?;
+    let mut raw = RawImage::new(
+        Format::Mrw,
+        sensor.width,
+        sensor.height,
+        1,
+        RawData::U16(data),
+        cfa.clone(),
+    );
+
+    // Nothing in the file records a saturation point, so the depth the
+    // converter wrote is the only honest ceiling. Black is likewise
+    // unrecorded: these sensors sit near zero and LibRaw subtracts
+    // nothing from them either.
+    raw.white_level = ((1u32 << sensor.data_bits.clamp(8, 16)) - 1) as f32;
+
+    if let Some(wbg) = header.get(b"\0WBG") {
+        if let Some(coeffs) = white_balance(wbg.body, &cfa) {
+            raw.wb_coeffs = coeffs;
+        }
+    }
+
+    // The vendor's "image" size (PRD bytes 12..16) is a few pixels
+    // smaller than the sensor on every body, but the format never says
+    // where inside the frame those pixels sit and there is no masked
+    // border to find it from — the extra columns carry picture, not
+    // black. Guessing an origin would shift the whole image, so the
+    // crop stays the full frame, which is what LibRaw also hands out.
+    raw.crop = Rect {
+        x: 0,
+        y: 0,
+        width: sensor.width,
+        height: sensor.height,
+    };
+
+    if let Some(ttw) = header.get(b"\0TTW") {
+        if let Ok(tiff) = Tiff::parse_embedded(bytes, ttw.start) {
+            let (make, model) = tiff.make_model();
+            raw.set_camera(&make, &model);
+            raw.orientation = common::orientation(&tiff);
+            raw.metadata = common::metadata(&tiff);
+            raw.preview = best_preview(&tiff);
+        }
+    }
+    if raw.make.is_empty() {
+        raw.set_camera("Minolta", "");
+    }
+
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    let header = Header::parse(bytes)?;
+    let Some(ttw) = header.get(b"\0TTW") else {
+        return Ok(None);
+    };
+    let Ok(tiff) = Tiff::parse_embedded(bytes, ttw.start) else {
+        return Ok(None);
+    };
+    Ok(best_preview(&tiff))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    /// Every file under `$SCHIST_RAW_CORPUS` with one of `extensions`,
+    /// recursively. Empty when the variable is unset, which is how the
+    /// corpus tests skip on a machine without the samples.
+    fn corpus(extensions: &[&str]) -> Vec<PathBuf> {
+        let Ok(root) = std::env::var("SCHIST_RAW_CORPUS") else {
+            return Vec::new();
+        };
+        let mut found = Vec::new();
+        let mut stack = vec![PathBuf::from(root)];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| extensions.iter().any(|want| e.eq_ignore_ascii_case(want)))
+                {
+                    found.push(path);
+                }
+            }
+        }
+        found.sort();
+        found
+    }
+
+    /// LibRaw's `unprocessed_raw -T` output beside the sample.
+    fn oracle(path: &Path) -> Option<(usize, usize, Vec<u16>)> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".tiff");
+        let image = image::open(PathBuf::from(name)).ok()?.into_luma16();
+        let (width, height) = (image.width() as usize, image.height() as usize);
+        Some((width, height, image.into_raw()))
+    }
+
+    /// `raw-identify -v -w` output beside the sample.
+    fn identify(path: &Path) -> Option<String> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".identify.txt");
+        std::fs::read_to_string(PathBuf::from(name)).ok()
+    }
+
+    /// The text after `key:` on the line that starts with it.
+    fn field<'a>(text: &'a str, key: &str) -> Option<&'a str> {
+        text.lines()
+            .map(str::trim)
+            .find(|line| line.starts_with(key))
+            .map(|line| line[key.len()..].trim())
+    }
+
+    /// A "W x H" pair.
+    fn size(text: &str, key: &str) -> Option<(usize, usize)> {
+        let value = field(text, key)?;
+        let (w, h) = value.split_once('x')?;
+        Some((w.trim().parse().ok()?, h.trim().parse().ok()?))
+    }
+
+    /// What LibRaw's "Image flip" means as an [`Orientation`].
+    fn flip(text: &str) -> Option<crate::Orientation> {
+        Some(match field(text, "Image flip:")?.parse::<u32>().ok()? {
+            3 => crate::Orientation::Rotate180,
+            5 => crate::Orientation::Rotate270CW,
+            6 => crate::Orientation::Rotate90CW,
+            _ => crate::Orientation::Normal,
+        })
+    }
+
+    /// The first four letters of the "Filter pattern" line as a CFA.
+    fn filter_pattern(text: &str) -> Option<Cfa> {
+        let pattern = field(text, "Filter pattern:")?;
+        let mut colors = [CfaColor::Red; 4];
+        for (color, letter) in colors.iter_mut().zip(pattern.chars()) {
+            *color = match letter {
+                'R' => CfaColor::Red,
+                'G' => CfaColor::Green,
+                'B' => CfaColor::Blue,
+                _ => return None,
+            };
+        }
+        Some(Cfa::Bayer(colors))
+    }
+
+    /// The as-shot multipliers, normalised to green, from the
+    /// "As shot" row of the makernote white-balance table.
+    fn as_shot(text: &str) -> Option<[f32; 3]> {
+        let row = field(text, "As shot")?;
+        let numbers: Vec<f32> = row
+            .split_whitespace()
+            .take(4)
+            .map_while(|v| v.parse::<f32>().ok())
+            .collect();
+        let [red, green, blue, ..] = numbers[..] else {
+            return None;
+        };
+        (green > 0.0).then(|| [red / green, 1.0, blue / green])
+    }
+
+    /// Compare a decoded frame with the oracle sample for sample.
+    fn compare(path: &Path, raw: &RawImage) {
+        let Some((width, height, expect)) = oracle(path) else {
+            eprintln!("{}: no oracle TIFF, data not checked", path.display());
+            return;
+        };
+        assert_eq!(
+            (raw.width, raw.height),
+            (width, height),
+            "{}: frame is {}x{}, oracle {width}x{height}",
+            path.display(),
+            raw.width,
+            raw.height
+        );
+        let RawData::U16(got) = &raw.data else {
+            panic!("{}: expected integer samples", path.display())
+        };
+        let mut wrong = 0usize;
+        let mut first = Vec::new();
+        for (i, (a, b)) in got.iter().zip(expect.iter()).enumerate() {
+            if a != b {
+                wrong += 1;
+                if first.len() < 8 {
+                    first.push(format!("({}, {}): {a} not {b}", i % width, i / width));
+                }
+            }
+        }
+        assert_eq!(
+            wrong,
+            0,
+            "{}: {wrong} samples differ; {}",
+            path.display(),
+            first.join(", ")
+        );
+    }
+
+    /// Levels, balance, crop, orientation and CFA against
+    /// `raw-identify`.
+    fn compare_metadata(path: &Path, raw: &RawImage) {
+        let Some(text) = identify(path) else { return };
+        if let Some(cfa) = filter_pattern(&text) {
+            assert_eq!(raw.cfa, cfa, "{}: filter pattern", path.display());
+        }
+        if let Some(orientation) = flip(&text) {
+            assert_eq!(
+                raw.orientation,
+                orientation,
+                "{}: orientation",
+                path.display()
+            );
+        }
+        if let Some((width, height)) = size(&text, "Image size:") {
+            let (x, y) = match field(&text, "Raw inset, width x height:") {
+                Some(inset) => {
+                    let left = inset
+                        .split("left:")
+                        .nth(1)
+                        .and_then(|v| v.split_whitespace().next().and_then(|v| v.parse().ok()));
+                    let top = inset
+                        .split("top:")
+                        .nth(1)
+                        .and_then(|v| v.split_whitespace().next().and_then(|v| v.parse().ok()));
+                    (left.unwrap_or(0), top.unwrap_or(0))
+                }
+                None => (0, 0),
+            };
+            let inset = field(&text, "Raw inset, width x height:")
+                .and_then(|v| v.split_whitespace().next().map(str::to_string));
+            let expect = match inset.and_then(|w| w.parse::<usize>().ok()) {
+                Some(w) => {
+                    let h = field(&text, "Raw inset, width x height:")
+                        .and_then(|v| v.split_whitespace().nth(2))
+                        .and_then(|v| v.parse().ok())
+                        .unwrap_or(height);
+                    Rect {
+                        x,
+                        y,
+                        width: w,
+                        height: h,
+                    }
+                }
+                None => Rect {
+                    x: 0,
+                    y: 0,
+                    width,
+                    height,
+                },
+            };
+            if raw.crop != expect {
+                eprintln!("{}: crop {:?}, LibRaw {expect:?}", path.display(), raw.crop);
+            }
+        }
+        if let Some(expect) = as_shot(&text) {
+            for (got, want) in raw.wb_coeffs.iter().zip(expect.iter()) {
+                if (got - want).abs() > want * 0.02 {
+                    eprintln!(
+                        "{}: white balance {:?}, LibRaw {expect:?}",
+                        path.display(),
+                        raw.wb_coeffs
+                    );
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Cutting a file short must never panic, whatever it does return.
+    fn truncations(path: &Path) {
+        let bytes = std::fs::read(path).expect("sample readable");
+        let mut seed = bytes.len() as u64;
+        for _ in 0..10 {
+            // A cheap deterministic spread of cut points.
+            seed = seed
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            let at = (seed >> 33) as usize % bytes.len().max(1);
+            let _ = crate::decode(&bytes[..at]);
+            let _ = crate::probe(&bytes[..at]);
+        }
+    }
+
+    /// A minimal MRW: the signature, a PRD block and one block of
+    /// padding, with the sensor data after them.
+    fn synthetic(prd: [u8; 24], data: &[u8]) -> Vec<u8> {
+        let mut out = b"\0MRM".to_vec();
+        let header = 8 + 24;
+        out.extend((header as u32).to_be_bytes());
+        out.extend(b"\0PRD");
+        out.extend(24u32.to_be_bytes());
+        out.extend(prd);
+        out.extend(data);
+        out
+    }
+
+    fn prd(width: u16, height: u16, storage: u8, pattern: u8) -> [u8; 24] {
+        let mut prd = [0u8; 24];
+        prd[..8].copy_from_slice(b"27470002");
+        prd[8..10].copy_from_slice(&height.to_be_bytes());
+        prd[10..12].copy_from_slice(&width.to_be_bytes());
+        prd[12..14].copy_from_slice(&height.to_be_bytes());
+        prd[14..16].copy_from_slice(&width.to_be_bytes());
+        prd[16] = storage;
+        prd[17] = 12;
+        prd[23] = pattern;
+        prd
+    }
+
+    #[test]
+    fn reads_the_block_chain() {
+        let file = synthetic(prd(2, 2, 16, 1), &[0; 8]);
+        let header = Header::parse(&file).expect("header parses");
+        assert_eq!(header.blocks.len(), 1);
+        assert_eq!(header.blocks[0].tag, b"\0PRD");
+        assert_eq!(header.data_offset, 40);
+    }
+
+    #[test]
+    fn rejects_a_block_that_overruns_the_header() {
+        let mut file = synthetic(prd(2, 2, 16, 1), &[0; 8]);
+        file[12..16].copy_from_slice(&9999u32.to_be_bytes());
+        assert!(matches!(Header::parse(&file), Err(Error::Corrupt(_))));
+    }
+
+    #[test]
+    fn unpacks_twelve_bit_samples_two_to_three_bytes() {
+        let sensor = Sensor::parse(&prd(4, 1, 12, 1)).expect("PRD parses");
+        // 0xABC, 0xDEF, 0x123, 0x456.
+        let data = [0xab, 0xcd, 0xef, 0x12, 0x34, 0x56];
+        assert_eq!(
+            unpack(&data, &sensor).unwrap(),
+            vec![0xabc, 0xdef, 0x123, 0x456]
+        );
+    }
+
+    #[test]
+    fn unpacks_sixteen_bit_samples_big_endian() {
+        let sensor = Sensor::parse(&prd(2, 1, 16, 1)).expect("PRD parses");
+        assert_eq!(
+            unpack(&[0x01, 0x02, 0x03, 0x04], &sensor).unwrap(),
+            vec![0x0102, 0x0304]
+        );
+    }
+
+    #[test]
+    fn short_sensor_data_is_corrupt_not_a_panic() {
+        let sensor = Sensor::parse(&prd(1000, 1000, 12, 1)).expect("PRD parses");
+        assert!(matches!(unpack(&[0; 16], &sensor), Err(Error::Corrupt(_))));
+    }
+
+    #[test]
+    fn white_balance_follows_the_filter_array() {
+        // Four numerators, scale 2 each: on an RGGB body they are
+        // R, G, G, B; on the A200's GBRG body the same twelve bytes
+        // are G, B, R, G.
+        let mut block = [2u8, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0];
+        block[4..6].copy_from_slice(&408u16.to_be_bytes());
+        block[6..8].copy_from_slice(&256u16.to_be_bytes());
+        block[8..10].copy_from_slice(&256u16.to_be_bytes());
+        block[10..12].copy_from_slice(&450u16.to_be_bytes());
+        let rggb = white_balance(&block, &Cfa::RGGB).expect("balance");
+        assert!((rggb[0] - 408.0 / 256.0).abs() < 1e-6);
+        assert!((rggb[2] - 450.0 / 256.0).abs() < 1e-6);
+
+        let mut block = [2u8, 2, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0];
+        block[4..6].copy_from_slice(&255u16.to_be_bytes());
+        block[6..8].copy_from_slice(&416u16.to_be_bytes());
+        block[8..10].copy_from_slice(&480u16.to_be_bytes());
+        block[10..12].copy_from_slice(&255u16.to_be_bytes());
+        let gbrg = white_balance(&block, &Cfa::GBRG).expect("balance");
+        assert!((gbrg[0] - 480.0 / 255.0).abs() < 1e-6, "{gbrg:?}");
+        assert!((gbrg[2] - 416.0 / 255.0).abs() < 1e-6, "{gbrg:?}");
+    }
+
+    #[test]
+    fn an_unknown_bayer_phase_is_unsupported() {
+        let sensor = Sensor::parse(&prd(2, 2, 12, 7)).expect("PRD parses");
+        assert!(matches!(sensor.cfa(), Err(Error::Unsupported(_))));
+    }
+
+    #[test]
+    fn garbage_is_rejected() {
+        assert!(decode(b"not an MRW at all").is_err());
+        assert!(decode(&[]).is_err());
+    }
+
+    #[test]
+    fn corpus_matches_the_oracle() {
+        for path in corpus(&["mrw"]) {
+            let bytes = std::fs::read(&path).expect("sample readable");
+            // The DiMAGE Z-series compacts write bare sensor data under
+            // the same extension: no signature, no blocks, nothing but
+            // pixels, and only a filename tells anybody what shape they
+            // are. `probe` declines them and so does this test.
+            if !bytes.starts_with(b"\0MRM") {
+                eprintln!("{}: headerless MRW dump, not a container", path.display());
+                continue;
+            }
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(crate::Format::Mrw),
+                "{}: probed as something else",
+                path.display()
+            );
+            let raw = match crate::decode(&bytes) {
+                Ok(raw) => raw,
+                Err(Error::Unsupported(why)) => {
+                    let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    let allowed: &[(&str, &str)] = &[];
+                    let reason = allowed
+                        .iter()
+                        .find(|(file, _)| name.contains(file))
+                        .unwrap_or_else(|| {
+                            panic!("{}: unexpected Unsupported: {why}", path.display())
+                        });
+                    eprintln!(
+                        "{}: unsupported as documented ({}): {why}",
+                        path.display(),
+                        reason.1
+                    );
+                    continue;
+                }
+                Err(other) => panic!("{}: {other}", path.display()),
+            };
+            raw.validate().expect("decoded frame is self-consistent");
+            compare(&path, &raw);
+            compare_metadata(&path, &raw);
+            if let Some(preview) = &raw.preview {
+                image::load_from_memory(preview)
+                    .unwrap_or_else(|e| panic!("{}: preview will not decode: {e}", path.display()));
+            }
+        }
+    }
+
+    #[test]
+    fn truncated_files_never_panic() {
+        for path in corpus(&["mrw"]) {
+            truncations(&path);
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/nef.rs
+++ b/crates/codec-raw/src/formats/nef.rs
@@ -1,0 +1,1858 @@
+//! Nikon NEF and NRW.
+//!
+//! A NEF is an ordinary TIFF whose IFD0 holds a small RGB thumbnail
+//! and whose SubIFDs hold the full-size JPEG preview and the sensor
+//! frame. The sensor IFD is the one whose PhotometricInterpretation is
+//! 32803 (CFA); on the bodies that write more than one, the largest
+//! wins. NRW — the raw of the Coolpix P-series and the Coolpix A — is
+//! the same container with a different extension.
+//!
+//! Three ways of storing the samples have shipped, and the tags do
+//! not tell them apart on their own — the strip length does, because
+//! only a coded frame is smaller than the samples it holds:
+//!
+//! * 12 bits packed. The bodies that tag the frame `Compression` 1
+//!   (the D1, the Coolpix E-series) pack it the way TIFF says to, most
+//!   significant bit first; the modern bodies' "uncompressed (reduced
+//!   to 12 bit)" mode keeps Nikon's private 34713 and packs least
+//!   significant bit first. Two old quirks live here: the D100 writes
+//!   ten samples into the first fifteen bytes of every sixteen and its
+//!   rows hold more samples than its ImageWidth admits to, and the
+//!   Coolpix E-series writes every even row of the frame before every
+//!   odd one. The Coolpix compacts' NRW packs into 32-bit
+//!   little-endian words — every four bytes reversed.
+//! * 14 or 16 bits in plain 16-bit words, in the file's byte order.
+//!   The Coolpix P-series' NRW spends two bytes a sample as well, but
+//!   puts its twelve bits at the top of a big-endian word whichever
+//!   way round the file itself is.
+//! * Nikon's own Huffman coding, `Compression` 34713, described at
+//!   [`Linearization`] and [`decompress`] below. The Z 8 and Z 9's
+//!   "High Efficiency" successor to it is not decoded.
+//!
+//! The interesting metadata is in the makernote, which is its own
+//! little TIFF: after the string `Nikon\0` and a two-byte version
+//! (`02 10`, `02 11` on everything since 2003) come two spare bytes
+//! and then a complete TIFF header at offset 10, with every offset
+//! inside it measured from there — [`Tiff::parse_embedded`] to the
+//! letter. The very first bodies (the D1) wrote a bare IFD with no
+//! header at all and offsets into the main file.
+//!
+//! What the makernote is read for: the as-shot white balance
+//! (WB_RBLevels, and the Coolpix E-series' own blob), the black level,
+//! the frame the camera means to show, and — on a coded frame — the
+//! curve and the initial predictors. Nikon also writes an encrypted
+//! ColorBalance (0x0097) whose key is the body's serial number and
+//! shutter count; nothing here decrypts it, because every body in the
+//! sample corpus writes the plain WB_RBLevels beside it.
+//!
+//! The crop this hands out is the camera's own CropArea, not LibRaw's
+//! per-model margin table: LibRaw trims a few columns off a D800E and
+//! two rows off a Nikon 1 from a list of its own, and those bodies
+//! record no such border anywhere in the file.
+//!
+//! Nothing here is derived from another decoder: the layouts come
+//! from the TIFF and Exif specifications, ExifTool's published tag
+//! tables, and observation of the sample files against LibRaw's
+//! `unprocessed_raw` output.
+
+use crate::bits::{BitPump, BitPumpLsb, BitPumpMsb, BitPumpMsb32, HuffTable};
+use crate::formats::common;
+use crate::tiff::{tags, Ifd, ImageLayout, Tiff};
+use crate::{Cfa, CfaColor, Error, Format, RawData, RawImage, Rect, Result};
+
+/// Nikon's makernote tags, by the names ExifTool's tables give them.
+mod maker {
+    /// WB_RBLevels: red, blue, green1, green2 as rationals.
+    pub const WB_RB_LEVELS: u16 = 0x000C;
+    /// ColorBalanceA, the Coolpix E-series' white balance blob.
+    pub const COLOR_BALANCE_A: u16 = 0x0014;
+    /// BlackLevel, four shorts, one per filter-array position.
+    pub const BLACK_LEVEL: u16 = 0x003D;
+    /// CropArea: left, top, width, height of the frame the camera
+    /// means to show.
+    pub const CROP_AREA: u16 = 0x0045;
+    /// NEFCompression: which of the storage modes above was used.
+    pub const COMPRESSION: u16 = 0x0093;
+    /// ColorBalance, in a dozen versioned shapes and encrypted in
+    /// most of them.
+    pub const COLOR_BALANCE: u16 = 0x0097;
+    /// NEFLinearizationTable: the curve, the initial predictors and
+    /// the Huffman variant of a compressed frame.
+    pub const LINEARIZATION: u16 = 0x0096;
+}
+
+/// Nikon's private `Compression` value for both the Huffman-coded
+/// frames and the "uncompressed" modes of the bodies that still tag
+/// them this way.
+const NIKON_COMPRESSION: u32 = 34713;
+
+// ------------------------------------------------------------ container
+
+/// The makernote as a TIFF of its own.
+///
+/// Two shapes exist. Since 2003 the entry begins `Nikon\0` and a
+/// version, and a whole TIFF (header included, byte order of its own,
+/// offsets relative to the header) starts ten bytes in. Before that —
+/// the D1 and the first Coolpix raws — the entry is a bare IFD in the
+/// file's byte order whose offsets point into the file.
+fn makernote<'a>(tiff: &Tiff<'a>) -> Option<Tiff<'a>> {
+    let entry = tiff.exif()?.get(tags::MAKER_NOTE)?;
+    let at = entry.offset;
+    let bytes = tiff.bytes();
+    if bytes.get(at..at + 6) == Some(b"Nikon\0") {
+        // Version 2 (`02 xx`) carries a header at +10. Version 1
+        // (`01 00`, some Coolpix) puts a bare IFD at +8 whose offsets
+        // are the main file's.
+        if bytes.get(at + 6) == Some(&2) {
+            return Tiff::parse_embedded(bytes, at + 10).ok();
+        }
+        return Tiff::parse_at(bytes, at + 8, tiff.little_endian()).ok();
+    }
+    Tiff::parse_at(bytes, at, tiff.little_endian()).ok()
+}
+
+/// The sensor IFD: PhotometricInterpretation 32803 (CFA), and where a
+/// body writes more than one such IFD, the biggest of them. Nikon
+/// itself has only ever written one, but a file that has been through
+/// a converter can carry a reduced copy beside it.
+fn sensor_ifd<'a>(tiff: &'a Tiff<'a>) -> Option<&'a Ifd> {
+    tiff.all()
+        .into_iter()
+        .filter(|ifd| ifd.get(tags::PHOTOMETRIC).and_then(|e| e.u32(0)) == Some(32803))
+        .max_by_key(|ifd| {
+            let side = |tag| ifd.get(tag).and_then(|e| e.u32(0)).unwrap_or(0) as u64;
+            side(tags::IMAGE_WIDTH) * side(tags::IMAGE_LENGTH)
+        })
+}
+
+/// The filter array from the IFD's own CFAPattern (0x828E): 0 red,
+/// 1 green, 2 blue, in a 2x2 repeat. Every Nikon sensor is Bayer.
+fn cfa_of(ifd: &Ifd) -> Result<Cfa> {
+    let pattern = ifd
+        .get(tags::CFA_PATTERN)
+        .and_then(|e| e.bytes().map(|b| b.to_vec()))
+        .filter(|b| b.len() >= 4)
+        .ok_or_else(|| Error::Corrupt("NEF sensor IFD without a 2x2 CFAPattern".into()))?;
+    let mut colors = [CfaColor::Green; 4];
+    for (out, code) in colors.iter_mut().zip(pattern.iter()) {
+        *out = match code {
+            0 => CfaColor::Red,
+            1 => CfaColor::Green,
+            2 => CfaColor::Blue,
+            other => return Err(Error::Corrupt(format!("NEF CFAPattern colour {other}"))),
+        };
+    }
+    Ok(Cfa::Bayer(colors))
+}
+
+// -------------------------------------------------------------- storage
+
+/// How the samples of a strip are laid out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Storage {
+    /// A packed bit stream.
+    Packed(Packing),
+    /// One 16-bit word a sample, in the file's byte order.
+    Words16,
+    /// Nikon's Huffman coding.
+    Huffman,
+}
+
+/// The shape of a packed bit stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Packing {
+    bits: u32,
+    /// Bytes from the start of one row to the start of the next.
+    /// `None` for one continuous stream in which a row may begin
+    /// part-way through a byte.
+    row_stride: Option<usize>,
+    /// Samples a group, and the group's size in bytes, for the bodies
+    /// that leave whole bytes spare at the end of every group. The
+    /// D100 writes ten 12-bit samples — fifteen bytes — into every
+    /// sixteen, and no other body in the sample corpus groups at all.
+    group: Option<(usize, usize)>,
+    /// Which end of the stream a sample's first bit comes from.
+    order: BitOrder,
+}
+
+/// How a packed stream's bits are ordered. Three have shipped, and
+/// nothing in the TIFF structure tells them apart — the makernote
+/// does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BitOrder {
+    /// Most significant bit first, which is TIFF's own packing: the
+    /// D1, the D100 and the Coolpix E-series.
+    Msb,
+    /// Least significant bit first: the modern bodies' "uncompressed
+    /// (reduced to 12 bit)" mode.
+    Lsb,
+    /// Most significant bit first within 32-bit little-endian words —
+    /// every four bytes reversed before reading. The Coolpix
+    /// compacts' NRW packs this way, whatever the file's own byte
+    /// order says.
+    Msb32,
+}
+
+/// The bit order a frame is packed in.
+///
+/// `Compression` 1 is TIFF's own uncompressed, and the bodies that use
+/// it pack the way TIFF says to. Under Nikon's private 34713 the
+/// makernote's NEFCompression says which mode it is, and mode 6,
+/// "uncompressed (reduced to 12 bit)", is the one that packs least
+/// significant bit first. The Coolpix compacts' NRW is its own thing
+/// again and says so in the makernote: its ColorBalanceA slot holds
+/// the string `NRW ` and a version rather than a colour table.
+fn bit_order(nef_compression: Option<u32>, nrw: bool) -> BitOrder {
+    if nrw {
+        BitOrder::Msb32
+    } else if nef_compression == Some(6) {
+        BitOrder::Lsb
+    } else {
+        BitOrder::Msb
+    }
+}
+
+/// The Coolpix compacts' own block, when this is one of their NRWs.
+///
+/// They put it in the slot the older Coolpix used for a colour table
+/// (0x0014) and mark it with the signature `NRW ` and a version. Two
+/// things are read out of it: that it is there at all, which is what
+/// says the frame is packed in 32-bit words, and the black level at
+/// offset 32.
+fn nrw_block<'a>(maker: &'a Tiff<'_>) -> Option<&'a [u8]> {
+    maker
+        .root()
+        .get(maker::COLOR_BALANCE_A)
+        .and_then(|e| e.bytes())
+        .filter(|blob| blob.starts_with(b"NRW "))
+}
+
+/// How the samples are stored, and how many of them a row really
+/// holds — which is not always the ImageWidth the IFD gives.
+///
+/// The `Compression` tag alone cannot say: the modern bodies'
+/// "uncompressed (reduced to 12 bit)" mode writes packed samples under
+/// Nikon's private 34713, so the honest test is whether the strips are
+/// big enough to hold the frame whole — a Huffman frame is always
+/// smaller than the packed one it codes. The makernote's own
+/// NEFCompression (0x0093) is used only where it is decisive: it names
+/// the two Huffman modes outright, and it is the only place the Z 8 and
+/// Z 9's new High Efficiency codec announces itself.
+fn storage(
+    order: BitOrder,
+    nef_compression: Option<u32>,
+    width: usize,
+    rows: usize,
+    bits: u32,
+    strips: usize,
+    bytes: usize,
+) -> Result<(usize, Storage)> {
+    match nef_compression {
+        // 1 lossy (type 1), 3 lossless, 4 lossy (type 2).
+        Some(1 | 3 | 4) => return Ok((width, Storage::Huffman)),
+        // 13 and 14 are "High Efficiency" and "High Efficiency*", the
+        // TicoRAW-derived codec of the Z 9 and Z 8. Nothing here
+        // decodes it, and it is worth saying so by name.
+        Some(mode @ 13..=16) => {
+            return Err(Error::Unsupported(format!(
+                "NEF High Efficiency compression (NEFCompression {mode}, the Z 8 and Z 9)"
+            )))
+        }
+        _ => {}
+    }
+    let words = width.saturating_mul(rows).saturating_mul(2);
+    let packed_row = (width * bits as usize).div_ceil(8);
+    let packed_tight = (width * rows * bits as usize).div_ceil(8);
+    let packing = |row_stride, group| {
+        Storage::Packed(Packing {
+            bits,
+            row_stride,
+            group,
+            order,
+        })
+    };
+    if bytes >= words {
+        // Two bytes a sample, but not always the sample itself:
+        // NEFCompression 7 is "unpacked 12 bits", the sample in the top
+        // of a big-endian word whatever byte order the file itself is
+        // in. Reading it as a group of one sample in every two bytes
+        // takes the twelve bits from the top of the pair and drops the
+        // four spare ones below them.
+        if nef_compression == Some(7) {
+            return Ok((width, packing(Some(width * 2), Some((1, 2)))));
+        }
+        return Ok((width, Storage::Words16));
+    }
+    // One strip whose rows are longer than the samples need, and whose
+    // length divides into sixteen-byte groups: the D100, which packs
+    // ten samples into the first fifteen bytes of every group and
+    // leaves the sixteenth alone. Its rows hold more samples than the
+    // IFD's ImageWidth admits to, and the group count is what says how
+    // many — LibRaw reads the same 3040 out of a frame the IFD calls
+    // 3034 wide.
+    if strips == 1 && bits == 12 && rows > 0 && bytes.is_multiple_of(rows) {
+        let stride = bytes / rows;
+        let grouped = stride / 16 * 10;
+        if stride != packed_row && stride.is_multiple_of(16) && grouped >= width {
+            return Ok((grouped, packing(Some(stride), Some((10, 16)))));
+        }
+    }
+    if bytes >= packed_row.saturating_mul(rows) {
+        // Room for every row to start on a byte boundary.
+        Ok((width, packing(Some(packed_row), None)))
+    } else if bytes >= packed_tight {
+        Ok((width, packing(None, None)))
+    } else {
+        Ok((width, Storage::Huffman))
+    }
+}
+
+/// Unpack `rows` rows of `width` packed samples.
+///
+/// Past the end of the data the pump reads zeros, so a truncated strip
+/// yields a short-but-black frame rather than an error.
+fn unpack_packed(data: &[u8], width: usize, rows: usize, packing: Packing, out: &mut [u16]) {
+    let bits = packing.bits;
+    let fill = |data: &[u8], out: &mut [u16]| match packing.order {
+        BitOrder::Msb => {
+            let mut pump = BitPumpMsb::new(data);
+            out.iter_mut().for_each(|s| *s = pump.get(bits) as u16);
+        }
+        BitOrder::Lsb => {
+            let mut pump = BitPumpLsb::new(data);
+            out.iter_mut().for_each(|s| *s = pump.get(bits) as u16);
+        }
+        BitOrder::Msb32 => {
+            let mut pump = BitPumpMsb32::new(data);
+            out.iter_mut().for_each(|s| *s = pump.get(bits) as u16);
+        }
+    };
+    let Some(stride) = packing.row_stride else {
+        let end = (width * rows).min(out.len());
+        fill(data, &mut out[..end]);
+        return;
+    };
+    for (row, samples) in out.chunks_mut(width).enumerate().take(rows) {
+        let row = data.get(row * stride..).unwrap_or_default();
+        match packing.group {
+            None => fill(row, samples),
+            Some((per_group, group_bytes)) => {
+                for (group, samples) in samples.chunks_mut(per_group).enumerate() {
+                    fill(row.get(group * group_bytes..).unwrap_or_default(), samples);
+                }
+            }
+        }
+    }
+}
+
+/// Put the rows of an E-series Coolpix frame back in order.
+///
+/// The Coolpix NEFs of the E5000/E8800 generation are written as two
+/// fields: every even row of the frame, then every odd one. Nothing in
+/// the file says so — the model name is the only mark, and the
+/// giveaway in a sample is that the second stored row is the frame's
+/// third.
+fn deinterlace_fields(data: &mut [u16], width: usize, height: usize) {
+    let mut sorted = vec![0u16; data.len()];
+    let fields = height.div_ceil(2);
+    for (stored, row) in data.chunks_exact(width).enumerate().take(height) {
+        let target = if stored < fields {
+            stored * 2
+        } else {
+            (stored - fields) * 2 + 1
+        };
+        sorted[target * width..(target + 1) * width].copy_from_slice(row);
+    }
+    data.copy_from_slice(&sorted);
+}
+
+/// Whether a body writes its rows in two fields: the Coolpix E-series
+/// and nothing else, which its model name (`E8800`) gives away.
+fn interlaced_fields(model: &str) -> bool {
+    let name = model.trim().trim_start_matches("NIKON ").trim();
+    let mut chars = name.chars();
+    chars.next() == Some('E') && !name[1..].is_empty() && chars.all(|c| c.is_ascii_digit())
+}
+
+/// Unpack 16-bit words in the file's byte order.
+fn unpack_words(data: &[u8], little_endian: bool, out: &mut [u16]) {
+    let (words, _) = data.as_chunks::<2>();
+    for (sample, word) in out.iter_mut().zip(words) {
+        *sample = if little_endian {
+            u16::from_le_bytes(*word)
+        } else {
+            u16::from_be_bytes(*word)
+        };
+    }
+}
+
+// ------------------------------------------------------------ compressed
+
+/// Nikon's Huffman coding, and the makernote table that configures it.
+///
+/// NEFLinearizationTable (makernote 0x0096) is not only a curve. Its
+/// bytes are, in the makernote's byte order:
+///
+/// ```text
+///   0   version, two bytes
+///  (2)  a 2110-byte block only the `0x49` version carries
+///   +0  four shorts: the initial predictors, one per filter position
+///   +8  a short: how many points the curve has
+///  +10  the curve
+/// ```
+///
+/// Three versions have shipped, and the version is also what says
+/// which Huffman variant coded the frame:
+///
+/// * `0x46` — "lossless". The curve is a straight ramp and is not
+///   stored at all (the point count is there, the points are not), so
+///   a sample means what it says and saturation is the full depth.
+/// * `0x44 0x20` — "lossy (type 2)". 257 points spaced `2^bits / 256`
+///   apart, linearly interpolated between: the stored sample is an
+///   index into a curve that is the identity at the bottom and
+///   stretches towards the top, which is where the lost precision
+///   went. A short at offset 562 — just past the curve and the first
+///   of the two Huffman tables the tag also carries — holds the row at
+///   which the second table takes over on the bodies that switch.
+/// * `0x44 0x10` — "lossy (type 1)", the older bodies. The curve is
+///   stored point for point and is shorter than the sample depth: the
+///   D60's is 683 long, so a sample is an index into 683 values, not a
+///   12-bit number.
+///
+/// Everything after the curve (a length and thirty-odd bytes, twice
+/// over on the lossy versions) is left alone: the six Huffman tables
+/// below are fixed, and a frame decodes to the oracle's samples
+/// exactly without reading it.
+struct Linearization {
+    /// The first version byte, which picks the Huffman variant.
+    version: u8,
+    /// Initial vertical predictors, `[row parity][column parity]`.
+    vpred: [[i32; 2]; 2],
+    /// Sample value for each stored index. Its length is also the
+    /// clamp: a prediction outside it is pinned to the ends.
+    curve: Vec<u16>,
+    /// The row at which the second Huffman table takes over, 0 for
+    /// the frames coded with one table throughout.
+    split: usize,
+}
+
+impl Linearization {
+    /// Parse the tag. `bits` is the sensor IFD's BitsPerSample, which
+    /// sets the curve's domain where the tag does not carry one.
+    fn parse(blob: &[u8], little_endian: bool, bits: u32) -> Result<Linearization> {
+        let short = |at: usize| -> Result<u16> {
+            let pair = blob
+                .get(at..at + 2)
+                .ok_or_else(|| Error::Corrupt("NEF linearization table cut short".into()))?;
+            let pair = [pair[0], pair[1]];
+            Ok(if little_endian {
+                u16::from_le_bytes(pair)
+            } else {
+                u16::from_be_bytes(pair)
+            })
+        };
+        let version = *blob
+            .first()
+            .ok_or_else(|| Error::Corrupt("empty NEF linearization table".into()))?;
+        let minor = blob.get(1).copied().unwrap_or(0);
+        // The 0x49 version parks 2110 bytes of something else between
+        // the version and the predictors.
+        let mut at = if version == 0x49 { 2 + 2110 } else { 2 };
+        let vpred = [
+            [short(at)? as i32, short(at + 2)? as i32],
+            [short(at + 4)? as i32, short(at + 6)? as i32],
+        ];
+        at += 8;
+        let points = short(at)? as usize;
+        at += 2;
+
+        let max = 1usize << bits.min(16);
+        let (curve, split) = if version == 0x46 || points < 2 {
+            // Lossless: the ramp, generated rather than read.
+            ((0..max).map(|i| i as u16).collect(), 0)
+        } else if minor == 0x20 {
+            let step = max / (points - 1);
+            if step == 0 {
+                return Err(Error::Corrupt(
+                    "NEF curve with more points than samples".into(),
+                ));
+            }
+            // The points sit `step` apart and the values between them
+            // are the straight line from one to the next. The last
+            // point lands one past the end of the domain, which is
+            // what the final run interpolates towards.
+            let mut anchors = Vec::with_capacity(points);
+            for i in 0..points {
+                anchors.push(short(at + 2 * i)? as u32);
+            }
+            let mut curve = Vec::with_capacity(max);
+            for i in 0..max {
+                let (whole, part) = (i / step, i % step);
+                let low = anchors.get(whole).copied().unwrap_or(0);
+                let high = anchors.get(whole + 1).copied().unwrap_or(low);
+                let value = low as i64 + (high as i64 - low as i64) * part as i64 / step as i64;
+                curve.push(value.clamp(0, 0xffff) as u16);
+            }
+            // A short at a fixed offset in the tag, past the curve and
+            // the first of its two Huffman tables.
+            let split = short(562).unwrap_or(0) as usize;
+            (curve, split)
+        } else {
+            // The whole curve, point for point; it is shorter than the
+            // sample depth and its length is the clamp.
+            let mut curve = Vec::with_capacity(points);
+            for i in 0..points {
+                curve.push(short(at + 2 * i)?);
+            }
+            (curve, 0)
+        };
+        if curve.is_empty() {
+            return Err(Error::Corrupt("NEF curve with no points".into()));
+        }
+        Ok(Linearization {
+            version,
+            vpred,
+            curve,
+            split,
+        })
+    }
+
+    /// The saturation point: the curve's last value, which on the
+    /// lossy versions is below the depth's own ceiling.
+    fn white_level(&self) -> f32 {
+        self.curve.iter().copied().max().unwrap_or(0) as f32
+    }
+}
+
+/// The Huffman tables, in JPEG's shape: how many codes there are of
+/// each length 1..=16, then the symbols in canonical order. A symbol's
+/// low four bits are how many bits of difference follow it; the high
+/// four are a left shift, which is how the tables used after a split
+/// code a coarse difference in fewer bits.
+///
+/// Which table a frame uses follows from the linearization version and
+/// the sample depth: `0x46` (lossless) picks the second of each pair,
+/// anything else the first, and 14-bit frames take the 14-bit pair.
+///
+/// These were read back out of the sample files rather than copied
+/// from anywhere: for a frame whose samples are known (LibRaw's
+/// `unprocessed_raw` output) every difference and therefore every
+/// symbol along the stream is known too, which pins each symbol's code
+/// down to one possibility. Every code below is one that a D850, D7200,
+/// D3500, Z 30, D300S, D3300, Nikon 1 V1 or D60 frame actually used.
+struct Tree {
+    counts: [u8; 16],
+    symbols: &'static [u8],
+}
+
+/// 12-bit, lossy.
+const TREE_12_LOSSY: Tree = Tree {
+    counts: [0, 1, 5, 1, 1, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0],
+    symbols: &[5, 4, 3, 6, 2, 7, 1, 0, 8, 9, 11, 10, 12],
+};
+/// 12-bit, lossless.
+const TREE_12_LOSSLESS: Tree = Tree {
+    counts: [0, 1, 4, 2, 3, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    symbols: &[5, 4, 6, 3, 7, 2, 8, 1, 9, 0, 10, 11, 12],
+};
+/// 14-bit, lossy.
+const TREE_14_LOSSY: Tree = Tree {
+    counts: [0, 1, 4, 3, 1, 1, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0],
+    symbols: &[5, 6, 4, 7, 8, 3, 9, 2, 1, 0, 10, 11, 12, 13, 14],
+};
+/// 14-bit, lossless.
+const TREE_14_LOSSLESS: Tree = Tree {
+    counts: [0, 1, 4, 2, 2, 3, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0],
+    symbols: &[7, 6, 8, 5, 9, 4, 10, 3, 11, 12, 2, 0, 1, 13, 14],
+};
+/// 12-bit lossy, from the split row down. This is where the shifted
+/// symbols live: a difference nine bits wide read six bits deep is the
+/// commonest thing in the frame, because the rows below the split have
+/// been lifted and their noise with them.
+///
+/// Two of its twelve codes never came up in the D5000 frame it was
+/// read out of — 8 million pixels of it — so their symbols are not
+/// known. `0x5a` fills the first because it is the only symbol that
+/// continues the run of widths in its group (10, 8, 7, 6, 5, each read
+/// five bits deep); the second is left as [`UNKNOWN`] rather
+/// than guessed at.
+const TREE_12_LOSSY_SPLIT: Tree = Tree {
+    counts: [0, 1, 5, 1, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0],
+    symbols: &[
+        0x39, 0x5a, 0x38, 0x27, 0x16, 0x05, 0x04, 0x03, 0x02, 0x01, 0x00, UNKNOWN,
+    ],
+};
+
+/// The one code in the second table whose symbol no sample has ever
+/// shown. A frame that uses it stops with an error rather than
+/// quietly garbling from that pixel on.
+const UNKNOWN: u8 = 0xf0;
+
+/// The table for a frame's version and depth.
+fn tree_for(version: u8, bits: u32) -> &'static Tree {
+    match (version, bits) {
+        (0x46, 14) => &TREE_14_LOSSLESS,
+        (0x46, _) => &TREE_12_LOSSLESS,
+        (_, 14) => &TREE_14_LOSSY,
+        (_, _) => &TREE_12_LOSSY,
+    }
+}
+
+/// The table a lossy frame changes to at its split row. Only the
+/// 12-bit one is known: the split is a 2008-vintage feature (the D40,
+/// the D5000, the D90 era) and no 14-bit body in the sample corpus
+/// sets one, so there is no frame to read a 14-bit second table out
+/// of and none is guessed at.
+fn split_tree_for(bits: u32) -> Result<&'static Tree> {
+    if bits == 12 {
+        Ok(&TREE_12_LOSSY_SPLIT)
+    } else {
+        Err(Error::Unsupported(
+            "NEF whose Huffman table changes partway down a 14-bit frame".into(),
+        ))
+    }
+}
+
+/// The difference a symbol and the bits after it stand for.
+///
+/// The symbol's low four bits are the width; the value is read that
+/// wide and sign-extended the way lossless JPEG does it, a leading
+/// zero bit meaning negative. The symbol's high four bits are a left
+/// shift: the value is read `width - shift` bits wide instead and
+/// moved up into place with its low bit set, so it lands in the middle
+/// of the step it stands for rather than at the bottom. None of the
+/// four tables above uses a shift — it belongs to the second table of
+/// each lossy pair, which [`decompress`] refuses — but the encoding is
+/// the symbol's, not the table's, so it is decoded here.
+fn difference(symbol: u16, pump: &mut impl BitPump) -> Result<i32> {
+    let len = (symbol & 15) as u32;
+    let shift = (symbol >> 4) as u32;
+    if shift > len {
+        return Err(Error::Corrupt(format!("NEF difference symbol {symbol:#x}")));
+    }
+    if len == 0 {
+        return Ok(0);
+    }
+    let raw = pump.get(len - shift) as i32;
+    let mut diff = (((raw << 1) + 1) << shift) >> 1;
+    if diff & (1 << (len - 1)) == 0 {
+        diff -= (1 << len) - i32::from(shift == 0);
+    }
+    Ok(diff)
+}
+
+/// Decode a Huffman-coded frame into `out`.
+///
+/// The stream begins at the first byte of the strip — no header, no
+/// marker — and is read most significant bit first with no stuffing of
+/// any kind. Each pixel is one Huffman symbol and the difference bits
+/// after it (see [`difference`]).
+///
+/// The prediction is horizontal but two pixels back, so each filter
+/// colour predicts from its own kind: `hpred[col & 1]`. The first two
+/// columns of a row have no such neighbour and predict from the same
+/// two columns of the row before last — one running predictor per row
+/// parity, seeded from the linearization table, which is why a frame's
+/// rows come in pairs. The result is an index into the curve, clamped
+/// to it; the curve turns it into the sample.
+fn decompress(
+    data: &[u8],
+    width: usize,
+    height: usize,
+    bits: u32,
+    table: &Linearization,
+    out: &mut [u16],
+) -> Result<()> {
+    let tree = tree_for(table.version, bits);
+    let split = (table.split != 0 && table.split < height).then_some(table.split);
+    let second = match split {
+        Some(_) => Some(HuffTable::new(
+            &split_tree_for(bits)?.counts,
+            split_tree_for(bits)?.symbols,
+        )?),
+        None => None,
+    };
+    let mut huffman = HuffTable::new(&tree.counts, tree.symbols)?;
+    let mut pump = BitPumpMsb::new(data);
+    let mut vpred = table.vpred;
+    let mut hpred = [0i32; 2];
+    let ceiling = table.curve.len() as i32 - 1;
+
+    for row in 0..height {
+        // The bodies that lift their shadows change table partway
+        // down, mid-stream: the bit position carries straight on and
+        // so do the predictors.
+        if split == Some(row) {
+            if let Some(second) = second.clone() {
+                huffman = second;
+            }
+        }
+        for col in 0..width {
+            let symbol = huffman.decode(&mut pump);
+            // The split table's other unobserved slot is a guess; a
+            // frame that reaches it is worth hearing about, since a
+            // wrong width would garble the rest silently.
+            if symbol == 0x5a {
+                log::warn!("NEF: split-table code 0x5a decoded at row {row}, column {col}; no sample has verified it");
+            }
+            if symbol == UNKNOWN as u16 {
+                return Err(Error::Unsupported(format!(
+                    "NEF using the one code of Nikon's second Huffman table that no \
+                     sample has ever shown (row {row}, column {col})"
+                )));
+            }
+            let diff = difference(symbol, &mut pump)?;
+            let predicted = if col < 2 {
+                vpred[row & 1][col] = vpred[row & 1][col].wrapping_add(diff);
+                hpred[col] = vpred[row & 1][col];
+                hpred[col]
+            } else {
+                hpred[col & 1] = hpred[col & 1].wrapping_add(diff);
+                hpred[col & 1]
+            };
+            out[row * width + col] = table.curve[predicted.clamp(0, ceiling) as usize];
+        }
+    }
+    Ok(())
+}
+
+// -------------------------------------------------------------- metadata
+
+/// The as-shot white balance as R, G, B, G2 multipliers with green 1.
+///
+/// WB_RBLevels (0x000C) is four rationals in the order red, blue,
+/// green1, green2 — the tag's own name says which two come first — and
+/// every body since the D1 writes it but the D100, which has the first
+/// version of ColorBalance (0x0097) instead: the same four numbers as
+/// plain shorts at offset 72. The Coolpix E-series has neither; its
+/// ColorBalanceA blob (0x0014) holds red and blue as big-endian
+/// 256ths at offset 1248, with green implicitly 1.
+fn white_balance(maker: &Tiff<'_>) -> Option<[f32; 4]> {
+    let root = maker.root();
+    let little_endian = maker.little_endian();
+    if let Some(entry) = root.get(maker::WB_RB_LEVELS) {
+        let value = |i: usize| entry.f64(i).map(|v| v as f32);
+        let (red, blue, green) = (value(0)?, value(1)?, value(2).unwrap_or(1.0));
+        let green2 = value(3).unwrap_or(green);
+        if green > 0.0 && green2 > 0.0 && red > 0.0 && blue > 0.0 {
+            return Some([red / green, 1.0, blue / green, green2 / green]);
+        }
+    }
+    // ColorBalance's first version is four plain shorts, red, blue and
+    // the two greens, at a fixed offset. The D100 is the one body in
+    // the sample corpus that writes no WB_RBLevels beside it. From
+    // version 0204 on the block is encrypted with the body's serial
+    // number and shutter count and this decoder does not undo it —
+    // nothing needs it to, because every body that writes an
+    // encrypted one writes WB_RBLevels as well.
+    if let Some(blob) = root.get(maker::COLOR_BALANCE).and_then(|e| e.bytes()) {
+        if blob.starts_with(b"0100") {
+            if let Some(levels) = blob.get(72..80) {
+                let short = |i: usize| {
+                    let pair = [levels[i * 2], levels[i * 2 + 1]];
+                    if little_endian {
+                        u16::from_le_bytes(pair)
+                    } else {
+                        u16::from_be_bytes(pair)
+                    }
+                };
+                let (red, blue, green) = (short(0) as f32, short(1) as f32, short(2) as f32);
+                let green2 = short(3) as f32;
+                if red > 0.0 && blue > 0.0 && green > 0.0 && green2 > 0.0 {
+                    return Some([red / green, 1.0, blue / green, green2 / green]);
+                }
+            }
+        }
+    }
+    if let Some(blob) = root.get(maker::COLOR_BALANCE_A).and_then(|e| e.bytes()) {
+        // Only the 2560-byte shape has been seen, and its layout is
+        // fixed; a blob of another length is a variant this does not
+        // know the offsets of.
+        if blob.len() == 2560 {
+            let at =
+                |offset: usize| u16::from_be_bytes([blob[offset], blob[offset + 1]]) as f32 / 256.0;
+            let (red, blue) = (at(1248), at(1250));
+            if red > 0.0 && blue > 0.0 {
+                return Some([red, 1.0, blue, 1.0]);
+            }
+        }
+    }
+    None
+}
+
+/// The black level, one value per filter-array position.
+///
+/// BlackLevel (0x003D) is written in 14-bit units whatever the frame's
+/// depth, so a 12-bit file's 400 means 100 — the sample corpus agrees
+/// with LibRaw on that for every body that carries the tag (D850,
+/// D7200, D3500, Z 30). The Coolpix compacts' NRW puts a single level
+/// in its own block instead, at a fixed offset past the `NRW `
+/// signature, in the samples' own units. Bodies older than either
+/// record no black at all and their frames sit at zero.
+fn black_levels(maker: &Tiff<'_>, bits: u32) -> Option<[f32; 4]> {
+    if let Some(blob) = nrw_block(maker) {
+        // Little-endian, as the two bodies that write the block are;
+        // it is a vendor blob and carries no byte order of its own.
+        let level = blob.get(32..34)?;
+        return Some([u16::from_le_bytes([level[0], level[1]]) as f32; 4]);
+    }
+    let entry = maker.root().get(maker::BLACK_LEVEL)?;
+    let shift = 14u32.saturating_sub(bits);
+    let level = |i: usize| entry.u32(i).map(|v| (v >> shift) as f32);
+    let first = level(0)?;
+    Some([
+        first,
+        level(1).unwrap_or(first),
+        level(2).unwrap_or(first),
+        level(3).unwrap_or(first),
+    ])
+}
+
+/// Masked columns at the right edge of a frame whose body records no
+/// CropArea: the D5000 keeps 42 of them, the D800E 46, the Coolpix A
+/// 52, the D300S 32. They are not the picture and not sensor black
+/// either — the readout leaves them at a constant (255/256 on the
+/// D5000, 599 then 0 on the Coolpix A), so shown, they are a coloured
+/// band. That constancy is the signature: a masked column varies down
+/// the rows only by read noise, while a column of a photograph varies
+/// by orders of magnitude more. The band is the run of such columns
+/// ending at the frame's edge, at most 64 wide and followed by columns
+/// that do vary; a lens-cap frame, flat everywhere, reaches the limit
+/// and is left alone.
+fn masked_right_columns(data: &[u16], width: usize, height: usize) -> usize {
+    const LOOK: usize = 64;
+    if width < 4 * LOOK || height < 8 || data.len() < width * height {
+        return 0;
+    }
+    let rows = (height / 4..height * 3 / 4).step_by(2);
+    // Standard deviation down the middle rows, in raw units.
+    let spread = |column: usize| -> f64 {
+        let (mut sum, mut squares, mut n) = (0f64, 0f64, 0f64);
+        for row in rows.clone() {
+            let v = data[row * width + column] as f64;
+            sum += v;
+            squares += v * v;
+            n += 1.0;
+        }
+        let mean = sum / n.max(1.0);
+        (squares / n.max(1.0) - mean * mean).max(0.0).sqrt()
+    };
+    // Masked columns sit at read-noise level (1–6 on every body seen)
+    // while the picture beside them spreads tens to thousands; both
+    // conditions, so a flat sky reaching the edge — flat inside too —
+    // is not taken for a border.
+    let reference: [f64; 2] = std::array::from_fn(|parity| {
+        let mut spreads: Vec<f64> = (width - 2 * LOOK..width - LOOK)
+            .filter(|c| c % 2 == parity)
+            .map(spread)
+            .collect();
+        spreads.sort_by(|a, b| a.total_cmp(b));
+        spreads[spreads.len() / 2]
+    });
+    let masked = |column: usize| {
+        let sd = spread(column);
+        sd < 8.0 && sd * 10.0 < reference[column % 2]
+    };
+    let mut band = 0;
+    while band < LOOK && masked(width - 1 - band) {
+        band += 1;
+    }
+    if !(2..LOOK).contains(&band) || masked(width - 1 - band) || masked(width - 2 - band) {
+        return 0;
+    }
+    band
+}
+
+/// The area the camera means to show: CropArea (0x0045) as left, top,
+/// width, height. Bodies older than the tag record none; see
+/// `masked_right_columns` for the border those keep.
+fn crop(maker: &Tiff<'_>, width: usize, height: usize) -> Rect {
+    let whole = Rect {
+        x: 0,
+        y: 0,
+        width,
+        height,
+    };
+    let Some(entry) = maker.root().get(maker::CROP_AREA) else {
+        return whole;
+    };
+    let value = |i: usize| entry.u32(i).map(|v| v as usize);
+    let (Some(x), Some(y), Some(w), Some(h)) = (value(0), value(1), value(2), value(3)) else {
+        return whole;
+    };
+    let outside = |start: usize, span: usize, whole: usize| {
+        start.checked_add(span).is_none_or(|end| end > whole)
+    };
+    if w == 0 || h == 0 || outside(x, w, width) || outside(y, h, height) {
+        return whole;
+    }
+    Rect {
+        x,
+        y,
+        width: w,
+        height: h,
+    }
+}
+
+// ---------------------------------------------------------------- decode
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let tiff = Tiff::parse(bytes)?;
+    let (make, model) = tiff.make_model();
+    if !make.to_ascii_uppercase().starts_with("NIKON") {
+        return Err(Error::NotRaw);
+    }
+    let ifd = sensor_ifd(&tiff).ok_or_else(|| {
+        // The COOLSCAN film scanners write their scans into a NEF with
+        // an RGB SubIFD and no filter array at all: three samples a
+        // pixel of scanner output, not sensor data.
+        Error::Unsupported(format!(
+            "{model}: a NEF with no CFA image (a COOLSCAN scan?)"
+        ))
+    })?;
+    let layout = ImageLayout::of(&tiff, ifd)?;
+    let (width, height) = (layout.width, layout.height);
+    if width == 0 || height == 0 || width > 1 << 16 || height > 1 << 16 {
+        return Err(Error::Corrupt(format!("NEF frame of {width}x{height}")));
+    }
+    let cfa = cfa_of(ifd)?;
+    let maker = makernote(&tiff);
+
+    let bits = layout.bits_per_sample;
+    if !matches!(bits, 12 | 14 | 16) {
+        return Err(Error::Unsupported(format!("NEF with {bits}-bit samples")));
+    }
+    if layout.samples_per_pixel != 1 {
+        return Err(Error::Unsupported(format!(
+            "NEF with {} samples a pixel",
+            layout.samples_per_pixel
+        )));
+    }
+
+    let nef_compression = maker
+        .as_ref()
+        .and_then(|m| m.root().get(maker::COMPRESSION))
+        .and_then(|e| e.u32(0));
+    if !matches!(layout.compression, 1 | NIKON_COMPRESSION) {
+        return Err(Error::Unsupported(format!(
+            "NEF with TIFF compression {}",
+            layout.compression
+        )));
+    }
+    let total: usize = layout.chunks.iter().map(|(_, len)| *len).sum();
+    // NEFCompression is Nikon's own word and only means anything under
+    // Nikon's own compression tag.
+    let nef_compression = nef_compression.filter(|_| layout.compression == NIKON_COMPRESSION);
+    let nrw = maker.as_ref().and_then(nrw_block).is_some();
+    let (width, store) = storage(
+        bit_order(nef_compression, nrw),
+        nef_compression,
+        width,
+        height,
+        bits,
+        layout.chunks.len(),
+        total,
+    )?;
+    // Every storage keeps at least a bit a sample, so the strips bound
+    // the frame a forged header may claim.
+    let samples = crate::frame_samples(width, height, 1)?;
+    if total.saturating_mul(8) < samples {
+        return Err(Error::Corrupt(format!(
+            "NEF frame of {samples} samples in {total} bytes of strips"
+        )));
+    }
+    let mut data = vec![0u16; samples];
+    let mut linearization = None;
+    match store {
+        Storage::Packed(packing) => {
+            // Every strip holds RowsPerStrip whole rows and starts its
+            // own bit stream: the D1 writes 67 strips of 20 rows.
+            let mut row = 0;
+            for (start, len) in &layout.chunks {
+                if row >= height {
+                    break;
+                }
+                let rows = layout.rows_per_chunk.min(height - row);
+                let out = &mut data[row * width..(row + rows) * width];
+                unpack_packed(&bytes[*start..*start + *len], width, rows, packing, out);
+                row += rows;
+            }
+            if interlaced_fields(&model) {
+                deinterlace_fields(&mut data, width, height);
+            }
+        }
+        Storage::Words16 => {
+            let mut row = 0;
+            for (start, len) in &layout.chunks {
+                if row >= height {
+                    break;
+                }
+                let rows = layout.rows_per_chunk.min(height - row);
+                let out = &mut data[row * width..(row + rows) * width];
+                unpack_words(&bytes[*start..*start + *len], tiff.little_endian(), out);
+                row += rows;
+            }
+        }
+        Storage::Huffman => {
+            let blob = maker
+                .as_ref()
+                .and_then(|m| m.root().get(maker::LINEARIZATION))
+                .and_then(|e| e.bytes())
+                .ok_or_else(|| {
+                    Error::Corrupt("Huffman-coded NEF without a linearization table".into())
+                })?;
+            let little_endian = maker.as_ref().is_some_and(|m| m.little_endian());
+            let table = Linearization::parse(blob, little_endian, bits)?;
+            // One strip, always: nothing splits a Nikon Huffman stream.
+            let (start, len) = layout.chunks[0];
+            decompress(
+                &bytes[start..start + len],
+                width,
+                height,
+                bits,
+                &table,
+                &mut data,
+            )?;
+            linearization = Some(table);
+        }
+    }
+
+    let mut raw = RawImage::new(Format::Nef, width, height, 1, RawData::U16(data), cfa);
+    raw.set_camera(&make, &model);
+    // A lossy frame's samples stop at the top of its curve, which is
+    // below the depth's own ceiling; everything else saturates at the
+    // depth.
+    raw.white_level = match &linearization {
+        Some(table) => table.white_level(),
+        None => ((1u32 << bits) - 1) as f32,
+    };
+    if let Some(maker) = &maker {
+        if let Some(coeffs) = white_balance(maker) {
+            raw.wb_coeffs = coeffs;
+        }
+        if let Some(black) = black_levels(maker, bits) {
+            raw.black_levels = black;
+        }
+        raw.crop = crop(maker, width, height);
+    }
+    // Bodies from before CropArea keep their masked right-hand columns
+    // in the frame; find them in the data rather than in a table.
+    if raw.crop.width == width && raw.crop.x == 0 {
+        if let RawData::U16(data) = &raw.data {
+            let masked = masked_right_columns(data, width, height);
+            if masked > 0 {
+                raw.crop.width = (width - masked) & !1;
+            }
+        }
+    }
+    raw.orientation = common::orientation(&tiff);
+    raw.metadata = common::metadata(&tiff);
+    raw.preview = common::largest_jpeg(&tiff);
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    let tiff = Tiff::parse(bytes)?;
+    Ok(common::largest_jpeg(&tiff))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------- units
+
+    /// A 12-bit `Packed` storage for the tests.
+    fn packed(row_stride: Option<usize>, order: BitOrder) -> Storage {
+        Storage::Packed(Packing {
+            bits: 12,
+            row_stride,
+            group: None,
+            order,
+        })
+    }
+
+    /// Its packing, for the unpacker's own tests.
+    fn packing(row_stride: Option<usize>, order: BitOrder) -> Packing {
+        let Storage::Packed(packing) = packed(row_stride, order) else {
+            unreachable!()
+        };
+        packing
+    }
+
+    #[test]
+    fn twelve_bit_samples_unpack_from_either_end_of_the_stream() {
+        // TIFF's order: AB CD EF -> 0xABC, 0xDEF.
+        let mut out = [0u16; 2];
+        unpack_packed(
+            &[0xab, 0xcd, 0xef],
+            2,
+            1,
+            packing(None, BitOrder::Msb),
+            &mut out,
+        );
+        assert_eq!(out, [0xabc, 0xdef]);
+        // Nikon's own: the same bytes the other way round.
+        unpack_packed(
+            &[0xab, 0xcd, 0xef],
+            2,
+            1,
+            packing(None, BitOrder::Lsb),
+            &mut out,
+        );
+        assert_eq!(out, [0xdab, 0xefc]);
+        // Rows padded to a byte boundary: an odd width leaves half a
+        // byte at the end of every row.
+        let mut out = [0u16; 2];
+        unpack_packed(
+            &[0x12, 0x30, 0x45, 0x60],
+            1,
+            2,
+            packing(Some(2), BitOrder::Msb),
+            &mut out,
+        );
+        assert_eq!(out, [0x123, 0x456]);
+        // ... and the same bytes read as one continuous stream are a
+        // different pair of samples: the second starts mid-byte.
+        unpack_packed(
+            &[0x12, 0x30, 0x45, 0x60],
+            1,
+            2,
+            packing(None, BitOrder::Msb),
+            &mut out,
+        );
+        assert_eq!(out, [0x123, 0x045]);
+        // Past the end the pump reads zeros rather than panicking.
+        let mut out = [0u16; 4];
+        unpack_packed(&[0xff], 4, 1, packing(None, BitOrder::Msb), &mut out);
+        assert_eq!(out, [0xff0, 0, 0, 0]);
+        // The D100's grouping: two samples in the first three bytes
+        // of every four, the fourth skipped. Four samples in a row of
+        // eight bytes are two such groups...
+        let mut out = [0u16; 4];
+        let grouped = Packing {
+            group: Some((2, 4)),
+            ..packing(Some(8), BitOrder::Msb)
+        };
+        let bytes = [0xab, 0xcd, 0xef, 0xff, 0x12, 0x34, 0x56, 0xff];
+        unpack_packed(&bytes, 4, 1, grouped, &mut out);
+        assert_eq!(out, [0xabc, 0xdef, 0x123, 0x456]);
+        // ... and the same bytes as two rows of one group each.
+        let grouped = Packing {
+            row_stride: Some(4),
+            ..grouped
+        };
+        unpack_packed(&bytes, 2, 2, grouped, &mut out);
+        assert_eq!(out, [0xabc, 0xdef, 0x123, 0x456]);
+    }
+
+    #[test]
+    fn the_bit_order_comes_from_the_makernote() {
+        // Plain TIFF uncompressed, and every Nikon mode but one.
+        assert_eq!(bit_order(None, false), BitOrder::Msb);
+        assert_eq!(bit_order(Some(2), false), BitOrder::Msb);
+        // "Uncompressed (reduced to 12 bit)".
+        assert_eq!(bit_order(Some(6), false), BitOrder::Lsb);
+        // The Coolpix compacts' NRW, whatever else it says.
+        assert_eq!(bit_order(None, true), BitOrder::Msb32);
+        assert_eq!(bit_order(Some(6), true), BitOrder::Msb32);
+    }
+
+    #[test]
+    fn thirty_two_bit_words_are_read_back_to_front() {
+        // Four bytes reversed, then twelve bits at a time.
+        let mut out = [0u16; 2];
+        unpack_packed(
+            &[0x0c, 0xce, 0xc0, 0x0c],
+            2,
+            1,
+            packing(None, BitOrder::Msb32),
+            &mut out,
+        );
+        assert_eq!(out, [0x0cc, 0x0ce]);
+    }
+
+    #[test]
+    fn the_coolpix_e_series_writes_its_rows_in_two_fields() {
+        assert!(interlaced_fields("E8800"));
+        assert!(interlaced_fields("NIKON E5400"));
+        assert!(!interlaced_fields("COOLPIX B700"));
+        assert!(!interlaced_fields("NIKON D850"));
+        assert!(!interlaced_fields("E"));
+        // Five rows: stored 0 2 4 1 3, read back 0 1 2 3 4.
+        let mut data = [0, 2, 4, 1, 3];
+        deinterlace_fields(&mut data, 1, 5);
+        assert_eq!(data, [0, 1, 2, 3, 4]);
+        let mut data = [0, 2, 1, 3];
+        deinterlace_fields(&mut data, 1, 4);
+        assert_eq!(data, [0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn sixteen_bit_samples_follow_the_files_byte_order() {
+        let mut out = [0u16; 2];
+        unpack_words(&[0x34, 0x12, 0xff, 0x3f], true, &mut out);
+        assert_eq!(out, [0x1234, 0x3fff]);
+        unpack_words(&[0x34, 0x12, 0xff, 0x3f], false, &mut out);
+        assert_eq!(out, [0x3412, 0xff3f]);
+        // A short strip leaves the rest of the row as it found it.
+        let mut out = [7u16; 3];
+        unpack_words(&[0x34, 0x12], true, &mut out);
+        assert_eq!(out, [0x1234, 7, 7]);
+    }
+
+    #[test]
+    fn storage_follows_the_strip_length() {
+        // 8288x5520: two bytes a pixel, three bytes to two pixels,
+        // and a compressed stream that is smaller than either.
+        let (w, h) = (8288, 5520);
+        assert_eq!(
+            storage(BitOrder::Msb, None, w, h, 14, 1, w * h * 2).unwrap(),
+            (w, Storage::Words16)
+        );
+        assert_eq!(
+            storage(BitOrder::Msb, None, w, h, 12, 1, w * h * 3 / 2).unwrap(),
+            (w, packed(Some(w * 3 / 2), BitOrder::Msb))
+        );
+        // Nikon's own compression tag on a packed frame also says
+        // which way round its bits go.
+        assert_eq!(
+            storage(BitOrder::Lsb, Some(6), w, h, 12, 1, w * h * 3 / 2).unwrap(),
+            (w, packed(Some(w * 3 / 2), BitOrder::Lsb))
+        );
+        assert_eq!(
+            storage(BitOrder::Msb, None, w, h, 12, 1, 36_987_742).unwrap(),
+            (w, Storage::Huffman)
+        );
+        // An odd width: four rows of five 12-bit samples are 30 bytes
+        // packed tight and 32 with every row on a byte boundary.
+        assert_eq!(
+            storage(BitOrder::Msb, None, 5, 4, 12, 1, 30).unwrap(),
+            (5, packed(None, BitOrder::Msb))
+        );
+        assert_eq!(
+            storage(BitOrder::Msb, None, 5, 4, 12, 1, 32).unwrap(),
+            (5, packed(Some(8), BitOrder::Msb))
+        );
+        assert_eq!(
+            storage(BitOrder::Msb, None, 5, 4, 12, 1, 29).unwrap(),
+            (5, Storage::Huffman)
+        );
+        // The D100: 2024 rows of 4864 bytes, ten samples to every
+        // sixteen, which is 3040 a row and not the 3034 the IFD says.
+        let (width, store) = storage(BitOrder::Msb, Some(2), 3034, 2024, 12, 1, 9_844_736).unwrap();
+        assert_eq!(width, 3040);
+        assert_eq!(
+            store,
+            Storage::Packed(Packing {
+                bits: 12,
+                row_stride: Some(4864),
+                group: Some((10, 16)),
+                order: BitOrder::Msb,
+            })
+        );
+        // The makernote's own word is taken where it is decisive.
+        assert_eq!(
+            storage(BitOrder::Msb, Some(3), w, h, 12, 1, w * h * 2).unwrap(),
+            (w, Storage::Huffman)
+        );
+        assert!(matches!(
+            storage(BitOrder::Msb, Some(13), w, h, 14, 1, 100),
+            Err(Error::Unsupported(_))
+        ));
+        // "Unpacked 12 bits": two bytes a sample, the sample at the
+        // top of the pair rather than the pair itself.
+        assert_eq!(
+            storage(BitOrder::Msb, Some(7), 8, 16, 12, 1, 8 * 16 * 2).unwrap(),
+            (
+                8,
+                Storage::Packed(Packing {
+                    bits: 12,
+                    row_stride: Some(16),
+                    group: Some((1, 2)),
+                    order: BitOrder::Msb,
+                })
+            )
+        );
+    }
+
+    /// A linearization tag: version, predictors, point count, points.
+    fn linearization(version: [u8; 2], vpred: u16, points: &[u16], tail: usize) -> Vec<u8> {
+        let mut out = version.to_vec();
+        for _ in 0..4 {
+            out.extend_from_slice(&vpred.to_le_bytes());
+        }
+        out.extend_from_slice(&(points.len() as u16).to_le_bytes());
+        for point in points {
+            out.extend_from_slice(&point.to_le_bytes());
+        }
+        out.resize(out.len() + tail, 0);
+        out
+    }
+
+    #[test]
+    fn the_lossless_version_makes_its_own_ramp() {
+        // 0x46 stores the point count but not the points.
+        let blob = linearization([0x46, 0x30], 2048, &[], 34);
+        let mut blob = blob;
+        blob[10..12].copy_from_slice(&34u16.to_le_bytes());
+        let table = Linearization::parse(&blob, true, 14).unwrap();
+        assert_eq!(table.vpred, [[2048, 2048], [2048, 2048]]);
+        assert_eq!(table.curve.len(), 16384);
+        assert_eq!(table.curve[0], 0);
+        assert_eq!(table.curve[16383], 16383);
+        assert_eq!(table.white_level(), 16383.0);
+        assert_eq!(table.split, 0);
+    }
+
+    #[test]
+    fn the_sparse_lossy_curve_interpolates_between_its_points() {
+        // Five points over a 16-sample domain: step 4.
+        let blob = linearization([0x44, 0x20], 328, &[0, 4, 8, 40, 100], 0);
+        let table = Linearization::parse(&blob, true, 4).unwrap();
+        assert_eq!(table.vpred, [[328, 328], [328, 328]]);
+        assert_eq!(
+            table.curve,
+            vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 24, 32, 40, 55, 70, 85]
+        );
+        assert_eq!(table.white_level(), 85.0);
+    }
+
+    #[test]
+    fn the_old_lossy_curve_is_stored_point_for_point() {
+        // Version 0x44 0x10: the points are the curve, and there are
+        // fewer of them than the depth allows, so the clamp is theirs.
+        let blob = linearization([0x44, 0x10], 328, &[0, 3, 9, 27, 81], 34);
+        let table = Linearization::parse(&blob, true, 12).unwrap();
+        assert_eq!(table.curve, vec![0, 3, 9, 27, 81]);
+        assert_eq!(table.white_level(), 81.0);
+    }
+
+    #[test]
+    fn a_truncated_linearization_table_is_an_error() {
+        assert!(Linearization::parse(&[], true, 12).is_err());
+        assert!(Linearization::parse(&[0x46, 0x30, 0, 0], true, 12).is_err());
+        // A point count that would make the step zero.
+        let blob = linearization([0x44, 0x20], 0, &[0; 40], 0);
+        assert!(Linearization::parse(&blob, true, 4).is_err());
+    }
+
+    #[test]
+    fn every_tree_is_a_complete_huffman_code() {
+        for tree in [
+            &TREE_12_LOSSY,
+            &TREE_12_LOSSLESS,
+            &TREE_14_LOSSY,
+            &TREE_14_LOSSLESS,
+            &TREE_12_LOSSY_SPLIT,
+        ] {
+            let total: usize = tree.counts.iter().map(|c| *c as usize).sum();
+            assert_eq!(total, tree.symbols.len(), "counts and symbols disagree");
+            // Kraft's equality: a code that leaves nothing over.
+            let kraft: f64 = tree
+                .counts
+                .iter()
+                .enumerate()
+                .map(|(i, count)| *count as f64 / (1u64 << (i + 1)) as f64)
+                .sum();
+            assert!(
+                (kraft - 1.0).abs() < 1e-9,
+                "tree leaves {kraft} of the code space"
+            );
+            HuffTable::new(&tree.counts, tree.symbols).expect("tree builds");
+        }
+        // The version and depth pick between them.
+        assert_eq!(tree_for(0x46, 12).symbols, TREE_12_LOSSLESS.symbols);
+        assert_eq!(tree_for(0x46, 14).symbols, TREE_14_LOSSLESS.symbols);
+        assert_eq!(tree_for(0x44, 12).symbols, TREE_12_LOSSY.symbols);
+        assert_eq!(tree_for(0x49, 14).symbols, TREE_14_LOSSY.symbols);
+        assert_eq!(
+            split_tree_for(12).unwrap().symbols,
+            TREE_12_LOSSY_SPLIT.symbols
+        );
+        assert!(split_tree_for(14).is_err());
+    }
+
+    #[test]
+    fn differences_are_sign_extended_the_lossless_jpeg_way() {
+        let bits = |text: &str| -> Vec<u8> {
+            let mut bits: Vec<u8> = text.chars().map(|c| (c == '1') as u8).collect();
+            while !bits.len().is_multiple_of(8) {
+                bits.push(0);
+            }
+            bits.chunks(8)
+                .map(|byte| byte.iter().fold(0u8, |acc, bit| (acc << 1) | bit))
+                .collect()
+        };
+        // A symbol with the top value bit set is the value itself...
+        let data = bits("110");
+        assert_eq!(difference(3, &mut BitPumpMsb::new(&data)).unwrap(), 6);
+        // ... and without it, that value less (1 << len) - 1.
+        let data = bits("001");
+        assert_eq!(difference(3, &mut BitPumpMsb::new(&data)).unwrap(), 1 - 7);
+        // Width zero is no difference and reads no bits.
+        assert_eq!(difference(0, &mut BitPumpMsb::new(&data)).unwrap(), 0);
+        // A shift reads fewer bits and lands mid-step: symbol 0x39 is
+        // nine bits wide read six bits deep, so 0b110011 stands for
+        // 0b1100111 (the low bit set) shifted up to 0b110011100 = 412.
+        let data = bits("110011");
+        assert_eq!(difference(0x39, &mut BitPumpMsb::new(&data)).unwrap(), 412);
+        // A shift wider than the value is not a symbol any table has.
+        assert!(difference(0x51, &mut BitPumpMsb::new(&data)).is_err());
+    }
+
+    #[test]
+    fn a_hand_coded_stream_predicts_along_the_row_and_down_the_pairs() {
+        // 12-bit lossless codes: 5 is "00", 4 "010", 3 "100", 0 "11110".
+        let mut bits: Vec<u8> = Vec::new();
+        let mut push = |text: &str| bits.extend(text.chars().map(|c| (c == '1') as u8));
+        // Row 0: +16, +17 seed the two column predictors, then two
+        // pixels that predict from two columns back: +7 and -6.
+        push("00");
+        push("10000");
+        push("00");
+        push("10001");
+        push("100");
+        push("111");
+        push("100");
+        push("001");
+        // Row 1 seeds from its own parity's predictors, still 512
+        // because no row 1 has been before it: +9 and -14. Then a
+        // zero-width difference and a five-bit -31.
+        push("010");
+        push("1001");
+        push("010");
+        push("0001");
+        push("11110");
+        push("00");
+        push("00000");
+        while !bits.len().is_multiple_of(8) {
+            bits.push(0);
+        }
+        let data: Vec<u8> = bits
+            .chunks(8)
+            .map(|byte| byte.iter().fold(0u8, |acc, bit| (acc << 1) | bit))
+            .collect();
+        let table = Linearization {
+            version: 0x46,
+            vpred: [[512, 512], [512, 512]],
+            curve: (0..4096).map(|i| i as u16).collect(),
+            split: 0,
+        };
+        let mut out = [0u16; 8];
+        decompress(&data, 4, 2, 12, &table, &mut out).unwrap();
+        assert_eq!(out, [528, 529, 535, 523, 521, 498, 521, 467]);
+
+        // The curve is what a prediction is looked up in, and it
+        // clamps: a curve of four values sees every prediction pinned
+        // into 0..=3.
+        let table = Linearization {
+            version: 0x46,
+            vpred: [[0, 0], [0, 0]],
+            curve: vec![10, 20, 30, 40],
+            split: 0,
+        };
+        let mut out = [0u16; 8];
+        decompress(&data, 4, 2, 12, &table, &mut out).unwrap();
+        assert_eq!(out, [40, 40, 40, 40, 40, 10, 40, 10]);
+    }
+
+    #[test]
+    fn a_frame_changes_table_at_its_split_row() {
+        let table = Linearization {
+            version: 0x44,
+            vpred: [[328, 328], [328, 328]],
+            curve: (0..4096).map(|i| i as u16).collect(),
+            split: 1,
+        };
+        // All-zero bits: the first table reads "00" as symbol 5, five
+        // bits of difference, all zeros, which is -31 a pixel; the
+        // second reads the same two bits as symbol 0x39, a nine-bit
+        // difference read six bits deep, which is -508 and takes the
+        // prediction below the curve, where it pins to its bottom.
+        let mut out = [0u16; 4];
+        decompress(&[0; 32], 2, 2, 12, &table, &mut out).unwrap();
+        assert_eq!(out, [297, 297, 0, 0]);
+        // There is no second table for a 14-bit frame.
+        assert!(matches!(
+            decompress(&[0; 32], 2, 2, 14, &table, &mut out),
+            Err(Error::Unsupported(_))
+        ));
+    }
+
+    #[test]
+    fn the_second_tables_unknown_code_is_refused_rather_than_guessed() {
+        let table = Linearization {
+            version: 0x44,
+            vpred: [[328, 328], [328, 328]],
+            curve: (0..4096).map(|i| i as u16).collect(),
+            split: 0,
+        };
+        // 0xff bits are the second table's longest code, the one no
+        // sample has ever used.
+        let split = Linearization { split: 1, ..table };
+        let mut out = [0u16; 4];
+        assert!(matches!(
+            decompress(&[0xff; 32], 2, 2, 12, &split, &mut out),
+            Err(Error::Unsupported(_))
+        ));
+    }
+
+    // ------------------------------------------------------------ corpus
+    //
+    // Gated on SCHIST_RAW_CORPUS: a directory of camera files, walked
+    // recursively for the two extensions this module claims. Beside
+    // each file the harness leaves LibRaw's own output, which is what
+    // "exactly" means here:
+    //
+    //   <file>.tiff          `unprocessed_raw -T`: the whole sensor
+    //                        frame, 16-bit grey, black not subtracted
+    //   <file>.identify.txt  `raw-identify -v -w`
+    //
+    // Both are optional; a file with neither is still decoded and
+    // validated.
+
+    use std::path::{Path, PathBuf};
+
+    /// Every NEF and NRW under `SCHIST_RAW_CORPUS`.
+    fn corpus() -> Vec<PathBuf> {
+        let Ok(root) = std::env::var("SCHIST_RAW_CORPUS") else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        let mut stack = vec![PathBuf::from(root)];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path
+                    .extension()
+                    .is_some_and(|e| e.eq_ignore_ascii_case("nef") || e.eq_ignore_ascii_case("nrw"))
+                {
+                    out.push(path);
+                }
+            }
+        }
+        out.sort();
+        out
+    }
+
+    /// Files this module knowingly does not decode, and why. A sample
+    /// that stops being on this list has to start decoding instead.
+    fn unsupported(path: &Path) -> Option<&'static str> {
+        let name = path.file_name()?.to_string_lossy().to_ascii_uppercase();
+        // The COOLSCAN film scanners put 16-bit RGB scans in a NEF:
+        // three samples a pixel through no filter array, so there is
+        // no sensor frame to hand out and nothing to demosaic.
+        name.contains("COOLSCAN")
+            .then_some("a COOLSCAN film scan, RGB rather than CFA")
+    }
+
+    /// Bodies whose black level LibRaw supplies from a table of its
+    /// own. The files record none anywhere — exiftool finds none
+    /// either — and this decoder does not invent one; the camera table
+    /// is where such a value belongs.
+    const BLACK_FROM_LIBRAW_TABLE: &[&str] = &["COOLPIX P330", "COOLPIX P7700"];
+
+    /// How far right the oracle's samples have to move to be this
+    /// decoder's.
+    ///
+    /// The P7700 and the P330 write the same thing — twelve bits at
+    /// the top of a sixteen-bit word — and LibRaw shifts the P330's
+    /// samples down to where they belong but hands the P7700's out in
+    /// the word it found them in, saying so with a black level and a
+    /// saturation point sixteen times the P330's. This decoder takes
+    /// the twelve bits on both, so its P7700 frame is the oracle's
+    /// four bits over and develops to the same picture.
+    fn oracle_shift(model: &str) -> u32 {
+        u32::from(model == "COOLPIX P7700") * 4
+    }
+
+    /// LibRaw's unpacked frame, when the harness left one.
+    fn oracle(path: &Path) -> Option<(usize, usize, Vec<u16>)> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".tiff");
+        let path = PathBuf::from(name);
+        if !path.exists() {
+            return None;
+        }
+        let image = image::open(&path).expect("oracle TIFF loads").into_luma16();
+        Some((
+            image.width() as usize,
+            image.height() as usize,
+            image.into_raw(),
+        ))
+    }
+
+    /// `raw-identify`'s report.
+    fn identify(path: &Path) -> Option<String> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".identify.txt");
+        std::fs::read_to_string(PathBuf::from(name)).ok()
+    }
+
+    /// The rest of the line introduced by `key`.
+    fn field<'a>(report: &'a str, key: &str) -> Option<&'a str> {
+        report
+            .lines()
+            .find_map(|line| line.trim_start().strip_prefix(key))
+            .map(str::trim)
+    }
+
+    /// The numbers on the line introduced by `key`.
+    fn numbers(report: &str, key: &str) -> Vec<f32> {
+        field(report, key)
+            .map(|rest| {
+                rest.split(|c: char| !(c.is_ascii_digit() || c == '.'))
+                    .filter(|t| !t.is_empty())
+                    .filter_map(|t| t.parse().ok())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// LibRaw's "Filter pattern" line as this crate's [`Cfa`].
+    fn cfa_of(report: &str) -> Option<Cfa> {
+        let pattern = field(report, "Filter pattern:")?;
+        let colors: Vec<CfaColor> = pattern
+            .chars()
+            .take(4)
+            .map(|c| match c {
+                'R' => CfaColor::Red,
+                'B' => CfaColor::Blue,
+                _ => CfaColor::Green,
+            })
+            .collect();
+        Some(Cfa::Bayer(colors.try_into().ok()?))
+    }
+
+    #[test]
+    fn corpus_matches_the_oracle() {
+        let files = corpus();
+        let (mut checked, mut failures, mut extra) = (0, Vec::new(), Vec::new());
+        for path in &files {
+            let bytes = std::fs::read(path).expect("corpus file reads");
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(Format::Nef),
+                "{} did not probe as NEF",
+                path.display()
+            );
+            let raw = match (crate::decode(&bytes), unsupported(path)) {
+                (Err(Error::Unsupported(message)), Some(reason)) => {
+                    // The allow-list still has to be right about why.
+                    assert!(!message.is_empty(), "{}: expected {reason}", path.display());
+                    continue;
+                }
+                (Ok(_), Some(reason)) => {
+                    panic!("{} decoded but is listed as {reason}", path.display())
+                }
+                (Err(error), _) => panic!("{}: {error}", path.display()),
+                (Ok(raw), None) => raw,
+            };
+            raw.validate().expect("decoded frame is self-consistent");
+            assert_eq!(raw.cpp, 1);
+            checked += 1;
+            let shift = oracle_shift(&raw.model);
+
+            if let Some((width, height, expected)) = oracle(path) {
+                assert_eq!(
+                    (raw.width, raw.height),
+                    (width, height),
+                    "{}: frame size",
+                    path.display()
+                );
+                let RawData::U16(got) = &raw.data else {
+                    panic!("{}: NEF frames are integers", path.display())
+                };
+                // LibRaw stops short of the bottom of the frame on the
+                // bodies its own table gives a smaller height than the
+                // sensor IFD does (the Nikon 1 bodies by two rows, the
+                // D60 by three): the rows are in the file, coded like
+                // every other row, and this decoder reads them, so the
+                // oracle's untouched zeros there are not a difference
+                // to hold against it. Everything the oracle did decode
+                // has to match sample for sample.
+                let decoded = height
+                    - expected
+                        .rchunks_exact(width)
+                        .take_while(|row| row.iter().all(|s| *s == 0))
+                        .count();
+                let wrong: Vec<usize> = got[..decoded * width]
+                    .iter()
+                    .zip(&expected)
+                    .enumerate()
+                    .filter(|(_, (a, b))| **a != **b >> shift)
+                    .map(|(i, _)| i)
+                    .collect();
+                if !wrong.is_empty() {
+                    failures.push(format!(
+                        "{}: {} of {} samples differ from the oracle; first: {:?}",
+                        path.display(),
+                        wrong.len(),
+                        decoded * width,
+                        wrong
+                            .iter()
+                            .take(4)
+                            .map(|i| (i % width, i / width, got[*i], expected[*i] >> shift))
+                            .collect::<Vec<_>>()
+                    ));
+                    continue;
+                }
+                if decoded < height {
+                    extra.push(format!(
+                        "{}: {} rows past LibRaw's {decoded}",
+                        path.display(),
+                        height - decoded
+                    ));
+                }
+            }
+
+            if let Some(report) = identify(path) {
+                if let [width, height] = numbers(&report, "Full size:")[..] {
+                    assert_eq!(
+                        (raw.width, raw.height),
+                        (width as usize, height as usize),
+                        "{}: full size",
+                        path.display()
+                    );
+                }
+                if let Some(cfa) = cfa_of(&report) {
+                    assert_eq!(raw.cfa, cfa, "{}: filter pattern", path.display());
+                }
+                // "black:" is printed only when it is not zero, which
+                // is exactly when the file carries a black level.
+                if !BLACK_FROM_LIBRAW_TABLE.contains(&raw.model.as_str()) {
+                    let black = numbers(&report, "black:");
+                    let want = black.first().copied().unwrap_or(0.0) / (1 << shift) as f32;
+                    assert_eq!(
+                        raw.black_levels,
+                        [want; 4],
+                        "{}: black level",
+                        path.display()
+                    );
+                }
+                // "As shot" is cam_mul: R G B G2, unnormalised.
+                let shot = numbers(&report, "As shot");
+                if let [r, g, b, g2] = shot[..4.min(shot.len())] {
+                    let want = [r / g, 1.0, b / g, g2 / g];
+                    // LibRaw hands out unit multipliers for the D1
+                    // whatever the file says; ours are the file's.
+                    if want != [1.0; 4] || raw.wb_coeffs == [1.0; 4] {
+                        for (got, want) in raw.wb_coeffs.iter().zip(want) {
+                            assert!(
+                                (got - want).abs() < 1e-4,
+                                "{}: white balance {:?} not {want:?}",
+                                path.display(),
+                                raw.wb_coeffs,
+                            );
+                        }
+                    }
+                }
+                // The "Raw inset" line is the makernote's CropArea,
+                // which is what this module hands out as the crop.
+                if let [w, h, x, y] = numbers(&report, "Raw inset, width x height:")[..] {
+                    assert_eq!(
+                        raw.crop,
+                        Rect {
+                            x: x as usize,
+                            y: y as usize,
+                            width: w as usize,
+                            height: h as usize
+                        },
+                        "{}: crop",
+                        path.display()
+                    );
+                }
+                if let Some(flip) = numbers(&report, "Image flip:").first() {
+                    let expected = match *flip as i32 {
+                        3 => crate::Orientation::Rotate180,
+                        5 => crate::Orientation::Rotate270CW,
+                        6 => crate::Orientation::Rotate90CW,
+                        _ => crate::Orientation::Normal,
+                    };
+                    assert_eq!(raw.orientation, expected, "{}: flip", path.display());
+                }
+            }
+
+            assert!(raw.crop.x + raw.crop.width <= raw.width);
+            assert!(raw.crop.y + raw.crop.height <= raw.height);
+            assert!(
+                raw.white_level > raw.black_levels[0],
+                "{}: saturation below black",
+                path.display()
+            );
+
+            // The preview is the camera's own full-size JPEG and has
+            // to be a picture something can show.
+            let preview = super::preview(&bytes).expect("preview reads");
+            assert_eq!(
+                preview,
+                raw.preview,
+                "{}: two ways to the preview",
+                path.display()
+            );
+            if let Some(preview) = preview {
+                let decoded = image::load_from_memory(&preview)
+                    .unwrap_or_else(|e| panic!("{}: preview does not decode: {e}", path.display()));
+                assert!(
+                    decoded.width() > 160,
+                    "{}: preview is only {}x{}",
+                    path.display(),
+                    decoded.width(),
+                    decoded.height()
+                );
+            }
+        }
+        assert!(
+            failures.is_empty(),
+            "{} of {checked} files differ from the oracle:\n  {}",
+            failures.len(),
+            failures.join("\n  ")
+        );
+        assert!(
+            files.is_empty() || checked > 0,
+            "corpus found no decodable NEF"
+        );
+        // Not a failure, but worth seeing in the log: which frames
+        // this decoder reads further down than LibRaw does.
+        for line in extra {
+            println!("decoded {line}");
+        }
+    }
+
+    /// A file cut short must fail, not panic and not hang.
+    #[test]
+    fn corpus_truncations_do_not_panic() {
+        for path in corpus() {
+            let bytes = std::fs::read(&path).expect("corpus file reads");
+            // Ten cuts spread over the file, plus the awkward ones at
+            // the very start where the header itself is incomplete.
+            let mut cuts: Vec<usize> = (1..=10).map(|i| bytes.len() * i / 11).collect();
+            cuts.extend([0, 4, 8, 16, 100]);
+            for cut in cuts {
+                let short = &bytes[..cut.min(bytes.len())];
+                // Any answer is fine as long as it is an answer.
+                let _ = decode(short);
+                let _ = super::preview(short);
+            }
+            // And a body whose bytes have been scribbled on.
+            let mut damaged = bytes.clone();
+            for (i, byte) in damaged.iter_mut().enumerate().skip(1024) {
+                *byte ^= (i as u8).wrapping_mul(31);
+            }
+            let _ = decode(&damaged);
+        }
+    }
+
+    #[test]
+    fn rejects_files_that_are_not_nikon_raws() {
+        assert!(decode(b"not a tiff at all").is_err());
+        assert!(preview(b"not a tiff at all").is_err());
+    }
+}

--- a/crates/codec-raw/src/formats/orf.rs
+++ b/crates/codec-raw/src/formats/orf.rs
@@ -1,0 +1,1310 @@
+//! ORF — Olympus and OM System raw.
+//!
+//! An ORF is an ordinary little-endian TIFF wearing a private magic
+//! (`IIRO`, `IIRS`, or `MMOR` for the big-endian variant), which
+//! [`Tiff::parse`] already accepts. IFD0 *is* the sensor image: it
+//! carries ImageWidth/Length, BitsPerSample and StripOffsets like any
+//! other TIFF image, but its PhotometricInterpretation is a plain 1 or
+//! 2 rather than 32803, so there is nothing in the directory itself
+//! that says "this is a raw". The strips hold one of four things:
+//!
+//! * 12-bit samples packed big-endian, in strips of a few rows — the
+//!   C-series and SP-series compacts, the ones whose magic is `IIRS`
+//!   and whose BitsPerSample is 12;
+//! * 12-bit samples packed *little*-endian in one strip — the early
+//!   Four Thirds bodies, which claim BitsPerSample 16 and then store
+//!   1.5 bytes a pixel;
+//! * 16-bit words, one a pixel;
+//! * Olympus's own lossless compression, the adaptive Golomb-like
+//!   scheme every body since the E-300 era uses. Nothing distinguishes
+//!   it in the directory — Compression still says 1 — so the byte
+//!   count decides: fewer bytes than 1.5 a pixel and it must be coded.
+//!
+//! Everything a developer needs beyond the samples lives in the
+//! makernote, which comes in three shapes ("OLYMP\0", "OLYMPUS\0II"
+//! and "OM SYSTEM\0\0\0II") described at [`MakerNote`].
+
+use crate::bits::{BitPump, BitPumpLsb, BitPumpMsb};
+use crate::formats::common;
+use crate::tiff::{tags, Entry, Ifd, ImageLayout, Tiff};
+use crate::{Cfa, CfaColor, Error, Format, RawData, RawImage, Rect, Result};
+
+/// Olympus's ImageProcessing sub-IFD (makernote 0x2040) and the
+/// CameraSettings one (0x2020), by the names ExifTool's tag
+/// documentation gives them.
+mod mn {
+    /// Makernote: CameraSettings sub-IFD.
+    pub const CAMERA_SETTINGS: u16 = 0x2020;
+    /// Makernote: ImageProcessing sub-IFD.
+    pub const IMAGE_PROCESSING: u16 = 0x2040;
+    /// Makernote: RawInfo sub-IFD. The compacts that have no
+    /// ImageProcessing put the same numbers, under the same tags, in
+    /// this one instead.
+    pub const RAW_INFO: u16 = 0x3000;
+    /// Makernote: a small JPEG of the frame, on the older bodies.
+    pub const THUMBNAIL_IMAGE: u16 = 0x0100;
+
+    /// CameraSettings: offset of the full-size preview JPEG, relative
+    /// to the makernote's own start.
+    pub const PREVIEW_START: u16 = 0x0101;
+    /// CameraSettings: that JPEG's length.
+    pub const PREVIEW_LENGTH: u16 = 0x0102;
+
+    /// ImageProcessing: as-shot red and blue levels, x256 with green 256.
+    pub const WB_RB_LEVELS: u16 = 0x0100;
+    /// ImageProcessing: black level per CFA position.
+    pub const BLACK_LEVEL_2: u16 = 0x0600;
+    /// ImageProcessing: how many of the 16 bits carry signal.
+    pub const VALID_BITS: u16 = 0x0611;
+    pub const CROP_LEFT: u16 = 0x0612;
+    pub const CROP_TOP: u16 = 0x0613;
+    pub const CROP_WIDTH: u16 = 0x0614;
+    pub const CROP_HEIGHT: u16 = 0x0615;
+    /// ImageProcessing: `[saturation, ...]` — the level above which the
+    /// sensor stops being linear, which is what a developer wants as
+    /// the white point.
+    pub const SENSOR_CALIBRATION: u16 = 0x0805;
+    /// ImageProcessing: `[left, top, right, bottom]`, inclusive, of the
+    /// frame the chosen aspect ratio keeps.
+    pub const ASPECT_FRAME: u16 = 0x1113;
+
+    /// RawInfo: offset of the full-size preview JPEG, from the start of
+    /// the file. (In ImageProcessing the same numbers are a tone curve,
+    /// so this pair is only ever read out of RawInfo.)
+    pub const RAW_PREVIEW_START: u16 = 0x0801;
+    /// RawInfo: that JPEG's length.
+    pub const RAW_PREVIEW_LENGTH: u16 = 0x0802;
+
+    /// Old (v1) makernote: red balance, x256.
+    pub const OLD_RED_BALANCE: u16 = 0x1017;
+    /// Old (v1) makernote: blue balance, x256.
+    pub const OLD_BLUE_BALANCE: u16 = 0x1018;
+    /// Old (v1) makernote: black level per CFA position.
+    pub const OLD_BLACK_LEVEL: u16 = 0x1012;
+    /// Old (v1) makernote: how many of the 16 bits carry signal.
+    pub const OLD_VALID_BITS: u16 = 0x102C;
+}
+
+/// EXIF's CFAPattern (0xA302). Olympus is one of the few makers that
+/// fills it in honestly on a raw, which saves this module a model
+/// table: the compacts are BGGR and the Four Thirds bodies RGGB, and
+/// the tag says so.
+const CFA_PATTERN: u16 = 0xA302;
+
+/// A parsed Olympus makernote: the entries plus the base its internal
+/// offsets are measured from.
+///
+/// Three generations, told apart by the bytes at its start:
+///
+/// * `OLYMP\0` + two bytes — the original. The IFD begins eight bytes
+///   in and its offsets are relative to the *file*, so `base` is 0.
+///   Its "sub-IFDs" (0x2010..0x2050) are UNDEFINED blobs whose bytes
+///   are simply an IFD, again with file-relative offsets.
+/// * `OLYMPUS\0` + `II`/`MM` + a version word — an embedded TIFF
+///   without the usual 42: the IFD begins twelve bytes in and every
+///   offset inside it, sub-IFDs included, counts from the makernote's
+///   own first byte.
+/// * `OM SYSTEM\0\0\0` + `II` + a version word — the same, four bytes
+///   longer, on the bodies OM Digital Solutions ships.
+struct MakerNote<'a> {
+    tiff: Tiff<'a>,
+}
+
+impl<'a> MakerNote<'a> {
+    fn parse(bytes: &'a [u8], entry: &Entry, file_little_endian: bool) -> Option<MakerNote<'a>> {
+        let at = entry.offset;
+        let head = bytes.get(at..)?;
+        let (ifd_at, base, little_endian) = if head.starts_with(b"OLYMPUS\0") {
+            (at.checked_add(12)?, at, byte_order(head.get(8..10)?)?)
+        } else if head.starts_with(b"OM SYSTEM\0\0\0") {
+            (at.checked_add(16)?, at, byte_order(head.get(12..14)?)?)
+        } else if head.starts_with(b"OLYMP\0") {
+            // The first generation shares the file's offsets *and* its
+            // byte order; the two bytes after the signature are a
+            // version, not a byte order of its own.
+            (at.checked_add(8)?, 0, file_little_endian)
+        } else {
+            return None;
+        };
+        let tiff = Tiff::parse_at_relative(bytes, ifd_at, base, little_endian).ok()?;
+        Some(MakerNote { tiff })
+    }
+
+    fn root(&self) -> &Ifd {
+        self.tiff.root()
+    }
+
+    /// One of the makernote's sub-directories, whichever way this
+    /// generation stores it: an IFD-typed pointer (relative to the
+    /// makernote base) on the newer ones, a blob of IFD bytes on the
+    /// first.
+    fn sub(&self, tag: u16) -> Option<Tiff<'a>> {
+        let entry = self.root().get(tag)?;
+        let bytes = self.tiff.bytes();
+        let base = self.tiff.base();
+        let at = match entry.kind {
+            crate::tiff::Kind::Ifd | crate::tiff::Kind::Long | crate::tiff::Kind::Ifd8 => {
+                base.checked_add(entry.u32(0)? as usize)?
+            }
+            crate::tiff::Kind::Undefined | crate::tiff::Kind::Byte => entry.offset,
+            _ => return None,
+        };
+        Tiff::parse_at_relative(bytes, at, base, self.tiff.little_endian()).ok()
+    }
+}
+
+fn byte_order(sig: &[u8]) -> Option<bool> {
+    match sig {
+        b"II" => Some(true),
+        b"MM" => Some(false),
+        _ => None,
+    }
+}
+
+/// Everything about the uncompressed layouts that is not in
+/// [`ImageLayout`]: how a sample is stored, how wide it really is, and
+/// whether the rows arrive in two interlaced passes.
+#[derive(Debug, Clone, Copy)]
+struct Unpacking {
+    packing: Packing,
+    valid_bits: u32,
+    little_endian: bool,
+    interlaced: bool,
+}
+
+/// How the strips hold their samples.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Packing {
+    /// Twelve bits a sample, most significant bit first.
+    Packed12Be,
+    /// Twelve bits a sample, least significant bit first, in blocks
+    /// of sixteen bytes that carry ten samples and a spare byte.
+    Packed12Blocks,
+    /// One 16-bit word a sample, in the file's byte order.
+    Words16,
+    /// Olympus's adaptive lossless coding.
+    Compressed,
+}
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let tiff = Tiff::parse(bytes)?;
+    let ifd = raw_ifd(&tiff)?;
+    let layout = ImageLayout::of(&tiff, ifd)?;
+    let width = layout.width;
+    // A few compacts record an odd number of rows and then store an
+    // even number: rounding up keeps the CFA whole, and the frame then
+    // matches what LibRaw reports.
+    let height = layout.height + (layout.height & 1);
+    if width == 0 || height == 0 || width > 1 << 16 || height > 1 << 16 {
+        return Err(Error::Corrupt(format!("ORF frame {width}x{height}")));
+    }
+    // The strips bound the frame: every layout stores at least a bit a
+    // sample, so a header claiming more than the file could hold is a
+    // forgery, not a big camera — and must not size an allocation.
+    let samples = crate::frame_samples(width, height, 1)?;
+    let stored: usize = layout.chunks.iter().map(|(_, len)| *len).sum();
+    if stored.saturating_mul(8) < samples {
+        return Err(Error::Corrupt(format!(
+            "ORF frame of {samples} samples in {stored} bytes of strips"
+        )));
+    }
+    if layout.compression != 1 {
+        return Err(Error::Unsupported(format!(
+            "ORF with compression {}",
+            layout.compression
+        )));
+    }
+    // The heuristic below weighs the strips against the frame the
+    // directory declares, not the row-padded one.
+    let samples = width * layout.height;
+    let total: usize = layout.chunks.iter().map(|(_, len)| len).sum();
+    let packing = match layout.bits_per_sample {
+        // The compacts say 12 and mean it, one strip every few rows.
+        12 => Packing::Packed12Be,
+        16 if total >= samples * 2 => Packing::Words16,
+        // Between 1.5 and 2 bytes a pixel there is only one thing it
+        // can be: 12-bit samples, ten to a sixteen-byte block — 1.6
+        // bytes a pixel.
+        16 if total >= samples * 3 / 2 => Packing::Packed12Blocks,
+        16 => Packing::Compressed,
+        other => {
+            return Err(Error::Unsupported(format!(
+                "ORF with {other} bits a sample"
+            )))
+        }
+    };
+
+    // Everything beyond the samples is in the makernote, and a file
+    // without one is still perfectly decodable — it just develops with
+    // defaults. It is read first because how wide a sample is decides
+    // how the 16-bit layout is aligned.
+    let maker = tiff
+        .exif()
+        .and_then(|exif| exif.get(tags::MAKER_NOTE))
+        .and_then(|entry| MakerNote::parse(bytes, entry, tiff.little_endian()));
+    let processing = maker
+        .as_ref()
+        .and_then(|m| m.sub(mn::IMAGE_PROCESSING).or_else(|| m.sub(mn::RAW_INFO)));
+    let valid_bits = processing
+        .as_ref()
+        .and_then(|ip| ip.root().get(mn::VALID_BITS).and_then(|e| e.u32(0)))
+        .or_else(|| {
+            maker
+                .as_ref()
+                .and_then(|m| m.root().get(mn::OLD_VALID_BITS).and_then(|e| e.u32(0)))
+        })
+        .filter(|bits| (8..=16).contains(bits))
+        .unwrap_or(12);
+
+    let data = match packing {
+        Packing::Compressed => {
+            let (start, len) = *layout
+                .chunks
+                .first()
+                .ok_or_else(|| Error::Corrupt("ORF with no strip".into()))?;
+            decompress(&bytes[start..start + len], width, height)
+        }
+        // The compacts that stamp their files `IIRS` read their sensor
+        // out as two interlaced fields and store them that way.
+        _ => unpack(
+            bytes,
+            &layout,
+            width,
+            height,
+            Unpacking {
+                packing,
+                valid_bits,
+                little_endian: tiff.little_endian(),
+                interlaced: bytes.starts_with(b"IIRS"),
+            },
+        ),
+    };
+
+    let mut raw = RawImage::new(
+        Format::Orf,
+        width,
+        height,
+        1,
+        RawData::U16(data),
+        cfa(&tiff),
+    );
+    let (make, model) = tiff.make_model();
+    raw.set_camera(&make, &model);
+    raw.orientation = common::orientation(&tiff);
+    raw.metadata = common::metadata(&tiff);
+
+    if let Some(ip) = processing.as_ref().map(|t| t.root()) {
+        if let (Some(r), Some(b)) = (
+            ip.get(mn::WB_RB_LEVELS).and_then(|e| e.f64(0)),
+            ip.get(mn::WB_RB_LEVELS).and_then(|e| e.f64(1)),
+        ) {
+            if r > 0.0 && b > 0.0 {
+                raw.wb_coeffs = [(r / 256.0) as f32, 1.0, (b / 256.0) as f32, 1.0];
+            }
+        }
+        if let Some(black) = ip.get(mn::BLACK_LEVEL_2) {
+            read_black(black, &mut raw.black_levels);
+        }
+        // The saturation level the camera measured beats the width of
+        // the field: sensors clip below their full scale, and Olympus
+        // records where.
+        if let Some(max) = ip.get(mn::SENSOR_CALIBRATION).and_then(|e| e.f64(0)) {
+            if max > 0.0 && max < 65536.0 {
+                raw.white_level = max as f32;
+            }
+        }
+        raw.crop = crop(ip, width, height).unwrap_or(raw.crop);
+    }
+    if let Some(root) = maker.as_ref().map(|m| m.root()) {
+        // The first-generation makernote keeps the same numbers loose
+        // in its root directory, for the bodies that have no
+        // ImageProcessing or RawInfo at all.
+        if raw.wb_coeffs == [1.0; 4] {
+            if let (Some(r), Some(b)) = (
+                root.get(mn::OLD_RED_BALANCE).and_then(|e| e.f64(0)),
+                root.get(mn::OLD_BLUE_BALANCE).and_then(|e| e.f64(0)),
+            ) {
+                if r > 0.0 && b > 0.0 {
+                    raw.wb_coeffs = [(r / 256.0) as f32, 1.0, (b / 256.0) as f32, 1.0];
+                }
+            }
+        }
+        if raw.black_levels == [0.0; 4] {
+            if let Some(black) = root.get(mn::OLD_BLACK_LEVEL) {
+                read_black(black, &mut raw.black_levels);
+            }
+        }
+    }
+    if raw.white_level == 65535.0 {
+        raw.white_level = ((1u32 << valid_bits) - 1) as f32;
+    }
+    // A black level at or above the white point would make `validate`
+    // reject the frame; trust the white point and drop the black.
+    if raw.black_levels.iter().any(|b| *b >= raw.white_level) {
+        raw.black_levels = [0.0; 4];
+    }
+
+    raw.preview = preview_from(&tiff, maker.as_ref());
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    let tiff = Tiff::parse(bytes)?;
+    let maker = tiff
+        .exif()
+        .and_then(|exif| exif.get(tags::MAKER_NOTE))
+        .and_then(|entry| MakerNote::parse(bytes, entry, tiff.little_endian()));
+    Ok(preview_from(&tiff, maker.as_ref()))
+}
+
+/// The biggest JPEG the file offers. On the Four Thirds and Micro Four
+/// Thirds bodies the full-size preview is only reachable through the
+/// makernote's CameraSettings, which points at it with an offset
+/// relative to the makernote's own start; the TIFF directories know
+/// nothing about it.
+fn preview_from(tiff: &Tiff<'_>, maker: Option<&MakerNote<'_>>) -> Option<Vec<u8>> {
+    let bytes = tiff.bytes();
+    let mut best = common::largest_jpeg(tiff);
+    let mut consider = |start: usize, len: usize| {
+        let stream = bytes.get(start..start.checked_add(len)?)?;
+        if !stream.starts_with(&[0xFF, 0xD8]) {
+            return None;
+        }
+        if best.as_ref().is_none_or(|found| stream.len() > found.len()) {
+            best = Some(stream.to_vec());
+        }
+        Some(())
+    };
+    if let Some(maker) = maker {
+        let base = maker.tiff.base();
+        if let Some(settings) = maker.sub(mn::CAMERA_SETTINGS) {
+            let root = settings.root();
+            if let (Some(start), Some(len)) = (
+                root.get(mn::PREVIEW_START).and_then(|e| e.u32(0)),
+                root.get(mn::PREVIEW_LENGTH).and_then(|e| e.u32(0)),
+            ) {
+                if let Some(start) = base.checked_add(start as usize) {
+                    consider(start, len as usize);
+                }
+            }
+        }
+        // The compacts point at theirs from RawInfo instead, and by an
+        // offset from the start of the file rather than the makernote.
+        if let Some(info) = maker.sub(mn::RAW_INFO) {
+            let root = info.root();
+            if let (Some(start), Some(len)) = (
+                root.get(mn::RAW_PREVIEW_START).and_then(|e| e.u32(0)),
+                root.get(mn::RAW_PREVIEW_LENGTH).and_then(|e| e.u32(0)),
+            ) {
+                consider(start as usize, len as usize);
+            }
+        }
+        // The oldest bodies keep their only JPEG right in the
+        // makernote's root, as a blob rather than a pointer.
+        if let Some(thumb) = maker.root().get(mn::THUMBNAIL_IMAGE) {
+            consider(thumb.offset, thumb.count);
+        }
+    }
+    best
+}
+
+/// Which IFD holds the sensor. It is IFD0 on every ORF seen, but the
+/// file also carries a thumbnail IFD with strips of its own, so pick by
+/// depth rather than by position: the raw is the deepest-strip IFD that
+/// is not JPEG-compressed.
+fn raw_ifd<'t>(tiff: &'t Tiff<'_>) -> Result<&'t Ifd> {
+    let mut best: Option<(&Ifd, u64)> = None;
+    for ifd in tiff.all() {
+        if !ifd.has(tags::STRIP_OFFSETS) {
+            continue;
+        }
+        let bits = ifd
+            .get(tags::BITS_PER_SAMPLE)
+            .and_then(|e| e.u32(0))
+            .unwrap_or(8);
+        let compression = ifd
+            .get(tags::COMPRESSION)
+            .and_then(|e| e.u32(0))
+            .unwrap_or(1);
+        if bits < 12 || compression != 1 {
+            continue;
+        }
+        let size = ifd
+            .get(tags::STRIP_BYTE_COUNTS)
+            .map(|e| e.u64s().iter().sum::<u64>())
+            .unwrap_or(0);
+        if best.is_none_or(|(_, best)| size > best) {
+            best = Some((ifd, size));
+        }
+    }
+    best.map(|(ifd, _)| ifd)
+        .ok_or_else(|| Error::Corrupt("ORF without a sensor IFD".into()))
+}
+
+/// The CFA, from EXIF's CFAPattern: two 16-bit repeat counts in the
+/// file's byte order, then one byte a cell (0 red, 1 green, 2 blue).
+/// RGGB when the tag is missing — every Olympus interchangeable-lens
+/// body is RGGB, and only the compacts differ.
+fn cfa(tiff: &Tiff<'_>) -> Cfa {
+    let color = |c: u8| match c {
+        0 => Some(CfaColor::Red),
+        1 => Some(CfaColor::Green),
+        2 => Some(CfaColor::Blue),
+        3 => Some(CfaColor::Cyan),
+        4 => Some(CfaColor::Magenta),
+        5 => Some(CfaColor::Yellow),
+        _ => None,
+    };
+    let parsed = (|| {
+        let entry = tiff.exif()?.get(CFA_PATTERN)?;
+        let raw = entry.bytes()?;
+        let n = |at: usize| -> Option<usize> {
+            let pair: [u8; 2] = raw.get(at..at + 2)?.try_into().ok()?;
+            Some(if tiff.little_endian() {
+                u16::from_le_bytes(pair)
+            } else {
+                u16::from_be_bytes(pair)
+            } as usize)
+        };
+        let (w, h) = (n(0)?, n(2)?);
+        if w != 2 || h != 2 {
+            return None;
+        }
+        let cells: Option<Vec<CfaColor>> = raw.get(4..8)?.iter().map(|c| color(*c)).collect();
+        let cells = cells?;
+        Some(Cfa::Bayer([cells[0], cells[1], cells[2], cells[3]]))
+    })();
+    parsed.unwrap_or(Cfa::RGGB)
+}
+
+/// Black level per CFA position. Olympus writes the four values in
+/// raster order (top-left, top-right, bottom-left, bottom-right),
+/// which is exactly [`RawImage::black_levels`]'s convention.
+fn read_black(entry: &Entry, out: &mut [f32; 4]) {
+    for (i, slot) in out.iter_mut().enumerate() {
+        if let Some(v) = entry.f64(i.min(entry.count.saturating_sub(1))) {
+            *slot = v as f32;
+        }
+    }
+}
+
+/// The area meant to be shown, from ImageProcessing's crop tags (or
+/// AspectFrame when a body records only that).
+///
+/// An odd origin is nudged to the next even pixel. A crop that started
+/// on an odd column would put a green under what the CFA calls red;
+/// the bodies that do it (the early Four Thirds ones) are the same
+/// bodies whose crop LibRaw reports one pixel further in, so this
+/// matches the oracle as well as the sensor.
+fn crop(ip: &Ifd, width: usize, height: usize) -> Option<Rect> {
+    let num = |tag: u16| ip.get(tag).and_then(|e| e.u32(0)).map(|v| v as usize);
+    let (mut x, mut y, mut w, mut h) = match (
+        num(mn::CROP_LEFT),
+        num(mn::CROP_TOP),
+        num(mn::CROP_WIDTH),
+        num(mn::CROP_HEIGHT),
+    ) {
+        (Some(x), Some(y), Some(w), Some(h)) => (x, y, w, h),
+        _ => {
+            let frame = ip.get(mn::ASPECT_FRAME)?;
+            let (l, t, r, b) = (
+                frame.u32(0)? as usize,
+                frame.u32(1)? as usize,
+                frame.u32(2)? as usize,
+                frame.u32(3)? as usize,
+            );
+            (l, t, r.checked_sub(l)? + 1, b.checked_sub(t)? + 1)
+        }
+    };
+    if x & 1 == 1 {
+        x += 1;
+        w = w.saturating_sub(1);
+    }
+    if y & 1 == 1 {
+        y += 1;
+        h = h.saturating_sub(1);
+    }
+    if w == 0 || h == 0 || x >= width || y >= height {
+        return None;
+    }
+    Some(Rect {
+        x,
+        y,
+        width: w.min(width - x),
+        height: h.min(height - y),
+    })
+}
+
+/// The three uncompressed layouts, strip by strip.
+///
+/// The strips are walked in order and their rows counted as they go,
+/// rather than assumed to be RowsPerStrip apart: the interlaced
+/// compacts end one strip early at the boundary between their two
+/// fields, so a strip's position in the stream is the sum of what came
+/// before it and nothing else.
+///
+/// `interlaced` maps that stream back onto the frame. Those sensors
+/// are read out in two passes, all the even rows and then all the odd
+/// ones, and the file keeps them in that order; the even field is the
+/// longer one when the frame has an odd number of rows.
+///
+/// A strip that runs short simply leaves the rest of its rows at zero:
+/// a truncated file gives a short picture rather than an error, and
+/// never a panic.
+fn unpack(
+    bytes: &[u8],
+    layout: &ImageLayout,
+    width: usize,
+    height: usize,
+    how: Unpacking,
+) -> Vec<u16> {
+    let Unpacking {
+        packing,
+        valid_bits,
+        little_endian,
+        interlaced,
+    } = how;
+    let mut out = vec![0u16; width * height];
+    let row_bytes = match packing {
+        Packing::Words16 => width * 2,
+        Packing::Packed12Be => (width * 12).div_ceil(8),
+        // Ten samples to sixteen bytes; every frame seen has a whole
+        // number of blocks in a row.
+        Packing::Packed12Blocks => width.div_ceil(10) * 16,
+        Packing::Compressed => width * 2,
+    }
+    .max(1);
+    let half = height.div_ceil(2);
+    let frame_row = |stream_row: usize| -> Option<usize> {
+        let row = if !interlaced {
+            stream_row
+        } else if stream_row < half {
+            stream_row * 2
+        } else {
+            (stream_row - half) * 2 + 1
+        };
+        (row < height).then_some(row)
+    };
+
+    let mut stream_row = 0usize;
+    for (start, len) in &layout.chunks {
+        let rows = layout.rows_per_chunk.max(1).min(len / row_bytes);
+        let src = &bytes[*start..*start + *len];
+        match packing {
+            Packing::Packed12Be => {
+                let mut pump = BitPumpMsb::new(src);
+                for row in 0..rows {
+                    read_row(&mut out, width, frame_row(stream_row + row), |i| {
+                        let _ = i;
+                        pump.get(12) as u16
+                    });
+                }
+            }
+            Packing::Packed12Blocks => {
+                let payload = block_payload(src);
+                let mut pump = BitPumpLsb::new(&payload);
+                for row in 0..rows {
+                    read_row(&mut out, width, frame_row(stream_row + row), |i| {
+                        let _ = i;
+                        pump.get(12) as u16
+                    });
+                }
+            }
+            Packing::Words16 => {
+                let word_at = |at: usize| -> u16 {
+                    let Some(word) = src.get(at..at + 2) else {
+                        return 0;
+                    };
+                    let word: [u8; 2] = word.try_into().unwrap();
+                    if little_endian {
+                        u16::from_le_bytes(word)
+                    } else {
+                        u16::from_be_bytes(word)
+                    }
+                };
+                // The bodies that spend a whole word on a sample leave
+                // the sample's bits at the *top* of it: the E-1's
+                // twelve read sixteen times too high, the E-10's ten
+                // sixty-four times. The makernote's ValidBits is what
+                // says how far down to push them — and it has to be
+                // trusted rather than sniffed from the data, because
+                // these sensors do set the odd bit below their own
+                // depth, which LibRaw discards along with the padding.
+                let shift = 16 - valid_bits.min(16);
+                for row in 0..rows {
+                    let base = row * row_bytes;
+                    read_row(&mut out, width, frame_row(stream_row + row), |i| {
+                        word_at(base + i * 2) >> shift
+                    });
+                }
+            }
+            Packing::Compressed => unreachable!("compressed strips take the other path"),
+        }
+        stream_row += rows;
+    }
+    out
+}
+
+/// The bits of a block-padded stream, with the sixteenth byte of every
+/// block dropped.
+///
+/// The early Four Thirds bodies write their 12-bit samples ten at a
+/// time: fifteen bytes hold exactly ten samples, and a sixteenth byte
+/// (always zero on every file seen) rounds the block up to a power of
+/// two. That is 1.6 bytes a pixel, which is how a frame this shape is
+/// told apart from a compressed one.
+fn block_payload(src: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(src.len() / 16 * 15 + 15);
+    for block in src.chunks(16) {
+        out.extend_from_slice(&block[..block.len().min(15)]);
+    }
+    out
+}
+
+/// Fill one frame row from `next`, which must be called `width` times
+/// whether or not the row lands inside the frame — the bit pumps'
+/// position is the stream's position, and skipping a row would lose
+/// the ones after it.
+fn read_row(out: &mut [u16], width: usize, row: Option<usize>, mut next: impl FnMut(usize) -> u16) {
+    match row {
+        Some(row) => {
+            let start = row * width;
+            for i in 0..width {
+                out[start + i] = next(i);
+            }
+        }
+        None => {
+            for i in 0..width {
+                next(i);
+            }
+        }
+    }
+}
+
+/// Olympus's lossless compression.
+///
+/// Each sample is stored as the difference from a predictor, and the
+/// difference is split three ways: its bottom two bits go out raw, its
+/// top bits as a count of leading zeros, and the middle `nbits` bits
+/// straight. `nbits` is not in the file — both ends derive it from the
+/// magnitude of the last difference in the same column parity, so the
+/// code adapts to the noise without spending a bit on saying so.
+///
+/// Three integers of state ride along per column parity: the last
+/// magnitude (which sets `nbits`), a running bias that is added to
+/// every difference, and a count of how many small differences have
+/// gone by in a row, which buys two extra bits of headroom while the
+/// image is quiet.
+///
+/// The predictor is the classic gradient one, over neighbours two
+/// pixels away so it always compares like colour with like: with the
+/// pixel to the left (`w`), the one above (`n`) and the one above-left
+/// (`nw`), a monotone run takes a planar prediction and anything else
+/// takes whichever neighbour the gradient favours.
+fn decompress(strip: &[u8], width: usize, height: usize) -> Vec<u16> {
+    let mut out = vec![0u16; width * height];
+    // Seven bytes of preamble sit in front of the coded data.
+    let mut pump = BitPumpMsb::new(strip.get(7..).unwrap_or(&[]));
+    for row in 0..height {
+        // Two rows back is where the same colour last appeared, and
+        // splitting the buffer there gives the predictor two plain
+        // slices instead of arithmetic on one.
+        let (earlier, rest) = out.split_at_mut(row * width);
+        let here = &mut rest[..width];
+        let above = (row >= 2).then(|| &earlier[(row - 2) * width..][..width]);
+        // The state starts afresh on every row: rows are independently
+        // recoverable even though the bitstream is not.
+        let mut carry = [[0i32; 3]; 2];
+        for col in 0..width {
+            // The predictor, before any bits are read: it depends only
+            // on samples already decoded.
+            let pred = match (above, col >= 2) {
+                (None, false) => 0,
+                (None, true) => here[col - 2] as i32,
+                (Some(above), false) => above[col] as i32,
+                (Some(above), true) => {
+                    let w = here[col - 2] as i32;
+                    let n = above[col] as i32;
+                    let nw = above[col - 2] as i32;
+                    if (w < nw && nw < n) || (n < nw && nw < w) {
+                        // A steep monotone run: extrapolate the plane
+                        // through the three, unless the step is small
+                        // enough that the average is the safer guess.
+                        if (w - nw).abs() > 32 || (n - nw).abs() > 32 {
+                            w + n - nw
+                        } else {
+                            (w + n) >> 1
+                        }
+                    } else if (w - nw).abs() > (n - nw).abs() {
+                        w
+                    } else {
+                        n
+                    }
+                }
+            };
+
+            let carry = &mut carry[col & 1];
+            // Two extra bits of field width while the run of small
+            // differences lasts, and `nbits` wide enough to hold the
+            // last magnitude on top of that.
+            let extra = if carry[2] < 3 { 2 } else { 0 };
+            let magnitude = 32 - (carry[0] as u32 & 0xFFFF).leading_zeros();
+            let nbits = (2 + extra).max(magnitude.saturating_sub(extra));
+
+            // Fifteen bits cover a whole difference's preamble, so one
+            // look at the stream is enough: a sign bit, the two low
+            // bits of the difference, then a leading-zero run
+            // terminated by a one, up to twelve. Twelve zeros is the
+            // escape for a difference too wide for the run to be worth
+            // coding.
+            let window = pump.peek(15);
+            let head = (window >> 12) as i32;
+            let low = head & 3;
+            // All-ones when negative, so `^` below flips the magnitude
+            // into its two's complement.
+            let sign = -(head >> 2);
+            let run = window & 0xFFF;
+            let high = if run == 0 {
+                pump.consume(15);
+                (pump.get(16 - nbits) >> 1) as i32
+            } else {
+                let zeros = run.leading_zeros() - 20;
+                pump.consume(3 + zeros + 1);
+                zeros as i32
+            };
+
+            carry[0] = (high << nbits) | pump.get(nbits) as i32;
+            let diff = (carry[0] ^ sign).wrapping_add(carry[1]);
+            // The bias tracks about a sixteenth of the recent
+            // differences, which is what keeps `nbits` honest when the
+            // signal has a slope.
+            carry[1] = (diff.wrapping_mul(3).wrapping_add(carry[1])) >> 5;
+            carry[2] = if carry[0] > 16 { 0 } else { carry[2] + 1 };
+
+            let value = pred + (diff << 2) + low;
+            here[col] = value.clamp(0, u16::MAX as i32) as u16;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal ORF: an `IIRO` header, IFD0 with the tags the decoder
+    /// needs, and `strip` as the sensor data.
+    fn build(
+        bits: u16,
+        width: u32,
+        height: u32,
+        strip: &[u8],
+        extra: &[(u16, u16, u32)],
+    ) -> Vec<u8> {
+        let mut entries: Vec<(u16, u16, u32)> = vec![
+            (tags::IMAGE_WIDTH, 4, width),
+            (tags::IMAGE_LENGTH, 4, height),
+            (tags::BITS_PER_SAMPLE, 3, bits as u32),
+            (tags::COMPRESSION, 3, 1),
+            (tags::PHOTOMETRIC, 3, 1),
+            (tags::STRIP_OFFSETS, 4, 0),
+            (tags::ROWS_PER_STRIP, 4, height),
+            (tags::STRIP_BYTE_COUNTS, 4, strip.len() as u32),
+        ];
+        entries.extend_from_slice(extra);
+        entries.sort_by_key(|e| e.0);
+        let ifd_at = 8usize;
+        let strip_at = ifd_at + 2 + entries.len() * 12 + 4;
+        let mut out = Vec::new();
+        out.extend_from_slice(b"IIRO");
+        out.extend_from_slice(&(ifd_at as u32).to_le_bytes());
+        out.extend_from_slice(&(entries.len() as u16).to_le_bytes());
+        for (tag, kind, value) in &entries {
+            out.extend_from_slice(&tag.to_le_bytes());
+            out.extend_from_slice(&kind.to_le_bytes());
+            out.extend_from_slice(&1u32.to_le_bytes());
+            let value = if *tag == tags::STRIP_OFFSETS {
+                strip_at as u32
+            } else {
+                *value
+            };
+            out.extend_from_slice(&value.to_le_bytes());
+        }
+        out.extend_from_slice(&0u32.to_le_bytes());
+        assert_eq!(out.len(), strip_at);
+        out.extend_from_slice(strip);
+        out
+    }
+
+    #[test]
+    fn twelve_bit_big_endian_strips() {
+        // 0x123, 0x456, 0x789, 0xabc packed MSB-first.
+        let strip = [0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc];
+        let file = build(12, 4, 1, &strip, &[]);
+        let raw = decode(&file).expect("decodes");
+        // The odd row count is rounded up, so the frame is 4x2 with a
+        // blank second row.
+        assert_eq!((raw.width, raw.height), (4, 2));
+        let RawData::U16(data) = &raw.data else {
+            panic!("u16")
+        };
+        assert_eq!(&data[..4], &[0x123, 0x456, 0x789, 0xabc]);
+        assert_eq!(&data[4..], &[0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn twelve_bit_blocks_when_the_count_says_so() {
+        // BitsPerSample 16 but 1.6 bytes a pixel: the early Four
+        // Thirds layout, low bit first, ten samples to a block whose
+        // last byte is skipped. Ten samples, so the second block's
+        // first sample must come from byte 16, not byte 15.
+        let mut strip = vec![0u8; 32];
+        strip[..3].copy_from_slice(&[0x12, 0x34, 0x56]);
+        strip[15] = 0xff; // the spare byte, ignored
+        strip[16..19].copy_from_slice(&[0x9a, 0xbc, 0xde]);
+        let file = build(16, 10, 2, &strip, &[]);
+        let raw = decode(&file).expect("decodes");
+        let RawData::U16(data) = &raw.data else {
+            panic!("u16")
+        };
+        assert_eq!(&data[..2], &[0x412, 0x563]);
+        assert_eq!(&data[10..12], &[0xc9a, 0xdeb]);
+    }
+
+    /// A whole word a sample, with the sample at the top of it: with
+    /// no makernote to say otherwise the samples are twelve bits, so
+    /// each word comes down by four.
+    #[test]
+    fn sixteen_bit_words_are_top_aligned() {
+        let strip = [0x34, 0x12, 0x78, 0x56, 0xbc, 0x0a, 0xff, 0x0f];
+        let file = build(16, 4, 1, &strip, &[]);
+        let raw = decode(&file).expect("decodes");
+        let RawData::U16(data) = &raw.data else {
+            panic!("u16")
+        };
+        assert_eq!(&data[..4], &[0x123, 0x567, 0x0ab, 0x0ff]);
+    }
+
+    /// The compressed coder, hand-encoded: with all state at zero the
+    /// first sample is `((high << 4) | extra) * 4 + low`, and the
+    /// second uses the same fresh state because it is the other column
+    /// parity.
+    #[test]
+    fn compressed_first_samples() {
+        // Seven bytes of preamble, then the bits
+        //   0 00 000000111110 1111  -> sign +, low 0, high 6, extra 15
+        //   0 11 000000000001 0101  -> sign +, low 3, high 11, extra 5
+        let mut strip = vec![0u8; 7];
+        strip.extend_from_slice(&[0x00, 0x7d, 0x80, 0x0a, 0xea, 0xfd, 0x65, 0x17]);
+        let out = decompress(&strip, 4, 1);
+        assert_eq!(out[0], (6 * 16 + 15) * 4);
+        assert_eq!(out[1], (11 * 16 + 5) * 4 + 3);
+    }
+
+    #[test]
+    fn hostile_input_never_panics() {
+        assert!(decode(&[]).is_err());
+        assert!(decode(b"IIRO").is_err());
+        let file = build(12, 4, 2, &[0x12, 0x34, 0x56], &[]);
+        for cut in 0..file.len() {
+            let _ = decode(&file[..cut]);
+            let _ = preview(&file[..cut]);
+        }
+    }
+
+    #[test]
+    fn a_crop_on_an_odd_column_moves_in_not_out() {
+        let mut ip = Ifd::default();
+        for (tag, value) in [
+            (mn::CROP_LEFT, 55u32),
+            (mn::CROP_TOP, 49),
+            (mn::CROP_WIDTH, 3136),
+            (mn::CROP_HEIGHT, 2352),
+        ] {
+            ip.entries.push(Entry {
+                tag,
+                kind: crate::tiff::Kind::Long,
+                count: 1,
+                offset: 0,
+                value: crate::tiff::Value::Long(vec![value]),
+            });
+        }
+        assert_eq!(
+            crop(&ip, 3280, 2450),
+            Some(Rect {
+                x: 56,
+                y: 50,
+                width: 3135,
+                height: 2351
+            })
+        );
+    }
+}
+
+/// The LibRaw oracle, for this module's corpus tests and the RW2
+/// module's — the two vendors share one set of reference tools, so the
+/// parsing of their output lives in one place rather than twice.
+///
+/// `SCHIST_RAW_CORPUS` names a directory walked recursively. Beside
+/// every sample sit `<name>.tiff` (`unprocessed_raw -T`: the whole
+/// uncropped frame as 16-bit grey, black not subtracted) and
+/// `<name>.identify.txt` (`raw-identify -v -w`). Both are optional;
+/// what is there is checked.
+#[cfg(test)]
+pub(super) mod oracle {
+    use crate::{Cfa, CfaColor, Orientation, RawData, RawImage};
+    use std::path::{Path, PathBuf};
+
+    /// Every file under `SCHIST_RAW_CORPUS` with one of `extensions`
+    /// (compared case-insensitively). Empty when the variable is unset,
+    /// which is how the corpus tests skip themselves.
+    pub fn corpus_files(extensions: &[&str]) -> Vec<PathBuf> {
+        let Ok(root) = std::env::var("SCHIST_RAW_CORPUS") else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        let mut stack = vec![PathBuf::from(root)];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                let matches = path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| extensions.iter().any(|want| e.eq_ignore_ascii_case(want)));
+                if matches {
+                    out.push(path);
+                }
+            }
+        }
+        out.sort();
+        out
+    }
+
+    /// What `raw-identify -v -w` says about a file.
+    #[derive(Debug, Default)]
+    pub struct Identify {
+        /// "Full size", LibRaw's `raw_width x raw_height`.
+        pub full: Option<(usize, usize)>,
+        /// "Raw inset": the vendor crop, origin and size.
+        pub inset: Option<(usize, usize, usize, usize)>,
+        /// "Image flip".
+        pub flip: Option<u32>,
+        /// The first four letters of "Filter pattern".
+        pub filters: Option<String>,
+        /// "black:", the level common to every colour.
+        pub black: f32,
+        /// "cblack[0 .. 3]", the per-colour extra, R G B G2.
+        pub cblack: Option<[f32; 4]>,
+        /// "Highlight linearity limits", the first value.
+        pub linear_max: Option<f32>,
+        /// The "As shot" row of the white-balance table, R G B G2.
+        pub as_shot: Option<[f32; 4]>,
+    }
+
+    pub fn identify(path: &Path) -> Option<Identify> {
+        let text = std::fs::read_to_string(with_suffix(path, "identify.txt")).ok()?;
+        let mut out = Identify::default();
+        for line in text.lines() {
+            let line = line.trim();
+            if let Some(rest) = line.strip_prefix("Full size:") {
+                out.full = pair(rest);
+            } else if let Some(rest) = line.strip_prefix("Raw inset, width x height:") {
+                let numbers = numbers(rest);
+                if let [w, h, x, y] = numbers[..] {
+                    out.inset = Some((x as usize, y as usize, w as usize, h as usize));
+                }
+            } else if let Some(rest) = line.strip_prefix("Image flip:") {
+                out.flip = rest.trim().parse().ok();
+            } else if let Some(rest) = line.strip_prefix("Filter pattern:") {
+                out.filters = Some(rest.trim().chars().take(4).collect());
+            } else if let Some(rest) = line.strip_prefix("black:") {
+                out.black = rest.trim().parse().unwrap_or(0.0);
+            } else if let Some(rest) = line.strip_prefix("cblack[0 .. 3]:") {
+                let n = numbers(rest);
+                if let [a, b, c, d] = n[..] {
+                    out.cblack = Some([a, b, c, d]);
+                }
+            } else if let Some(rest) = line.strip_prefix("Highlight linearity limits:") {
+                out.linear_max = numbers(rest).first().copied();
+            } else if let Some(rest) = line.strip_prefix("As shot") {
+                let n = numbers(rest);
+                if n.len() >= 3 && n[1] > 0.0 {
+                    out.as_shot = Some([n[0] / n[1], 1.0, n[2] / n[1], 1.0]);
+                }
+            }
+        }
+        Some(out)
+    }
+
+    fn numbers(text: &str) -> Vec<f32> {
+        text.split(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
+            .filter(|s| !s.is_empty())
+            .filter_map(|s| s.parse().ok())
+            .collect()
+    }
+
+    fn pair(text: &str) -> Option<(usize, usize)> {
+        let n = numbers(text);
+        (n.len() >= 2).then(|| (n[0] as usize, n[1] as usize))
+    }
+
+    fn with_suffix(path: &Path, suffix: &str) -> PathBuf {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".");
+        name.push(suffix);
+        PathBuf::from(name)
+    }
+
+    /// Compare `raw.data` with `unprocessed_raw`'s frame, sample for
+    /// sample.
+    ///
+    /// One family of differences is accepted, because it is LibRaw
+    /// throwing information away rather than this crate inventing it:
+    /// on a handful of bodies LibRaw's `width` is a few pixels short of
+    /// the frame the file actually stores, and the columns past it come
+    /// out zero. Those columns hold real sensor readings, so they are
+    /// kept here; the test insists the oracle's side is zero and that
+    /// they are within 64 pixels of the right edge.
+    pub fn compare_samples(path: &Path, raw: &RawImage) {
+        let oracle = with_suffix(path, "tiff");
+        if !oracle.exists() {
+            eprintln!("{}: no oracle frame, samples unchecked", path.display());
+            return;
+        }
+        let image = image::open(&oracle)
+            .unwrap_or_else(|e| panic!("{}: {e}", oracle.display()))
+            .into_luma16();
+        assert_eq!(
+            (image.width() as usize, image.height() as usize),
+            (raw.width, raw.height),
+            "{}: frame size",
+            path.display()
+        );
+        let RawData::U16(mine) = &raw.data else {
+            panic!("{}: expected 16-bit samples", path.display())
+        };
+        let theirs = image.as_raw();
+        let mut mismatches = Vec::new();
+        for (i, (a, b)) in mine.iter().zip(theirs.iter()).enumerate() {
+            if a != b {
+                mismatches.push((i / raw.width, i % raw.width, *a, *b));
+            }
+        }
+        if mismatches.is_empty() {
+            return;
+        }
+        let edge = raw.width.saturating_sub(64);
+        if mismatches
+            .iter()
+            .all(|(_, col, _, theirs)| *theirs == 0 && *col >= edge)
+        {
+            let first = mismatches
+                .iter()
+                .map(|(_, col, _, _)| *col)
+                .min()
+                .unwrap_or(0);
+            eprintln!(
+                "{}: {} samples in columns {}..{} kept where LibRaw writes zero",
+                path.display(),
+                mismatches.len(),
+                first,
+                raw.width
+            );
+            return;
+        }
+        // The other accepted difference runs the other way: where a
+        // file declares an odd number of rows, the frame is rounded up
+        // to keep the CFA whole and the last row has no data behind it.
+        // This crate leaves it at zero; LibRaw leaves whatever its own
+        // buffer held.
+        if mismatches
+            .iter()
+            .all(|(row, _, mine, _)| *row + 1 == raw.height && *mine == 0)
+        {
+            eprintln!(
+                "{}: the padding row past the file's own row count is left blank",
+                path.display()
+            );
+            return;
+        }
+        let shown: Vec<_> = mismatches.iter().take(8).collect();
+        panic!(
+            "{}: {} of {} samples differ from the oracle, first {:?} (row, col, mine, theirs)",
+            path.display(),
+            mismatches.len(),
+            mine.len(),
+            shown
+        );
+    }
+
+    /// Levels, white balance, crop, orientation and CFA against
+    /// `raw-identify`. Deviations this crate makes deliberately are
+    /// named in each check.
+    pub fn compare_metadata(path: &Path, raw: &RawImage) {
+        let Some(identify) = identify(path) else {
+            eprintln!("{}: no identify output, metadata unchecked", path.display());
+            return;
+        };
+        let name = path.display();
+        if let Some((w, h)) = identify.full {
+            assert_eq!((raw.width, raw.height), (w, h), "{name}: full size");
+        }
+        if let Some(filters) = &identify.filters {
+            let mine: String = (0..4)
+                .map(|i| match raw.cfa.color_at(i % 2, i / 2) {
+                    Some(CfaColor::Red) => 'R',
+                    Some(CfaColor::Blue) => 'B',
+                    Some(CfaColor::Green) | Some(CfaColor::Green2) => 'G',
+                    Some(CfaColor::Cyan) => 'C',
+                    Some(CfaColor::Magenta) => 'M',
+                    Some(CfaColor::Yellow) => 'Y',
+                    _ => '?',
+                })
+                .collect();
+            assert_eq!(&mine, filters, "{name}: filter pattern");
+        }
+        if let Some(flip) = identify.flip {
+            let want = match flip {
+                3 => Orientation::Rotate180,
+                5 => Orientation::Rotate270CW,
+                6 => Orientation::Rotate90CW,
+                _ => Orientation::Normal,
+            };
+            assert_eq!(raw.orientation, want, "{name}: orientation");
+        }
+        if let Some(shot) = identify.as_shot {
+            for (i, want) in shot.iter().enumerate().take(3) {
+                let got = raw.wb_coeffs[i];
+                assert!(
+                    (got - want).abs() <= 0.01 * want.max(1.0),
+                    "{name}: white balance {:?} want {shot:?}",
+                    raw.wb_coeffs
+                );
+            }
+        }
+        // LibRaw reports black as a base plus a per-colour extra,
+        // indexed by colour (R, G, B, G2); this crate keeps one value a
+        // CFA position, so the two are compared through the pattern.
+        let cblack = identify.cblack.unwrap_or([0.0; 4]);
+        for position in 0..4 {
+            let want = identify.black + cblack[libraw_color(&raw.cfa, position)];
+            assert!(
+                (raw.black_levels[position] - want).abs() < 0.5,
+                "{name}: black {:?} want {want} at position {position}",
+                raw.black_levels
+            );
+        }
+        if let Some(max) = identify.linear_max {
+            assert!(
+                (raw.white_level - max).abs() <= 1.0 + 0.01 * max,
+                "{name}: white level {} want about {max}",
+                raw.white_level
+            );
+        }
+        if let Some((x, y, w, h)) = identify.inset {
+            assert_eq!(
+                (raw.crop.x, raw.crop.y, raw.crop.width, raw.crop.height),
+                (x, y, w, h),
+                "{name}: crop"
+            );
+        }
+    }
+
+    /// LibRaw's colour index (0 red, 1 green, 2 blue, 3 the second
+    /// green) for a CFA position 0..4 in raster order.
+    fn libraw_color(cfa: &Cfa, position: usize) -> usize {
+        let color = cfa.color_at(position % 2, position / 2);
+        let first_green = (0..4).find(|i| {
+            matches!(
+                cfa.color_at(i % 2, i / 2),
+                Some(CfaColor::Green) | Some(CfaColor::Green2)
+            )
+        });
+        match color {
+            Some(CfaColor::Red) => 0,
+            Some(CfaColor::Blue) => 2,
+            Some(CfaColor::Green) | Some(CfaColor::Green2) => {
+                if first_green == Some(position) {
+                    1
+                } else {
+                    3
+                }
+            }
+            _ => 0,
+        }
+    }
+
+    /// The preview has to be a JPEG a viewer can actually show.
+    pub fn check_preview(path: &Path, raw: &RawImage) {
+        let Some(preview) = &raw.preview else {
+            eprintln!("{}: no preview", path.display());
+            return;
+        };
+        image::load_from_memory(preview)
+            .unwrap_or_else(|e| panic!("{}: preview does not decode: {e}", path.display()));
+    }
+
+    /// Run `body` on `count` truncation lengths spread over a file,
+    /// including the awkward ends.
+    pub fn truncations(len: usize, count: usize, mut body: impl FnMut(usize)) {
+        for i in 0..count {
+            // A cheap deterministic spread: prime steps through the
+            // file, so the cuts land in headers, in the middle of the
+            // directory and inside the sensor data alike.
+            let cut = (len / (count + 1)) * (i + 1) + (i * 7919) % 1024;
+            body(cut.min(len));
+        }
+        for cut in [0, 1, 4, 8, 16, len.saturating_sub(1)] {
+            body(cut.min(len));
+        }
+    }
+}
+
+/// Corpus tests: every ORF under `SCHIST_RAW_CORPUS`, checked against
+/// the LibRaw oracle files beside it.
+#[cfg(test)]
+mod corpus {
+    use super::oracle;
+    use super::*;
+
+    fn files() -> Vec<std::path::PathBuf> {
+        oracle::corpus_files(&["orf"])
+    }
+
+    #[test]
+    fn every_file_matches_the_oracle() {
+        for path in &files() {
+            let bytes = std::fs::read(path).expect("corpus file readable");
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(Format::Orf),
+                "{} did not probe as ORF",
+                path.display()
+            );
+            let raw = crate::decode(&bytes).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+            raw.validate().expect("valid");
+            oracle::compare_samples(path, &raw);
+            oracle::compare_metadata(path, &raw);
+            oracle::check_preview(path, &raw);
+        }
+    }
+
+    #[test]
+    fn truncation_never_panics() {
+        for path in &files() {
+            let bytes = std::fs::read(path).expect("corpus file readable");
+            oracle::truncations(bytes.len(), 10, |cut| {
+                let _ = crate::decode(&bytes[..cut]);
+                let _ = crate::preview(&bytes[..cut]);
+            });
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/pef.rs
+++ b/crates/codec-raw/src/formats/pef.rs
@@ -1,0 +1,870 @@
+//! Pentax PEF: a big-endian TIFF whose IFD0 *is* the sensor frame.
+//!
+//! Pentax is unusual in putting the raw data in IFD0 (photometric
+//! 32803) rather than a SubIFD, and in giving it one of three
+//! compressions:
+//!
+//! * `1` — plain, one 16-bit word a pixel even when BitsPerSample says
+//!   12 (the `*ist D`).
+//! * `32773` — the same samples packed end to end, 12 bits each,
+//!   most-significant bit first (the `*ist DL` and the other 2005
+//!   bodies). TIFF gives 32773 to PackBits; Pentax reused the number.
+//! * `65535` — Pentax's own lossless compression: a Huffman-coded
+//!   difference per pixel, with the code table carried in the
+//!   makernote rather than in the stream. Everything from the K10D on.
+//!
+//! The metadata a developer needs — white balance, black point,
+//! saturation, the sensor's active area — is all in the makernote,
+//! which comes in two dialects that differ in where their offsets are
+//! measured from. See [`makernote`].
+//!
+//! Written from observation of the files and the TIFF 6.0 and Exif
+//! specifications; the tag *meanings* are ExifTool's published Pentax
+//! tag tables. No decoder source was consulted.
+
+use crate::bits::{BitPump, BitPumpMsb, HuffTable};
+use crate::formats::common;
+use crate::tiff::{tags, Ifd, ImageLayout, Tiff};
+use crate::{Cfa, CfaColor, Error, Format, RawData, RawImage, Rect, Result};
+
+/// Pentax's own lossless compression (Compression 65535).
+const COMPRESSION_PENTAX: u32 = 65535;
+/// Samples packed at their bit depth, no compression. TIFF spells
+/// PackBits with this number; Pentax means something else by it.
+const COMPRESSION_PACKED: u32 = 32773;
+
+/// Makernote tags this decoder reads. Names are ExifTool's.
+mod mn {
+    /// `ImageAreaOffset`: the active area's left and top in the frame.
+    pub const IMAGE_AREA_OFFSET: u16 = 0x0038;
+    /// `RawImageSize`: the active area's width and height.
+    pub const RAW_IMAGE_SIZE: u16 = 0x0039;
+    /// `WhiteLevel`: the sensor's saturation point, per body and ISO.
+    pub const WHITE_LEVEL: u16 = 0x007E;
+    /// `BlackPoint`: four shorts, R G1 G2 B.
+    pub const BLACK_POINT: u16 = 0x0200;
+    /// `WhitePoint`: the as-shot white balance, four shorts, R G1 G2 B,
+    /// scaled so green is `DataScaling` (8192 on every body seen).
+    pub const WHITE_POINT: u16 = 0x0201;
+    /// `HuffmanTable`: the code table for Compression 65535.
+    pub const HUFFMAN_TABLE: u16 = 0x0220;
+}
+
+/// Decode a PEF into its sensor frame and metadata.
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let tiff = Tiff::parse(bytes)?;
+    let ifd = raw_ifd(&tiff)?;
+    let layout = ImageLayout::of(&tiff, ifd)?;
+    let (width, height) = (layout.width, layout.height);
+    if width == 0 || height == 0 || width > 1 << 16 || height > 1 << 16 {
+        return Err(Error::Corrupt(format!("PEF frame is {width}x{height}")));
+    }
+
+    let maker = makernote(&tiff);
+    let data = match layout.compression {
+        COMPRESSION_PENTAX => {
+            let table = maker
+                .as_ref()
+                .and_then(|m| m.find(mn::HUFFMAN_TABLE))
+                .and_then(|e| e.bytes())
+                .ok_or_else(|| {
+                    Error::Corrupt("Pentax-compressed PEF without makernote tag 0x0220".into())
+                })?;
+            // The table's shorts follow the makernote's byte order, not
+            // necessarily the file's: an "AOC" makernote can be
+            // big-endian inside a big-endian file while the newer
+            // "PENTAX" one is little-endian inside the same.
+            let little_endian = maker.as_ref().is_some_and(|m| m.little_endian());
+            let huffman = huffman_table(table, little_endian)?;
+            let stream = strip(bytes, &layout);
+            // A coded sample is at least a bit: the strips bound the
+            // frame a forged header may claim.
+            let samples = crate::frame_samples(width, height, 1)?;
+            if stream.len().saturating_mul(8) < samples {
+                return Err(Error::Corrupt(format!(
+                    "PEF frame of {samples} samples in {} bytes",
+                    stream.len()
+                )));
+            }
+            decompress(&stream, &huffman, width, height)
+        }
+        COMPRESSION_PACKED | 1 => unpack(&tiff, &layout)?,
+        other => {
+            return Err(Error::Unsupported(format!(
+                "PEF compression {other}, not 1 (plain), 32773 (packed) or 65535 (Pentax)"
+            )))
+        }
+    };
+
+    let mut raw = RawImage::new(
+        Format::Pef,
+        width,
+        height,
+        1,
+        RawData::U16(data),
+        Cfa::Bayer([CfaColor::Red; 4]),
+    );
+    let (make, model) = tiff.make_model();
+    raw.set_camera(&make, &model);
+    raw.cfa = cfa_for(&raw.clean_model);
+    raw.orientation = common::orientation(&tiff);
+    raw.metadata = common::metadata(&tiff);
+    raw.preview = common::largest_jpeg(&tiff);
+
+    // Saturation: the body records the real one, which sits a little
+    // below the bit depth's ceiling (16316 rather than 16383 on the
+    // K-5) because the sensor's response bends before it clips. Older
+    // bodies record nothing and the bit depth is all there is.
+    raw.white_level = maker
+        .as_ref()
+        .and_then(|m| m.find(mn::WHITE_LEVEL))
+        .and_then(|e| e.f64(0))
+        .filter(|w| *w > 0.0)
+        .map(|w| w as f32)
+        .unwrap_or_else(|| ((1u32 << layout.bits_per_sample.min(16)) - 1) as f32);
+
+    if let Some(levels) = maker.as_ref().and_then(|m| quad(m, mn::BLACK_POINT)) {
+        raw.black_levels = by_position(&raw.cfa, levels);
+    }
+    if let Some(wb) = maker.as_ref().and_then(|m| quad(m, mn::WHITE_POINT)) {
+        // R G1 G2 B in the tag; R G B G2 in `wb_coeffs`, green at 1.0.
+        let green = wb[1];
+        if green > 0.0 && wb.iter().all(|v| *v > 0.0) {
+            raw.wb_coeffs = [wb[0] / green, 1.0, wb[3] / green, wb[2] / green];
+        }
+    }
+    raw.crop = active_area(maker.as_ref(), width, height);
+
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+/// The largest embedded JPEG: the full-size preview Pentax keeps in
+/// its own IFD, not the 160x120 thumbnail in IFD1.
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    Ok(common::largest_jpeg(&Tiff::parse(bytes)?))
+}
+
+// ------------------------------------------------------------ structure
+
+/// The IFD holding sensor samples. Pentax puts it in IFD0, but look
+/// for the photometric rather than assume the position.
+fn raw_ifd<'a>(tiff: &'a Tiff<'_>) -> Result<&'a Ifd> {
+    tiff.all()
+        .into_iter()
+        .find(|ifd| ifd.get(tags::PHOTOMETRIC).and_then(|e| e.u32(0)) == Some(32803))
+        .ok_or_else(|| Error::Corrupt("PEF with no CFA image IFD".into()))
+}
+
+/// The makernote as a TIFF, in whichever of the two dialects it uses.
+///
+/// Both start with a signature and a two-byte order mark, and both
+/// then hold a plain IFD, but they disagree about offsets:
+///
+/// * `AOC\0` (through the K-5 and the 645D) — six bytes of header,
+///   and the IFD's offsets are file-absolute like any other IFD's.
+/// * `PENTAX \0` (the K-3 on) — ten bytes of header, and offsets are
+///   measured from the start of the makernote itself, so the whole
+///   block can be moved without rewriting it.
+///
+/// Reading one with the other's rule yields entries that point into
+/// unrelated parts of the file rather than an obvious failure, so the
+/// signature has to be honoured exactly.
+fn makernote<'a>(tiff: &Tiff<'a>) -> Option<Tiff<'a>> {
+    let bytes = tiff.bytes();
+    let entry = tiff.find(tags::MAKER_NOTE)?;
+    let start = entry.offset;
+    let header = match bytes.get(start..start.checked_add(8)?)? {
+        b if b.starts_with(b"AOC\0") => 4,
+        b if b.starts_with(b"PENTAX \0") => 8,
+        _ => return None,
+    };
+    let little_endian = match bytes.get(start + header..start + header + 2)? {
+        b"II" => true,
+        b"MM" => false,
+        _ => return None,
+    };
+    let ifd = start + header + 2;
+    let base = if header == 4 { 0 } else { start };
+    Tiff::parse_at_relative(bytes, ifd, base, little_endian).ok()
+}
+
+/// A four-short makernote value as floats, in the tag's own R G1 G2 B
+/// order.
+fn quad(maker: &Tiff<'_>, tag: u16) -> Option<[f32; 4]> {
+    let entry = maker.find(tag)?;
+    let values: Vec<f32> = (0..4)
+        .filter_map(|i| entry.f64(i))
+        .map(|v| v as f32)
+        .collect();
+    values.try_into().ok()
+}
+
+/// Spread a tag's R G1 G2 B quad over the frame's four CFA positions.
+///
+/// The tag is always in sensor-colour order; `black_levels` is in
+/// row-major position order, and the two only coincide on the RGGB
+/// bodies. The first green a row-major walk meets is taken for G1.
+fn by_position(cfa: &Cfa, values: [f32; 4]) -> [f32; 4] {
+    let mut greens = 0;
+    std::array::from_fn(|i| match cfa.color_at(i % 2, i / 2) {
+        Some(CfaColor::Red) => values[0],
+        Some(CfaColor::Blue) => values[3],
+        Some(CfaColor::Green | CfaColor::Green2) => {
+            greens += 1;
+            values[greens.min(2)]
+        }
+        _ => values[0],
+    })
+}
+
+/// The active area: everything but the sensor's dark border.
+///
+/// The bodies through the 645D record it as `ImageAreaOffset` and
+/// `RawImageSize`, which agree exactly with the size of the camera's
+/// own full-size preview. The K-3 and later record neither and their
+/// frames have no border to trim, so the whole frame is the picture.
+fn active_area(maker: Option<&Tiff<'_>>, width: usize, height: usize) -> Rect {
+    let whole = Rect {
+        x: 0,
+        y: 0,
+        width,
+        height,
+    };
+    let Some(maker) = maker else { return whole };
+    let pair = |tag: u16| -> Option<(usize, usize)> {
+        let entry = maker.find(tag)?;
+        Some((entry.u32(0)? as usize, entry.u32(1)? as usize))
+    };
+    let (Some((x, y)), Some((w, h))) = (pair(mn::IMAGE_AREA_OFFSET), pair(mn::RAW_IMAGE_SIZE))
+    else {
+        return whole;
+    };
+    if w == 0 || h == 0 || x + w > width || y + h > height {
+        return whole;
+    }
+    Rect {
+        x,
+        y,
+        width: w,
+        height: h,
+    }
+}
+
+/// Which way round the Bayer quad sits, by body.
+///
+/// A PEF says nothing about its filter array: IFD0 carries no
+/// CFAPattern, and the makernote has no equivalent. The layout is a
+/// property of the sensor, so it is looked up by model. Every entry
+/// here was read out of the CFAPattern of a DNG the same body wrote
+/// (Pentax bodies can shoot DNG) or, where none was to hand, confirmed
+/// against the greens of a real frame from that body.
+///
+/// Pentax has used RGGB on nearly everything; the exceptions below are
+/// the bodies in this crate's corpus that are not. An unlisted body
+/// gets RGGB, which is right far more often than not — and wrong in a
+/// way a developed picture makes obvious at once (red and blue swap).
+fn cfa_for(clean_model: &str) -> Cfa {
+    let model = clean_model.to_ascii_uppercase();
+    match model.as_str() {
+        // source: CFAPattern of 645D2839.DNG (the same camera's DNG
+        // output) and of the K20D's and K-5's frames.
+        "645D" | "K20D" | "K-5" => Cfa::BGGR,
+        _ => Cfa::RGGB,
+    }
+}
+
+/// The compressed stream as one contiguous slice. Pentax writes a
+/// single strip, which is handed back borrowed; the join is only for
+/// files that do not.
+fn strip<'a>(bytes: &'a [u8], layout: &ImageLayout) -> std::borrow::Cow<'a, [u8]> {
+    if let [(start, len)] = layout.chunks[..] {
+        // `ImageLayout::of` has already checked every chunk lies
+        // inside the file, so this cannot be out of range.
+        return std::borrow::Cow::Borrowed(&bytes[start..start + len]);
+    }
+    // Strips that add up to more than the file are a forgery (the same
+    // bytes named over and over); an empty stream fails the decode.
+    let total: usize = layout.chunks.iter().map(|(_, len)| len).sum();
+    if total > bytes.len() {
+        return std::borrow::Cow::Owned(Vec::new());
+    }
+    let mut out = Vec::with_capacity(total);
+    for (start, len) in &layout.chunks {
+        out.extend_from_slice(&bytes[*start..*start + *len]);
+    }
+    std::borrow::Cow::Owned(out)
+}
+
+// ------------------------------------------------------- uncompressed
+
+/// Plain frames: 16-bit words when the strip is big enough for them,
+/// otherwise samples packed at `BitsPerSample`.
+///
+/// Compression 1 and 32773 do not reliably tell the two apart — the
+/// `*ist D` writes 12-bit samples in 16-bit words under Compression 1
+/// — so the strip's own size decides, which is a fact of the file
+/// rather than a guess about the body.
+fn unpack(tiff: &Tiff<'_>, layout: &ImageLayout) -> Result<Vec<u16>> {
+    let bytes = tiff.bytes();
+    let (width, height) = (layout.width, layout.height);
+    let bits = layout.bits_per_sample;
+    if !(1..=16).contains(&bits) {
+        return Err(Error::Unsupported(format!("PEF with {bits} bits a sample")));
+    }
+    let total: usize = layout.chunks.iter().map(|(_, len)| *len).sum();
+    let words = total >= width.saturating_mul(height).saturating_mul(2);
+
+    // The strips bound the frame a forged header may claim.
+    let samples = crate::frame_samples(width, height, 1)?;
+    if total.saturating_mul(8) < samples {
+        return Err(Error::Corrupt(format!(
+            "PEF frame of {samples} samples in {total} bytes of strips"
+        )));
+    }
+    let mut out = vec![0u16; samples];
+    let rows_per_chunk = layout.rows_per_chunk.max(1);
+    for (chunk, (start, len)) in layout.chunks.iter().enumerate() {
+        let first_row = chunk * rows_per_chunk;
+        if first_row >= height {
+            break;
+        }
+        let rows = rows_per_chunk.min(height - first_row);
+        let Some(data) = bytes.get(*start..*start + *len) else {
+            return Err(Error::Corrupt("PEF strip outside the file".into()));
+        };
+        // Rows are padded to a byte boundary; at 12 and 16 bits and
+        // the widths Pentax uses this is never actually padding, but
+        // deriving the stride rather than assuming it keeps a frame
+        // with an odd width honest.
+        let stride = if words {
+            width * 2
+        } else {
+            (width * bits as usize).div_ceil(8)
+        };
+        let target = &mut out[first_row * width..(first_row + rows) * width];
+        for (row, samples) in target.chunks_mut(width).enumerate() {
+            let from = row * stride;
+            let source = data
+                .get(from..(from + stride).min(data.len()))
+                .unwrap_or(&[]);
+            if words {
+                for (i, sample) in samples.iter_mut().enumerate() {
+                    let at = i * 2;
+                    let pair: [u8; 2] = match source.get(at..at + 2) {
+                        Some(b) => [b[0], b[1]],
+                        // A truncated strip leaves the rest of the
+                        // frame black rather than failing: the file is
+                        // still worth showing as far as it goes.
+                        None => break,
+                    };
+                    *sample = if tiff.little_endian() {
+                        u16::from_le_bytes(pair)
+                    } else {
+                        u16::from_be_bytes(pair)
+                    };
+                }
+            } else {
+                let mut pump = BitPumpMsb::new(source);
+                for sample in samples.iter_mut() {
+                    *sample = pump.get(bits) as u16;
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+// --------------------------------------------------------- compression
+
+/// Build a [`HuffTable`] from makernote tag 0x0220.
+///
+/// The tag is a compact form of a canonical Huffman code:
+///
+/// ```text
+///   u16  n          the entry count, disguised: (n + 12) & 15
+///   u16  [6]        unread; zero on most bodies
+///   u16  code[N]    each code left-aligned in twelve bits
+///   u8   length[N]  the code's real length in bits
+/// ```
+///
+/// The symbol of entry `i` is `i` itself: the number of extra bits the
+/// pixel's difference is written in, exactly as in lossless JPEG. So a
+/// 12-bit body has thirteen entries (differences of 0..=12 bits) and a
+/// 14-bit body fifteen.
+///
+/// The codes are canonical — sorted by length, and by code within a
+/// length, they are the sequence JPEG's DHT rules generate — so the
+/// table can be handed to the crate's shared [`HuffTable`] once the
+/// symbols are put in that order. This is checked rather than assumed:
+/// a table that is not canonical would decode to silent nonsense.
+pub fn huffman_table(tag: &[u8], little_endian: bool) -> Result<HuffTable> {
+    let short = |at: usize| -> Option<u16> {
+        let pair: [u8; 2] = tag.get(at..at + 2)?.try_into().ok()?;
+        Some(if little_endian {
+            u16::from_le_bytes(pair)
+        } else {
+            u16::from_be_bytes(pair)
+        })
+    };
+    let count = short(0).ok_or_else(|| Error::Corrupt("empty Pentax Huffman table".into()))?;
+    // Wrapping at sixteen is the format's own arithmetic: the stored
+    // count is the entry count less twelve, modulo sixteen, so a
+    // thirteen-entry table stores 1 and a fifteen-entry table 3.
+    let entries = ((count as usize + 12) & 15).max(1);
+    let needed = 14 + entries * 3;
+    if tag.len() < needed {
+        return Err(Error::Corrupt(format!(
+            "Pentax Huffman table promises {entries} entries but carries {} bytes, not {needed}",
+            tag.len()
+        )));
+    }
+    let mut table: Vec<(u8, u16, u8)> = Vec::with_capacity(entries);
+    for i in 0..entries {
+        let code = short(14 + i * 2).unwrap_or(0);
+        let length = tag[14 + entries * 2 + i];
+        if length == 0 || length > 12 {
+            return Err(Error::Corrupt(format!(
+                "Pentax Huffman code {i} is {length} bits, outside 1..=12"
+            )));
+        }
+        // Stored left-aligned in twelve bits, however long it is.
+        table.push((length, code >> (12 - length as u32), i as u8));
+    }
+
+    let mut sorted = table.clone();
+    sorted.sort_by_key(|(length, code, _)| (*length, *code));
+    let mut counts = [0u8; 16];
+    let mut symbols = Vec::with_capacity(entries);
+    for (length, _, symbol) in &sorted {
+        counts[*length as usize - 1] += 1;
+        symbols.push(*symbol);
+    }
+    // Re-derive the canonical code of each entry and insist the file's
+    // agrees. Cheap, and it turns a malformed table into an error
+    // instead of an image of noise.
+    let mut code: u32 = 0;
+    let mut previous = 0u8;
+    for (length, stored, _) in &sorted {
+        code <<= length - previous;
+        previous = *length;
+        if code != *stored as u32 {
+            return Err(Error::Corrupt(format!(
+                "Pentax Huffman table is not canonical: a {length}-bit code is \
+                 {stored:#x} where the canonical order gives {code:#x}"
+            )));
+        }
+        code += 1;
+    }
+    HuffTable::new(&counts, &symbols)
+}
+
+/// Decode a Pentax-compressed frame.
+///
+/// One Huffman-coded difference per pixel, in row-major order, over a
+/// single MSB-first bit stream with no marker stuffing and no
+/// restarts. The predictor is the pixel two to the left — the previous
+/// one of the same colour — which leaves the first two pixels of every
+/// row without one; those continue a running total kept per column
+/// (0 or 1) and per row parity, so each of the four CFA positions has
+/// its own left-hand seed running down the frame. The seeds start at
+/// zero, which makes the top-left corner of the frame the origin the
+/// whole image is differenced from.
+fn decompress(data: &[u8], huffman: &HuffTable, width: usize, height: usize) -> Vec<u16> {
+    // The frame ceiling alone: a truncated stream decodes to zeros
+    // past its end (see `a_truncated_stream_does_not_panic`), and the
+    // caller has already checked the strips are plausible for it.
+    let Ok(samples) = crate::frame_samples(width, height, 1) else {
+        return Vec::new();
+    };
+    let mut out = vec![0u16; samples];
+    let mut pump = BitPumpMsb::new(data);
+    // [row parity][column parity]: the left edge's running totals.
+    let mut vertical = [[0u16; 2]; 2];
+    for (row, samples) in out.chunks_mut(width).enumerate() {
+        let mut horizontal = [0u16; 2];
+        for (col, sample) in samples.iter_mut().enumerate() {
+            // Wrapping: a difference is a 16-bit quantity and a
+            // corrupt stream must wrap rather than panic in debug.
+            let diff = huffman.decode_diff(&mut pump) as u16;
+            let value = if col < 2 {
+                let seed = &mut vertical[row & 1][col];
+                *seed = seed.wrapping_add(diff);
+                horizontal[col] = *seed;
+                *seed
+            } else {
+                horizontal[col & 1] = horizontal[col & 1].wrapping_add(diff);
+                horizontal[col & 1]
+            };
+            *sample = value;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The K10D's table, as its makernote carries it: thirteen
+    /// entries, big-endian, differences of up to twelve bits.
+    const K10D_TABLE: &[u8] = &[
+        0x00, 0x01, 0x00, 0x00, 0x00, 0x16, 0x00, 0x28, 0x00, 0x49, 0x00, 0x23, 0x00, 0x4d, //
+        0x0f, 0x00, 0x0c, 0x00, 0x08, 0x00, 0x00, 0x00, 0x04, 0x00, 0x0a, 0x00, 0x0e, 0x00, //
+        0x0f, 0x80, 0x0f, 0xc0, 0x0f, 0xe0, 0x0f, 0xf0, 0x0f, 0xf8, 0x0f, 0xfc, //
+        5, 3, 3, 2, 2, 3, 4, 6, 7, 8, 9, 10, 10,
+    ];
+
+    #[test]
+    fn huffman_table_reads_the_stored_count() {
+        // (1 + 12) & 15 == 13 entries, so 14 + 39 bytes are consumed.
+        let table = huffman_table(K10D_TABLE, false).expect("K10D table");
+        // Symbol 3 has the shortest code, 0b00: a two-bit read of two
+        // zero bits must give it.
+        let mut pump = BitPumpMsb::new(&[0b0001_1001, 0b0100_0000]);
+        assert_eq!(table.decode(&mut pump), 3);
+        assert_eq!(table.decode(&mut pump), 4); // 0b01
+        assert_eq!(table.decode(&mut pump), 2); // 0b100
+        assert_eq!(table.decode(&mut pump), 5); // 0b101
+    }
+
+    #[test]
+    fn huffman_table_rejects_a_short_tag() {
+        assert!(huffman_table(&K10D_TABLE[..20], false).is_err());
+        assert!(huffman_table(&[], false).is_err());
+        assert!(huffman_table(&[0x00], false).is_err());
+    }
+
+    #[test]
+    fn huffman_table_rejects_a_non_canonical_table() {
+        let mut broken = K10D_TABLE.to_vec();
+        // Move the first code without touching its length: still a
+        // valid-looking table, no longer the canonical one.
+        broken[14] = 0x0e;
+        assert!(huffman_table(&broken, false).is_err());
+    }
+
+    #[test]
+    fn huffman_table_rejects_an_impossible_length() {
+        let mut broken = K10D_TABLE.to_vec();
+        *broken.last_mut().expect("lengths") = 13;
+        assert!(huffman_table(&broken, false).is_err());
+    }
+
+    /// Differences accumulate along a row from the pixel two to the
+    /// left, and the first two pixels of a row from the same-parity
+    /// row above. Encoded by hand with the K10D's code: symbol 3 is
+    /// 0b00 and takes three value bits, symbol 0 is 0b11110 and takes
+    /// none.
+    #[test]
+    fn differences_run_along_rows_and_down_the_edges() {
+        let table = huffman_table(K10D_TABLE, false).expect("K10D table");
+        let mut bits = BitWriter::default();
+        // Row 0: seeds of +7 and +6, then four zero differences.
+        bits.put(0b00, 2);
+        bits.put(0b111, 3);
+        bits.put(0b00, 2);
+        bits.put(0b110, 3);
+        for _ in 0..4 {
+            bits.put(0b11110, 5);
+        }
+        // Row 1: seeds of +1 and +2 (a one-bit difference is symbol 1,
+        // 0b110), then four more zero differences.
+        bits.put(0b110, 3);
+        bits.put(1, 1);
+        bits.put(0b110, 3);
+        bits.put(1, 1);
+        for _ in 0..4 {
+            bits.put(0b11110, 5);
+        }
+        let out = decompress(&bits.finish(), &table, 6, 2);
+        assert_eq!(out, vec![7, 6, 7, 6, 7, 6, 1, 1, 1, 1, 1, 1]);
+    }
+
+    /// A truncated stream reads zero bits past the end, so the rest of
+    /// the frame repeats its last value instead of panicking.
+    #[test]
+    fn a_truncated_stream_does_not_panic() {
+        let table = huffman_table(K10D_TABLE, false).expect("K10D table");
+        for len in 0..8 {
+            let out = decompress(&vec![0xff; len], &table, 64, 8);
+            assert_eq!(out.len(), 64 * 8);
+        }
+    }
+
+    #[test]
+    fn by_position_follows_the_filter_array() {
+        // R G1 G2 B = 1 2 3 4.
+        let values = [1.0, 2.0, 3.0, 4.0];
+        assert_eq!(by_position(&Cfa::RGGB, values), [1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(by_position(&Cfa::BGGR, values), [4.0, 2.0, 3.0, 1.0]);
+        assert_eq!(by_position(&Cfa::GRBG, values), [2.0, 1.0, 4.0, 3.0]);
+    }
+
+    #[derive(Default)]
+    struct BitWriter {
+        out: Vec<u8>,
+        cache: u32,
+        bits: u32,
+    }
+
+    impl BitWriter {
+        fn put(&mut self, value: u32, bits: u32) {
+            self.cache = (self.cache << bits) | (value & ((1 << bits) - 1));
+            self.bits += bits;
+            while self.bits >= 8 {
+                self.bits -= 8;
+                self.out.push((self.cache >> self.bits) as u8);
+            }
+        }
+        fn finish(mut self) -> Vec<u8> {
+            if self.bits > 0 {
+                self.out.push((self.cache << (8 - self.bits)) as u8);
+            }
+            self.out
+        }
+    }
+
+    // ------------------------------------------------------------ corpus
+    //
+    // Gated on SCHIST_RAW_CORPUS: a directory of camera files, walked
+    // recursively. Beside each file the harness leaves LibRaw's own
+    // output, which is what "exactly" is measured against:
+    //
+    //   <file>.tiff          `unprocessed_raw -T`: the whole sensor
+    //                        frame, 16-bit grey, black not subtracted
+    //   <file>.identify.txt  `raw-identify -v -w`
+    //
+    // Both are optional; a file with neither is still decoded and
+    // validated.
+
+    use std::path::{Path, PathBuf};
+
+    /// Every file under `SCHIST_RAW_CORPUS` this module claims.
+    fn corpus() -> Vec<PathBuf> {
+        let Ok(root) = std::env::var("SCHIST_RAW_CORPUS") else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        let mut stack = vec![PathBuf::from(root)];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path
+                    .extension()
+                    .is_some_and(|e| e.eq_ignore_ascii_case("pef"))
+                {
+                    out.push(path);
+                }
+            }
+        }
+        out.sort();
+        out
+    }
+
+    /// LibRaw's unpacked frame, when the harness left one.
+    fn oracle(path: &Path) -> Option<(usize, usize, Vec<u16>)> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".tiff");
+        let path = PathBuf::from(name);
+        if !path.exists() {
+            return None;
+        }
+        let image = image::open(&path).expect("oracle TIFF loads").into_luma16();
+        let (width, height) = (image.width() as usize, image.height() as usize);
+        Some((width, height, image.into_raw()))
+    }
+
+    /// `raw-identify`'s report, as lines.
+    fn identify(path: &Path) -> Option<String> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".identify.txt");
+        std::fs::read_to_string(PathBuf::from(name)).ok()
+    }
+
+    /// The rest of the line introduced by `key`.
+    fn field<'a>(report: &'a str, key: &str) -> Option<&'a str> {
+        report
+            .lines()
+            .find_map(|line| line.trim_start().strip_prefix(key))
+            .map(str::trim)
+    }
+
+    /// The numbers on the line introduced by `key`.
+    fn numbers(report: &str, key: &str) -> Vec<f32> {
+        field(report, key)
+            .map(|rest| {
+                rest.split(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
+                    .filter(|t| !t.is_empty())
+                    .filter_map(|t| t.parse().ok())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// LibRaw's "Filter pattern" line as this crate's [`Cfa`].
+    fn cfa_of(report: &str) -> Option<Cfa> {
+        let pattern = field(report, "Filter pattern:")?;
+        let colors: Vec<CfaColor> = pattern
+            .chars()
+            .take(4)
+            .map(|c| match c {
+                'R' => CfaColor::Red,
+                'B' => CfaColor::Blue,
+                _ => CfaColor::Green,
+            })
+            .collect();
+        Some(Cfa::Bayer(colors.try_into().ok()?))
+    }
+
+    #[test]
+    fn corpus_matches_the_oracle() {
+        let files = corpus();
+        for path in &files {
+            let bytes = std::fs::read(path).expect("corpus file reads");
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(Format::Pef),
+                "{} did not probe as PEF",
+                path.display()
+            );
+            let raw = match crate::decode(&bytes) {
+                Ok(raw) => raw,
+                Err(error) => panic!("{}: {error}", path.display()),
+            };
+            raw.validate().expect("decoded frame is self-consistent");
+            assert_eq!(raw.cpp, 1);
+
+            if let Some((width, height, expected)) = oracle(path) {
+                assert_eq!(
+                    (raw.width, raw.height),
+                    (width, height),
+                    "{}: frame size",
+                    path.display()
+                );
+                let RawData::U16(got) = &raw.data else {
+                    panic!("{}: PEF frames are integers", path.display())
+                };
+                let wrong: Vec<usize> = got
+                    .iter()
+                    .zip(&expected)
+                    .enumerate()
+                    .filter(|(_, (a, b))| a != b)
+                    .map(|(i, _)| i)
+                    .collect();
+                assert!(
+                    wrong.is_empty(),
+                    "{}: {} of {} samples differ from the oracle; first: {:?}",
+                    path.display(),
+                    wrong.len(),
+                    got.len(),
+                    wrong
+                        .iter()
+                        .take(4)
+                        .map(|i| (i % width, i / width, got[*i], expected[*i]))
+                        .collect::<Vec<_>>()
+                );
+            }
+
+            if let Some(report) = identify(path) {
+                let size = numbers(&report, "Full size:");
+                if let [width, height] = size[..] {
+                    assert_eq!(
+                        (raw.width, raw.height),
+                        (width as usize, height as usize),
+                        "{}: full size",
+                        path.display()
+                    );
+                }
+                if let Some(cfa) = cfa_of(&report) {
+                    assert_eq!(raw.cfa, cfa, "{}: filter pattern", path.display());
+                }
+                // cblack is per sensor colour (R G B G2); ours is per
+                // position, so compare through the pattern.
+                let black = numbers(&report, "cblack[0 .. 3]:");
+                if let [r, g, b, g2] = black[..] {
+                    let expected = by_position(&raw.cfa, [r, g, g2, b]);
+                    assert_eq!(
+                        raw.black_levels,
+                        expected,
+                        "{}: black levels",
+                        path.display()
+                    );
+                }
+                // "As shot" is cam_mul: R G B G2, unnormalised.
+                let shot = numbers(&report, "As shot");
+                if let [r, g, b, g2] = shot[..4.min(shot.len())] {
+                    for (got, want) in raw.wb_coeffs.iter().zip([r / g, 1.0, b / g, g2 / g]) {
+                        assert!(
+                            (got - want).abs() < 1e-4,
+                            "{}: white balance {:?} not {:?}",
+                            path.display(),
+                            raw.wb_coeffs,
+                            [r / g, 1.0, b / g, g2 / g]
+                        );
+                    }
+                }
+                // LibRaw's saturation, where it prints one.
+                let white = numbers(&report, "Highlight linearity limits:");
+                if let Some(first) = white.first() {
+                    assert_eq!(raw.white_level, *first, "{}: white level", path.display());
+                }
+                if let Some(flip) = numbers(&report, "Image flip:").first() {
+                    let expected = match *flip as i32 {
+                        3 => crate::Orientation::Rotate180,
+                        5 => crate::Orientation::Rotate270CW,
+                        6 => crate::Orientation::Rotate90CW,
+                        _ => crate::Orientation::Normal,
+                    };
+                    assert_eq!(raw.orientation, expected, "{}: flip", path.display());
+                }
+            }
+
+            // The crop is deliberately the camera's own active area
+            // rather than LibRaw's per-model margins (see the module
+            // notes), so it is checked against the makernote instead:
+            // where the body records one, the crop is exactly it, and
+            // where it does not, the crop is the whole frame.
+            let maker = makernote(&Tiff::parse(&bytes).expect("parses"));
+            let recorded = maker
+                .as_ref()
+                .is_some_and(|m| m.find(mn::RAW_IMAGE_SIZE).is_some());
+            if !recorded {
+                assert_eq!(
+                    (raw.crop.width, raw.crop.height),
+                    (raw.width, raw.height),
+                    "{}: a body that records no active area keeps the whole frame",
+                    path.display()
+                );
+            }
+            assert!(raw.crop.x + raw.crop.width <= raw.width);
+            assert!(raw.crop.y + raw.crop.height <= raw.height);
+
+            let preview = raw.preview.as_ref().expect("every PEF carries a preview");
+            let decoded = image::load_from_memory(preview).expect("preview decodes");
+            assert!(decoded.width() > 0 && decoded.height() > 0);
+        }
+        eprintln!("pef: {} corpus files matched", files.len());
+    }
+
+    /// Truncation must never panic, however deep into the file it
+    /// happens: a partial frame or an error, both are fine.
+    #[test]
+    fn truncated_files_do_not_panic() {
+        for path in corpus() {
+            let bytes = std::fs::read(&path).expect("corpus file reads");
+            // A spread of cuts: the header, the IFDs, the makernote,
+            // and points through the image data.
+            for numerator in [0usize, 1, 2, 3, 5, 8, 13, 100, 500, 900, 999] {
+                let cut = bytes.len() * numerator / 1000;
+                let _ = crate::decode(&bytes[..cut]);
+                let _ = preview(&bytes[..cut]);
+            }
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/raf.rs
+++ b/crates/codec-raw/src/formats/raf.rs
@@ -1,0 +1,1195 @@
+//! RAF — Fujifilm's own container, and the only one here that is not a
+//! TIFF at heart.
+//!
+//! A RAF is three blobs bolted to a fixed 100-byte header: the
+//! camera's full-size JPEG (which carries the only Exif in the file),
+//! a tagged "CFA header" of Fujifilm's own metadata, and the sensor
+//! frame. The header gives each an offset and a length as big-endian
+//! 32-bit words, at 84, 92 and 100 respectively; nothing else in the
+//! file points anywhere, so a RAF is read strictly top-down.
+//!
+//! The metadata block is a big-endian count followed by that many
+//! `tag: u16, size: u16, data[size]` records. The handful this decoder
+//! needs are named in [`meta`]; the rest are colour-science tables the
+//! camera uses for its own JPEG engine.
+//!
+//! The sensor frame comes in two generations. Cameras up to about 2010
+//! store bare 16-bit samples. Everything since wraps them in a tiny
+//! private TIFF whose one IFD0 entry, 0xF000, points at the real
+//! directory: dimensions, bit depth, one strip, the black levels and
+//! the as-shot white balance. That strip is either 16-bit words, one
+//! of two packings of narrower samples, or Fujifilm's own compression
+//! (see [`super::raf_compressed`]).
+//!
+//! Everything here was written from observation of real files, the
+//! oracle outputs beside them and ExifTool's published RAF tag tables.
+
+use crate::bits::{BitPump, BitPumpMsb32};
+use crate::formats::common;
+use crate::tiff::Tiff;
+use crate::{Cfa, CfaColor, Error, Format, RawData, RawImage, Rect, Result};
+use rayon::prelude::*;
+
+/// The magic every RAF starts with. The 16th byte is a space in every
+/// file seen, but it is not checked: [`crate::probe`] matches 15.
+const MAGIC: &[u8] = b"FUJIFILMCCD-RAW";
+
+/// Tags of the "CFA header" metadata block, as ExifTool documents them.
+pub mod meta {
+    /// Full sensor frame, `(height, width)`.
+    pub const RAW_FULL_SIZE: u16 = 0x0100;
+    /// Where the picture starts inside that frame, `(top, left)`.
+    pub const CROP_TOP_LEFT: u16 = 0x0110;
+    /// How much of it is picture, `(height, width)`.
+    pub const CROPPED_SIZE: u16 = 0x0111;
+    /// Four bytes describing how the samples are laid out; see
+    /// [`super::Layout`].
+    pub const FUJI_LAYOUT: u16 = 0x0130;
+    /// The 6x6 X-Trans filter array, one byte a cell.
+    pub const XTRANS_LAYOUT: u16 = 0x0131;
+    /// `(bits, bits * 3)` — the only bit depth the pre-TIFF
+    /// generation records.
+    pub const BIT_DEPTH: u16 = 0x0141;
+    /// Per-CFA-position black, in G R G2 B order.
+    pub const BLACK_LEVELS: u16 = 0x4000;
+    /// As-shot white balance, in G R G2 B order.
+    pub const WB_GRGB: u16 = 0x2ff0;
+}
+
+/// Tags of the private TIFF in front of the sensor frame. ExifTool
+/// names the ones it knows under `FujiFilm::RAFTags`; the numbering is
+/// Fujifilm's own and has nothing to do with TIFF 6.0.
+mod raw_tags {
+    /// IFD0's only entry: an offset (relative to the block) to the
+    /// directory that actually says anything.
+    pub const RAW_IFD: u16 = 0xf000;
+    pub const WIDTH: u16 = 0xf001;
+    pub const HEIGHT: u16 = 0xf002;
+    pub const BITS_PER_SAMPLE: u16 = 0xf003;
+    /// Where the samples start, relative to the block.
+    pub const STRIP_OFFSET: u16 = 0xf007;
+    pub const STRIP_BYTE_COUNT: u16 = 0xf008;
+    /// Black, one value a CFA position: 4 for Bayer, 36 for X-Trans.
+    pub const BLACK_LEVELS: u16 = 0xf00a;
+    /// White balance the camera's auto mode chose, `(G, R, B)`.
+    pub const WB_AUTO: u16 = 0xf00d;
+    /// White balance the shot was actually taken at, `(G, R, B)`.
+    pub const WB_AS_SHOT: u16 = 0xf00e;
+}
+
+/// The fixed header, with every blob bounds-checked against the file.
+struct Header<'a> {
+    bytes: &'a [u8],
+    /// Bytes 28..60, NUL-padded.
+    model: String,
+    /// Position of the camera's JPEG in `bytes`, and the JPEG itself.
+    jpeg_at: usize,
+    jpeg: &'a [u8],
+    meta: &'a [u8],
+    /// Position of the sensor block in `bytes`; offsets inside the
+    /// private TIFF are relative to it.
+    cfa_at: usize,
+    cfa: &'a [u8],
+}
+
+fn be16(bytes: &[u8], at: usize) -> Option<u16> {
+    Some(u16::from_be_bytes(bytes.get(at..at + 2)?.try_into().ok()?))
+}
+
+fn be32(bytes: &[u8], at: usize) -> Option<u32> {
+    Some(u32::from_be_bytes(bytes.get(at..at + 4)?.try_into().ok()?))
+}
+
+impl<'a> Header<'a> {
+    fn parse(bytes: &'a [u8]) -> Result<Header<'a>> {
+        if !bytes.starts_with(MAGIC) {
+            return Err(Error::NotRaw);
+        }
+        // The three pointer pairs sit at fixed offsets; a file too
+        // short to hold them is not a RAF at all.
+        let slice = |at: usize, what: &str| -> Result<(usize, &'a [u8])> {
+            let (offset, len) = match (be32(bytes, at), be32(bytes, at + 4)) {
+                (Some(offset), Some(len)) => (offset as usize, len as usize),
+                _ => return Err(Error::Corrupt("truncated RAF header".into())),
+            };
+            let end = offset
+                .checked_add(len)
+                .ok_or_else(|| Error::Corrupt(format!("{what} length out of range")))?;
+            let blob = bytes.get(offset..end).ok_or_else(|| {
+                Error::Corrupt(format!("{what} at {offset}..{end} is outside the file"))
+            })?;
+            Ok((offset, blob))
+        };
+        let (jpeg_at, jpeg) = slice(84, "the preview JPEG")?;
+        let (_, meta) = slice(92, "the metadata block")?;
+        let (cfa_at, cfa) = slice(100, "the sensor frame")?;
+        let model = bytes
+            .get(28..60)
+            .map(|raw| {
+                String::from_utf8_lossy(raw)
+                    .trim_end_matches('\0')
+                    .trim()
+                    .to_string()
+            })
+            .unwrap_or_default();
+        Ok(Header {
+            bytes,
+            model,
+            jpeg_at,
+            jpeg,
+            meta,
+            cfa_at,
+            cfa,
+        })
+    }
+
+    /// Every record of the metadata block, in file order. A record
+    /// whose size runs off the end simply ends the list: the block is
+    /// self-delimiting and a truncated one still has usable records
+    /// before the break.
+    fn meta_records(&self) -> Vec<(u16, &'a [u8])> {
+        let Some(count) = be32(self.meta, 0) else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        let mut at = 4usize;
+        // The count is a 32-bit field in a block that is a few tens of
+        // kilobytes; cap it at what could physically fit.
+        for _ in 0..count.min(self.meta.len() as u32 / 4) {
+            let (Some(tag), Some(size)) = (be16(self.meta, at), be16(self.meta, at + 2)) else {
+                break;
+            };
+            let Some(data) = self.meta.get(at + 4..at + 4 + size as usize) else {
+                break;
+            };
+            out.push((tag, data));
+            at += 4 + size as usize;
+        }
+        out
+    }
+}
+
+/// One metadata record's payload, read as big-endian 16-bit words.
+fn words(data: &[u8], n: usize) -> Option<Vec<u16>> {
+    if data.len() < n * 2 {
+        return None;
+    }
+    Some((0..n).filter_map(|i| be16(data, i * 2)).collect())
+}
+
+/// What tag 0x0130 says about the sample arrangement.
+///
+/// The first byte's top bit is set on the SuperCCD bodies that write
+/// their two half-height fields interleaved; the second byte's bit 3
+/// is *clear* on the ones whose octagonal photosites are recorded on a
+/// grid turned 45 degrees, which is what makes their stored frame
+/// nearly twice as wide as the picture and turns the developed image
+/// into a diamond. Both need geometry this crate does not model, so
+/// both are refused rather than decoded into a smeared frame.
+struct Layout {
+    interleaved: bool,
+    rotated: bool,
+}
+
+impl Layout {
+    fn parse(data: &[u8]) -> Layout {
+        Layout {
+            interleaved: data.first().is_some_and(|b| b & 0x80 != 0),
+            rotated: data.get(1).is_some_and(|b| b & 8 == 0),
+        }
+    }
+}
+
+/// The 6x6 X-Trans array from tag 0x0131.
+///
+/// The 36 bytes are 0 red, 1 green, 2 blue — but they run from the
+/// *last* cell backwards: the camera writes the array as the sensor is
+/// read out, which is a 180-degree turn from the frame origin the
+/// samples arrive in. Reversing them reproduces the filter pattern the
+/// oracle reports for every X-Trans body in the corpus (three
+/// generations, two distinct arrays).
+fn xtrans_cfa(data: &[u8]) -> Result<Cfa> {
+    if data.len() < 36 {
+        return Err(Error::Corrupt(format!(
+            "X-Trans layout is {} bytes, not 36",
+            data.len()
+        )));
+    }
+    let mut grid = [[CfaColor::Green; 6]; 6];
+    for y in 0..6 {
+        for x in 0..6 {
+            grid[y][x] = match data[35 - (y * 6 + x)] {
+                0 => CfaColor::Red,
+                1 => CfaColor::Green,
+                2 => CfaColor::Blue,
+                other => {
+                    return Err(Error::Corrupt(format!(
+                        "X-Trans layout holds colour {other}"
+                    )))
+                }
+            };
+        }
+    }
+    Ok(Cfa::XTrans(grid))
+}
+
+/// The sensor frame's own description, however the file states it.
+struct Frame<'a> {
+    width: usize,
+    height: usize,
+    bits: u32,
+    /// The samples, without the private TIFF around them.
+    strip: &'a [u8],
+    /// Black per CFA position, in the file's order (4 or 36 values).
+    black: Vec<u32>,
+    /// As-shot white balance as `(G, R, B)`.
+    wb: Option<[f32; 3]>,
+}
+
+/// The private TIFF in front of the samples on 2011-and-later bodies.
+fn parse_raw_tiff<'a>(header: &Header<'a>) -> Result<Option<Frame<'a>>> {
+    if !matches!(header.cfa.get(0..2), Some(b"II") | Some(b"MM")) {
+        return Ok(None);
+    }
+    let outer = Tiff::parse_embedded(header.bytes, header.cfa_at)?;
+    // IFD0 carries a single entry pointing at the directory that holds
+    // everything. It is type 13 (IFD) but not SubIFDs, so the shared
+    // parser does not follow it for us.
+    let at = outer
+        .root()
+        .get(raw_tags::RAW_IFD)
+        .and_then(|e| e.u32(0))
+        .ok_or_else(|| Error::Corrupt("sensor TIFF without its 0xF000 directory pointer".into()))?;
+    let at = (at as usize)
+        .checked_add(header.cfa_at)
+        .ok_or_else(|| Error::Corrupt("0xF000 offset out of range".into()))?;
+    let inner = Tiff::parse_at_relative(header.bytes, at, header.cfa_at, outer.little_endian())?;
+    let ifd = inner.root();
+    let int = |tag: u16| ifd.get(tag).and_then(|e| e.u32(0));
+    let width =
+        int(raw_tags::WIDTH).ok_or_else(|| Error::Corrupt("sensor TIFF without a width".into()))?;
+    let height = int(raw_tags::HEIGHT)
+        .ok_or_else(|| Error::Corrupt("sensor TIFF without a height".into()))?;
+    let bits = int(raw_tags::BITS_PER_SAMPLE).unwrap_or(16);
+    let offset = int(raw_tags::STRIP_OFFSET).unwrap_or(0) as usize;
+    let len = int(raw_tags::STRIP_BYTE_COUNT).unwrap_or(0) as usize;
+    let end = offset
+        .checked_add(len)
+        .ok_or_else(|| Error::Corrupt("sensor strip length out of range".into()))?;
+    let strip = header.cfa.get(offset..end).ok_or_else(|| {
+        Error::Corrupt(format!("sensor strip {offset}..{end} is outside its block"))
+    })?;
+    let black = ifd
+        .get(raw_tags::BLACK_LEVELS)
+        .map(|e| e.u32s())
+        .unwrap_or_default();
+    // 0xF00E is the balance the picture was shot at and 0xF00D the one
+    // auto mode would have picked; they differ only when the shot was
+    // not on auto, and the oracle's "As shot" follows 0xF00E.
+    let wb = ifd
+        .get(raw_tags::WB_AS_SHOT)
+        .or_else(|| ifd.get(raw_tags::WB_AUTO))
+        .and_then(|e| {
+            let v = e.u32s();
+            Some([*v.first()? as f32, *v.get(1)? as f32, *v.get(2)? as f32])
+        });
+    Ok(Some(Frame {
+        width: width as usize,
+        height: height as usize,
+        bits,
+        strip,
+        black,
+        wb,
+    }))
+}
+
+/// How the samples of an uncompressed strip are stored.
+///
+/// Fujifilm has used three layouts, and the strip's own byte count
+/// tells them apart without guessing: it is exactly the pixel count
+/// times two (16-bit words), or times the bit depth over eight
+/// (packed), or neither — and neither means compressed.
+///
+/// The two packings differ, and not in a way any tag announces. The
+/// 12-bit EXR compacts pack least significant bit first across plain
+/// bytes. The 14-bit Bayer bodies (X-A5 and its relatives) pack most
+/// significant bit first *inside 32-bit little-endian words*, which is
+/// what [`BitPumpMsb32`] reads; their 0xF005 tag counts those words a
+/// row, which is how the layout announces itself indirectly. Both are
+/// pinned to the oracle sample for sample.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Storage {
+    Words16,
+    /// Least significant bit first over bytes.
+    PackedLsb(u32),
+    /// Most significant bit first inside 32-bit little-endian words.
+    PackedMsb32(u32),
+    Compressed,
+}
+
+fn storage(pixels: usize, bits: u32, len: usize) -> Storage {
+    if len == pixels * 2 {
+        return Storage::Words16;
+    }
+    if (8..=16).contains(&bits) {
+        let packed_bits = (pixels as u64) * bits as u64;
+        if packed_bits.is_multiple_of(8) && len as u64 == packed_bits / 8 {
+            return if bits >= 13 {
+                Storage::PackedMsb32(bits)
+            } else {
+                Storage::PackedLsb(bits)
+            };
+        }
+    }
+    Storage::Compressed
+}
+
+/// Little-endian 16-bit words, the simplest and oldest layout.
+fn unpack_words16(strip: &[u8], pixels: usize) -> Vec<u16> {
+    let mut out = vec![0u16; pixels];
+    let (words, _) = strip.as_chunks::<2>();
+    for (sample, word) in out.iter_mut().zip(words) {
+        *sample = u16::from_le_bytes(*word);
+    }
+    out
+}
+
+/// `bits` samples an entry, one row at a time.
+///
+/// Rows start on a whole number of the packing's own units — a byte
+/// for the LSB-first layout, a 32-bit word for the other — for every
+/// real frame, so they unpack independently and in parallel. When a
+/// width makes that untrue the whole strip is read as one run, which
+/// is what a stream reader would do anyway.
+fn unpack_packed(strip: &[u8], width: usize, height: usize, bits: u32, msb32: bool) -> Vec<u16> {
+    let mut out = vec![0u16; width * height];
+    let row_bits = width * bits as usize;
+    let unit = if msb32 { 32 } else { 8 };
+    if row_bits.is_multiple_of(unit) && height > 0 {
+        let row_bytes = row_bits / 8;
+        out.par_chunks_mut(width).enumerate().for_each(|(y, row)| {
+            let start = y * row_bytes;
+            let bytes = strip.get(start..start + row_bytes).unwrap_or(&[]);
+            unpack_packed_row(bytes, row, bits, msb32);
+        });
+    } else {
+        unpack_packed_row(strip, &mut out, bits, msb32);
+    }
+    out
+}
+
+fn unpack_packed_row(bytes: &[u8], out: &mut [u16], bits: u32, msb32: bool) {
+    // Both pumps read zeros past the end, so a truncated strip leaves
+    // the tail of the frame black rather than failing.
+    if msb32 {
+        let mut pump = BitPumpMsb32::new(bytes);
+        for sample in out.iter_mut() {
+            *sample = pump.get(bits) as u16;
+        }
+        return;
+    }
+    let mask = (1u32 << bits) - 1;
+    let (mut cache, mut have) = (0u32, 0u32);
+    let mut at = 0usize;
+    for sample in out.iter_mut() {
+        while have < bits {
+            let byte = bytes.get(at).copied().unwrap_or(0) as u32;
+            at += 1;
+            cache |= byte << have;
+            have += 8;
+        }
+        *sample = (cache & mask) as u16;
+        cache >>= bits;
+        have -= bits;
+    }
+}
+
+/// Black levels reduced to the four slots [`RawImage`] has.
+///
+/// Bayer frames record one value per CFA position and map straight
+/// across. X-Trans frames record all 36 cells of the array; every file
+/// seen writes the same number 36 times, since the levels come from
+/// the sensor's masked columns and not from the colour, so the mean
+/// loses nothing and is honest when a file disagrees.
+fn black_levels(values: &[u32]) -> Option<[f32; 4]> {
+    match values.len() {
+        0 => None,
+        4 => Some([
+            values[0] as f32,
+            values[1] as f32,
+            values[2] as f32,
+            values[3] as f32,
+        ]),
+        n => {
+            let mean = values.iter().map(|v| *v as f64).sum::<f64>() / n as f64;
+            Some([mean as f32; 4])
+        }
+    }
+}
+
+/// Black or white-balance levels the old metadata block writes in
+/// G, R, G2, B order, spread over the CFA positions they belong to.
+fn grgb_by_position(cfa: &Cfa, values: &[u16]) -> Option<[f32; 4]> {
+    let (g, r, g2, b) = (
+        *values.first()? as f32,
+        *values.get(1)? as f32,
+        *values.get(2)? as f32,
+        *values.get(3)? as f32,
+    );
+    let mut out = [0.0f32; 4];
+    let mut greens = 0;
+    for (i, level) in out.iter_mut().enumerate() {
+        *level = match cfa.color_at(i % 2, i / 2)? {
+            CfaColor::Red => r,
+            CfaColor::Blue => b,
+            _ => {
+                greens += 1;
+                if greens == 1 {
+                    g
+                } else {
+                    g2
+                }
+            }
+        };
+    }
+    Some(out)
+}
+
+/// The Exif of a RAF lives in the camera's JPEG and nowhere else, so
+/// orientation, ISO, lens and the rest come from its APP1 segment.
+/// The scan walks marker segments only and stops at the first scan.
+fn jpeg_exif<'a>(bytes: &'a [u8], jpeg_at: usize, jpeg: &[u8]) -> Option<Tiff<'a>> {
+    if !jpeg.starts_with(&[0xff, 0xd8]) {
+        return None;
+    }
+    let mut at = 2usize;
+    while at + 4 <= jpeg.len() {
+        if jpeg[at] != 0xff {
+            return None;
+        }
+        let marker = jpeg[at + 1];
+        match marker {
+            // Fill bytes, and the standalone markers with no length.
+            0xff => {
+                at += 1;
+                continue;
+            }
+            0x01 | 0xd0..=0xd8 => {
+                at += 2;
+                continue;
+            }
+            // Entropy-coded data starts here; there is no Exif past it.
+            0xda | 0xd9 => return None,
+            _ => {}
+        }
+        let len = u16::from_be_bytes([jpeg[at + 2], jpeg[at + 3]]) as usize;
+        if len < 2 {
+            return None;
+        }
+        if marker == 0xe1 && jpeg.get(at + 4..at + 10) == Some(b"Exif\0\0") {
+            return Tiff::parse_embedded(bytes, jpeg_at + at + 10).ok();
+        }
+        at += 2 + len;
+    }
+    None
+}
+
+/// Decode a RAF.
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let header = Header::parse(bytes)?;
+    let records = header.meta_records();
+    let meta = |tag: u16| {
+        records
+            .iter()
+            .find(|(t, _)| *t == tag)
+            .map(|(_, data)| *data)
+    };
+
+    let layout = meta(meta::FUJI_LAYOUT).map(Layout::parse);
+    if let Some(layout) = &layout {
+        if layout.rotated || layout.interleaved {
+            // SuperCCD: the samples are on a grid rotated 45 degrees
+            // (and on some bodies split into two interleaved fields),
+            // so no colour filter array describes the stored frame and
+            // the picture only appears after a shear this crate has no
+            // place to express.
+            return Err(Error::Unsupported(format!(
+                "RAF: SuperCCD sensor layout ({}{}) on the {}",
+                if layout.rotated { "45-degree grid" } else { "" },
+                if layout.interleaved {
+                    ", interleaved fields"
+                } else {
+                    ""
+                },
+                header.model
+            )));
+        }
+    }
+
+    let cfa = match meta(meta::XTRANS_LAYOUT) {
+        Some(data) => xtrans_cfa(data)?,
+        // Fujifilm's Bayer bodies record no array at all. Every one in
+        // the corpus (GFX, X-A, the EXR compacts) reads out RGGB from
+        // the frame origin, and so does every oracle for them.
+        None => Cfa::RGGB,
+    };
+
+    let full = meta(meta::RAW_FULL_SIZE).and_then(|data| words(data, 2));
+    let frame = parse_raw_tiff(&header)?;
+    let (width, height) = match (&frame, &full) {
+        (Some(frame), _) => (frame.width, frame.height),
+        (None, Some(size)) => (size[1] as usize, size[0] as usize),
+        (None, None) => return Err(Error::Corrupt("RAF states no sensor frame size".into())),
+    };
+    if width == 0 || height == 0 || width > 1 << 16 || height > 1 << 16 {
+        return Err(Error::Corrupt(format!("sensor frame is {width}x{height}")));
+    }
+    let pixels = width * height;
+
+    // The private TIFF's depth wins; the older generation records it
+    // only in the metadata block, as (bits, bits * 3).
+    let bits = match &frame {
+        Some(frame) => frame.bits,
+        None => meta(meta::BIT_DEPTH)
+            .and_then(|data| be16(data, 0))
+            .map(u32::from)
+            .unwrap_or(16),
+    };
+    if !(8..=16).contains(&bits) {
+        return Err(Error::Unsupported(format!("RAF: {bits} bits a sample")));
+    }
+
+    let strip = match &frame {
+        Some(frame) => frame.strip,
+        None => header.cfa,
+    };
+    let data = match storage(pixels, bits, strip.len()) {
+        Storage::Words16 => unpack_words16(strip, pixels),
+        Storage::PackedLsb(bits) => unpack_packed(strip, width, height, bits, false),
+        Storage::PackedMsb32(bits) => unpack_packed(strip, width, height, bits, true),
+        Storage::Compressed => super::raf_compressed::decode(strip, width, height, &cfa)?,
+    };
+
+    let mut raw = RawImage::new(Format::Raf, width, height, 1, RawData::U16(data), cfa);
+    raw.white_level = ((1u32 << bits) - 1) as f32;
+    if let Some(black) = frame.as_ref().and_then(|frame| black_levels(&frame.black)) {
+        raw.black_levels = black;
+    } else if let Some(black) = meta(meta::BLACK_LEVELS)
+        .and_then(|data| words(data, 4))
+        .and_then(|values| grgb_by_position(&raw.cfa, &values))
+    {
+        raw.black_levels = black;
+    }
+
+    // White balance: three values on the newer bodies, four in the
+    // older block because it names both greens. Green is the
+    // reference in both, as it is in `wb_coeffs`.
+    if let Some([g, r, b]) = frame.as_ref().and_then(|frame| frame.wb) {
+        if g > 0.0 {
+            raw.wb_coeffs = [r / g, 1.0, b / g, 1.0];
+        }
+    } else if let Some(values) = meta(meta::WB_GRGB).and_then(|data| words(data, 4)) {
+        let (g, r, g2, b) = (
+            values[0] as f32,
+            values[1] as f32,
+            values[2] as f32,
+            values[3] as f32,
+        );
+        if g > 0.0 && g2 > 0.0 {
+            raw.wb_coeffs = [r / g, 1.0, b / g, g2 / g];
+        }
+    }
+
+    raw.crop = crop(
+        &raw.cfa,
+        meta(meta::CROP_TOP_LEFT),
+        meta(meta::CROPPED_SIZE),
+        width,
+        height,
+    );
+
+    let exif = jpeg_exif(bytes, header.jpeg_at, header.jpeg);
+    if let Some(exif) = &exif {
+        raw.orientation = common::orientation(exif);
+        raw.metadata = common::metadata(exif);
+        let (make, model) = exif.make_model();
+        if !model.is_empty() {
+            raw.set_camera(&make, &model);
+        }
+    }
+    if raw.model.is_empty() {
+        raw.set_camera("FUJIFILM", &header.model);
+    }
+    if header.jpeg.starts_with(&[0xff, 0xd8]) {
+        raw.preview = Some(header.jpeg.to_vec());
+    }
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+/// The picture's rectangle inside the sensor frame.
+///
+/// Tags 0x0110 and 0x0111 give it directly, but their origin is not
+/// always on the filter array's period — the X-Pro3 starts its picture
+/// on row 13 of a six-row array. A crop whose phase differs from the
+/// frame's would make `cfa` describe the frame and not the picture, so
+/// the origin is moved forward to the next cell boundary and the size
+/// shrunk to match. LibRaw does the same, which is why its "Raw inset"
+/// line agrees with this to the pixel on every file in the corpus.
+fn crop(
+    cfa: &Cfa,
+    top_left: Option<&[u8]>,
+    size: Option<&[u8]>,
+    width: usize,
+    height: usize,
+) -> Rect {
+    let whole = Rect {
+        x: 0,
+        y: 0,
+        width,
+        height,
+    };
+    let (Some(top_left), Some(size)) = (
+        top_left.and_then(|data| words(data, 2)),
+        size.and_then(|data| words(data, 2)),
+    ) else {
+        return whole;
+    };
+    let period = match cfa {
+        Cfa::XTrans(_) => 6,
+        _ => 2,
+    };
+    let round_up = |v: usize| v.div_ceil(period) * period;
+    let (top, left) = (top_left[0] as usize, top_left[1] as usize);
+    let (x, y) = (round_up(left), round_up(top));
+    let cropped = Rect {
+        x,
+        y,
+        width: (size[1] as usize).saturating_sub(x - left),
+        height: (size[0] as usize).saturating_sub(y - top),
+    };
+    if cropped.width == 0
+        || cropped.height == 0
+        || cropped.x + cropped.width > width
+        || cropped.y + cropped.height > height
+    {
+        return whole;
+    }
+    cropped
+}
+
+/// The camera's JPEG, which a RAF always carries at full resolution.
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    let header = Header::parse(bytes)?;
+    Ok(header
+        .jpeg
+        .starts_with(&[0xff, 0xd8])
+        .then(|| header.jpeg.to_vec()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal RAF: the header's three pointers and nothing else
+    /// valid, to check the bounds checks rather than any decoding.
+    fn skeleton(jpeg: (u32, u32), meta: (u32, u32), cfa: (u32, u32), len: usize) -> Vec<u8> {
+        let mut out = vec![0u8; len.max(108)];
+        out[..MAGIC.len()].copy_from_slice(MAGIC);
+        out[MAGIC.len()] = b' ';
+        for (at, (offset, size)) in [(84, jpeg), (92, meta), (100, cfa)] {
+            out[at..at + 4].copy_from_slice(&offset.to_be_bytes());
+            out[at + 4..at + 8].copy_from_slice(&size.to_be_bytes());
+        }
+        out
+    }
+
+    #[test]
+    fn rejects_a_file_that_is_not_a_raf() {
+        assert!(matches!(decode(b"not a raf at all"), Err(Error::NotRaw)));
+    }
+
+    #[test]
+    fn rejects_blobs_outside_the_file() {
+        let file = skeleton((108, 16), (124, 8), (1 << 30, 1 << 30), 200);
+        assert!(matches!(decode(&file), Err(Error::Corrupt(_))));
+        let file = skeleton((108, 16), (124, 8), (140, u32::MAX), 200);
+        assert!(matches!(decode(&file), Err(Error::Corrupt(_))));
+    }
+
+    #[test]
+    fn a_truncated_metadata_block_keeps_the_records_before_the_break() {
+        let mut file = skeleton((108, 2), (124, 20), (150, 40), 200);
+        file[108..110].copy_from_slice(&[0xff, 0xd8]);
+        // Three records claimed, one complete, the second cut short.
+        file[124..128].copy_from_slice(&3u32.to_be_bytes());
+        file[128..132].copy_from_slice(&[0x01, 0x00, 0x00, 0x04]);
+        file[132..136].copy_from_slice(&[0x00, 0x04, 0x00, 0x08]);
+        file[136..140].copy_from_slice(&[0x01, 0x11, 0x00, 0x40]);
+        let header = Header::parse(&file).unwrap();
+        let records = header.meta_records();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].0, meta::RAW_FULL_SIZE);
+        assert_eq!(words(records[0].1, 2), Some(vec![4, 8]));
+    }
+
+    #[test]
+    fn the_xtrans_array_is_read_backwards() {
+        // The X-T1/X-T10 generation's tag 0x0131, whose frame-anchored
+        // array the oracle prints as R B / G G / G G / B R ...
+        let layout = [
+            2, 1, 1, 0, 1, 1, 0, 1, 1, 2, 1, 1, 1, 2, 0, 1, 0, 2, 0, 1, 1, 2, 1, 1, 2, 1, 1, 0, 1,
+            1, 1, 0, 2, 1, 2, 0,
+        ];
+        let cfa = xtrans_cfa(&layout).unwrap();
+        assert_eq!(cfa.color_at(0, 0), Some(CfaColor::Red));
+        assert_eq!(cfa.color_at(1, 0), Some(CfaColor::Blue));
+        assert_eq!(cfa.color_at(0, 1), Some(CfaColor::Green));
+        assert_eq!(cfa.color_at(0, 3), Some(CfaColor::Blue));
+        assert_eq!(cfa.color_at(1, 3), Some(CfaColor::Red));
+        // Eight of each of red and blue, twenty green, as X-Trans is.
+        let mut reds = 0;
+        for y in 0..6 {
+            for x in 0..6 {
+                if cfa.color_at(x, y) == Some(CfaColor::Red) {
+                    reds += 1;
+                }
+            }
+        }
+        assert_eq!(reds, 8);
+        assert!(matches!(xtrans_cfa(&[0, 1, 2]), Err(Error::Corrupt(_))));
+        assert!(matches!(xtrans_cfa(&[7; 36]), Err(Error::Corrupt(_))));
+    }
+
+    #[test]
+    fn the_layout_byte_names_superccd() {
+        // X-Trans and the modern Bayer bodies: neither bit set.
+        assert!(!Layout::parse(&[0x0c, 0x0c, 0x0c, 0x0c]).rotated);
+        assert!(!Layout::parse(&[0x0a, 0x0b, 0x09, 0x08]).interleaved);
+        // The S9600's interleaved, rotated SuperCCD, and the GX680
+        // digital back's rotated-only one.
+        assert!(Layout::parse(&[0x83, 0x82, 0x81, 0x80]).interleaved);
+        assert!(Layout::parse(&[0x83, 0x82, 0x81, 0x80]).rotated);
+        assert!(Layout::parse(&[0x00, 0x01, 0x02, 0x01]).rotated);
+    }
+
+    #[test]
+    fn storage_follows_the_strip_length() {
+        assert_eq!(storage(1000, 14, 2000), Storage::Words16);
+        assert_eq!(storage(1000, 14, 1750), Storage::PackedMsb32(14));
+        assert_eq!(storage(1000, 12, 1500), Storage::PackedLsb(12));
+        assert_eq!(storage(1000, 14, 900), Storage::Compressed);
+    }
+
+    #[test]
+    fn twelve_bit_samples_come_out_least_significant_bit_first() {
+        // 0xABC then 0x123 packs as BC 3A 12.
+        let mut out = [0u16; 2];
+        unpack_packed_row(&[0xbc, 0x3a, 0x12], &mut out, 12, false);
+        assert_eq!(out, [0xabc, 0x123]);
+        // Past the end the pump reads zeros rather than panicking.
+        let mut out = [0u16; 4];
+        unpack_packed_row(&[0xff], &mut out, 12, false);
+        assert_eq!(out, [0xff, 0, 0, 0]);
+    }
+
+    #[test]
+    fn fourteen_bit_samples_are_read_down_from_the_top_of_each_word() {
+        // The word here is 0x3FFF0000: its top fourteen bits are
+        // 0b00_1111_1111_1111 and the next fourteen 0b11_0000_0000_0000.
+        let mut out = [0u16; 2];
+        unpack_packed_row(&[0x00, 0x00, 0xff, 0x3f], &mut out, 14, true);
+        assert_eq!(out, [0x0fff, 0x3000]);
+        // A tail shorter than a word is padded with zeros, so the
+        // frame runs out black instead of panicking.
+        let mut out = [0u16; 4];
+        unpack_packed_row(&[0xff], &mut out, 14, true);
+        assert_eq!(out, [0x0000, 0x000f, 0x3c00, 0x0000]);
+    }
+
+    #[test]
+    fn the_crop_moves_forward_to_the_filter_array_period() {
+        let xtrans = xtrans_cfa(&[1; 36]).unwrap();
+        // The X-Pro3: top 13, left 6, 4160x6240 -> top 18, 4155 high.
+        let rect = crop(
+            &xtrans,
+            Some(&[0, 13, 0, 6]),
+            Some(&[0x10, 0x40, 0x18, 0x60]),
+            6384,
+            4182,
+        );
+        assert_eq!(
+            rect,
+            Rect {
+                x: 6,
+                y: 18,
+                width: 6240,
+                height: 4155
+            }
+        );
+        // A Bayer frame moves by at most one row or column.
+        let rect = crop(
+            &Cfa::RGGB,
+            Some(&[0, 7, 0, 8]),
+            Some(&[0x0f, 0xa0, 0x17, 0x70]),
+            6016,
+            4014,
+        );
+        assert_eq!(
+            rect,
+            Rect {
+                x: 8,
+                y: 8,
+                width: 6000,
+                height: 3999
+            }
+        );
+        // A crop that does not fit is dropped rather than trusted.
+        let rect = crop(
+            &Cfa::RGGB,
+            Some(&[0, 0, 0, 0]),
+            Some(&[0xff, 0xff, 0xff, 0xff]),
+            16,
+            16,
+        );
+        assert_eq!(rect.width, 16);
+    }
+
+    #[test]
+    fn the_old_block_names_both_greens() {
+        // G R G2 B, spread over an RGGB array: R, G, G2, B.
+        let levels = grgb_by_position(&Cfa::RGGB, &[518, 517, 517, 516]).unwrap();
+        assert_eq!(levels, [517.0, 518.0, 517.0, 516.0]);
+        // ... and over a GBRG one: G, B, R, G2.
+        let levels = grgb_by_position(&Cfa::GBRG, &[129, 118, 129, 118]).unwrap();
+        assert_eq!(levels, [129.0, 118.0, 118.0, 129.0]);
+    }
+
+    #[test]
+    fn black_levels_collapse_to_four() {
+        assert_eq!(black_levels(&[]), None);
+        assert_eq!(black_levels(&[1, 2, 3, 4]), Some([1.0, 2.0, 3.0, 4.0]));
+        assert_eq!(black_levels(&[1022; 36]), Some([1022.0; 4]));
+    }
+}
+
+/// Corpus tests: every RAF under `SCHIST_RAW_CORPUS`, against the
+/// oracle files beside it (`<name>.tiff` from `unprocessed_raw -T`,
+/// `<name>.identify.txt` from `raw-identify -v -w`).
+#[cfg(test)]
+mod corpus {
+    use super::*;
+    use crate::Orientation;
+    use std::path::{Path, PathBuf};
+
+    /// Files this decoder knowingly refuses, and why. A corpus file
+    /// that fails for any other reason is a test failure.
+    const UNSUPPORTED: &[(&str, &str)] = &[
+        // SuperCCD: samples on a grid turned 45 degrees, so the frame
+        // is nearly twice as wide as the picture and no CFA describes
+        // it. LibRaw shears these into a diamond and crops; this crate
+        // has nowhere to put that.
+        ("FinePix_S9600", "SuperCCD"),
+        ("DBP_for_GX680", "SuperCCD"),
+        // Fujifilm's compressed strips, lossless and lossy alike: the
+        // container, levels and geometry are read, the entropy-coded
+        // body is not. See `super::super::raf_compressed`.
+        ("GFX100S", "compression"),
+        ("X100F-DSCF5760", "compression"),
+        ("X-Pro3-_DSF2385", "compression"),
+        ("X-T5", "compression"),
+    ];
+
+    fn corpus_files() -> Vec<PathBuf> {
+        let Ok(root) = std::env::var("SCHIST_RAW_CORPUS") else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        let mut stack = vec![PathBuf::from(root)];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path
+                    .extension()
+                    .is_some_and(|e| e.eq_ignore_ascii_case("raf"))
+                {
+                    out.push(path);
+                }
+            }
+        }
+        out.sort();
+        out
+    }
+
+    /// The value after `key:` on the line that holds it.
+    fn field<'a>(text: &'a str, key: &str) -> Option<&'a str> {
+        text.lines()
+            .find(|line| line.trim_start().starts_with(key))
+            .map(|line| line.trim_start()[key.len()..].trim())
+    }
+
+    fn numbers(text: &str) -> Vec<i64> {
+        text.split(|c: char| !c.is_ascii_digit() && c != '-')
+            .filter_map(|t| t.parse().ok())
+            .collect()
+    }
+
+    struct Oracle {
+        text: String,
+    }
+
+    impl Oracle {
+        fn load(path: &Path) -> Option<Oracle> {
+            let mut sidecar = path.as_os_str().to_os_string();
+            sidecar.push(".identify.txt");
+            std::fs::read_to_string(PathBuf::from(sidecar))
+                .ok()
+                .map(|text| Oracle { text })
+        }
+        /// `Full size: W x H`.
+        fn full_size(&self) -> Option<(usize, usize)> {
+            let v = numbers(field(&self.text, "Full size:")?);
+            Some((*v.first()? as usize, *v.get(1)? as usize))
+        }
+        /// `Raw inset, width x height: W x H left: L top: T`.
+        fn inset(&self) -> Option<Rect> {
+            let v = numbers(field(&self.text, "Raw inset, width x height:")?);
+            Some(Rect {
+                width: *v.first()? as usize,
+                height: *v.get(1)? as usize,
+                x: *v.get(2)? as usize,
+                y: *v.get(3)? as usize,
+            })
+        }
+        fn flip(&self) -> Option<i64> {
+            numbers(field(&self.text, "Image flip:")?).first().copied()
+        }
+        /// The 16 characters LibRaw prints are the colours of rows 0..7
+        /// at columns 0 and 1.
+        fn filter_pattern(&self) -> Option<String> {
+            field(&self.text, "Filter pattern:").map(str::to_string)
+        }
+        /// `As shot  R G B G2` in the makernote white-balance table.
+        fn as_shot(&self) -> Option<[f32; 4]> {
+            let v = numbers(field(&self.text, "As shot")?);
+            Some([
+                *v.first()? as f32,
+                *v.get(1)? as f32,
+                *v.get(2)? as f32,
+                *v.get(3)? as f32,
+            ])
+        }
+        /// `cblack[a .. b]: ...`, LibRaw's per-channel black in R G B G2
+        /// order (or, for X-Trans, all 36 array cells).
+        fn cblack(&self) -> Option<Vec<i64>> {
+            let line = self
+                .text
+                .lines()
+                .find(|l| l.trim_start().starts_with("cblack["))?;
+            Some(numbers(line.split_once(':')?.1))
+        }
+    }
+
+    fn allowed_unsupported(path: &Path) -> Option<&'static str> {
+        let name = path.file_name()?.to_str()?;
+        UNSUPPORTED
+            .iter()
+            .find(|(stem, _)| name.contains(stem))
+            .map(|(_, why)| *why)
+    }
+
+    #[test]
+    fn decodes_the_corpus_against_the_oracle() {
+        let files = corpus_files();
+        if files.is_empty() {
+            return;
+        }
+        let mut checked = 0;
+        for path in &files {
+            let bytes = std::fs::read(path).expect("corpus file");
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(Format::Raf),
+                "{} did not probe as RAF",
+                path.display()
+            );
+            let raw = match decode(&bytes) {
+                Ok(raw) => raw,
+                Err(Error::Unsupported(why)) => {
+                    let allowed = allowed_unsupported(path);
+                    assert!(
+                        allowed.is_some(),
+                        "{} is unsupported: {why}",
+                        path.display()
+                    );
+                    continue;
+                }
+                Err(other) => panic!("{}: {other}", path.display()),
+            };
+            assert!(
+                allowed_unsupported(path).is_none(),
+                "{} decoded but is on the unsupported list",
+                path.display()
+            );
+            raw.validate()
+                .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+            checked += 1;
+
+            // The preview must be a JPEG a viewer can actually show.
+            let preview = raw.preview.as_ref().expect("every RAF carries a JPEG");
+            image::load_from_memory(preview)
+                .unwrap_or_else(|e| panic!("{}: preview does not decode: {e}", path.display()));
+            assert_eq!(preview, &super::preview(&bytes).unwrap().unwrap());
+
+            // A RAF's only Exif is the one in its JPEG, so an empty
+            // metadata block means the APP1 walk missed it.
+            assert!(raw.metadata.iso.is_some(), "{}: no ISO", path.display());
+            assert!(
+                raw.metadata.exposure_time.is_some() && raw.metadata.f_number.is_some(),
+                "{}: no exposure",
+                path.display()
+            );
+            assert!(
+                raw.metadata.date_time.is_some(),
+                "{}: no date",
+                path.display()
+            );
+            assert_eq!(raw.clean_make, "Fujifilm", "{}: make", path.display());
+            assert!(!raw.clean_model.is_empty(), "{}: model", path.display());
+
+            let Some(oracle) = Oracle::load(path) else {
+                continue;
+            };
+            if let Some((width, height)) = oracle.full_size() {
+                assert_eq!(
+                    (raw.width, raw.height),
+                    (width, height),
+                    "{}: frame size",
+                    path.display()
+                );
+            }
+            if let Some(inset) = oracle.inset() {
+                assert_eq!(raw.crop, inset, "{}: crop", path.display());
+            }
+            if let Some(flip) = oracle.flip() {
+                let expect = match flip {
+                    3 => Orientation::Rotate180,
+                    5 => Orientation::Rotate270CW,
+                    6 => Orientation::Rotate90CW,
+                    _ => Orientation::Normal,
+                };
+                assert_eq!(raw.orientation, expect, "{}: orientation", path.display());
+            }
+            if let Some(pattern) = oracle.filter_pattern() {
+                let mine: String = (0..16)
+                    .map(|i| match raw.cfa.color_at(i & 1, i >> 1) {
+                        Some(CfaColor::Red) => 'R',
+                        Some(CfaColor::Green) | Some(CfaColor::Green2) => 'G',
+                        Some(CfaColor::Blue) => 'B',
+                        _ => '?',
+                    })
+                    .collect();
+                assert_eq!(mine, pattern, "{}: filter pattern", path.display());
+            }
+            if let Some(shot) = oracle.as_shot() {
+                // LibRaw prints the same R G B G2 multipliers this
+                // crate stores, unnormalised, with green as the unit.
+                let expect = [shot[0] / shot[1], 1.0, shot[2] / shot[1], 1.0];
+                for (mine, want) in raw.wb_coeffs.iter().zip(expect.iter()) {
+                    assert!(
+                        (mine - want).abs() < 1e-4,
+                        "{}: white balance {:?} vs {expect:?}",
+                        path.display(),
+                        raw.wb_coeffs
+                    );
+                }
+            }
+            if let Some(cblack) = oracle.cblack() {
+                // LibRaw indexes its per-channel black by colour, this
+                // crate by CFA position, so compare the sets.
+                let mut mine: Vec<i64> = raw.black_levels.iter().map(|b| *b as i64).collect();
+                let mut theirs: Vec<i64> = cblack.clone();
+                if theirs.len() > 4 {
+                    theirs.truncate(4);
+                }
+                mine.sort_unstable();
+                theirs.sort_unstable();
+                assert_eq!(mine, theirs, "{}: black levels", path.display());
+            }
+
+            let mut tiff = path.as_os_str().to_os_string();
+            tiff.push(".tiff");
+            let tiff = PathBuf::from(tiff);
+            if !tiff.exists() {
+                continue;
+            }
+            let want = image::open(&tiff)
+                .unwrap_or_else(|e| panic!("{}: {e}", tiff.display()))
+                .into_luma16();
+            assert_eq!(
+                (want.width() as usize, want.height() as usize),
+                (raw.width, raw.height),
+                "{}: oracle frame size",
+                path.display()
+            );
+            let RawData::U16(mine) = &raw.data else {
+                panic!("{}: RAF is never float", path.display())
+            };
+            // Nothing prints Fujifilm's saturation level, so the check
+            // is that the bit depth the file states actually holds the
+            // samples it stores.
+            let peak = mine.iter().copied().max().unwrap_or(0);
+            assert!(
+                f32::from(peak) <= raw.white_level,
+                "{}: sample {peak} above the white level {}",
+                path.display(),
+                raw.white_level
+            );
+            let mut wrong = 0usize;
+            let mut first = Vec::new();
+            for (i, (mine, want)) in mine.iter().zip(want.as_raw().iter()).enumerate() {
+                if mine != want {
+                    wrong += 1;
+                    if first.len() < 8 {
+                        first.push((i % raw.width, i / raw.width, *mine, *want));
+                    }
+                }
+            }
+            assert_eq!(
+                wrong,
+                0,
+                "{}: {wrong} samples differ from the oracle, first (x, y, mine, oracle): {first:?}",
+                path.display()
+            );
+        }
+        assert!(checked > 0, "the corpus held no decodable RAF");
+    }
+
+    #[test]
+    fn truncation_never_panics() {
+        for path in corpus_files() {
+            let bytes = std::fs::read(&path).expect("corpus file");
+            for cut in 1..=10 {
+                // Spread the cuts over the file, including inside the
+                // header, the metadata block and the sensor strip.
+                let at = bytes.len() * cut / 11;
+                let _ = crate::probe(&bytes[..at]);
+                let _ = decode(&bytes[..at]);
+                let _ = super::preview(&bytes[..at]);
+            }
+            // A file whose pointers survive but whose payload is gone.
+            let mut damaged = bytes.clone();
+            for (i, byte) in damaged.iter_mut().enumerate().take(4096) {
+                if i >= 108 {
+                    *byte = 0xff;
+                }
+            }
+            let _ = decode(&damaged);
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/raf_compressed.rs
+++ b/crates/codec-raw/src/formats/raf_compressed.rs
@@ -1,0 +1,345 @@
+//! Fujifilm's compressed sensor strips, from the X-T2 (2016) onwards.
+//!
+//! This module reads the compressed stream's *header* — which is
+//! documented enough to check a file against its own container and to
+//! say precisely what a file is — and refuses the entropy-coded body.
+//! Nothing in the RAF container announces compression: the decision is
+//! made in [`super::raf`] from the strip's byte count, and a strip that
+//! is neither 16-bit words nor packed samples arrives here.
+//!
+//! # What the header says
+//!
+//! Sixteen big-endian bytes, then one 32-bit length per vertical
+//! stripe, the table padded to a 16-byte boundary:
+//!
+//! ```text
+//! 0   u16  0x4953, the signature
+//! 2   u8   version: 0 on the Bayer bodies, 1 on the X-Trans ones
+//! 3   u8   sensor: 0x10 X-Trans, 0x00 Bayer
+//! 4   u8   bits a sample (12 or 14)
+//! 5   u16  frame height
+//! 7   u16  frame width rounded up to a whole number of stripes
+//! 9   u16  frame width
+//! 11  u16  stripe width in pixels (768 in every file seen)
+//! 13  u8   stripes across the frame
+//! 14  u16  six-row blocks down the frame (height / 6)
+//! ```
+//!
+//! Every field is redundant with the container or with another field,
+//! which is what makes the header worth parsing even without a
+//! decoder: `rounded_width == stripes * stripe_width`,
+//! `blocks * 6 == height`, and the width, height and depth must equal
+//! the ones the RAF's own tags gave. A file that disagrees with itself
+//! is corrupt, and saying so is more use to a caller than a blanket
+//! "unsupported".
+//!
+//! # What is not implemented
+//!
+//! The body. Each stripe is decoded independently, six sensor rows at
+//! a time, into twelve line buffers — three red, six green, three blue,
+//! each `stripe_width * 2 / 3` samples for X-Trans (`/ 2` for Bayer),
+//! with the previous block's last two lines of each colour kept as
+//! history. A sample is predicted from its neighbours in the line
+//! above (and, at odd positions, from the two already-decoded
+//! neighbours beside it), the prediction error is classified into one
+//! of 41 gradient contexts, and the error is Golomb-Rice coded with a
+//! per-context adaptive parameter.
+//!
+//! The entropy layer is fully pinned down against real files, and is
+//! recorded here so that whoever finishes this starts from the part
+//! that is already known to be right:
+//!
+//! * A context is a pair `(sum, count)` starting at
+//!   `(max(2, ((1 << bits) + 32) >> 6), 1)` — `(256, 1)` at 14 bits —
+//!   and `k` is the smallest shift with `count << k >= sum`, capped at
+//!   12. Before each update, `sum` and `count` are halved if `count`
+//!   has reached 64; then `count` is incremented and `sum` grows by
+//!   the magnitude of the difference just decoded.
+//! * A symbol is a unary run of zero bits terminated by a one, then
+//!   `k` more bits: `sample = (zeros << k) + rest`. When the run
+//!   reaches `4 * bits - bits - 1` zeros (41 at 14 bits) the symbol
+//!   escapes: the terminating one is still consumed, then `bits`
+//!   literal bits follow and `sample = literal + 1`. Consuming that
+//!   one bit is the whole difference between decoding a file and
+//!   decoding noise.
+//! * `sample` folds to a signed difference: even gives `sample / 2`,
+//!   odd gives `-(sample + 1) / 2`.
+//! * The gradient quantiser has thresholds 0, 0x12, 0x43, 0x114 and
+//!   the saturation value, giving nine levels from two differences;
+//!   the context is `9 * a + b`, folded to 41 by taking the magnitude
+//!   and negating the difference when the index was negative.
+//!
+//! Two checks say this is right rather than merely plausible. Decoding
+//! a stripe's leading run of identical samples reproduces the observed
+//! code lengths exactly — one code of 9 bits, two of 8, four of 7,
+//! eight of 6, sixteen of 5, thirty-two of 4, then thirty-two each of
+//! 3, 2 and 1, for two contexts in step — and the first symbol after
+//! that run, an escape, yields a difference of 1067 against a
+//! prediction of zero, which is the value the oracle has for the first
+//! non-blank pixel of the frame (the X100F sample's row 5, column 0).
+//! Samples also arrive in groups of `stripe_width`, each group taking
+//! the next of three gradient sets, so the sets cycle 0, 1, 2, 0, 1, 2
+//! over a six-row block.
+//!
+//! What is *not* pinned down is the order the twelve line buffers'
+//! even and odd positions are visited in, and which of their slots
+//! hold sensor pixels rather than interpolated filler. The three
+//! two-row passes of an X-Trans block are not alike — the array puts
+//! two red pixels in the first pair of rows and three in each of the
+//! others — so there is no single loop over the passes to infer, and
+//! every uniform arrangement tried desynchronises the bit reader
+//! within the first row. Rather than return a frame that looks decoded
+//! and is not, this module refuses, and [`Header::parse`] still
+//! extracts everything the stream says about itself.
+
+use crate::{Cfa, Error, Result};
+
+/// A compressed strip's header.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Header {
+    pub version: u8,
+    /// 0x10 on the X-Trans bodies, 0 on the Bayer ones.
+    pub sensor: u8,
+    pub bits: u32,
+    pub width: usize,
+    pub height: usize,
+    /// `width` rounded up to a whole number of stripes.
+    pub rounded_width: usize,
+    pub stripe_width: usize,
+    pub stripes: usize,
+    /// Six-row blocks down the frame.
+    pub blocks: usize,
+}
+
+/// The signature every compressed strip starts with.
+pub const SIGNATURE: u16 = 0x4953;
+
+/// Rows of the sensor in one coded block, for both filter arrays.
+pub const BLOCK_ROWS: usize = 6;
+
+impl Header {
+    /// Read and check a header. `Err(Corrupt)` when the strip claims a
+    /// geometry that contradicts itself.
+    pub fn parse(strip: &[u8]) -> Result<Header> {
+        let be16 = |at: usize| -> Result<usize> {
+            strip
+                .get(at..at + 2)
+                .and_then(|b| b.try_into().ok())
+                .map(|b| u16::from_be_bytes(b) as usize)
+                .ok_or_else(|| Error::Corrupt("truncated compressed strip header".into()))
+        };
+        let byte = |at: usize| -> Result<u8> {
+            strip
+                .get(at)
+                .copied()
+                .ok_or_else(|| Error::Corrupt("truncated compressed strip header".into()))
+        };
+        if be16(0)? != SIGNATURE as usize {
+            return Err(Error::Corrupt(
+                "compressed sensor strip without its 0x4953 signature".into(),
+            ));
+        }
+        let header = Header {
+            version: byte(2)?,
+            sensor: byte(3)?,
+            bits: byte(4)? as u32,
+            height: be16(5)?,
+            rounded_width: be16(7)?,
+            width: be16(9)?,
+            stripe_width: be16(11)?,
+            stripes: byte(13)? as usize,
+            blocks: be16(14)?,
+        };
+        // Four cross-checks the format makes free: every one of them
+        // holds in every sample file, and a stream that fails one is
+        // not a stream this crate could decode even with a decoder.
+        if header.stripe_width == 0 || header.stripes == 0 {
+            return Err(Error::Corrupt("compressed strip with no stripes".into()));
+        }
+        if header.stripes * header.stripe_width != header.rounded_width {
+            return Err(Error::Corrupt(format!(
+                "{} stripes of {} do not make the rounded width {}",
+                header.stripes, header.stripe_width, header.rounded_width
+            )));
+        }
+        if header.rounded_width < header.width
+            || header.rounded_width - header.width >= header.stripe_width
+        {
+            return Err(Error::Corrupt(format!(
+                "rounded width {} does not round {} up by less than a stripe",
+                header.rounded_width, header.width
+            )));
+        }
+        if header.blocks * BLOCK_ROWS != header.height {
+            return Err(Error::Corrupt(format!(
+                "{} six-row blocks do not make {} rows",
+                header.blocks, header.height
+            )));
+        }
+        Ok(header)
+    }
+
+    /// Where the entropy-coded data starts: the header, then a 32-bit
+    /// length for each stripe, padded to a 16-byte boundary.
+    pub fn data_offset(&self) -> usize {
+        16 + (self.stripes * 4).div_ceil(16) * 16
+    }
+
+    /// Each stripe's compressed length, in order.
+    pub fn stripe_lengths(&self, strip: &[u8]) -> Result<Vec<usize>> {
+        let mut out = Vec::with_capacity(self.stripes);
+        for i in 0..self.stripes {
+            let at = 16 + i * 4;
+            let bytes: [u8; 4] = strip
+                .get(at..at + 4)
+                .and_then(|b| b.try_into().ok())
+                .ok_or_else(|| Error::Corrupt("truncated stripe length table".into()))?;
+            out.push(u32::from_be_bytes(bytes) as usize);
+        }
+        Ok(out)
+    }
+
+    /// Whether the entropy-coded body is lossless.
+    ///
+    /// Nothing in the header says so directly, so this asks the only
+    /// question a header can answer: how much room the body takes.
+    /// Fujifilm's lossless mode spends between seven and nine bits a
+    /// pixel on every sample in the corpus (X100F 8.51, X-Pro3 8.15,
+    /// X-T5 7.64); the lossy mode quantises first and spends far less
+    /// — the GFX100S sample takes 4.71, which no lossless coder gets
+    /// from a 14-bit frame with ordinary photon noise. Six bits is
+    /// comfortably between the two.
+    pub fn looks_lossless(&self, body_bytes: usize) -> bool {
+        let pixels = self.width as u64 * self.height as u64;
+        pixels > 0 && (body_bytes as u64 * 8) / pixels >= 6
+    }
+}
+
+/// Decode a compressed sensor strip into `width * height` samples.
+///
+/// Always `Err`: see the module documentation for what is known about
+/// the coding and what is not.
+pub fn decode(strip: &[u8], width: usize, height: usize, cfa: &Cfa) -> Result<Vec<u16>> {
+    let header = Header::parse(strip)?;
+    if header.width != width || header.height != height {
+        return Err(Error::Corrupt(format!(
+            "compressed strip is {}x{} inside a {width}x{height} frame",
+            header.width, header.height
+        )));
+    }
+    // The header names the filter array too, and disagreeing with the
+    // container would mean one of the two was misread.
+    let x_trans = matches!(cfa, Cfa::XTrans(_));
+    if x_trans != (header.sensor == 0x10) {
+        return Err(Error::Corrupt(format!(
+            "compressed strip says sensor type {:#04x} for a {} frame",
+            header.sensor,
+            if x_trans { "X-Trans" } else { "Bayer" }
+        )));
+    }
+    let body = strip.len().saturating_sub(header.data_offset());
+    Err(Error::Unsupported(format!(
+        "RAF: Fujifilm {} compression ({} {}-bit, {} stripes of {})",
+        if header.looks_lossless(body) {
+            "lossless"
+        } else {
+            "lossy"
+        },
+        if x_trans { "X-Trans" } else { "Bayer" },
+        header.bits,
+        header.stripes,
+        header.stripe_width
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The X100F's real header, byte for byte.
+    const X100F: [u8; 16] = [
+        0x49, 0x53, 0x01, 0x10, 0x0e, 0x0f, 0xc6, 0x18, 0x00, 0x17, 0xa0, 0x03, 0x00, 0x08, 0x02,
+        0xa1,
+    ];
+
+    #[test]
+    fn reads_a_real_header() {
+        let header = Header::parse(&X100F).unwrap();
+        assert_eq!(
+            header,
+            Header {
+                version: 1,
+                sensor: 0x10,
+                bits: 14,
+                height: 4038,
+                rounded_width: 6144,
+                width: 6048,
+                stripe_width: 768,
+                stripes: 8,
+                blocks: 673,
+            }
+        );
+        // Eight lengths is 32 bytes, which is already a multiple of 16.
+        assert_eq!(header.data_offset(), 48);
+    }
+
+    #[test]
+    fn the_length_table_is_padded_to_sixteen_bytes() {
+        // The X-Pro3's nine stripes: 36 bytes of table, padded to 48.
+        let mut header = Header::parse(&X100F).unwrap();
+        header.stripes = 9;
+        assert_eq!(header.data_offset(), 64);
+        header.stripes = 16;
+        assert_eq!(header.data_offset(), 80);
+    }
+
+    #[test]
+    fn rejects_a_header_that_contradicts_itself() {
+        assert!(matches!(Header::parse(&X100F[..8]), Err(Error::Corrupt(_))));
+        let mut bad = X100F;
+        bad[0] = 0;
+        assert!(matches!(Header::parse(&bad), Err(Error::Corrupt(_))));
+        // Stripes that do not cover the rounded width.
+        let mut bad = X100F;
+        bad[13] = 7;
+        assert!(matches!(Header::parse(&bad), Err(Error::Corrupt(_))));
+        // A block count that does not make the height.
+        let mut bad = X100F;
+        bad[14..16].copy_from_slice(&100u16.to_be_bytes());
+        assert!(matches!(Header::parse(&bad), Err(Error::Corrupt(_))));
+        // A rounded width that rounds by more than a whole stripe.
+        let mut bad = X100F;
+        bad[9..11].copy_from_slice(&1000u16.to_be_bytes());
+        assert!(matches!(Header::parse(&bad), Err(Error::Corrupt(_))));
+    }
+
+    #[test]
+    fn the_body_size_tells_lossless_from_lossy() {
+        let header = Header::parse(&X100F).unwrap();
+        // The X100F's own body: 8.5 bits a pixel.
+        assert!(header.looks_lossless(25_977_312));
+        // The GFX100S's rate, scaled to this frame: 4.7 bits a pixel.
+        assert!(!header.looks_lossless(6048 * 4038 * 47 / 80));
+        assert!(!header.looks_lossless(0));
+    }
+
+    #[test]
+    fn decoding_says_what_the_file_is() {
+        let mut strip = X100F.to_vec();
+        strip.resize(16 + 32 + 25_977_264, 0);
+        let cfa = Cfa::XTrans([[crate::CfaColor::Green; 6]; 6]);
+        let why = decode(&strip, 6048, 4038, &cfa).unwrap_err().to_string();
+        assert!(why.contains("lossless"), "{why}");
+        assert!(why.contains("X-Trans"), "{why}");
+        // A Bayer container with an X-Trans header is a misread, not
+        // an unsupported file.
+        assert!(matches!(
+            decode(&strip, 6048, 4038, &Cfa::RGGB),
+            Err(Error::Corrupt(_))
+        ));
+        assert!(matches!(
+            decode(&strip, 10, 10, &cfa),
+            Err(Error::Corrupt(_))
+        ));
+    }
+}

--- a/crates/codec-raw/src/formats/rw2.rs
+++ b/crates/codec-raw/src/formats/rw2.rs
@@ -1,0 +1,824 @@
+//! RW2 — Panasonic, and the Leica bodies Panasonic builds (RWL, and
+//! the `.RAW` of the Digilux 2).
+//!
+//! An RW2 is a little-endian TIFF behind the signature `IIU\0`, but
+//! almost nothing in it is a TIFF tag: IFD0's low numbers are
+//! Panasonic's own, and they describe the sensor rather than an image.
+//! There is no ImageWidth, no BitsPerSample in the TIFF sense and no
+//! usable StripOffsets — 0x0111 is `0xFFFFFFFF` on every compressed
+//! body, and the sensor data is at 0x0118 instead, running to the end
+//! of the file.
+//!
+//! Four codecs have shipped, told apart by RawFormat (0x002D):
+//!
+//! * no tag at all, Compression 34826 — the oldest bodies (Digilux 2,
+//!   LC1) store whole 16-bit words with the sample at the top of each;
+//! * 4 — the one nearly every Panasonic ever made uses: fourteen
+//!   12-bit pixels to sixteen bytes, read through a stream that is
+//!   shuffled in 16 KB blocks. See [`decode_v4`];
+//! * 6 and 7 — the 14-bit scheme on the full-frame S bodies;
+//! * 8 — the newest (GH6, G9 II), 16-bit.
+//!
+//! Only the first two are implemented; the others return
+//! [`Error::Unsupported`] naming their version.
+//!
+//! The other oddity is where the metadata lives. Shutter speed,
+//! aperture, focal length and the lens name are *not* in the RW2's own
+//! directories: they are in the EXIF of the full-size JPEG that tag
+//! 0x002E carries inline, so that JPEG is parsed as well.
+
+use crate::formats::common;
+use crate::tiff::{tags, Ifd, Tiff};
+use crate::{Cfa, CfaColor, Error, Format, RawData, RawImage, Rect, Result};
+use rayon::prelude::*;
+
+/// Panasonic's own IFD0 tags, by the names ExifTool's tag
+/// documentation gives them. They occupy the numbers below 0x0100
+/// that TIFF leaves free.
+mod tag {
+    /// The full sensor frame, padding included.
+    pub const SENSOR_WIDTH: u16 = 0x0002;
+    pub const SENSOR_HEIGHT: u16 = 0x0003;
+    /// The frame the camera means to show, as four edges.
+    pub const SENSOR_TOP: u16 = 0x0004;
+    pub const SENSOR_LEFT: u16 = 0x0005;
+    pub const SENSOR_BOTTOM: u16 = 0x0006;
+    pub const SENSOR_RIGHT: u16 = 0x0007;
+    /// 1 RGGB, 2 GRBG, 3 GBRG, 4 BGGR.
+    pub const CFA_PATTERN: u16 = 0x0009;
+    pub const BITS_PER_SAMPLE: u16 = 0x000A;
+    /// 34316 for the Panasonic codecs, 34826 for the oldest bodies.
+    pub const COMPRESSION: u16 = 0x000B;
+    /// The level above which the sensor stops being linear, per
+    /// channel; the first is the one a developer wants.
+    pub const LINEARITY_LIMIT: u16 = 0x000E;
+    /// Red and blue balance x256, on the bodies too old for 0x0024.
+    pub const RED_BALANCE: u16 = 0x0011;
+    pub const BLUE_BALANCE: u16 = 0x0012;
+    pub const BLACK_LEVEL_RED: u16 = 0x001C;
+    pub const BLACK_LEVEL_GREEN: u16 = 0x001D;
+    pub const BLACK_LEVEL_BLUE: u16 = 0x001E;
+    pub const WB_RED_LEVEL: u16 = 0x0024;
+    pub const WB_GREEN_LEVEL: u16 = 0x0025;
+    pub const WB_BLUE_LEVEL: u16 = 0x0026;
+    /// The aspect-ratio crop, on the bodies that offer one: a
+    /// rectangle inside the sensor borders, four edges again but
+    /// numbered out of order.
+    pub const CROP_TOP: u16 = 0x002F;
+    pub const CROP_LEFT: u16 = 0x0030;
+    pub const CROP_BOTTOM: u16 = 0x0031;
+    pub const CROP_RIGHT: u16 = 0x0032;
+    /// Which codec the sensor data uses.
+    pub const RAW_FORMAT: u16 = 0x002D;
+    /// The full-size JPEG, inline.
+    pub const JPEG_FROM_RAW: u16 = 0x002E;
+    /// Where the sensor data starts, on every body that has a codec.
+    pub const RAW_DATA_OFFSET: u16 = 0x0118;
+}
+
+/// The codec version, from RawFormat.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Codec {
+    /// No RawFormat and Compression 34826: whole words.
+    Uncompressed,
+    /// RawFormat 4: fourteen pixels to sixteen bytes.
+    Blocks14,
+    /// RawFormat 7: nine 14-bit samples to sixteen bytes, packed
+    /// plainly with two bits left over.
+    PackedBlocks,
+    /// RawFormat 6: eleven 14-bit pixels to sixteen bytes, two of them
+    /// whole and the other nine predicted.
+    Groups11,
+    /// A version this module knows of but cannot decode.
+    Unsupported(u32),
+}
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let tiff = Tiff::parse(bytes)?;
+    let ifd = tiff.root();
+    let int = |tag: u16| ifd.get(tag).and_then(|e| e.u32(0));
+
+    let width = int(tag::SENSOR_WIDTH).unwrap_or(0) as usize;
+    let height = int(tag::SENSOR_HEIGHT).unwrap_or(0) as usize;
+    if width == 0 || height == 0 || width > 1 << 16 || height > 1 << 16 {
+        return Err(Error::Corrupt(format!("RW2 sensor {width}x{height}")));
+    }
+    let samples = crate::frame_samples(width, height, 1)?;
+    // Twelve bits on everything up to the GH5, fourteen on the S
+    // bodies, sixteen on the newest.
+    let bits = int(tag::BITS_PER_SAMPLE)
+        .filter(|b| (8..=16).contains(b))
+        .unwrap_or(12);
+    let compression = int(tag::COMPRESSION).unwrap_or(34316);
+    let codec = match int(tag::RAW_FORMAT) {
+        Some(4) => Codec::Blocks14,
+        Some(6) => Codec::Groups11,
+        Some(7) => Codec::PackedBlocks,
+        Some(other) => Codec::Unsupported(other),
+        None if compression == 34826 => Codec::Uncompressed,
+        None => Codec::Unsupported(0),
+    };
+
+    // The sensor data runs from RawDataOffset to the end of the file.
+    // StripOffsets is 0xFFFFFFFF on every compressed body — a
+    // deliberate "do not read me as a TIFF image" — so it is only
+    // trusted when RawDataOffset is missing and it looks like an
+    // offset.
+    let start = int(tag::RAW_DATA_OFFSET)
+        .or_else(|| int(tags::STRIP_OFFSETS).filter(|o| *o != u32::MAX))
+        .map(|o| o as usize)
+        .filter(|o| *o < bytes.len())
+        .ok_or_else(|| Error::Corrupt("RW2 with no sensor data offset".into()))?;
+    let data = &bytes[start..];
+
+    // Every codec stores at least a bit a sample, so the data bounds
+    // the frame a forged header may claim; the 11-pixel groups of
+    // RawFormat 6 are only known to tile rows that are whole groups.
+    if data.len().saturating_mul(8) < samples {
+        return Err(Error::Corrupt(format!(
+            "RW2 frame of {samples} samples in {} bytes",
+            data.len()
+        )));
+    }
+    if matches!(codec, Codec::Groups11) && !width.is_multiple_of(11) {
+        return Err(Error::Unsupported(format!(
+            "RW2 RawFormat 6 with a width of {width}, not a whole number of 11-pixel groups"
+        )));
+    }
+    let samples = match codec {
+        Codec::Blocks14 => decode_v4(data, width, height),
+        Codec::Groups11 => decode_v6(data, width, height),
+        Codec::PackedBlocks => decode_packed_blocks(data, width, height, bits),
+        Codec::Uncompressed => decode_words(data, width, height, bits),
+        Codec::Unsupported(version) => {
+            return Err(Error::Unsupported(format!(
+                "RW2 RawFormat {version}: the 12-bit block codec (4), the \
+                 14-bit ones (6, 7) and the uncompressed layout are implemented"
+            )))
+        }
+    };
+
+    let mut raw = RawImage::new(
+        Format::Rw2,
+        width,
+        height,
+        1,
+        RawData::U16(samples),
+        cfa(ifd),
+    );
+    let (make, model) = tiff.make_model();
+    raw.set_camera(&make, &model);
+
+    // Two rectangles, and the tighter one wins: the sensor borders say
+    // where the active area is, and the crop tags — present only on
+    // the bodies that offer 16:9, 3:2 and 1:1 in camera — say which
+    // part of it the photographer framed.
+    for edges in [
+        (
+            tag::SENSOR_TOP,
+            tag::SENSOR_LEFT,
+            tag::SENSOR_BOTTOM,
+            tag::SENSOR_RIGHT,
+        ),
+        (
+            tag::CROP_TOP,
+            tag::CROP_LEFT,
+            tag::CROP_BOTTOM,
+            tag::CROP_RIGHT,
+        ),
+    ] {
+        let (Some(top), Some(left), Some(bottom), Some(right)) =
+            (int(edges.0), int(edges.1), int(edges.2), int(edges.3))
+        else {
+            continue;
+        };
+        let (x, y) = (left as usize, top as usize);
+        let (right, bottom) = (right as usize, bottom as usize);
+        if right > x && bottom > y && right <= width && bottom <= height {
+            raw.crop = Rect {
+                x,
+                y,
+                width: right - x,
+                height: bottom - y,
+            };
+        }
+    }
+
+    // The codecs' zero sits fifteen counts above the level the tag
+    // records — it is the bias the block coder starts each group from.
+    // The 14-bit and uncompressed layouts have no such bias.
+    let bias = if codec == Codec::Blocks14 { 15.0 } else { 0.0 };
+    let black = |tag: u16| ifd.get(tag).and_then(|e| e.f64(0)).map(|v| v as f32 + bias);
+    if let (Some(r), Some(g), Some(b)) = (
+        black(tag::BLACK_LEVEL_RED),
+        black(tag::BLACK_LEVEL_GREEN),
+        black(tag::BLACK_LEVEL_BLUE),
+    ) {
+        for position in 0..4 {
+            raw.black_levels[position] = match raw.cfa.color_at(position % 2, position / 2) {
+                Some(CfaColor::Red) => r,
+                Some(CfaColor::Blue) => b,
+                _ => g,
+            };
+        }
+    }
+    raw.white_level = ifd
+        .get(tag::LINEARITY_LIMIT)
+        .and_then(|e| e.f64(0))
+        .map(|v| v as f32)
+        .filter(|v| *v > 0.0)
+        .unwrap_or(((1u32 << bits) - 1) as f32);
+    if raw.black_levels.iter().any(|b| *b >= raw.white_level) {
+        raw.black_levels = [0.0; 4];
+    }
+
+    if let (Some(r), Some(g), Some(b)) = (
+        ifd.get(tag::WB_RED_LEVEL).and_then(|e| e.f64(0)),
+        ifd.get(tag::WB_GREEN_LEVEL).and_then(|e| e.f64(0)),
+        ifd.get(tag::WB_BLUE_LEVEL).and_then(|e| e.f64(0)),
+    ) {
+        if g > 0.0 && r > 0.0 && b > 0.0 {
+            raw.wb_coeffs = [(r / g) as f32, 1.0, (b / g) as f32, 1.0];
+        }
+    } else if let (Some(r), Some(b)) = (
+        ifd.get(tag::RED_BALANCE).and_then(|e| e.f64(0)),
+        ifd.get(tag::BLUE_BALANCE).and_then(|e| e.f64(0)),
+    ) {
+        // The oldest bodies give the two balances against a green of
+        // 256 and no green level of their own.
+        if r > 0.0 && b > 0.0 {
+            raw.wb_coeffs = [(r / 256.0) as f32, 1.0, (b / 256.0) as f32, 1.0];
+        }
+    }
+
+    raw.orientation = common::orientation(&tiff);
+    raw.metadata = common::metadata(&tiff);
+    raw.preview = preview_from(&tiff);
+    // Shutter, aperture, focal length and lens are only in the
+    // preview's EXIF; so is the orientation, on the bodies whose IFD0
+    // leaves 0x0112 out.
+    if let Some(jpeg) = jpeg_exif(&tiff) {
+        let from_jpeg = common::metadata(&jpeg);
+        let meta = &mut raw.metadata;
+        meta.iso = meta.iso.or(from_jpeg.iso);
+        meta.exposure_time = meta.exposure_time.or(from_jpeg.exposure_time);
+        meta.f_number = meta.f_number.or(from_jpeg.f_number);
+        meta.focal_length = meta.focal_length.or(from_jpeg.focal_length);
+        meta.lens = meta.lens.take().or(from_jpeg.lens);
+        meta.date_time = meta.date_time.take().or(from_jpeg.date_time);
+        if !tiff.root().has(tags::ORIENTATION) {
+            raw.orientation = common::orientation(&jpeg);
+        }
+    }
+
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    let tiff = Tiff::parse(bytes)?;
+    Ok(preview_from(&tiff))
+}
+
+/// The full-size JPEG tag 0x002E carries inline, or whatever
+/// [`common::largest_jpeg`] can find if a body ever leaves it out.
+fn preview_from(tiff: &Tiff<'_>) -> Option<Vec<u8>> {
+    let inline = tiff.root().get(tag::JPEG_FROM_RAW).and_then(|entry| {
+        let stream = tiff
+            .bytes()
+            .get(entry.offset..entry.offset.checked_add(entry.count)?)?;
+        stream.starts_with(&[0xFF, 0xD8]).then(|| stream.to_vec())
+    });
+    match (inline, common::largest_jpeg(tiff)) {
+        (Some(inline), Some(found)) if found.len() > inline.len() => Some(found),
+        (Some(inline), _) => Some(inline),
+        (None, found) => found,
+    }
+}
+
+/// The TIFF inside the preview JPEG's APP1 segment, positioned so its
+/// offsets resolve against the whole file.
+fn jpeg_exif<'a>(tiff: &Tiff<'a>) -> Option<Tiff<'a>> {
+    let bytes = tiff.bytes();
+    let entry = tiff.root().get(tag::JPEG_FROM_RAW)?;
+    let end = entry.offset.checked_add(entry.count)?.min(bytes.len());
+    let jpeg = bytes.get(entry.offset..end)?;
+    if !jpeg.starts_with(&[0xFF, 0xD8]) {
+        return None;
+    }
+    // Walk marker segments only; APP1 is normally the first or second.
+    let mut at = 2;
+    while at + 4 <= jpeg.len() {
+        if jpeg[at] != 0xFF {
+            return None;
+        }
+        let marker = jpeg[at + 1];
+        // SOS or EOI: no metadata past here.
+        if marker == 0xDA || marker == 0xD9 {
+            return None;
+        }
+        let len = u16::from_be_bytes([jpeg[at + 2], jpeg[at + 3]]) as usize;
+        if len < 2 {
+            return None;
+        }
+        if marker == 0xE1 && jpeg.get(at + 4..at + 10) == Some(b"Exif\0\0") {
+            return Tiff::parse_embedded(bytes, entry.offset + at + 10).ok();
+        }
+        at += 2 + len;
+    }
+    None
+}
+
+/// The filter array, from Panasonic's own one-number code.
+fn cfa(ifd: &Ifd) -> Cfa {
+    match ifd.get(tag::CFA_PATTERN).and_then(|e| e.u32(0)) {
+        Some(1) => Cfa::RGGB,
+        Some(2) => Cfa::GRBG,
+        Some(3) => Cfa::GBRG,
+        Some(4) => Cfa::BGGR,
+        // Every body seen says which; RGGB is the majority when one
+        // does not.
+        _ => Cfa::RGGB,
+    }
+}
+
+/// The oldest layout: one 16-bit little-endian word a sample, with the
+/// sample's bits at the *top* of the word, so a 12-bit Digilux 2 reads
+/// sixteen times too high until it comes down.
+fn decode_words(data: &[u8], width: usize, height: usize, bits: u32) -> Vec<u16> {
+    let shift = 16 - bits.min(16);
+    let mut out = vec![0u16; width * height];
+    let (words, _) = data.as_chunks::<2>();
+    for (sample, word) in out.iter_mut().zip(words) {
+        *sample = u16::from_le_bytes(*word) >> shift;
+    }
+    out
+}
+
+/// The block every Panasonic codec is built on: sixteen bytes, holding
+/// a whole number of pixels so that a row of them starts clean.
+const BLOCK_BYTES: usize = 16;
+/// How many bytes of the shuffled stream one refill takes.
+const BLOCK: usize = 0x4000;
+/// Where a block is cut in two before being reassembled. The bytes
+/// after this point in the file arrive *first* in the buffer.
+const SPLIT: usize = 0x2008;
+/// Pixels to a group; the group is the unit the predictor restarts on.
+const GROUP: usize = 14;
+/// Bytes a group costs. Every pixel spends eight bits, each group
+/// spends eight more on its four shift codes, and each of the two
+/// column parities spends exactly one four-bit tail — 128 bits, always.
+const GROUP_BYTES: usize = BLOCK_BYTES;
+
+/// RawFormat 7: whole 14-bit samples, low bit first, as many as fit in
+/// a sixteen-byte block — nine of them, with two bits going to waste.
+/// Nothing is predicted or coded; the block is only there to keep the
+/// rows byte-aligned.
+fn decode_packed_blocks(data: &[u8], width: usize, height: usize, bits: u32) -> Vec<u16> {
+    let bits = bits.clamp(1, 16) as usize;
+    let per_block = BLOCK_BYTES * 8 / bits;
+    let mask = (1u128 << bits) - 1;
+    let mut out = vec![0u16; width * height];
+    out.par_chunks_mut(per_block)
+        .enumerate()
+        .for_each(|(block, chunk)| {
+            let from = block * BLOCK_BYTES;
+            let mut bytes = [0u8; BLOCK_BYTES];
+            if let Some(src) = data.get(from..from + BLOCK_BYTES) {
+                bytes.copy_from_slice(src);
+            }
+            let word = u128::from_le_bytes(bytes);
+            for (i, sample) in chunk.iter_mut().enumerate() {
+                *sample = ((word >> (i * bits)) & mask) as u16;
+            }
+        });
+    out
+}
+
+/// RawFormat 6: eleven 14-bit pixels to every sixteen bytes.
+///
+/// A block is one 128-bit word, filled from the top down: two whole
+/// 14-bit pixels, then three groups of three predicted ones, then four
+/// bits nobody uses. Each group opens with a two-bit code giving the
+/// step its three pixels are measured in — 1, 2, 4 or 16 counts — and
+/// then three ten-bit numbers, each the difference from the pixel two
+/// places back (the one under the same colour) biased by 512.
+///
+/// The subtlety is what happens when a difference cannot reach: the
+/// predictor is first lowered by half the step's range, and if that
+/// takes it below zero — or if the step is at its widest, which is the
+/// coder's way of saying "start again here" — it is dropped to zero
+/// and the ten bits stand for the pixel outright.
+///
+/// Everything is coded fifteen counts high; the offset comes off at
+/// the end. It is the same fifteen the 12-bit codec leaves in the
+/// samples for the black level tag to carry.
+fn decode_v6(data: &[u8], width: usize, height: usize) -> Vec<u16> {
+    /// Two bits of step code, as a shift.
+    const STEPS: [u32; 4] = [0, 1, 2, 4];
+    const PIXELS: usize = 11;
+    /// What every sample is coded above its true value.
+    const BIAS: i32 = 15;
+
+    let mut out = vec![0u16; width * height];
+    out.par_chunks_mut(PIXELS)
+        .enumerate()
+        .for_each(|(block, chunk)| {
+            let from = block * BLOCK_BYTES;
+            let mut bytes = [0u8; BLOCK_BYTES];
+            if let Some(src) = data.get(from..from + BLOCK_BYTES) {
+                bytes.copy_from_slice(src);
+            }
+            let word = u128::from_le_bytes(bytes);
+            let field = |at: u32, width: u32| ((word >> at) & ((1 << width) - 1)) as i32;
+
+            let mut pixel = [0i32; PIXELS];
+            pixel[0] = field(114, 14);
+            pixel[1] = field(100, 14);
+            for group in 0..3u32 {
+                let step = STEPS[field(98 - group * 32, 2) as usize];
+                for j in 0..3u32 {
+                    let at = 2 + (group * 3 + j) as usize;
+                    let mut pred = pixel[at - 2] - (512 << step);
+                    if pred < 0 || step == 4 {
+                        pred = 0;
+                    }
+                    pixel[at] = pred + (field(88 - group * 32 - j * 10, 10) << step);
+                }
+            }
+            for (sample, value) in chunk.iter_mut().zip(pixel) {
+                *sample = (value - BIAS).clamp(0, u16::MAX as i32) as u16;
+            }
+        });
+    out
+}
+
+/// Panasonic's bit reader.
+///
+/// The stream is not read straight through. It arrives in 16 KB
+/// blocks, and each block is cut at [`SPLIT`] and reassembled with its
+/// tail first; within the reassembled buffer the bit counter runs
+/// *backwards* from the top, and the byte it lands on is passed
+/// through `^ 0x3FF0`, which walks the buffer forwards in groups of
+/// sixteen bytes. The two inversions cancel: a reader that simply
+/// followed the file would see the same bits, in a different order.
+struct PanaBits<'a> {
+    data: &'a [u8],
+    pos: usize,
+    /// The bit cursor, counted down modulo one buffer's worth of bits.
+    /// Zero means "the buffer is spent, refill before reading".
+    vbits: u32,
+    buf: [u8; BLOCK + 1],
+}
+
+impl<'a> PanaBits<'a> {
+    fn new(data: &'a [u8]) -> PanaBits<'a> {
+        PanaBits {
+            data,
+            pos: 0,
+            vbits: 0,
+            buf: [0; BLOCK + 1],
+        }
+    }
+
+    fn refill(&mut self) {
+        let take = |data: &'a [u8], from: usize, len: usize| -> &'a [u8] {
+            data.get(from..(from + len).min(data.len())).unwrap_or(&[])
+        };
+        self.buf = [0; BLOCK + 1];
+        let tail = take(self.data, self.pos, BLOCK - SPLIT);
+        self.buf[SPLIT..SPLIT + tail.len()].copy_from_slice(tail);
+        let head = take(self.data, self.pos + (BLOCK - SPLIT), SPLIT);
+        self.buf[..head.len()].copy_from_slice(head);
+        self.pos += BLOCK;
+    }
+
+    /// The next `n` bits (at most 8, which is all this codec ever asks
+    /// for). Past the end of the data the buffer is zeros, so a
+    /// truncated file decodes to a short picture instead of failing.
+    fn get(&mut self, n: u32) -> u32 {
+        if self.vbits == 0 {
+            self.refill();
+        }
+        // 0x1FFFF is one buffer of bits less one: the cursor wraps
+        // to 0 exactly when the buffer is spent.
+        self.vbits = (self.vbits.wrapping_sub(n)) & 0x1FFFF;
+        let at = ((self.vbits >> 3) ^ 0x3FF0) as usize;
+        let word = self.buf[at] as u32 | (self.buf[at + 1] as u32) << 8;
+        (word >> (self.vbits & 7)) & ((1 << n) - 1)
+    }
+}
+
+/// The predictor state, restarted every [`GROUP`] pixels. Odd and even
+/// columns are predicted apart, so that each side of the filter array
+/// tracks its own colour.
+#[derive(Default)]
+struct Group {
+    pred: [i32; 2],
+    nonz: [i32; 2],
+    shift: u32,
+}
+
+impl Group {
+    /// Decode pixel `i` of a group.
+    ///
+    /// A pixel is normally an eight-bit difference from the last pixel
+    /// of the same parity, scaled by a shift that a two-bit code
+    /// refreshes every third pixel — 0, 1, 2 or 4 bits, so the step can
+    /// coarsen where the signal is loud. Until a parity has produced
+    /// its first non-zero byte it is not predicting anything yet, and
+    /// that first byte is instead the top eight bits of a twelve-bit
+    /// absolute value; a parity that stays at zero to the end of the
+    /// group is given its absolute value anyway, which is what keeps
+    /// every group exactly sixteen bytes long.
+    fn pixel(&mut self, bits: &mut PanaBits<'_>, i: usize) -> u16 {
+        if i == 0 {
+            self.pred = [0; 2];
+            self.nonz = [0; 2];
+        }
+        if i % 3 == 2 {
+            // 0, 1, 2, 4 — the code counts down from the widest.
+            self.shift = 4u32.checked_shr(3 - bits.get(2)).unwrap_or(0);
+        }
+        let side = i & 1;
+        let shift = self.shift;
+        if self.nonz[side] != 0 {
+            let step = bits.get(8) as i32;
+            if step != 0 {
+                let low = self.pred[side] - (0x80 << shift);
+                // The difference is biased by half its range. Where
+                // that would take the prediction below zero — or where
+                // the shift is at its widest — only the bits the shift
+                // leaves behind are kept, which wraps rather than
+                // clips.
+                self.pred[side] = if low < 0 || shift == 4 {
+                    low & !(-1 << shift)
+                } else {
+                    low
+                };
+                self.pred[side] += step << shift;
+            }
+        } else {
+            self.nonz[side] = bits.get(8) as i32;
+            if self.nonz[side] != 0 || i > GROUP - 3 {
+                self.pred[side] = (self.nonz[side] << 4) | bits.get(4) as i32;
+            }
+        }
+        self.pred[side].clamp(0, u16::MAX as i32) as u16
+    }
+}
+
+/// RawFormat 4: fourteen 12-bit pixels to every sixteen bytes.
+///
+/// Because a group is exactly sixteen bytes and a refill is exactly
+/// 16 KB, one refill covers exactly 1024 groups — 14336 pixels — and
+/// the predictor restarts at every group. So long as a row is a whole
+/// number of groups (every body seen makes it so), the blocks are
+/// independent and decode in parallel.
+fn decode_v4(data: &[u8], width: usize, height: usize) -> Vec<u16> {
+    let pixels = width * height;
+    let mut out = vec![0u16; pixels];
+    let per_block = BLOCK / GROUP_BYTES * GROUP;
+    if !width.is_multiple_of(GROUP) {
+        // A frame whose rows are not whole groups has to be walked in
+        // order: the predictor restarts at the start of every row as
+        // well, so groups and blocks stop lining up.
+        let mut bits = PanaBits::new(data);
+        let mut group = Group::default();
+        for row in 0..height {
+            for col in 0..width {
+                out[row * width + col] = group.pixel(&mut bits, col % GROUP);
+            }
+        }
+        return out;
+    }
+    out.par_chunks_mut(per_block)
+        .enumerate()
+        .for_each(|(block, chunk)| {
+            let from = block * BLOCK;
+            let mut bits = PanaBits::new(data.get(from..).unwrap_or(&[]));
+            let mut group = Group::default();
+            for (i, sample) in chunk.iter_mut().enumerate() {
+                *sample = group.pixel(&mut bits, i % GROUP);
+            }
+        });
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A minimal RW2: the `IIU\0` signature and an IFD0 of Panasonic
+    /// tags, with `data` at the end as the sensor stream.
+    fn build(entries: &[(u16, u16, u32)], data: &[u8]) -> Vec<u8> {
+        let mut entries = entries.to_vec();
+        let ifd_at = 8usize;
+        let data_at = ifd_at + 2 + (entries.len() + 1) * 12 + 4;
+        entries.push((tag::RAW_DATA_OFFSET, 4, data_at as u32));
+        entries.sort_by_key(|e| e.0);
+        let mut out = Vec::new();
+        out.extend_from_slice(b"IIU\0");
+        out.extend_from_slice(&(ifd_at as u32).to_le_bytes());
+        out.extend_from_slice(&(entries.len() as u16).to_le_bytes());
+        for (tag, kind, value) in &entries {
+            out.extend_from_slice(&tag.to_le_bytes());
+            out.extend_from_slice(&kind.to_le_bytes());
+            out.extend_from_slice(&1u32.to_le_bytes());
+            out.extend_from_slice(&value.to_le_bytes());
+        }
+        out.extend_from_slice(&0u32.to_le_bytes());
+        assert_eq!(out.len(), data_at);
+        out.extend_from_slice(data);
+        out
+    }
+
+    fn sensor(width: u32, height: u32, format: Option<u32>, bits: u32) -> Vec<(u16, u16, u32)> {
+        let mut out = vec![
+            (tag::SENSOR_WIDTH, 3, width),
+            (tag::SENSOR_HEIGHT, 3, height),
+            (tag::SENSOR_TOP, 3, 0),
+            (tag::SENSOR_LEFT, 3, 0),
+            (tag::SENSOR_BOTTOM, 3, height),
+            (tag::SENSOR_RIGHT, 3, width),
+            (tag::CFA_PATTERN, 3, 1),
+            (tag::BITS_PER_SAMPLE, 3, bits),
+            (
+                tag::COMPRESSION,
+                3,
+                if format.is_some() { 34316 } else { 34826 },
+            ),
+        ];
+        if let Some(format) = format {
+            out.push((tag::RAW_FORMAT, 3, format));
+        }
+        out
+    }
+
+    #[test]
+    fn the_oldest_layout_is_top_aligned_words() {
+        let data = [0x00, 0x12, 0x00, 0x34, 0xf0, 0xff, 0x00, 0x00];
+        let file = build(&sensor(4, 1, None, 12), &data);
+        let raw = decode(&file).expect("decodes");
+        let RawData::U16(samples) = &raw.data else {
+            panic!("u16")
+        };
+        assert_eq!(samples, &[0x120, 0x340, 0xfff, 0]);
+        assert_eq!(raw.cfa, Cfa::RGGB);
+    }
+
+    /// The shuffled reader. The cursor starts at the top of the
+    /// buffer and runs down, and the byte it lands on goes through
+    /// `^ 0x3FF0`, so the first byte out is buffer index 15 — which,
+    /// because a block's tail is loaded ahead of its head, is file
+    /// byte `BLOCK - SPLIT + 15`. The second byte out is index 14, and
+    /// so on down each group of sixteen.
+    #[test]
+    fn the_reader_walks_a_shuffled_block() {
+        let mut data = vec![0u8; BLOCK * 2];
+        data[BLOCK - SPLIT + 15] = 0xA5;
+        data[BLOCK - SPLIT + 14] = 0x5A;
+        // The first byte of the file lands at buffer index SPLIT,
+        // which the cursor reaches much later.
+        data[0] = 0x11;
+        let mut bits = PanaBits::new(&data);
+        assert_eq!(bits.get(8), 0xA5);
+        assert_eq!(bits.get(8), 0x5A);
+        for _ in 2..16 {
+            assert_eq!(bits.get(8), 0);
+        }
+        // Sixteen bytes in, the cursor jumps to the next group of
+        // sixteen rather than continuing straight down.
+        assert_eq!(bits.get(8), 0);
+    }
+
+    /// A group is always sixteen bytes: 14 pixels x 8 bits, 4 shift
+    /// codes x 2 bits, and one 4-bit tail for each column parity.
+    #[test]
+    fn a_group_costs_exactly_sixteen_bytes() {
+        let data = vec![0u8; BLOCK * 2];
+        let mut bits = PanaBits::new(&data);
+        let mut group = Group::default();
+        let start = bits.vbits;
+        for i in 0..GROUP {
+            group.pixel(&mut bits, i);
+        }
+        // The cursor runs down, so a spent group shows as a fall of
+        // 128 bits (modulo the buffer).
+        assert_eq!((start.wrapping_sub(bits.vbits)) & 0x1FFFF, 128);
+    }
+
+    #[test]
+    fn an_unknown_codec_says_which() {
+        let file = build(&sensor(14, 1, Some(9), 14), &[0; 64]);
+        let error = decode(&file).expect_err("unsupported");
+        assert!(format!("{error}").contains("RawFormat 9"), "{error}");
+    }
+
+    /// The 14-bit group codec, hand-built: the two leaders sit at the
+    /// top of the block and read out whole, and a group whose step
+    /// code is at its widest ignores the predictor entirely.
+    #[test]
+    fn the_group_codec_reads_leaders_whole_and_restarts_at_the_widest_step() {
+        let mut word: u128 = 0;
+        word |= (1000u128 + 15) << 114; // pixel 0
+        word |= (2000u128 + 15) << 100; // pixel 1
+                                        // Group 0: step code 0, three differences of exactly zero.
+        for j in 0..3 {
+            word |= 512u128 << (88 - j * 10);
+        }
+        // Group 1: step code 3 (a shift of four), so its three pixels
+        // are the ten-bit fields scaled up, predictor discarded.
+        word |= 3u128 << 66;
+        for j in 0..3 {
+            word |= 100u128 << (56 - j * 10);
+        }
+        let data = word.to_le_bytes();
+        let out = decode_v6(&data, 11, 1);
+        assert_eq!(&out[..2], &[1000, 2000]);
+        // Zero differences carry the leaders forward, parity by parity.
+        assert_eq!(&out[2..5], &[1000, 2000, 1000]);
+        assert_eq!(&out[5..8], &[100 * 16 - 15; 3]);
+    }
+
+    #[test]
+    fn hostile_input_never_panics() {
+        assert!(decode(&[]).is_err());
+        assert!(decode(b"IIU\0").is_err());
+        let file = build(&sensor(14, 4, Some(4), 12), &[0x5a; 128]);
+        assert!(decode(&file).is_ok());
+        for cut in 0..file.len() {
+            let _ = decode(&file[..cut]);
+            let _ = preview(&file[..cut]);
+        }
+    }
+}
+
+/// Corpus tests: every RW2, RWL and Panasonic-shaped RAW under
+/// `SCHIST_RAW_CORPUS`, against the LibRaw oracle beside it. The
+/// oracle helpers live in the ORF module, which shares them.
+#[cfg(test)]
+mod corpus {
+    use super::super::orf::oracle;
+    use super::*;
+
+    /// Files this crate knowingly cannot decode yet, with the reason.
+    /// A file on this list still has to probe as an RW2 and fail with
+    /// `Unsupported` rather than a panic or a wrong picture.
+    const UNSUPPORTED: &[&str] = &[
+        // RawFormat 6 and 7: the 14-bit codec on the full-frame S
+        // bodies. RawFormat 8: the 16-bit one on the GH6 and G9 II.
+        "RawFormat",
+    ];
+
+    /// `.RAW` is on the list for the Digilux 2 and the LC1, whose
+    /// files predate the RW2 extension; other makers use it too, so
+    /// anything that does not probe as an RW2 is left to its own
+    /// module.
+    fn files() -> Vec<std::path::PathBuf> {
+        oracle::corpus_files(&["rw2", "rwl", "raw"])
+            .into_iter()
+            .filter(|path| {
+                path.extension()
+                    .is_none_or(|e| !e.eq_ignore_ascii_case("raw"))
+                    || std::fs::read(path).is_ok_and(|b| crate::probe(&b) == Some(Format::Rw2))
+            })
+            .collect()
+    }
+
+    #[test]
+    fn every_file_matches_the_oracle() {
+        for path in &files() {
+            let bytes = std::fs::read(path).expect("corpus file readable");
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(Format::Rw2),
+                "{} did not probe as RW2",
+                path.display()
+            );
+            let raw = match crate::decode(&bytes) {
+                Ok(raw) => raw,
+                Err(Error::Unsupported(why)) if UNSUPPORTED.iter().any(|m| why.contains(m)) => {
+                    eprintln!("{}: {why}", path.display());
+                    continue;
+                }
+                Err(e) => panic!("{}: {e}", path.display()),
+            };
+            raw.validate().expect("valid");
+            oracle::compare_samples(path, &raw);
+            oracle::compare_metadata(path, &raw);
+            oracle::check_preview(path, &raw);
+        }
+    }
+
+    #[test]
+    fn truncation_never_panics() {
+        for path in &files() {
+            let bytes = std::fs::read(path).expect("corpus file readable");
+            oracle::truncations(bytes.len(), 10, |cut| {
+                let _ = crate::decode(&bytes[..cut]);
+                let _ = crate::preview(&bytes[..cut]);
+            });
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/srw.rs
+++ b/crates/codec-raw/src/formats/srw.rs
@@ -1,0 +1,967 @@
+//! Samsung SRW: a TIFF whose sensor frame hides in a SubIFD with no
+//! PhotometricInterpretation, under one of five compressions.
+//!
+//! Samsung's SubIFD claims `SamplesPerPixel` 3 on most bodies even
+//! though a CFA frame has one sample a pixel, and never says the strip
+//! is CFA data. What it does carry is `CFARepeatPatternDim` and
+//! `CFAPattern`, so the filter array is read from the file rather than
+//! looked up, and the strip's own byte count says whether the data is
+//! compressed at all. Nothing here is decided by camera model.
+//!
+//! The compressions, all private numbers:
+//!
+//! * `32769`, and `32770` on the 2010 bodies — not compressed. Either
+//!   one 16-bit little-endian word a pixel or samples packed at
+//!   `BitsPerSample`; the strip's size tells which.
+//! * `32770` with a row-pointer table — the first lossless codec (the
+//!   NX300 generation). See [`decompress_v1`].
+//! * `32772` — a Huffman-coded difference per pixel against a table
+//!   built into the firmware (NX mini, NX3000). See [`decompress_v2`].
+//! * `32773` — the last codec, on the NX1 and NX500. Not implemented;
+//!   [`decode`] returns [`crate::Error::Unsupported`] for it.
+//!
+//! Written from observation of the files and their LibRaw-unpacked
+//! frames, plus the TIFF 6.0 and Exif specifications and ExifTool's
+//! published Samsung tag tables. No decoder source was consulted.
+
+use crate::bits::{BitPump, BitPumpLsb, BitPumpMsb, BitPumpMsb32};
+use crate::formats::common;
+use crate::tiff::{tags, Ifd, ImageLayout, Tiff};
+use crate::{Cfa, CfaColor, Error, Format, RawData, RawImage, Rect, Result};
+
+/// Uncompressed, one 16-bit word a pixel (the EX1 and the compacts).
+const COMPRESSION_PLAIN: u32 = 32769;
+/// The first lossless codec — but also what the 2010 NX bodies write
+/// on a frame that is merely packed, which is why the strip's size
+/// decides rather than this number.
+const COMPRESSION_V1: u32 = 32770;
+/// The firmware-table Huffman codec.
+const COMPRESSION_V2: u32 = 32772;
+/// The NX1/NX500 codec.
+const COMPRESSION_V3: u32 = 32773;
+
+/// Makernote tags this decoder reads. Names are ExifTool's.
+mod mn {
+    /// `SensorAreas`: two rectangles as `x0 y0 x1 y1`, the second of
+    /// which is the active area.
+    pub const SENSOR_AREAS: u16 = 0xA010;
+    /// `EncryptionKey`: eleven longs, the first four of which are
+    /// added to the white-balance and black-level tags.
+    pub const ENCRYPTION_KEY: u16 = 0xA020;
+    /// `WB_RGGBLevelsUncorrected`: the as-shot balance, R G1 G2 B,
+    /// green at 4096.
+    pub const WB_LEVELS: u16 = 0xA021;
+    /// `WB_RGGBLevelsBlack`: the black point, R G1 G2 B.
+    pub const BLACK_LEVELS: u16 = 0xA028;
+}
+
+/// SubIFD tag 0xA010, `SamsungRawPointersOffset`: where the per-row
+/// offsets of a v1 stream live. Not to be confused with the makernote
+/// tag of the same number.
+const RAW_POINTERS_OFFSET: u16 = 0xA010;
+
+/// Decode an SRW into its sensor frame and metadata.
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let tiff = Tiff::parse(bytes)?;
+    let ifd = raw_ifd(&tiff)?;
+    let layout = ImageLayout::of(&tiff, ifd)?;
+    let (width, height) = (layout.width, layout.height);
+    if width == 0 || height == 0 || width > 1 << 16 || height > 1 << 16 {
+        return Err(Error::Corrupt(format!("SRW frame is {width}x{height}")));
+    }
+    let bits = layout.bits_per_sample;
+    if !(8..=16).contains(&bits) {
+        return Err(Error::Unsupported(format!("SRW with {bits} bits a sample")));
+    }
+    // One strip is what every SRW writes, and every codec below is a
+    // single stream over it.
+    let [(start, len)] = layout.chunks[..] else {
+        return Err(Error::Unsupported(format!(
+            "SRW frame in {} strips, not one",
+            layout.chunks.len()
+        )));
+    };
+    let strip = &bytes[start..start + len];
+
+    // The strip bounds the frame: every layout stores at least a bit
+    // a sample, so a header claiming more is a forgery and must not
+    // size an allocation.
+    let pixels = crate::frame_samples(width, height, 1)?;
+    if len.saturating_mul(8) < pixels {
+        return Err(Error::Corrupt(format!(
+            "SRW frame of {pixels} samples in {len} bytes"
+        )));
+    }
+    let packed_bytes = (width * bits as usize).div_ceil(8) * height;
+    let data = if len >= pixels * 2 {
+        // Samsung writes its sensor words little-endian whatever the
+        // TIFF's own byte order says, so this does not follow `tiff`.
+        plain(strip, pixels)
+    } else if len >= packed_bytes {
+        // Two packings, differing only in which end of a byte the
+        // first sample comes from. The 2010 bodies (NX5, NX10) write
+        // the frame MSB-first and are the only ones in the corpus that
+        // set SamplesPerPixel to 1; every later body writes it
+        // LSB-first and claims three samples a pixel. That tag is the
+        // only thing in the file that tracks the split.
+        let msb_first = ifd.get(tags::SAMPLES_PER_PIXEL).and_then(|e| e.u32(0)) == Some(1);
+        packed(strip, width, height, bits, msb_first)
+    } else {
+        match layout.compression {
+            // 32769 promises whole samples and nothing else; a strip
+            // too small to hold them is a broken file, not a codec
+            // this crate has yet to learn.
+            COMPRESSION_PLAIN => {
+                return Err(Error::Corrupt(format!(
+                    "SRW says uncompressed but its {len}-byte strip cannot hold {pixels} samples"
+                )))
+            }
+            COMPRESSION_V1 => {
+                let pointers = row_pointers(&tiff, ifd, height)?;
+                decompress_v1(strip, &pointers, width, height)
+            }
+            COMPRESSION_V2 => decompress_v2(strip, width, height),
+            COMPRESSION_V3 => {
+                return Err(Error::Unsupported(
+                    "SRW compression 32773, the NX1 and NX500 codec".into(),
+                ))
+            }
+            other => {
+                return Err(Error::Unsupported(format!(
+                    "SRW compression {other} with a strip too small to be plain samples"
+                )))
+            }
+        }
+    };
+
+    let mut raw = RawImage::new(
+        Format::Srw,
+        width,
+        height,
+        1,
+        RawData::U16(data),
+        cfa(ifd).unwrap_or(Cfa::GRBG),
+    );
+    let (make, model) = tiff.make_model();
+    raw.set_camera(&make, &model);
+    // The sensor SubIFD's CFAPattern is wrong on several bodies —
+    // checked three ways against the oracle frames and the cameras'
+    // own JPEGs — so those are corrected by model.
+    if let Some(fixed) = cfa_override(&raw.clean_model) {
+        raw.cfa = fixed;
+    }
+    raw.orientation = common::orientation(&tiff);
+    raw.metadata = common::metadata(&tiff);
+    raw.preview = common::largest_jpeg(&tiff);
+    // Samsung records no saturation point anywhere; the bit depth is
+    // it, and the frames in the corpus do clip at exactly that.
+    raw.white_level = ((1u32 << bits) - 1) as f32;
+
+    let maker = makernote(&tiff);
+    if let Some(maker) = maker.as_ref() {
+        let key = quad(maker, mn::ENCRYPTION_KEY).unwrap_or([0.0; 4]);
+        // Samsung stores both level quads with a fixed eleven-long
+        // "encryption key" added, the first four entries of which
+        // apply here. Subtracting it is what turns the tag into the
+        // number the camera meant, and every body in the corpus ships
+        // the same key.
+        if let Some(levels) = quad(maker, mn::BLACK_LEVELS) {
+            let levels = std::array::from_fn(|i| levels[i] - key[i]);
+            raw.black_levels = by_position(&raw.cfa, levels);
+        }
+        if let Some(wb) = quad(maker, mn::WB_LEVELS) {
+            let wb: [f32; 4] = std::array::from_fn(|i| wb[i] - key[i]);
+            let green = wb[1];
+            if green > 0.0 && wb.iter().all(|v| *v > 0.0) {
+                // R G1 G2 B in the tag; R G B G2 in `wb_coeffs`.
+                raw.wb_coeffs = [wb[0] / green, 1.0, wb[3] / green, wb[2] / green];
+            }
+        }
+        raw.crop = active_area(maker, width, height);
+    }
+
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+/// The largest embedded JPEG: SRW keeps a full-size one in the first
+/// SubIFD and a thumbnail in IFD1's.
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    Ok(common::largest_jpeg(&Tiff::parse(bytes)?))
+}
+
+// ------------------------------------------------------------ structure
+
+/// The SubIFD holding sensor samples.
+///
+/// No SRW sets PhotometricInterpretation on it, so it is found the way
+/// [`crate::probe`] finds it: the IFD with strips more than eight bits
+/// deep. The full-size preview's IFD is JPEG-compressed and has no
+/// BitsPerSample at all, so the two never collide.
+fn raw_ifd<'a>(tiff: &'a Tiff<'_>) -> Result<&'a Ifd> {
+    tiff.all()
+        .into_iter()
+        .find(|ifd| {
+            ifd.has(tags::STRIP_OFFSETS)
+                && ifd
+                    .get(tags::BITS_PER_SAMPLE)
+                    .and_then(|e| e.u32(0))
+                    .unwrap_or(0)
+                    > 8
+        })
+        .ok_or_else(|| Error::Corrupt("SRW with no sensor SubIFD".into()))
+}
+
+/// Bodies whose CFAPattern tag does not describe the frame it sits
+/// in. Verified per body by the green-parity correlation of the
+/// oracle frame and by chroma against the camera's embedded JPEG; a
+/// wrong phase here swaps red and blue in the developed picture.
+fn cfa_override(clean_model: &str) -> Option<Cfa> {
+    let model = clean_model.to_ascii_uppercase();
+    let model = model.trim();
+    match model {
+        "NX2000" | "NX300" | "EK-GN120" | "NX3000" => Some(Cfa::GRBG),
+        "NX MINI" => Some(Cfa::RGGB),
+        _ => None,
+    }
+}
+
+/// `CFARepeatPatternDim` and `CFAPattern` from the sensor SubIFD, as
+/// the pattern at the frame's own origin.
+///
+/// LibRaw's "Filter pattern" line names the pattern at *its* crop
+/// origin, which on several bodies is an odd column in and so reads a
+/// column-shifted version of this. The file's tag is the frame's, and
+/// [`crate::RawImage::cfa`] is defined at the frame origin.
+fn cfa(ifd: &Ifd) -> Option<Cfa> {
+    let dim = ifd.get(tags::CFA_REPEAT_PATTERN_DIM)?;
+    let (width, height) = (dim.u32(0)? as usize, dim.u32(1)? as usize);
+    let pattern = ifd.get(tags::CFA_PATTERN)?.bytes()?;
+    if width == 0 || height == 0 || pattern.len() < width * height {
+        return None;
+    }
+    let color = |v: u8| match v {
+        0 => Some(CfaColor::Red),
+        1 => Some(CfaColor::Green),
+        2 => Some(CfaColor::Blue),
+        _ => None,
+    };
+    let colors: Option<Vec<CfaColor>> = pattern[..width * height]
+        .iter()
+        .map(|v| color(*v))
+        .collect();
+    let colors = colors?;
+    if (width, height) == (2, 2) {
+        Some(Cfa::Bayer([colors[0], colors[1], colors[2], colors[3]]))
+    } else {
+        Some(Cfa::Pattern {
+            width,
+            height,
+            colors,
+        })
+    }
+}
+
+/// The makernote as a TIFF.
+///
+/// Samsung's is a bare IFD — no signature, no byte-order mark — whose
+/// offsets are measured from the makernote's own start. It shares the
+/// file's byte order.
+fn makernote<'a>(tiff: &Tiff<'a>) -> Option<Tiff<'a>> {
+    let start = tiff.find(tags::MAKER_NOTE)?.offset;
+    Tiff::parse_at_relative(tiff.bytes(), start, start, tiff.little_endian()).ok()
+}
+
+/// A four-element makernote value as floats, in the tag's own order.
+fn quad(maker: &Tiff<'_>, tag: u16) -> Option<[f32; 4]> {
+    let entry = maker.find(tag)?;
+    let values: Vec<f32> = (0..4)
+        .filter_map(|i| entry.f64(i))
+        .map(|v| v as f32)
+        .collect();
+    values.try_into().ok()
+}
+
+/// Spread a tag's R G1 G2 B quad over the frame's four CFA positions.
+fn by_position(cfa: &Cfa, values: [f32; 4]) -> [f32; 4] {
+    let mut greens = 0;
+    std::array::from_fn(|i| match cfa.color_at(i % 2, i / 2) {
+        Some(CfaColor::Red) => values[0],
+        Some(CfaColor::Blue) => values[3],
+        Some(CfaColor::Green | CfaColor::Green2) => {
+            greens += 1;
+            values[greens.min(2)]
+        }
+        _ => values[0],
+    })
+}
+
+/// The active area, from the second rectangle of `SensorAreas`.
+///
+/// The tag holds two `x0 y0 x1 y1` rectangles: the sensor's whole
+/// readout and, second, the part meant to be developed. The corners
+/// are inclusive of the first and exclusive of the second, so the
+/// width is `x1 - x0`.
+fn active_area(maker: &Tiff<'_>, width: usize, height: usize) -> Rect {
+    let whole = Rect {
+        x: 0,
+        y: 0,
+        width,
+        height,
+    };
+    let Some(areas) = maker.find(mn::SENSOR_AREAS) else {
+        return whole;
+    };
+    let corner = |i: usize| areas.u32(i).map(|v| v as usize);
+    let (Some(x0), Some(y0), Some(x1), Some(y1)) = (corner(4), corner(5), corner(6), corner(7))
+    else {
+        return whole;
+    };
+    if x1 <= x0 || y1 <= y0 || x1 > width || y1 > height {
+        return whole;
+    }
+    Rect {
+        x: x0,
+        y: y0,
+        width: x1 - x0,
+        height: y1 - y0,
+    }
+}
+
+/// The per-row byte offsets of a v1 stream, relative to the strip.
+fn row_pointers(tiff: &Tiff<'_>, ifd: &Ifd, height: usize) -> Result<Vec<u32>> {
+    let offset = ifd
+        .get(RAW_POINTERS_OFFSET)
+        .and_then(|e| e.u32(0))
+        .filter(|o| *o != 0)
+        .ok_or_else(|| Error::Corrupt("compressed SRW without a row-pointer table".into()))?
+        as usize;
+    // The table is four bytes a row; the frame's height, not the
+    // length tag (which is only ever that number), says how many.
+    let base = tiff.base() + offset;
+    let want = height * 4;
+    let table = tiff
+        .bytes()
+        .get(base..base + want)
+        .ok_or_else(|| Error::Corrupt("SRW row-pointer table outside the file".into()))?;
+    Ok(table
+        .chunks(4)
+        .filter(|b| b.len() == 4)
+        .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect())
+}
+
+// ------------------------------------------------------- uncompressed
+
+/// One 16-bit little-endian word a pixel.
+fn plain(strip: &[u8], pixels: usize) -> Vec<u16> {
+    let mut out = vec![0u16; pixels];
+    for (sample, word) in out.iter_mut().zip(strip.chunks(2)) {
+        if let [low, high] = word {
+            *sample = u16::from_le_bytes([*low, *high]);
+        }
+    }
+    out
+}
+
+/// Samples packed at `bits`, rows starting on byte boundaries.
+fn packed(strip: &[u8], width: usize, height: usize, bits: u32, msb_first: bool) -> Vec<u16> {
+    let stride = (width * bits as usize).div_ceil(8);
+    let mut out = vec![0u16; width * height];
+    for (row, samples) in out.chunks_mut(width).enumerate() {
+        let from = row * stride;
+        let source = strip
+            .get(from..(from + stride).min(strip.len()))
+            .unwrap_or(&[]);
+        if msb_first {
+            let mut pump = BitPumpMsb::new(source);
+            for sample in samples.iter_mut() {
+                *sample = pump.get(bits) as u16;
+            }
+        } else {
+            let mut pump = BitPumpLsb::new(source);
+            for sample in samples.iter_mut() {
+                *sample = pump.get(bits) as u16;
+            }
+        }
+    }
+    out
+}
+
+// ------------------------------------------------------------ codec v1
+
+/// How many pixels of one row a v1 block covers.
+const V1_BLOCK: usize = 16;
+
+/// Decode Samsung's first lossless codec (Compression 32770 with a
+/// row-pointer table).
+///
+/// The pointer table has an entry a row, but a *stream* is not a row:
+/// stream `s` holds the columns of parity `s & 1` from both rows of
+/// the pair `s & !1`. Two streams therefore cover two rows, and the
+/// frame is read as four interleaved colour planes rather than as
+/// scan lines.
+///
+/// A stream is a bit sequence read most-significant bit first out of
+/// 32-bit *little-endian* words, in blocks of sixteen values covering
+/// sixteen columns: eight from the pair's first row and eight from its
+/// second, at the eight columns of the stream's parity. Each block
+/// opens with
+///
+/// ```text
+///   1 bit   direction: 0 predict along the row, 1 predict up
+///   2 bits  x4  what to do to each of the four difference lengths:
+///               0 leave it, 1 add one, 2 take one off,
+///               3 read a fresh 4-bit length
+/// ```
+///
+/// The four lengths are indexed by which row of the pair the value
+/// belongs to and which half of the block it is in, so a block can
+/// spend more bits on its noisier half. Each value is then that many
+/// bits, two's complement, added to a predictor:
+///
+/// * along the row (direction 0), every value in a row of the block
+///   shares one predictor: the last value of the same row in the
+///   *previous* block. The first block of a row starts from 128.
+/// * upwards (direction 1), the predictor is the value in the same
+///   slot of an earlier stream — the one before this for the first
+///   row of the pair, two before for the second, which is what puts
+///   each value against the nearest already-decoded sample of a
+///   neighbouring colour plane.
+fn decompress_v1(strip: &[u8], pointers: &[u32], width: usize, height: usize) -> Vec<u16> {
+    let mut out = vec![0u16; width * height];
+    let at = |out: &[u16], row: usize, col: usize| -> u16 {
+        out.get(row * width + col).copied().unwrap_or(0)
+    };
+    for stream in 0..height {
+        let pair = stream & !1;
+        let parity = stream & 1;
+        let start = pointers.get(stream).copied().unwrap_or(0) as usize;
+        let mut pump = BitPumpMsb32::new(strip.get(start..).unwrap_or(&[]));
+        // The first two rows have no row above to lean on, so they
+        // start expecting wider differences.
+        let mut lengths = [if pair < 2 { 7i32 } else { 4 }; 4];
+        for base in (0..width).step_by(V1_BLOCK) {
+            let up = pump.get(1) == 1;
+            let ops = [pump.get(2), pump.get(2), pump.get(2), pump.get(2)];
+            for (length, op) in lengths.iter_mut().zip(ops) {
+                match op {
+                    3 => *length = pump.get(4) as i32,
+                    2 => *length -= 1,
+                    1 => *length += 1,
+                    _ => {}
+                }
+            }
+            // Evens first, then odds: within a block the pair's first
+            // row is decoded before its second.
+            for c in (0..16).map(|i| (i % 8) * 2 + i / 8) {
+                let index = ((c & 1) << 1) | (c >> 3);
+                let length = lengths[index];
+                if !(0..=16).contains(&length) {
+                    // A length outside the format's range means the
+                    // stream has come apart; leave the rest of the row
+                    // black rather than read wild widths.
+                    break;
+                }
+                let value = pump.get(length as u32) as i32;
+                let diff = if length > 0 && value & (1 << (length - 1)) != 0 {
+                    value - (1 << length)
+                } else {
+                    value
+                };
+                let row = pair + (c & 1);
+                let col = base + (c & !1) + parity;
+                if col >= width || row >= height {
+                    continue;
+                }
+                let predictor = if up {
+                    if c & 1 == 1 {
+                        // The same slot two streams back: the same
+                        // colour, one row pair up.
+                        if pair >= 1 {
+                            at(&out, pair - 1, col)
+                        } else {
+                            0
+                        }
+                    } else if parity == 1 {
+                        // The stream before this one is the same row
+                        // pair's other parity: the pixel to the left.
+                        at(&out, pair, col - 1)
+                    } else if pair >= 2 && col + 1 < width {
+                        at(&out, pair - 2, col + 1)
+                    } else {
+                        0
+                    }
+                } else if base >= 2 {
+                    at(&out, row, base - 2 + parity)
+                } else {
+                    128
+                };
+                out[row * width + col] = predictor.wrapping_add(diff as u16);
+            }
+        }
+    }
+    out
+}
+
+// ------------------------------------------------------------ codec v2
+
+/// The Huffman code of Compression 32772, as `(code length, symbol)`
+/// in the order the codes are handed out.
+///
+/// Nothing in the file carries it: the camera and the decoder both
+/// have it built in, so it is a fact about the format, recovered here
+/// by fitting a prefix code to real frames until they reproduced their
+/// LibRaw-unpacked samples exactly (they do, on every 32772 file in
+/// this crate's corpus, to the last bit).
+///
+/// The symbol is the number of extra bits the difference is written
+/// in, as in lossless JPEG. The lengths are not monotonic — a 6-bit
+/// code is handed out before a 5-bit one — so this is *not* a
+/// canonical table and cannot go through [`crate::bits::HuffTable`];
+/// [`V2Huffman`] decodes it with a flat lookup instead.
+const V2_CODE: [(u8, u8); 14] = [
+    (3, 4),
+    (3, 7),
+    (2, 6),
+    (2, 5),
+    (4, 3),
+    (6, 0),
+    (7, 9),
+    (8, 10),
+    (9, 11),
+    (10, 12),
+    (10, 13),
+    (5, 1),
+    (4, 8),
+    (4, 2),
+];
+
+/// Width of [`V2Huffman`]'s lookup, and the longest code in
+/// [`V2_CODE`].
+const V2_BITS: u32 = 10;
+
+/// A complete lookup for [`V2_CODE`]: every ten-bit window maps
+/// straight to `(code length, symbol)`.
+struct V2Huffman {
+    lookup: Vec<(u8, u8)>,
+}
+
+impl V2Huffman {
+    fn new() -> V2Huffman {
+        let mut lookup = Vec::with_capacity(1 << V2_BITS);
+        for (length, symbol) in V2_CODE {
+            // A code of `length` bits owns every window that begins
+            // with it, and the codes are handed out in order, so
+            // filling the table in order places them.
+            lookup.resize(
+                lookup.len() + (1 << (V2_BITS - length as u32)),
+                (length, symbol),
+            );
+        }
+        // The code is complete: the fourteen entries tile the window
+        // exactly. Anything else would be a bug in the table above.
+        debug_assert_eq!(lookup.len(), 1 << V2_BITS);
+        lookup.resize(1 << V2_BITS, (V2_BITS as u8, 0));
+        V2Huffman { lookup }
+    }
+
+    /// The next difference: a length symbol, then that many bits,
+    /// sign-extended the way lossless JPEG does it.
+    fn diff(&self, pump: &mut impl BitPump) -> i32 {
+        let (length, symbol) = self.lookup[pump.peek(V2_BITS) as usize];
+        pump.consume(length as u32);
+        if symbol == 0 {
+            return 0;
+        }
+        let bits = symbol as u32;
+        let value = pump.get(bits) as i32;
+        if value < 1 << (bits - 1) {
+            value - (1 << bits) + 1
+        } else {
+            value
+        }
+    }
+}
+
+/// Decode Compression 32772: one Huffman-coded difference a pixel over
+/// a single stream, predicted from the pixel two to the left, with the
+/// first two pixels of each row continuing a total kept per row parity
+/// and column parity. The same predictor Pentax uses, over Samsung's
+/// own fixed code.
+fn decompress_v2(strip: &[u8], width: usize, height: usize) -> Vec<u16> {
+    let huffman = V2Huffman::new();
+    let mut pump = BitPumpMsb::new(strip);
+    let mut out = vec![0u16; width * height];
+    let mut vertical = [[0u16; 2]; 2];
+    for (row, samples) in out.chunks_mut(width).enumerate() {
+        let mut horizontal = [0u16; 2];
+        for (col, sample) in samples.iter_mut().enumerate() {
+            let diff = huffman.diff(&mut pump) as u16;
+            if col < 2 {
+                let seed = &mut vertical[row & 1][col];
+                *seed = seed.wrapping_add(diff);
+                horizontal[col] = *seed;
+            } else {
+                horizontal[col & 1] = horizontal[col & 1].wrapping_add(diff);
+            }
+            *sample = horizontal[col & 1];
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn the_v2_code_tiles_its_window() {
+        // A prefix code is complete exactly when its lengths' weights
+        // sum to one; anything else and some bit pattern decodes to
+        // nothing, or two codes overlap.
+        let total: u32 = V2_CODE
+            .iter()
+            .map(|(length, _)| 1u32 << (V2_BITS - *length as u32))
+            .sum();
+        assert_eq!(total, 1 << V2_BITS);
+        // Every symbol 0..=13 appears exactly once: they are difference
+        // lengths, and a missing one could not be encoded.
+        let mut symbols: Vec<u8> = V2_CODE.iter().map(|(_, symbol)| *symbol).collect();
+        symbols.sort_unstable();
+        assert_eq!(symbols, (0..14).collect::<Vec<u8>>());
+    }
+
+    #[test]
+    fn the_v2_code_decodes_its_own_symbols() {
+        let huffman = V2Huffman::new();
+        // Symbol 6 has the two-bit code 01 and takes six value bits.
+        // JPEG's categories put the positive half at the top: 0b111111
+        // is 63, the largest a six-bit difference reaches.
+        let mut pump = BitPumpMsb::new(&[0b01_111111, 0b00_000000]);
+        assert_eq!(huffman.diff(&mut pump), 63);
+        // The bottom half is negative: 0b011111 is one below the
+        // halfway mark, so -32.
+        let mut pump = BitPumpMsb::new(&[0b01_011111, 0b00_000000]);
+        assert_eq!(huffman.diff(&mut pump), -32);
+        // Symbol 5 has code 10 and takes five bits; 0b00000 is the
+        // bottom of the negative half, -31.
+        let mut pump = BitPumpMsb::new(&[0b1000_0000]);
+        assert_eq!(huffman.diff(&mut pump), -31);
+        // Symbol 0 (code 110100) is a difference of zero and reads no
+        // value bits at all.
+        let mut pump = BitPumpMsb::new(&[0b1101_0011, 0b0100_0000]);
+        assert_eq!(huffman.diff(&mut pump), 0);
+        assert_eq!(huffman.diff(&mut pump), 0);
+    }
+
+    #[test]
+    fn v2_differences_run_along_rows() {
+        // Six pixels of two rows, every difference zero except the
+        // four seeds. Symbol 3 is the code 1100 with three value bits,
+        // whose positive half is 4..=7; symbol 0, the code 110100, is
+        // a difference of zero and reads nothing after it.
+        fn seed(bits: &mut BitWriter, value: u32) {
+            bits.put(0b1100, 4);
+            bits.put(value, 3);
+        }
+        let mut bits = BitWriter::default();
+        for row in [[4, 5], [6, 7]] {
+            seed(&mut bits, row[0]);
+            seed(&mut bits, row[1]);
+            for _ in 0..4 {
+                bits.put(0b110100, 6);
+            }
+        }
+        let out = decompress_v2(&bits.finish(), 6, 2);
+        assert_eq!(out, vec![4, 5, 4, 5, 4, 5, 6, 7, 6, 7, 6, 7]);
+    }
+
+    #[test]
+    fn packed_reads_both_bit_orders() {
+        // 0x012 and 0x345 packed twelve bits at a time.
+        let msb = packed(&[0x01, 0x23, 0x45], 2, 1, 12, true);
+        assert_eq!(msb, vec![0x012, 0x345]);
+        // The same two samples the other way up: 0x012 first means the
+        // low nibble of byte 1 carries the top of the sample.
+        let lsb = packed(&[0x12, 0x50, 0x34], 2, 1, 12, false);
+        assert_eq!(lsb, vec![0x012, 0x345]);
+    }
+
+    #[test]
+    fn plain_words_are_little_endian() {
+        assert_eq!(plain(&[0x34, 0x12, 0x78, 0x56], 2), vec![0x1234, 0x5678]);
+        // A short strip leaves the rest of the frame black.
+        assert_eq!(plain(&[0x34], 2), vec![0, 0]);
+    }
+
+    #[test]
+    fn truncated_streams_do_not_panic() {
+        for len in [0usize, 1, 3, 7, 16, 64] {
+            assert_eq!(decompress_v2(&vec![0xa5; len], 32, 4).len(), 128);
+            let pointers = vec![0u32; 4];
+            assert_eq!(decompress_v1(&vec![0x5a; len], &pointers, 32, 4).len(), 128);
+            assert_eq!(packed(&vec![0xff; len], 32, 4, 12, true).len(), 128);
+        }
+        // Row pointers past the end of the strip must not read wildly.
+        let pointers = vec![u32::MAX; 4];
+        assert_eq!(decompress_v1(&[0; 64], &pointers, 32, 4).len(), 128);
+    }
+
+    #[test]
+    fn by_position_follows_the_filter_array() {
+        let values = [1.0, 2.0, 3.0, 4.0];
+        assert_eq!(by_position(&Cfa::RGGB, values), [1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(by_position(&Cfa::GRBG, values), [2.0, 1.0, 4.0, 3.0]);
+        assert_eq!(by_position(&Cfa::GBRG, values), [2.0, 4.0, 1.0, 3.0]);
+    }
+
+    #[derive(Default)]
+    struct BitWriter {
+        out: Vec<u8>,
+        cache: u32,
+        bits: u32,
+    }
+
+    impl BitWriter {
+        fn put(&mut self, value: u32, bits: u32) {
+            self.cache = (self.cache << bits) | (value & ((1 << bits) - 1));
+            self.bits += bits;
+            while self.bits >= 8 {
+                self.bits -= 8;
+                self.out.push((self.cache >> self.bits) as u8);
+            }
+        }
+        fn finish(mut self) -> Vec<u8> {
+            if self.bits > 0 {
+                self.out.push((self.cache << (8 - self.bits)) as u8);
+            }
+            self.out
+        }
+    }
+
+    // ------------------------------------------------------------ corpus
+
+    /// Files this decoder knowingly cannot read, with the reason. A
+    /// corpus file that is `Unsupported` for any other reason fails.
+    const UNSUPPORTED: &[&str] = &[
+        // Compression 32773, the NX1/NX500 codec: a sixteen-by-sixteen
+        // block predictor this crate has not reverse-engineered.
+        "SRW compression 32773",
+    ];
+
+    fn corpus() -> Vec<PathBuf> {
+        let Ok(root) = std::env::var("SCHIST_RAW_CORPUS") else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        let mut stack = vec![PathBuf::from(root)];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path
+                    .extension()
+                    .is_some_and(|e| e.eq_ignore_ascii_case("srw"))
+                {
+                    out.push(path);
+                }
+            }
+        }
+        out.sort();
+        out
+    }
+
+    fn oracle(path: &Path) -> Option<(usize, usize, Vec<u16>)> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".tiff");
+        let path = PathBuf::from(name);
+        if !path.exists() {
+            return None;
+        }
+        let image = image::open(&path).expect("oracle TIFF loads").into_luma16();
+        let (width, height) = (image.width() as usize, image.height() as usize);
+        Some((width, height, image.into_raw()))
+    }
+
+    fn identify(path: &Path) -> Option<String> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".identify.txt");
+        std::fs::read_to_string(PathBuf::from(name)).ok()
+    }
+
+    fn field<'a>(report: &'a str, key: &str) -> Option<&'a str> {
+        report
+            .lines()
+            .find_map(|line| line.trim_start().strip_prefix(key))
+            .map(str::trim)
+    }
+
+    fn numbers(report: &str, key: &str) -> Vec<f32> {
+        field(report, key)
+            .map(|rest| {
+                rest.split(|c: char| !(c.is_ascii_digit() || c == '.' || c == '-'))
+                    .filter(|t| !t.is_empty())
+                    .filter_map(|t| t.parse().ok())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn cfa_of(report: &str) -> Option<Cfa> {
+        let pattern = field(report, "Filter pattern:")?;
+        let colors: Vec<CfaColor> = pattern
+            .chars()
+            .take(4)
+            .map(|c| match c {
+                'R' => CfaColor::Red,
+                'B' => CfaColor::Blue,
+                _ => CfaColor::Green,
+            })
+            .collect();
+        Some(Cfa::Bayer(colors.try_into().ok()?))
+    }
+
+    #[test]
+    fn corpus_matches_the_oracle() {
+        let files = corpus();
+        let mut matched = 0;
+        let mut skipped = 0;
+        for path in &files {
+            let bytes = std::fs::read(path).expect("corpus file reads");
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(Format::Srw),
+                "{} did not probe as SRW",
+                path.display()
+            );
+            let raw = match crate::decode(&bytes) {
+                Ok(raw) => raw,
+                Err(Error::Unsupported(why)) if UNSUPPORTED.iter().any(|a| why.contains(a)) => {
+                    skipped += 1;
+                    // Even a frame we cannot decode must give up its
+                    // preview without a fuss.
+                    let preview = preview(&bytes).expect("preview of an unsupported SRW");
+                    assert!(preview.is_some(), "{}: no preview", path.display());
+                    continue;
+                }
+                Err(error) => panic!("{}: {error}", path.display()),
+            };
+            raw.validate().expect("decoded frame is self-consistent");
+            matched += 1;
+
+            if let Some((width, height, expected)) = oracle(path) {
+                assert_eq!(
+                    (raw.width, raw.height),
+                    (width, height),
+                    "{}: frame size",
+                    path.display()
+                );
+                let RawData::U16(got) = &raw.data else {
+                    panic!("{}: SRW frames are integers", path.display())
+                };
+                let wrong: Vec<usize> = got
+                    .iter()
+                    .zip(&expected)
+                    .enumerate()
+                    .filter(|(_, (a, b))| a != b)
+                    .map(|(i, _)| i)
+                    .collect();
+                assert!(
+                    wrong.is_empty(),
+                    "{}: {} of {} samples differ from the oracle; first: {:?}",
+                    path.display(),
+                    wrong.len(),
+                    got.len(),
+                    wrong
+                        .iter()
+                        .take(4)
+                        .map(|i| (i % width, i / width, got[*i], expected[*i]))
+                        .collect::<Vec<_>>()
+                );
+            }
+
+            if let Some(report) = identify(path) {
+                let size = numbers(&report, "Full size:");
+                if let [width, height] = size[..] {
+                    assert_eq!(
+                        (raw.width, raw.height),
+                        (width as usize, height as usize),
+                        "{}: full size",
+                        path.display()
+                    );
+                }
+                // LibRaw names the pattern at its own crop origin,
+                // which on several Samsung bodies is an odd column in.
+                // Ours is the file's CFAPattern at the frame origin,
+                // so one of the four phases of ours must be LibRaw's.
+                // Strictly: the pattern at the crop origin must be the
+                // one LibRaw names at its crop origin. Any phase of
+                // ours would pass for any Bayer pattern. LibRaw rounds
+                // an odd origin (the NX10's column 21) up to even to
+                // keep the phase, so compare there.
+                if let Some(theirs) = cfa_of(&report) {
+                    assert_eq!(
+                        raw.cfa.shifted(
+                            raw.crop.x.next_multiple_of(2),
+                            raw.crop.y.next_multiple_of(2)
+                        ),
+                        theirs,
+                        "{}: filter pattern at the crop origin disagrees with LibRaw",
+                        path.display()
+                    );
+                }
+                let black = numbers(&report, "cblack[0 .. 3]:");
+                if let [r, g, b, g2] = black[..] {
+                    let expected = by_position(&raw.cfa, [r, g, g2, b]);
+                    assert_eq!(raw.black_levels, expected, "{}: black", path.display());
+                }
+                let shot = numbers(&report, "As shot");
+                if let [r, g, b, g2] = shot[..4.min(shot.len())] {
+                    let want = [r / g, 1.0, b / g, g2 / g];
+                    for (got, want) in raw.wb_coeffs.iter().zip(want) {
+                        assert!(
+                            (got - want).abs() < 1e-4,
+                            "{}: white balance {:?} not {:?}",
+                            path.display(),
+                            raw.wb_coeffs,
+                            want
+                        );
+                    }
+                }
+                if let Some(flip) = numbers(&report, "Image flip:").first() {
+                    let expected = match *flip as i32 {
+                        3 => crate::Orientation::Rotate180,
+                        5 => crate::Orientation::Rotate270CW,
+                        6 => crate::Orientation::Rotate90CW,
+                        _ => crate::Orientation::Normal,
+                    };
+                    assert_eq!(raw.orientation, expected, "{}: flip", path.display());
+                }
+            }
+
+            assert!(raw.crop.x + raw.crop.width <= raw.width);
+            assert!(raw.crop.y + raw.crop.height <= raw.height);
+            let preview = raw.preview.as_ref().expect("every SRW carries a preview");
+            image::load_from_memory(preview).expect("preview decodes");
+        }
+        eprintln!("srw: {matched} corpus files matched, {skipped} unsupported");
+    }
+
+    #[test]
+    fn truncated_files_do_not_panic() {
+        for path in corpus() {
+            let bytes = std::fs::read(&path).expect("corpus file reads");
+            for numerator in [0usize, 1, 2, 3, 5, 8, 13, 100, 500, 900, 999] {
+                let cut = bytes.len() * numerator / 1000;
+                let _ = crate::decode(&bytes[..cut]);
+                let _ = preview(&bytes[..cut]);
+            }
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/x3f.rs
+++ b/crates/codec-raw/src/formats/x3f.rs
@@ -1,0 +1,639 @@
+//! Sigma X3F: the raw of the Foveon cameras, whose sensor stacks
+//! three photodiodes at every pixel instead of putting a colour
+//! filter over each one. An X3F frame therefore has three samples a
+//! pixel and no CFA at all — [`Cfa::None`], `cpp = 3`.
+//!
+//! The container is Sigma's own. A file opens with `FOVb`, a version
+//! and a header whose shape depends on that version, and *ends* with
+//! a `u32` pointing at the directory: `SECd`, a version, a count, and
+//! then twelve bytes an entry — offset, length, and a four-character
+//! type.
+//!
+//! The sections that matter:
+//!
+//!  * `IMA2` (and `IMAG` on the oldest bodies) — an image, headed
+//!    `SECi` with a type (1 raw, 2 processed), a data format, the
+//!    dimensions and a row size. A camera writes two or three of
+//!    them: a full-size JPEG, sometimes a small one, and the sensor
+//!    data.
+//!  * `PROP` — a property list, UTF-16 keys and values, holding the
+//!    camera's name, exposure and white-balance mode. The Quattro
+//!    bodies dropped it and put an Exif block in their preview JPEG
+//!    instead, so both are read.
+//!  * `CAMF` — the camera's calibration, including the matrices that
+//!    turn Foveon's three stacked responses into colour. It is
+//!    obfuscated, and decoding it is out of this module's scope:
+//!    `color_matrix` is left to the camera table.
+//!
+//! What this module does **not** do is the sensor data of any modern
+//! body. The Merrill's format 30 and the Quattro's format 35 are
+//! Foveon's "TRUE" codes, and the Quattro's top layer carries four
+//! times the resolution of the two below it — a frame that does not
+//! fit [`RawImage`]'s one-size-per-plane shape without a resampling
+//! policy this crate has not chosen. Both return
+//! [`Error::Unsupported`]; the preview and the metadata still come
+//! out, which is what a gallery needs from a file it cannot develop.
+//!
+//! LibRaw 0.21 cannot read X3F at all, so there is no oracle frame
+//! for any of these files and nothing here is checked against one.
+
+use crate::tiff::Tiff;
+use crate::{Cfa, Error, Format, Metadata, Orientation, RawData, RawImage, Result};
+
+/// Every X3F begins here.
+const MAGIC: &[u8; 4] = b"FOVb";
+
+/// One directory entry: where a section is and what it is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Section {
+    offset: usize,
+    length: usize,
+    kind: [u8; 4],
+}
+
+/// An image section's header, and where its data starts.
+#[derive(Debug, Clone, Copy)]
+struct Image {
+    /// 1 for the sensor's own data, 2 for a processed picture.
+    kind: u32,
+    /// How the data is coded; see [`formats`].
+    format: u32,
+    columns: usize,
+    rows: usize,
+    data: usize,
+    length: usize,
+}
+
+/// The data formats an image section declares.
+mod formats {
+    /// Three 16-bit samples a pixel, uncompressed.
+    pub const PLAIN: u32 = 3;
+    /// The Huffman code of the SD9/SD10/SD14 era.
+    pub const HUFFMAN: u32 = 11;
+    // 18 and 25 are the baseline JPEGs a camera writes for its
+    // previews; they are recognised by their SOI rather than by
+    // number, because the code varies with the body and any of them
+    // may be the largest one.
+    /// Foveon's "TRUE" entropy code, on the DP/SD Merrill bodies.
+    pub const TRUE: u32 = 30;
+    pub const MERRILL: u32 = 32;
+    /// The Quattro's code, whose top layer is twice as wide and twice
+    /// as tall as the two below it.
+    pub const QUATTRO: u32 = 35;
+}
+
+fn u32_at(bytes: &[u8], at: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(bytes.get(at..at + 4)?.try_into().ok()?))
+}
+
+/// The file's sections, in directory order.
+fn directory(bytes: &[u8]) -> Result<Vec<Section>> {
+    if bytes.get(0..4) != Some(MAGIC) {
+        return Err(Error::Corrupt("not an X3F: no FOVb signature".into()));
+    }
+    // The directory's position is the last four bytes of the file.
+    let end = bytes
+        .len()
+        .checked_sub(4)
+        .ok_or_else(|| Error::Corrupt("X3F too short to hold a directory pointer".into()))?;
+    let start = u32_at(bytes, end).unwrap_or(0) as usize;
+    if bytes.get(start..start + 4) != Some(b"SECd") {
+        return Err(Error::Corrupt(
+            "X3F directory pointer does not lead to a SECd".into(),
+        ));
+    }
+    let count = u32_at(bytes, start + 8).unwrap_or(0) as usize;
+    // Twelve bytes an entry: a count larger than the file could hold
+    // is a lie, and capping it keeps the allocation honest.
+    let count = count.min(bytes.len() / 12);
+    let mut sections = Vec::with_capacity(count);
+    for i in 0..count {
+        let at = start + 12 + i * 12;
+        let (Some(offset), Some(length)) = (u32_at(bytes, at), u32_at(bytes, at + 4)) else {
+            break;
+        };
+        let Some(kind) = bytes.get(at + 8..at + 12) else {
+            break;
+        };
+        let (offset, length) = (offset as usize, length as usize);
+        // A section reaching past the end of the file is not one.
+        if offset
+            .checked_add(length)
+            .is_none_or(|end| end > bytes.len())
+        {
+            continue;
+        }
+        sections.push(Section {
+            offset,
+            length,
+            kind: [kind[0], kind[1], kind[2], kind[3]],
+        });
+    }
+    if sections.is_empty() {
+        return Err(Error::Corrupt(
+            "X3F directory holds no readable section".into(),
+        ));
+    }
+    Ok(sections)
+}
+
+/// An image section's header. Seven `u32`s — magic, version, type,
+/// format, columns, rows, row size — and then the data.
+fn image(bytes: &[u8], section: &Section) -> Option<Image> {
+    if bytes.get(section.offset..section.offset + 4) != Some(b"SECi") {
+        return None;
+    }
+    let word = |i: usize| u32_at(bytes, section.offset + i * 4);
+    let data = section.offset + 28;
+    Some(Image {
+        kind: word(2)?,
+        format: word(3)?,
+        columns: word(4)? as usize,
+        rows: word(5)? as usize,
+        data,
+        length: section.length.checked_sub(28)?,
+    })
+}
+
+/// Whether a stream is a JPEG a viewer could show: a real frame
+/// header, not a lossless or hierarchical one. Walks marker segments
+/// only, and stops at the first frame or at anything malformed.
+fn is_displayable_jpeg(stream: &[u8]) -> bool {
+    if !stream.starts_with(&[0xFF, 0xD8]) {
+        return false;
+    }
+    let mut at = 2;
+    while at + 4 <= stream.len() {
+        if stream[at] != 0xFF {
+            return false;
+        }
+        match stream[at + 1] {
+            0xFF => {
+                at += 1;
+                continue;
+            }
+            0x01 | 0xD0..=0xD8 => {
+                at += 2;
+                continue;
+            }
+            0xC0 | 0xC1 | 0xC2 | 0xC9 | 0xCA => return true,
+            0xC3 | 0xC5..=0xC7 | 0xCB | 0xCD..=0xCF => return false,
+            0xDA | 0xD9 => return false,
+            _ => {}
+        }
+        let length = u16::from_be_bytes([stream[at + 2], stream[at + 3]]) as usize;
+        if length < 2 {
+            return false;
+        }
+        at += 2 + length;
+    }
+    false
+}
+
+/// The largest showable JPEG among the file's image sections.
+fn largest_jpeg(bytes: &[u8], sections: &[Section]) -> Option<Vec<u8>> {
+    sections
+        .iter()
+        .filter(|s| s.kind == *b"IMA2" || s.kind == *b"IMAG")
+        .filter_map(|s| image(bytes, s))
+        .filter_map(|i| bytes.get(i.data..i.data + i.length))
+        .filter(|stream| is_displayable_jpeg(stream))
+        .max_by_key(|stream| stream.len())
+        .map(<[u8]>::to_vec)
+}
+
+/// The PROP section: a header of six `u32`s (magic, version, entry
+/// count, character format, reserved, total length), then a pair of
+/// `u32` offsets an entry, then a pool of NUL-terminated UTF-16
+/// strings the offsets index **in characters**.
+fn properties(bytes: &[u8], section: &Section) -> Vec<(String, String)> {
+    if bytes.get(section.offset..section.offset + 4) != Some(b"SECp") {
+        return Vec::new();
+    }
+    let count = u32_at(bytes, section.offset + 8).unwrap_or(0) as usize;
+    // Eight bytes an entry, and the pool has to hold something.
+    let count = count.min(section.length / 8);
+    let pool = section.offset + 24 + count * 8;
+    let string = |chars: usize| -> Option<String> {
+        let mut at = pool.checked_add(chars.checked_mul(2)?)?;
+        let mut out = String::new();
+        loop {
+            let unit = u16::from_le_bytes(bytes.get(at..at + 2)?.try_into().ok()?);
+            if unit == 0 {
+                return Some(out);
+            }
+            // The camera writes plain ASCII in UTF-16 units; anything
+            // outside the basic plane would be a surrogate, and there
+            // is no camera that writes one.
+            out.push(char::from_u32(unit as u32)?);
+            at += 2;
+            if out.len() > 512 {
+                return Some(out);
+            }
+        }
+    };
+    let mut out = Vec::with_capacity(count);
+    for i in 0..count {
+        let at = section.offset + 24 + i * 8;
+        let (Some(name), Some(value)) = (u32_at(bytes, at), u32_at(bytes, at + 4)) else {
+            break;
+        };
+        if let (Some(name), Some(value)) = (string(name as usize), string(value as usize)) {
+            if !name.is_empty() {
+                out.push((name, value));
+            }
+        }
+    }
+    out
+}
+
+/// The Exif block inside a preview JPEG, which is where the Quattro
+/// bodies put what earlier ones put in PROP.
+fn preview_exif(jpeg: &[u8]) -> Option<Tiff<'_>> {
+    let mut at = 2;
+    while at + 4 <= jpeg.len() {
+        if jpeg[at] != 0xFF {
+            return None;
+        }
+        let marker = jpeg[at + 1];
+        if marker == 0xFF {
+            at += 1;
+            continue;
+        }
+        if matches!(marker, 0xD8..=0xDA) {
+            return None;
+        }
+        let length = u16::from_be_bytes([jpeg[at + 2], jpeg[at + 3]]) as usize;
+        if length < 2 {
+            return None;
+        }
+        if marker == 0xE1 && jpeg.get(at + 4..at + 10) == Some(b"Exif\0\0") {
+            // The TIFF header sits at the end of the marker's own
+            // identifier, and every offset in it is relative to there.
+            return Tiff::parse_embedded(jpeg, at + 10).ok();
+        }
+        at += 2 + length;
+    }
+    None
+}
+
+/// A property list, with the lookups the rest of the module wants.
+struct Properties(Vec<(String, String)>);
+
+impl Properties {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0
+            .iter()
+            .find(|(name, _)| name == key)
+            .map(|(_, value)| value.trim())
+            .filter(|value| !value.is_empty())
+    }
+    fn number(&self, key: &str) -> Option<f32> {
+        self.get(key).and_then(|v| v.parse().ok())
+    }
+}
+
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let sections = directory(bytes)?;
+    let raw = sections
+        .iter()
+        .filter(|s| s.kind == *b"IMA2" || s.kind == *b"IMAG")
+        .filter_map(|s| image(bytes, s))
+        // Type 1 is the sensor's own data; type 2 is a picture the
+        // camera made from it.
+        .find(|i| i.kind == 1)
+        .ok_or_else(|| Error::Unsupported("X3F with no sensor image section".into()))?;
+
+    let samples = match raw.format {
+        formats::PLAIN => {
+            let count = raw
+                .columns
+                .checked_mul(raw.rows)
+                .and_then(|n| n.checked_mul(3))
+                .ok_or_else(|| Error::Corrupt("X3F frame too large".into()))?;
+            let end = count
+                .checked_mul(2)
+                .and_then(|n| raw.data.checked_add(n))
+                .ok_or_else(|| Error::Corrupt("X3F frame too large".into()))?;
+            let data = bytes
+                .get(raw.data..end)
+                .ok_or_else(|| Error::Corrupt("X3F plain frame runs past the file".into()))?;
+            data.as_chunks::<2>()
+                .0
+                .iter()
+                .map(|b| u16::from_le_bytes(*b))
+                .collect()
+        }
+        formats::HUFFMAN | formats::TRUE | formats::MERRILL => {
+            return Err(Error::Unsupported(format!(
+                "Foveon entropy-coded sensor data (X3F image format {}); the preview and \
+                 the metadata are still readable",
+                raw.format
+            )))
+        }
+        formats::QUATTRO => {
+            return Err(Error::Unsupported(
+                "Foveon Quattro sensor data (X3F image format 35): the top layer has four \
+                 times the pixels of the two below it, which needs a resampling policy this \
+                 crate has not chosen"
+                    .into(),
+            ))
+        }
+        other => return Err(Error::Unsupported(format!("X3F image format {other}"))),
+    };
+
+    let mut image = RawImage::new(
+        Format::X3f,
+        raw.columns,
+        raw.rows,
+        3,
+        RawData::U16(samples),
+        // Three stacked photodiodes: every pixel already has all
+        // three colours, so there is no filter array to describe.
+        Cfa::None,
+    );
+    describe(bytes, &sections, &mut image);
+    image.apply_camera_table();
+    Ok(image)
+}
+
+/// Everything about a frame that is not its samples: the camera, the
+/// exposure, the orientation and the preview. Shared by [`decode`]
+/// and used on its own for the frames this module cannot unpack.
+fn describe(bytes: &[u8], sections: &[Section], image: &mut RawImage) {
+    let properties = Properties(
+        sections
+            .iter()
+            .find(|s| s.kind == *b"PROP")
+            .map(|s| properties(bytes, s))
+            .unwrap_or_default(),
+    );
+    let preview = largest_jpeg(bytes, sections);
+    // The Quattro bodies dropped PROP and put an ordinary Exif block
+    // in the preview instead.
+    let exif = preview.as_deref().and_then(preview_exif);
+
+    let (mut make, mut model) = (
+        properties.get("CAMMANUF").unwrap_or("").to_string(),
+        properties.get("CAMMODEL").unwrap_or("").to_string(),
+    );
+    if let Some(tiff) = &exif {
+        let (exif_make, exif_model) = tiff.make_model();
+        if make.is_empty() {
+            make = exif_make;
+        }
+        if model.is_empty() {
+            model = exif_model;
+        }
+    }
+    image.set_camera(&make, &model);
+
+    image.metadata = Metadata {
+        iso: properties.number("ISO"),
+        // SHUTTER is seconds; EXPTIME is the same in microseconds.
+        exposure_time: properties
+            .number("SHUTTER")
+            .or_else(|| properties.number("EXPTIME").map(|t| t / 1e6)),
+        f_number: properties.number("APERTURE"),
+        focal_length: properties.number("FLENGTH"),
+        lens: properties.get("LENSMODEL").map(str::to_string),
+        date_time: None,
+    };
+    if let Some(tiff) = &exif {
+        // Exif fills whatever the properties did not, and is the only
+        // source of a formatted timestamp: PROP's TIME is a Unix
+        // second count, which this crate has no clock to format.
+        let from_exif = crate::formats::common::metadata(tiff);
+        let take = |a: &mut Option<f32>, b: Option<f32>| {
+            if a.is_none() {
+                *a = b;
+            }
+        };
+        take(&mut image.metadata.iso, from_exif.iso);
+        take(&mut image.metadata.exposure_time, from_exif.exposure_time);
+        take(&mut image.metadata.f_number, from_exif.f_number);
+        take(&mut image.metadata.focal_length, from_exif.focal_length);
+        if image.metadata.lens.is_none() {
+            image.metadata.lens = from_exif.lens;
+        }
+        image.metadata.date_time = from_exif.date_time;
+    }
+
+    // ROTATION is degrees clockwise, the way the camera was held.
+    image.orientation = match properties.number("ROTATION").map(|r| r as i32) {
+        Some(90) => Orientation::Rotate90CW,
+        Some(180) => Orientation::Rotate180,
+        Some(270) => Orientation::Rotate270CW,
+        Some(_) => Orientation::Normal,
+        None => exif
+            .as_ref()
+            .map(crate::formats::common::orientation)
+            .unwrap_or_default(),
+    };
+    // The white balance a Foveon needs lives in the obfuscated CAMF
+    // block; PROP only names the mode ("Auto", "Daylight"). Unit
+    // multipliers are the honest answer, and the developer's own
+    // white balance is what a Foveon frame gets in practice.
+    drop(exif);
+    image.preview = preview;
+}
+
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    Ok(largest_jpeg(bytes, &directory(bytes)?))
+}
+
+/// The camera and exposure of an X3F whose sensor data this module
+/// cannot unpack — everything [`decode`] would have filled in.
+///
+/// A gallery that has a preview and a name for a file is not stuck
+/// just because the Foveon entropy code is unread.
+pub fn metadata(bytes: &[u8]) -> Result<(String, String, Metadata, Option<Vec<u8>>)> {
+    let sections = directory(bytes)?;
+    let mut image = RawImage::new(Format::X3f, 1, 1, 3, RawData::U16(vec![0; 3]), Cfa::None);
+    describe(bytes, &sections, &mut image);
+    Ok((image.make, image.model, image.metadata, image.preview))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::formats::hasselblad::corpus;
+
+    /// A file with one image section and one property list.
+    fn build(image_kind: u32, format: u32, columns: u32, rows: u32, data: &[u8]) -> Vec<u8> {
+        let mut out = MAGIC.to_vec();
+        out.extend_from_slice(&0x0003_0000u32.to_le_bytes());
+        out.resize(104, 0);
+        let image_at = out.len();
+        out.extend_from_slice(b"SECi");
+        for word in [0x0002_0000u32, image_kind, format, columns, rows, 0] {
+            out.extend_from_slice(&word.to_le_bytes());
+        }
+        out.extend_from_slice(data);
+        let image_len = out.len() - image_at;
+
+        let property_at = out.len();
+        let entries: [(&str, &str); 2] = [("CAMMODEL", "SIGMA DP2 Merrill"), ("ISO", "400")];
+        out.extend_from_slice(b"SECp");
+        out.extend_from_slice(&0x0002_0000u32.to_le_bytes());
+        out.extend_from_slice(&(entries.len() as u32).to_le_bytes());
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(&0u32.to_le_bytes());
+        out.extend_from_slice(&0u32.to_le_bytes());
+        let mut pool: Vec<u16> = Vec::new();
+        let mut offsets = Vec::new();
+        for (name, value) in entries {
+            let name_at = pool.len();
+            pool.extend(name.encode_utf16());
+            pool.push(0);
+            let value_at = pool.len();
+            pool.extend(value.encode_utf16());
+            pool.push(0);
+            offsets.push((name_at as u32, value_at as u32));
+        }
+        for (name, value) in &offsets {
+            out.extend_from_slice(&name.to_le_bytes());
+            out.extend_from_slice(&value.to_le_bytes());
+        }
+        for unit in &pool {
+            out.extend_from_slice(&unit.to_le_bytes());
+        }
+        let property_len = out.len() - property_at;
+
+        let directory_at = out.len();
+        out.extend_from_slice(b"SECd");
+        out.extend_from_slice(&0x0002_0000u32.to_le_bytes());
+        out.extend_from_slice(&2u32.to_le_bytes());
+        for (offset, length, kind) in [
+            (image_at, image_len, b"IMA2"),
+            (property_at, property_len, b"PROP"),
+        ] {
+            out.extend_from_slice(&(offset as u32).to_le_bytes());
+            out.extend_from_slice(&(length as u32).to_le_bytes());
+            out.extend_from_slice(kind);
+        }
+        out.extend_from_slice(&(directory_at as u32).to_le_bytes());
+        out
+    }
+
+    #[test]
+    fn a_plain_frame_is_three_samples_a_pixel() {
+        let pixels: Vec<u16> = (0..2 * 2 * 3).map(|i| 1000 + i as u16).collect();
+        let data: Vec<u8> = pixels.iter().flat_map(|v| v.to_le_bytes()).collect();
+        let file = build(1, formats::PLAIN, 2, 2, &data);
+        let raw = decode(&file).unwrap();
+        raw.validate().unwrap();
+        assert_eq!((raw.width, raw.height, raw.cpp), (2, 2, 3));
+        assert_eq!(raw.cfa, Cfa::None);
+        assert_eq!(raw.data, RawData::U16(pixels));
+        assert_eq!(raw.clean_model, "DP2 Merrill");
+        assert_eq!(raw.metadata.iso, Some(400.0));
+    }
+
+    #[test]
+    fn the_true_codes_are_unsupported_by_name() {
+        for format in [
+            formats::HUFFMAN,
+            formats::TRUE,
+            formats::MERRILL,
+            formats::QUATTRO,
+        ] {
+            let file = build(1, format, 8, 8, &[0; 64]);
+            match decode(&file) {
+                Err(Error::Unsupported(message)) => {
+                    assert!(message.contains("Foveon"), "{message}")
+                }
+                other => panic!("format {format}: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn properties_are_utf16_indexed_by_character() {
+        let file = build(1, formats::PLAIN, 1, 1, &[0; 6]);
+        let sections = directory(&file).unwrap();
+        let list = properties(&file, sections.iter().find(|s| s.kind == *b"PROP").unwrap());
+        assert_eq!(
+            list,
+            vec![
+                ("CAMMODEL".to_string(), "SIGMA DP2 Merrill".to_string()),
+                ("ISO".to_string(), "400".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn a_lossless_jpeg_is_not_a_preview() {
+        // SOF3 is sensor data wearing a JPEG's clothes.
+        let lossless = [
+            0xFFu8, 0xD8, 0xFF, 0xC3, 0, 11, 16, 0, 1, 0, 1, 1, 0, 0x11, 0,
+        ];
+        assert!(!is_displayable_jpeg(&lossless));
+        let baseline = [
+            0xFFu8, 0xD8, 0xFF, 0xC0, 0, 11, 8, 0, 1, 0, 1, 1, 0, 0x11, 0,
+        ];
+        assert!(is_displayable_jpeg(&baseline));
+        assert!(!is_displayable_jpeg(&[]));
+    }
+
+    #[test]
+    fn garbage_is_not_an_x3f() {
+        assert!(decode(&[0u8; 64]).is_err());
+        assert!(decode(b"FOVb").is_err());
+        let file = build(1, formats::PLAIN, 2, 2, &[0; 24]);
+        for cut in 0..file.len() {
+            let _ = decode(&file[..cut]);
+            let _ = preview(&file[..cut]);
+        }
+    }
+
+    #[test]
+    fn corpus_previews_and_metadata() {
+        let files = corpus::files(&["x3f"]);
+        for path in &files {
+            let bytes = std::fs::read(path).unwrap();
+            let name = corpus::name(path);
+            assert_eq!(
+                crate::probe(&bytes),
+                Some(Format::X3f),
+                "{name} did not probe as X3F"
+            );
+            // No LibRaw build reads X3F, so there is no oracle frame
+            // for any of these: the checks are the ones that can be
+            // made without one.
+            let (make, model, metadata, jpeg) = super::metadata(&bytes).unwrap();
+            assert_eq!(make, "SIGMA", "{name}: make");
+            assert!(model.starts_with("SIGMA"), "{name}: model {model:?}");
+            let jpeg = jpeg.unwrap_or_else(|| panic!("{name}: no preview"));
+            let decoded = image::load_from_memory(&jpeg)
+                .unwrap_or_else(|e| panic!("{name}: preview will not decode: {e}"));
+            assert!(
+                decoded.width() >= 640,
+                "{name}: preview is only {}px wide",
+                decoded.width()
+            );
+            assert_eq!(preview(&bytes).unwrap(), Some(jpeg), "{name}");
+            match decode(&bytes) {
+                Ok(raw) => raw.validate().unwrap_or_else(|e| panic!("{name}: {e}")),
+                Err(Error::Unsupported(message)) => {
+                    eprintln!("{name}: {model}, {metadata:?} — unsupported: {message}")
+                }
+                Err(e) => panic!("{name}: {e}"),
+            }
+        }
+        eprintln!("x3f: {} corpus files checked", files.len());
+    }
+
+    #[test]
+    fn corpus_truncations_do_not_panic() {
+        for path in corpus::files(&["x3f"]) {
+            corpus::check_truncations(&path, decode);
+            let Ok(bytes) = std::fs::read(&path) else {
+                continue;
+            };
+            for cut in [0, 1, 4, 64, 1024, bytes.len() / 2, bytes.len() - 1] {
+                let _ = preview(&bytes[..cut.min(bytes.len())]);
+            }
+        }
+    }
+}

--- a/crates/codec-raw/src/lib.rs
+++ b/crates/codec-raw/src/lib.rs
@@ -1,0 +1,831 @@
+//! Camera raw files, decoded and developed in pure Rust.
+//!
+//! Two steps, deliberately separate:
+//!
+//! 1. [`decode`] reads a file into a [`RawImage`]: the sensor data as
+//!    the camera stored it (one sample a pixel under a colour filter
+//!    array, or three for the few linear formats), plus everything a
+//!    developer needs to make a picture of it — black and white levels,
+//!    the as-shot white balance, the camera's colour matrix, the crop,
+//!    the orientation — and the camera's own embedded JPEG.
+//! 2. [`develop`] turns a `RawImage` into linear sRGB: black
+//!    subtraction, white balance, demosaic, the matrix, then crop and
+//!    orientation.
+//!
+//! Every vendor container is a module under [`formats`]; the shared
+//! machinery (TIFF, bit readers, lossless JPEG, ISO-BMFF) sits beside
+//! them. [`probe`] says which module a file belongs to without decoding
+//! it.
+//!
+//! This is a clean-room implementation written from the public DNG
+//! specification and published format descriptions. Nothing in it is
+//! derived from dcraw, LibRaw, rawspeed, rawler or any other
+//! copyleft decoder, and nothing here may read their source.
+
+pub mod bits;
+pub mod bmff;
+pub mod cameras;
+pub mod demosaic;
+pub mod develop;
+pub mod formats;
+pub mod ljpeg;
+pub mod tiff;
+
+pub use develop::{develop, DevelopOptions, Developed};
+
+/// Which container a file is. One variant per decoder module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Format {
+    /// Adobe DNG, including Apple ProRAW, Pixel, Leica and Pentax DNGs.
+    Dng,
+    /// Nikon NEF and NRW.
+    Nef,
+    /// Sony ARW, SR2 and SRF.
+    Arw,
+    /// Canon CR2.
+    Cr2,
+    /// Canon CRW (CIFF).
+    Crw,
+    /// Canon CR3 (ISO-BMFF with the CRX codec).
+    Cr3,
+    /// Fujifilm RAF.
+    Raf,
+    /// Olympus / OM System ORF.
+    Orf,
+    /// Panasonic RW2 and Leica RWL.
+    Rw2,
+    /// Pentax PEF.
+    Pef,
+    /// Samsung SRW.
+    Srw,
+    /// Minolta MRW.
+    Mrw,
+    /// Kodak DCR and KDC.
+    Kodak,
+    /// Epson ERF.
+    Erf,
+    /// Mamiya MEF.
+    Mef,
+    /// Phase One IIQ.
+    Iiq,
+    /// Hasselblad 3FR and FFF.
+    Hasselblad,
+    /// Leaf MOS.
+    Mos,
+    /// Sigma X3F (Foveon).
+    X3f,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A file this crate recognises but cannot decode: an unknown
+    /// compression variant, a camera it has no data for, a feature not
+    /// yet implemented. The caller may have another decoder to try.
+    #[error("unsupported: {0}")]
+    Unsupported(String),
+    /// The file is not what its header says.
+    #[error("corrupt: {0}")]
+    Corrupt(String),
+    /// Not a raw file at all (from [`decode`] on bytes [`probe`] rejects).
+    #[error("not a camera raw file")]
+    NotRaw,
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// The largest frame a decoder will allocate for, in samples of one
+/// plane: 400 megapixels, past every sensor shipped (the largest
+/// medium-format backs are 150 MP) while refusing the multi-gigabyte
+/// requests a forged header can make, which the allocator answers by
+/// aborting the process rather than by an error anyone can catch.
+pub const MAX_FRAME_SAMPLES: usize = 400 << 20;
+
+/// `width * height * cpp`, checked against overflow and against
+/// [`MAX_FRAME_SAMPLES`]. Every decoder sizes its output through this
+/// before allocating.
+pub fn frame_samples(width: usize, height: usize, cpp: usize) -> Result<usize> {
+    width
+        .checked_mul(height)
+        .and_then(|n| n.checked_mul(cpp))
+        .filter(|n| *n <= MAX_FRAME_SAMPLES)
+        .ok_or_else(|| {
+            Error::Corrupt(format!(
+                "frame of {width}x{height}x{cpp} samples is not plausible"
+            ))
+        })
+}
+
+/// Sensor samples: 16-bit integers for nearly everything, floats for
+/// floating-point DNGs.
+#[derive(Debug, Clone, PartialEq)]
+pub enum RawData {
+    U16(Vec<u16>),
+    F32(Vec<f32>),
+}
+
+impl RawData {
+    pub fn len(&self) -> usize {
+        match self {
+            RawData::U16(v) => v.len(),
+            RawData::F32(v) => v.len(),
+        }
+    }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+    /// Sample `i` as a float, unscaled.
+    pub fn get(&self, i: usize) -> f32 {
+        match self {
+            RawData::U16(v) => v.get(i).map_or(0.0, |s| *s as f32),
+            RawData::F32(v) => v.get(i).copied().unwrap_or(0.0),
+        }
+    }
+}
+
+/// One colour of a filter array.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CfaColor {
+    Red,
+    Green,
+    Blue,
+    /// Panasonic and a few others record a second, separately
+    /// balanced green; treat as green when in doubt.
+    Green2,
+    /// Cyan, magenta, yellow: old Kodak/Canon/Nikon CMYG sensors.
+    Cyan,
+    Magenta,
+    Yellow,
+    /// Emerald, on Sony's four-colour sensors.
+    Emerald,
+}
+
+/// The colour filter array over the sensor, as a repeating pattern
+/// anchored at the top-left of the *uncropped* `data`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Cfa {
+    /// Three samples a pixel already (linear DNG, Foveon, Canon sRAW).
+    None,
+    /// A 2x2 Bayer pattern, row-major: `[top-left, top-right,
+    /// bottom-left, bottom-right]`.
+    Bayer([CfaColor; 4]),
+    /// Fujifilm X-Trans, 6x6 row-major.
+    XTrans([[CfaColor; 6]; 6]),
+    /// Anything else: `width` x `height` row-major.
+    Pattern {
+        width: usize,
+        height: usize,
+        colors: Vec<CfaColor>,
+    },
+}
+
+impl Cfa {
+    pub const RGGB: Cfa = Cfa::Bayer([
+        CfaColor::Red,
+        CfaColor::Green,
+        CfaColor::Green,
+        CfaColor::Blue,
+    ]);
+    pub const BGGR: Cfa = Cfa::Bayer([
+        CfaColor::Blue,
+        CfaColor::Green,
+        CfaColor::Green,
+        CfaColor::Red,
+    ]);
+    pub const GRBG: Cfa = Cfa::Bayer([
+        CfaColor::Green,
+        CfaColor::Red,
+        CfaColor::Blue,
+        CfaColor::Green,
+    ]);
+    pub const GBRG: Cfa = Cfa::Bayer([
+        CfaColor::Green,
+        CfaColor::Blue,
+        CfaColor::Red,
+        CfaColor::Green,
+    ]);
+
+    /// The colour under sensor pixel (`x`, `y`) of the uncropped data.
+    pub fn color_at(&self, x: usize, y: usize) -> Option<CfaColor> {
+        match self {
+            Cfa::None => None,
+            Cfa::Bayer(p) => Some(p[(y % 2) * 2 + (x % 2)]),
+            Cfa::XTrans(p) => Some(p[y % 6][x % 6]),
+            Cfa::Pattern {
+                width,
+                height,
+                colors,
+            } => {
+                if *width == 0 || *height == 0 {
+                    return None;
+                }
+                colors.get((y % height) * width + (x % width)).copied()
+            }
+        }
+    }
+
+    /// Whether the pattern describes itself consistently: non-zero
+    /// dimensions and one colour per cell. `validate` checks it, so a
+    /// decoder cannot hand the developer a pattern that indexes past
+    /// its own colours.
+    pub fn is_well_formed(&self) -> bool {
+        match self {
+            Cfa::Pattern {
+                width,
+                height,
+                colors,
+            } => *width > 0 && *height > 0 && colors.len() == width * height,
+            _ => true,
+        }
+    }
+
+    /// The same pattern with its origin moved by (`dx`, `dy`) pixels,
+    /// for describing a crop of the data. A malformed `Pattern` comes
+    /// back unchanged rather than panicking.
+    pub fn shifted(&self, dx: usize, dy: usize) -> Cfa {
+        if !self.is_well_formed() {
+            return self.clone();
+        }
+        match self {
+            Cfa::None => Cfa::None,
+            Cfa::Bayer(_) => Cfa::Bayer(std::array::from_fn(|i| {
+                self.color_at(dx + i % 2, dy + i / 2).unwrap()
+            })),
+            Cfa::XTrans(_) => Cfa::XTrans(std::array::from_fn(|y| {
+                std::array::from_fn(|x| self.color_at(dx + x, dy + y).unwrap())
+            })),
+            Cfa::Pattern { width, height, .. } => Cfa::Pattern {
+                width: *width,
+                height: *height,
+                colors: (0..height * width)
+                    .map(|i| self.color_at(dx + i % width, dy + i / width).unwrap())
+                    .collect(),
+            },
+        }
+    }
+}
+
+/// The camera's orientation tag, TIFF/EXIF values 1..=8.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Orientation {
+    #[default]
+    Normal,
+    MirrorHorizontal,
+    Rotate180,
+    MirrorVertical,
+    /// Mirror horizontal then rotate 270° CW.
+    Transpose,
+    Rotate90CW,
+    /// Mirror horizontal then rotate 90° CW.
+    Transverse,
+    Rotate270CW,
+}
+
+impl Orientation {
+    pub fn from_exif(value: u32) -> Orientation {
+        match value {
+            2 => Orientation::MirrorHorizontal,
+            3 => Orientation::Rotate180,
+            4 => Orientation::MirrorVertical,
+            5 => Orientation::Transpose,
+            6 => Orientation::Rotate90CW,
+            7 => Orientation::Transverse,
+            8 => Orientation::Rotate270CW,
+            _ => Orientation::Normal,
+        }
+    }
+    /// Whether width and height swap when applied.
+    pub fn transposes(self) -> bool {
+        matches!(
+            self,
+            Orientation::Transpose
+                | Orientation::Rotate90CW
+                | Orientation::Transverse
+                | Orientation::Rotate270CW
+        )
+    }
+}
+
+/// A rectangle in sensor pixels of the uncropped data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Rect {
+    pub x: usize,
+    pub y: usize,
+    pub width: usize,
+    pub height: usize,
+}
+
+/// Shooting metadata worth carrying out, when the container has it.
+/// Everything optional; the gallery reads EXIF separately.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Metadata {
+    pub iso: Option<f32>,
+    pub exposure_time: Option<f32>,
+    pub f_number: Option<f32>,
+    pub focal_length: Option<f32>,
+    pub lens: Option<String>,
+    /// "YYYY:MM:DD HH:MM:SS" as EXIF writes it.
+    pub date_time: Option<String>,
+}
+
+/// A decoded raw: the sensor data and what it takes to develop it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RawImage {
+    pub format: Format,
+    /// The make and model strings as the file carries them.
+    pub make: String,
+    pub model: String,
+    /// The same, normalised for the camera table: `cameras::normalize`.
+    pub clean_make: String,
+    pub clean_model: String,
+
+    /// Dimensions of `data` — the full decoded frame, masked borders
+    /// included, so `cfa` and `crop` are anchored at its origin.
+    pub width: usize,
+    pub height: usize,
+    /// Samples per pixel: 1 under a CFA, 3 for `Cfa::None`.
+    pub cpp: usize,
+    pub data: RawData,
+    pub cfa: Cfa,
+
+    /// Black level per CFA position (row-major 2x2 for Bayer; all four
+    /// equal is the common case), in `data`'s units. For `Cfa::None`,
+    /// per channel with the fourth unused.
+    pub black_levels: [f32; 4],
+    /// Saturation level in `data`'s units, one value for the sensor.
+    pub white_level: f32,
+    /// As-shot white balance as multipliers for R, G, B, G2, normalised
+    /// so green is 1.0. `[1.0; 4]` when the file records none.
+    pub wb_coeffs: [f32; 4],
+    /// XYZ (D65) to camera colour, rows camera R/G/B (the DNG
+    /// ColorMatrix convention). From the file where it carries one
+    /// (DNG), else the camera table, else `None`.
+    pub color_matrix: Option<[[f32; 3]; 3]>,
+
+    /// The area meant to be shown: the sensor's active region minus
+    /// the masked borders and any vendor crop. As the file records
+    /// it: the origin may be odd, so a consumer re-deriving a filter
+    /// pattern for the cropped region must shift `cfa` by it (`develop`
+    /// interpolates the whole frame and crops afterwards, and needs no
+    /// such care).
+    pub crop: Rect,
+    pub orientation: Orientation,
+    /// The camera's own JPEG preview, the largest one in the file, as
+    /// its bytes.
+    pub preview: Option<Vec<u8>>,
+    pub metadata: Metadata,
+}
+
+impl RawImage {
+    /// A `RawImage` with every field at its plainest, for decoders to
+    /// fill in: no crop (the whole frame), no orientation, unit white
+    /// balance, no matrix.
+    pub fn new(
+        format: Format,
+        width: usize,
+        height: usize,
+        cpp: usize,
+        data: RawData,
+        cfa: Cfa,
+    ) -> RawImage {
+        RawImage {
+            format,
+            make: String::new(),
+            model: String::new(),
+            clean_make: String::new(),
+            clean_model: String::new(),
+            width,
+            height,
+            cpp,
+            data,
+            cfa,
+            black_levels: [0.0; 4],
+            white_level: 65535.0,
+            wb_coeffs: [1.0; 4],
+            color_matrix: None,
+            crop: Rect {
+                x: 0,
+                y: 0,
+                width,
+                height,
+            },
+            orientation: Orientation::Normal,
+            preview: None,
+            metadata: Metadata::default(),
+        }
+    }
+
+    /// Set make and model, deriving the normalised pair.
+    pub fn set_camera(&mut self, make: &str, model: &str) {
+        self.make = make.trim().to_string();
+        self.model = model.trim().to_string();
+        let (clean_make, clean_model) = cameras::normalize(&self.make, &self.model);
+        self.clean_make = clean_make;
+        self.clean_model = clean_model;
+    }
+
+    /// Fill `color_matrix` (and black/white levels, when the decoder
+    /// left them at their defaults and the table has values) from the
+    /// camera table. Decoders call this last; a matrix the file itself
+    /// carries wins.
+    pub fn apply_camera_table(&mut self) {
+        if let Some(camera) = cameras::lookup(&self.clean_make, &self.clean_model) {
+            if self.color_matrix.is_none() {
+                self.color_matrix = Some(camera.color_matrix);
+            }
+            if self.black_levels == [0.0; 4] {
+                if let Some(black) = camera.black_level {
+                    self.black_levels = [black as f32; 4];
+                }
+            }
+            if self.white_level == 65535.0 {
+                if let Some(white) = camera.white_level {
+                    self.white_level = white as f32;
+                }
+            }
+        }
+    }
+
+    /// Internal consistency: data length matches the dimensions, the
+    /// crop lies inside the frame, levels are sane. Decoders' tests
+    /// call this on everything they produce.
+    pub fn validate(&self) -> Result<()> {
+        // Checked arithmetic throughout: this is the last guard between
+        // a decoder and the developer, and a product that wraps to the
+        // data length would pass garbage through in release builds.
+        let expect = frame_samples(self.width, self.height, self.cpp)?;
+        if self.data.len() != expect {
+            return Err(Error::Corrupt(format!(
+                "data holds {} samples for {}x{}x{}",
+                self.data.len(),
+                self.width,
+                self.height,
+                self.cpp
+            )));
+        }
+        let inside = self
+            .crop
+            .x
+            .checked_add(self.crop.width)
+            .is_some_and(|right| right <= self.width)
+            && self
+                .crop
+                .y
+                .checked_add(self.crop.height)
+                .is_some_and(|bottom| bottom <= self.height);
+        if !inside || self.crop.width == 0 || self.crop.height == 0 {
+            return Err(Error::Corrupt(format!(
+                "crop {:?} outside {}x{}",
+                self.crop, self.width, self.height
+            )));
+        }
+        if self.cpp == 1 && self.cfa == Cfa::None || self.cpp == 3 && self.cfa != Cfa::None {
+            return Err(Error::Corrupt(format!(
+                "cpp {} with cfa {:?}",
+                self.cpp, self.cfa
+            )));
+        }
+        if !self.cfa.is_well_formed() {
+            return Err(Error::Corrupt(format!("malformed cfa {:?}", self.cfa)));
+        }
+        // Written to catch NaN as well as the wrong sign.
+        let bad = |v: f32| v.is_nan() || v <= 0.0;
+        if bad(self.white_level)
+            || self
+                .black_levels
+                .iter()
+                .any(|b| b.is_nan() || *b >= self.white_level)
+        {
+            return Err(Error::Corrupt(format!(
+                "levels black {:?} white {}",
+                self.black_levels, self.white_level
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// Which format a file is, from its bytes, without decoding it. `None`
+/// for anything that is not a camera raw (a plain TIFF from a
+/// converter included: it has no sensor data).
+pub fn probe(bytes: &[u8]) -> Option<Format> {
+    let at = |offset: usize, want: &[u8]| bytes.get(offset..offset + want.len()) == Some(want);
+    if at(0, b"FUJIFILMCCD-RAW") {
+        return Some(Format::Raf);
+    }
+    if at(0, b"IIRO") || at(0, b"IIRS") || at(0, b"MMOR") {
+        return Some(Format::Orf);
+    }
+    if at(0, b"IIU\0") {
+        return Some(Format::Rw2);
+    }
+    if at(6, b"HEAPCCDR") {
+        return Some(Format::Crw);
+    }
+    if at(0, b"FOVb") {
+        return Some(Format::X3f);
+    }
+    if at(0, b"\0MRM") {
+        return Some(Format::Mrw);
+    }
+    if at(4, b"ftyp") && at(8, b"crx ") {
+        return Some(Format::Cr3);
+    }
+    if at(0, b"II*\0") && at(8, b"CR") {
+        return Some(Format::Cr2);
+    }
+    // Phase One: an ordinary little-endian TIFF header (IFD0 is a
+    // thumbnail at the end of the file) with the signature "IIIICwaR"
+    // right after it; the private directory the iiq module reads is
+    // reached from there.
+    if at(0, b"II*\0") && at(8, b"IIIICwaR") {
+        return Some(Format::Iiq);
+    }
+    probe_tiff(bytes)
+}
+
+/// The TIFF-shaped formats, told apart by the maker and by whether
+/// any IFD holds sensor data. This is a minimal walk that does not
+/// depend on the full parser, so a truncated or odd file cannot make
+/// probing fail loudly.
+fn probe_tiff(bytes: &[u8]) -> Option<Format> {
+    let le = match bytes.get(0..4)? {
+        b"II*\0" => true,
+        b"MM\0*" => false,
+        _ => return None,
+    };
+    let u16_at = |at: usize| -> Option<u16> {
+        let b: [u8; 2] = bytes.get(at..at + 2)?.try_into().ok()?;
+        Some(if le {
+            u16::from_le_bytes(b)
+        } else {
+            u16::from_be_bytes(b)
+        })
+    };
+    let u32_at = |at: usize| -> Option<u32> {
+        let b: [u8; 4] = bytes.get(at..at + 4)?.try_into().ok()?;
+        Some(if le {
+            u32::from_le_bytes(b)
+        } else {
+            u32::from_be_bytes(b)
+        })
+    };
+    const MAKE: u16 = 0x010F;
+    const PHOTOMETRIC: u16 = 0x0106;
+    const BITS_PER_SAMPLE: u16 = 0x0102;
+    const STRIP_OFFSETS: u16 = 0x0111;
+    const STRIP_BYTE_COUNTS: u16 = 0x0117;
+    const SUB_IFDS: u16 = 0x014A;
+    const LEAF_DATA: u16 = 0x8606;
+    const DNG_VERSION: u16 = 0xC612;
+    const DNG_PRIVATE_DATA: u16 = 0xC634;
+
+    let mut make = String::new();
+    let mut sensor_data = false;
+    let mut dng = false;
+    let mut leaf = false;
+    // Sony's first bodies (DSLR-A100) point SubIFDs at bare data and
+    // the DSC-F828 writes strips with no offsets; both carry Sony's
+    // private block, which no converter's TIFF does.
+    let mut private = false;
+    let mut queue = vec![u32_at(4)? as usize];
+    let mut visited = 0;
+    while let Some(ifd) = queue.pop() {
+        if visited >= 12 {
+            break;
+        }
+        visited += 1;
+        let Some(count) = u16_at(ifd) else { continue };
+        let count = count.min(512) as usize;
+        // An IFD of strips more than 8 bits deep is sensor data in the
+        // formats that never say so with PhotometricInterpretation
+        // (Samsung SRW, Sony SRF).
+        let (mut deep, mut strips) = (false, false);
+        for i in 0..count {
+            let entry = ifd + 2 + i * 12;
+            let (Some(tag), Some(kind), Some(n)) =
+                (u16_at(entry), u16_at(entry + 2), u32_at(entry + 4))
+            else {
+                break;
+            };
+            match tag {
+                // One SHORT sits in the entry; three (RGB) live at the
+                // offset the entry holds, and reading the offset as the
+                // value would call every colour thumbnail deep.
+                BITS_PER_SAMPLE if kind == 3 => {
+                    let Some(at) = (if n <= 2 {
+                        Some(entry + 8)
+                    } else {
+                        u32_at(entry + 8).map(|o| o as usize)
+                    }) else {
+                        break;
+                    };
+                    deep = u16_at(at).is_some_and(|b| b > 8);
+                }
+                STRIP_OFFSETS | STRIP_BYTE_COUNTS => strips = true,
+                LEAF_DATA => leaf = true,
+                DNG_PRIVATE_DATA => private = true,
+                MAKE if kind == 2 && make.is_empty() => {
+                    let n = n as usize;
+                    let Some(at) = (if n <= 4 {
+                        Some(entry + 8)
+                    } else {
+                        u32_at(entry + 8).map(|o| o as usize)
+                    }) else {
+                        break;
+                    };
+                    if let Some(s) = bytes.get(at..at + n) {
+                        make = String::from_utf8_lossy(s)
+                            .trim_end_matches('\0')
+                            .trim()
+                            .to_string();
+                    }
+                }
+                PHOTOMETRIC if kind == 3 => {
+                    if matches!(u16_at(entry + 8), Some(32803 | 34892)) {
+                        sensor_data = true;
+                    }
+                }
+                DNG_VERSION => dng = true,
+                SUB_IFDS if kind == 4 || kind == 13 => {
+                    let n = n.min(8) as usize;
+                    let Some(at) = (if n == 1 {
+                        Some(entry + 8)
+                    } else {
+                        u32_at(entry + 8).map(|o| o as usize)
+                    }) else {
+                        break;
+                    };
+                    for j in 0..n {
+                        if let Some(off) = u32_at(at + j * 4) {
+                            queue.push(off as usize);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if deep && strips {
+            sensor_data = true;
+        }
+        if let Some(next) = u32_at(ifd + 2 + count * 12) {
+            if next != 0 {
+                queue.push(next as usize);
+            }
+        }
+    }
+    if dng {
+        return Some(Format::Dng);
+    }
+    // Leaf backs name themselves only in XMP; their private metadata
+    // tag is the mark.
+    if leaf && make.is_empty() {
+        return Some(Format::Mos);
+    }
+    let make = make.to_ascii_uppercase();
+    let by_make = if make.starts_with("NIKON") {
+        Format::Nef
+    } else if make.starts_with("SONY") {
+        Format::Arw
+    } else if make.starts_with("CANON") {
+        Format::Cr2
+    } else if make.starts_with("PENTAX") || make.starts_with("RICOH") || make.starts_with("ASAHI") {
+        Format::Pef
+    } else if make.starts_with("SAMSUNG") {
+        Format::Srw
+    } else if make.starts_with("KODAK") || make.starts_with("EASTMAN") {
+        Format::Kodak
+    } else if make.starts_with("SEIKO EPSON") || make.starts_with("EPSON") {
+        Format::Erf
+    } else if make.starts_with("MAMIYA") {
+        Format::Mef
+    } else if make.starts_with("HASSELBLAD") {
+        Format::Hasselblad
+    } else if make.starts_with("LEAF") {
+        Format::Mos
+    } else if make.starts_with("PHASE ONE") {
+        Format::Iiq
+    } else if make.starts_with("OLYMPUS") || make.starts_with("OM DIGITAL") {
+        Format::Orf
+    } else if make.starts_with("PANASONIC") || make.starts_with("LEICA") {
+        Format::Rw2
+    } else if make.starts_with("MINOLTA") || make.starts_with("KONICA") {
+        Format::Mrw
+    } else {
+        return None;
+    };
+    // Sony ARW, Samsung SRW, Leaf MOS and Hasselblad files mark their
+    // sensor IFDs as CFA; a converter's TIFF with the same Make does
+    // not. Nikon, Canon and Pentax likewise. The makers whose raws do
+    // not use the CFA photometric are trusted on make alone.
+    let cfa_optional = matches!(
+        by_make,
+        Format::Mos | Format::Kodak | Format::Mef | Format::Erf
+    ) || (by_make == Format::Arw && private);
+    (sensor_data || cfa_optional).then_some(by_make)
+}
+
+/// The camera's orientation tag without decoding sensor data, for
+/// turning the embedded preview upright: IFD0's tag for the
+/// TIFF-shaped formats, the CMT1 block for CR3, the embedded JPEG's
+/// EXIF for RAF. `Normal` for the containers that carry none, and for
+/// anything unreadable.
+pub fn orientation(bytes: &[u8]) -> Orientation {
+    fn tiff_orientation(bytes: &[u8], base: usize) -> Option<Orientation> {
+        let tiff = tiff::Tiff::parse_embedded(bytes, base).ok()?;
+        Some(formats::common::orientation(&tiff))
+    }
+    /// The orientation inside a JPEG's Exif APP1 segment.
+    fn jpeg_orientation(jpeg: &[u8], base: usize) -> Option<Orientation> {
+        let mut at = 2;
+        while at + 4 <= jpeg.len() && jpeg[at] == 0xFF {
+            let marker = jpeg[at + 1];
+            let len = u16::from_be_bytes([jpeg[at + 2], jpeg[at + 3]]) as usize;
+            if marker == 0xE1 && jpeg.get(at + 4..at + 10) == Some(b"Exif\0\0") {
+                return tiff_orientation(jpeg, base + at + 10);
+            }
+            if marker == 0xDA {
+                break;
+            }
+            at += 2 + len;
+        }
+        None
+    }
+    let found = match probe(bytes) {
+        Some(Format::Cr3) => bmff::parse(bytes).ok().and_then(|boxes| {
+            boxes
+                .iter()
+                .flat_map(|b| std::iter::once(b).chain(b.find_all(b"CMT1")))
+                .find(|b| &b.kind == b"CMT1")
+                .and_then(|cmt1| tiff_orientation(bytes, cmt1.data.start))
+        }),
+        Some(Format::Raf) => {
+            let field = |at: usize| -> Option<usize> {
+                Some(u32::from_be_bytes(bytes.get(at..at + 4)?.try_into().ok()?) as usize)
+            };
+            field(84)
+                .zip(field(88))
+                .and_then(|(at, len)| bytes.get(at..at.checked_add(len)?))
+                .and_then(|jpeg| jpeg_orientation(jpeg, 0))
+        }
+        Some(Format::Crw) | Some(Format::X3f) | Some(Format::Mrw) | None => None,
+        Some(_) => tiff_orientation(bytes, 0),
+    };
+    found.unwrap_or_default()
+}
+
+/// Decode a raw file into its sensor data and metadata.
+pub fn decode(bytes: &[u8]) -> Result<RawImage> {
+    let format = probe(bytes).ok_or(Error::NotRaw)?;
+    let mut raw = match format {
+        Format::Dng => formats::dng::decode(bytes)?,
+        Format::Nef => formats::nef::decode(bytes)?,
+        Format::Arw => formats::arw::decode(bytes)?,
+        Format::Cr2 => formats::cr2::decode(bytes)?,
+        Format::Crw => formats::crw::decode(bytes)?,
+        Format::Cr3 => formats::cr3::decode(bytes)?,
+        Format::Raf => formats::raf::decode(bytes)?,
+        Format::Orf => formats::orf::decode(bytes)?,
+        Format::Rw2 => formats::rw2::decode(bytes)?,
+        Format::Pef => formats::pef::decode(bytes)?,
+        Format::Srw => formats::srw::decode(bytes)?,
+        Format::Mrw => formats::mrw::decode(bytes)?,
+        Format::Kodak => formats::kodak::decode(bytes)?,
+        Format::Erf => formats::erf::decode(bytes)?,
+        Format::Mef => formats::mef::decode(bytes)?,
+        Format::Iiq => formats::iiq::decode(bytes)?,
+        Format::Hasselblad => formats::hasselblad::decode(bytes)?,
+        Format::Mos => formats::mos::decode(bytes)?,
+        Format::X3f => formats::x3f::decode(bytes)?,
+    };
+    raw.format = format;
+    raw.validate()?;
+    Ok(raw)
+}
+
+/// The camera's embedded JPEG preview, without decoding the sensor
+/// data. Decoders that can find it cheaply implement
+/// `formats::<x>::preview`; the default goes through `decode`.
+pub fn preview(bytes: &[u8]) -> Result<Option<Vec<u8>>> {
+    let format = probe(bytes).ok_or(Error::NotRaw)?;
+    match format {
+        Format::Dng => formats::dng::preview(bytes),
+        Format::Nef => formats::nef::preview(bytes),
+        Format::Arw => formats::arw::preview(bytes),
+        Format::Cr2 => formats::cr2::preview(bytes),
+        Format::Crw => formats::crw::preview(bytes),
+        Format::Cr3 => formats::cr3::preview(bytes),
+        Format::Raf => formats::raf::preview(bytes),
+        Format::Orf => formats::orf::preview(bytes),
+        Format::Rw2 => formats::rw2::preview(bytes),
+        Format::Pef => formats::pef::preview(bytes),
+        Format::Srw => formats::srw::preview(bytes),
+        Format::Mrw => formats::mrw::preview(bytes),
+        Format::Kodak => formats::kodak::preview(bytes),
+        Format::Erf => formats::erf::preview(bytes),
+        Format::Mef => formats::mef::preview(bytes),
+        Format::Iiq => formats::iiq::preview(bytes),
+        Format::Hasselblad => formats::hasselblad::preview(bytes),
+        Format::Mos => formats::mos::preview(bytes),
+        Format::X3f => formats::x3f::preview(bytes),
+    }
+}

--- a/crates/codec-raw/src/ljpeg.rs
+++ b/crates/codec-raw/src/ljpeg.rs
@@ -1,0 +1,1588 @@
+//! Lossless JPEG (ITU T.81 process 14, SOF3), the compression of DNG,
+//! Canon CR2, Pentax, Kodak, Hasselblad and Leaf raws.
+//!
+//! Handles 2–16-bit precision, 1–4 components, all seven predictors,
+//! point transforms, restart intervals, and the two habits of
+//! camera-written streams: Canon's SOF3 that declares two or four
+//! components over a width that is a slice of the sensor, and DNG
+//! tiles whose components are simply interleaved pixels.
+//!
+//! Both habits need no special case here. A lossless JPEG scan is a
+//! plain raster of `width * components` samples a row, and every
+//! camera that plays games with the component count is only choosing
+//! how to group the sensor's samples into that raster: Canon splits a
+//! row into two or four interleaved slices, Adobe's CFA tiles
+//! interleave two adjacent sensor columns. Handing the caller the
+//! samples in stream order is therefore the only useful thing to do —
+//! un-slicing needs the container's tags, which this module does not
+//! see.
+
+use crate::bits::{BitPumpJpeg, HuffTable};
+use crate::{Error, Result};
+
+/// A decoded frame: `width * height * components` samples, row-major,
+/// components interleaved, exactly as the stream orders them.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LjpegImage {
+    pub width: usize,
+    pub height: usize,
+    pub components: usize,
+    pub precision: u32,
+    pub data: Vec<u16>,
+}
+
+/// A ceiling on what a frame header may claim, so a corrupt or hostile
+/// two-byte dimension cannot ask for a terabyte. 256 M samples is far
+/// past the largest sensor anyone has shipped (a 100 MP back's CFA
+/// frame is 0.1 G) while still being a half-gigabyte allocation at
+/// worst.
+const MAX_SAMPLES: usize = 1 << 28;
+
+/// Everything the markers before the entropy-coded data say.
+struct Header {
+    precision: u32,
+    width: usize,
+    height: usize,
+    components: usize,
+    /// SOS's `Ss`: which of T.81's seven prediction rules the scan
+    /// uses away from the first row and column.
+    predictor: u8,
+    /// SOS's `Al`: the encoder right-shifted every sample by this
+    /// much, so decoded samples are shifted back on the way out.
+    point_transform: u32,
+    /// DRI's interval in MCUs; 0 when the stream has no restarts.
+    restart_interval: usize,
+    /// Up to four DHT tables, by table id.
+    tables: [Option<HuffTable>; 4],
+    /// Which table each scan component reads its differences with.
+    component_tables: [usize; 4],
+    /// Offset of the first entropy-coded byte.
+    scan_start: usize,
+}
+
+/// Decode a complete lossless JPEG stream (SOI through EOI; trailing
+/// bytes ignored).
+pub fn decode(bytes: &[u8]) -> Result<LjpegImage> {
+    let header = parse(bytes, false)?;
+    let samples = header
+        .width
+        .checked_mul(header.height)
+        .and_then(|n| n.checked_mul(header.components))
+        .filter(|n| *n <= MAX_SAMPLES)
+        .ok_or_else(|| {
+            Error::Unsupported(format!(
+                "lossless JPEG frame of {}x{}x{} is larger than this decoder allows",
+                header.width, header.height, header.components
+            ))
+        })?;
+
+    // The shortest a symbol can be is one bit, so a scan that holds
+    // fewer bits than the frame has samples is truncated (or lying)
+    // and there is no point allocating for it.
+    let scan = &bytes[header.scan_start..];
+    if (scan.len() as u64).saturating_mul(8) < samples as u64 {
+        return Err(Error::Corrupt(format!(
+            "lossless JPEG scan holds {} bytes for {samples} samples",
+            scan.len()
+        )));
+    }
+
+    let tables = scan_tables(&header)?;
+    let mut data = vec![0u16; samples];
+    // The predictor is fixed for the whole scan, so it is chosen once
+    // here and compiled into the sample loop rather than tested per
+    // sample.
+    match header.predictor {
+        1 => decode_scan::<1>(scan, &header, &tables, &mut data)?,
+        2 => decode_scan::<2>(scan, &header, &tables, &mut data)?,
+        3 => decode_scan::<3>(scan, &header, &tables, &mut data)?,
+        4 => decode_scan::<4>(scan, &header, &tables, &mut data)?,
+        5 => decode_scan::<5>(scan, &header, &tables, &mut data)?,
+        6 => decode_scan::<6>(scan, &header, &tables, &mut data)?,
+        7 => decode_scan::<7>(scan, &header, &tables, &mut data)?,
+        p => {
+            return Err(Error::Unsupported(format!(
+                "lossless JPEG predictor {p} (0 is the differential/hierarchical mode)"
+            )))
+        }
+    }
+
+    // T.81's point transform: the encoder divided every sample by
+    // 2^Al, and prediction runs on those divided values, so the shift
+    // back happens only once the whole scan is decoded. Cameras all
+    // use Al = 0.
+    if header.point_transform > 0 {
+        for sample in &mut data {
+            *sample <<= header.point_transform;
+        }
+    }
+
+    Ok(LjpegImage {
+        width: header.width,
+        height: header.height,
+        components: header.components,
+        precision: header.precision,
+        data,
+    })
+}
+
+/// The frame header alone (dimensions, components, precision), for
+/// callers that size their output before decoding. `data` is empty.
+pub fn header(bytes: &[u8]) -> Result<LjpegImage> {
+    let header = parse(bytes, true)?;
+    Ok(LjpegImage {
+        width: header.width,
+        height: header.height,
+        components: header.components,
+        precision: header.precision,
+        data: Vec::new(),
+    })
+}
+
+/// The scan's Huffman tables, one borrow per component.
+fn scan_tables(header: &Header) -> Result<Vec<&HuffTable>> {
+    (0..header.components)
+        .map(|c| {
+            let id = header.component_tables[c];
+            header.tables[id].as_ref().ok_or_else(|| {
+                Error::Corrupt(format!(
+                    "scan component {c} uses Huffman table {id}, which the file never defines"
+                ))
+            })
+        })
+        .collect()
+}
+
+/// Big-endian `u16` at `at`, the only integer width JPEG headers use.
+fn be16(bytes: &[u8], at: usize) -> Result<usize> {
+    match bytes.get(at..at + 2) {
+        Some(b) => Ok(((b[0] as usize) << 8) | b[1] as usize),
+        None => Err(Error::Corrupt("JPEG header ends mid-value".into())),
+    }
+}
+
+/// Walk the marker segments up to (and including) SOS. With
+/// `header_only` the tables are still read — they cost little and a
+/// caller asking only for the size does not pay for the scan.
+fn parse(bytes: &[u8], header_only: bool) -> Result<Header> {
+    if bytes.len() < 4 || bytes[0] != 0xFF || bytes[1] != 0xD8 {
+        return Err(Error::Corrupt("not a JPEG stream: no SOI".into()));
+    }
+    let mut precision = 0u32;
+    let mut width = 0usize;
+    let mut height = 0usize;
+    let mut components = 0usize;
+    let mut ids = [0u8; 4];
+    let mut restart_interval = 0usize;
+    let mut tables: [Option<HuffTable>; 4] = [None, None, None, None];
+
+    let mut at = 2usize;
+    loop {
+        // Segments are separated by a 0xFF; any number of extra 0xFF
+        // fill bytes may precede the marker itself.
+        let Some(&lead) = bytes.get(at) else {
+            return Err(Error::Corrupt("JPEG stream ends before its scan".into()));
+        };
+        if lead != 0xFF {
+            return Err(Error::Corrupt(format!(
+                "expected a JPEG marker at {at}, found {lead:#04x}"
+            )));
+        }
+        at += 1;
+        while bytes.get(at) == Some(&0xFF) {
+            at += 1;
+        }
+        let Some(&marker) = bytes.get(at) else {
+            return Err(Error::Corrupt("JPEG stream ends on a marker".into()));
+        };
+        at += 1;
+
+        match marker {
+            // Standalone markers: no payload.
+            0xD8 | 0x01 | 0xD0..=0xD7 => continue,
+            0xD9 => {
+                return Err(Error::Corrupt(
+                    "JPEG stream ends (EOI) before its scan".into(),
+                ))
+            }
+            _ => {}
+        }
+        let length = be16(bytes, at)?;
+        if length < 2 {
+            return Err(Error::Corrupt(format!(
+                "JPEG segment {marker:#04x} has length {length}"
+            )));
+        }
+        let payload = bytes.get(at + 2..at + length).ok_or_else(|| {
+            Error::Corrupt(format!(
+                "JPEG segment {marker:#04x} runs past the end of the file"
+            ))
+        })?;
+        let next = at + length;
+
+        match marker {
+            // SOF3: the lossless frame header.
+            0xC3 => {
+                if payload.len() < 6 {
+                    return Err(Error::Corrupt("SOF3 segment is too short".into()));
+                }
+                precision = payload[0] as u32;
+                height = ((payload[1] as usize) << 8) | payload[2] as usize;
+                width = ((payload[3] as usize) << 8) | payload[4] as usize;
+                components = payload[5] as usize;
+                if !(2..=16).contains(&precision) {
+                    return Err(Error::Unsupported(format!(
+                        "lossless JPEG precision {precision}"
+                    )));
+                }
+                if height == 0 {
+                    // A zero height means the real one arrives in a
+                    // DNL marker after the scan. No camera writes
+                    // that, and honouring it means decoding blind.
+                    return Err(Error::Unsupported(
+                        "lossless JPEG with the height deferred to DNL".into(),
+                    ));
+                }
+                if width == 0 {
+                    return Err(Error::Corrupt("SOF3 declares a zero width".into()));
+                }
+                if !(1..=4).contains(&components) {
+                    return Err(Error::Unsupported(format!(
+                        "lossless JPEG with {components} components"
+                    )));
+                }
+                if payload.len() < 6 + components * 3 {
+                    return Err(Error::Corrupt(
+                        "SOF3 segment is shorter than its component list".into(),
+                    ));
+                }
+                for c in 0..components {
+                    let spec = &payload[6 + c * 3..9 + c * 3];
+                    ids[c] = spec[0];
+                    // Subsampling has no meaning for a lossless frame
+                    // and nothing writes it, but a file that claims it
+                    // would decode to nonsense if it were ignored.
+                    if spec[1] != 0x11 {
+                        // Canon's sRAW and mRAW are the only raw
+                        // streams that do this: a subsampled YCbCr
+                        // lossless frame. Decoding it needs the MCU
+                        // interleave rules and a chroma upsampler,
+                        // neither of which belongs here yet.
+                        return Err(Error::Unsupported(format!(
+                            "lossless JPEG component {c} with sampling factors {:#04x} (Canon sRAW/mRAW)",
+                            spec[1]
+                        )));
+                    }
+                }
+            }
+            // Any other SOFn is a different JPEG process entirely.
+            0xC0..=0xCF if marker != 0xC4 && marker != 0xC8 && marker != 0xCC => {
+                return Err(Error::Unsupported(format!(
+                    "JPEG process SOF{} ({marker:#04x}); only lossless SOF3 belongs in a raw file",
+                    marker & 0x0F
+                )));
+            }
+            // DHT: one or more tables in the one segment.
+            0xC4 => {
+                let mut p = 0usize;
+                while p < payload.len() {
+                    let class_and_id = payload[p];
+                    let id = (class_and_id & 0x0F) as usize;
+                    if class_and_id >> 4 != 0 {
+                        return Err(Error::Unsupported(
+                            "an AC Huffman table in a lossless JPEG (only DC tables are used)"
+                                .into(),
+                        ));
+                    }
+                    if id >= 4 {
+                        return Err(Error::Corrupt(format!(
+                            "Huffman table id {id} is outside 0..=3"
+                        )));
+                    }
+                    let counts = payload.get(p + 1..p + 17).ok_or_else(|| {
+                        Error::Corrupt("DHT segment ends inside its code lengths".into())
+                    })?;
+                    let total: usize = counts.iter().map(|c| *c as usize).sum();
+                    let symbols = payload.get(p + 17..p + 17 + total).ok_or_else(|| {
+                        Error::Corrupt("DHT segment ends inside its symbols".into())
+                    })?;
+                    // A caller after the frame's shape alone does
+                    // not need the codes built.
+                    if !header_only {
+                        tables[id] = Some(HuffTable::new(counts, symbols)?);
+                    }
+                    p += 17 + total;
+                }
+            }
+            // DRI: how many MCUs between restart markers.
+            0xDD => {
+                restart_interval = be16(payload, 0)?;
+            }
+            // SOS: the scan header, and then the entropy-coded data.
+            0xDA => {
+                if width == 0 {
+                    return Err(Error::Corrupt("SOS before SOF3".into()));
+                }
+                let ns = *payload
+                    .first()
+                    .ok_or_else(|| Error::Corrupt("empty SOS segment".into()))?
+                    as usize;
+                if ns != components {
+                    // Non-interleaved scans (one component per scan)
+                    // are legal but nothing writes them for raw.
+                    return Err(Error::Unsupported(format!(
+                        "a lossless JPEG scan over {ns} of the frame's {components} components"
+                    )));
+                }
+                if payload.len() < 1 + ns * 2 + 3 {
+                    return Err(Error::Corrupt("SOS segment is too short".into()));
+                }
+                let mut component_tables = [0usize; 4];
+                for c in 0..ns {
+                    let selector = payload[1 + c * 2];
+                    let table = (payload[2 + c * 2] >> 4) as usize;
+                    if table >= 4 {
+                        return Err(Error::Corrupt(format!(
+                            "scan component {c} names Huffman table {table}"
+                        )));
+                    }
+                    // The scan lists components by the ids SOF3 gave
+                    // them; they are normally in frame order, but a
+                    // permuted scan is legal.
+                    let index = ids[..components]
+                        .iter()
+                        .position(|id| *id == selector)
+                        .ok_or_else(|| {
+                            Error::Corrupt(format!(
+                                "scan names component {selector}, which the frame does not have"
+                            ))
+                        })?;
+                    component_tables[index] = table;
+                }
+                let tail = &payload[1 + ns * 2..];
+                let predictor = tail[0];
+                let point_transform = (tail[2] & 0x0F) as u32;
+                if point_transform >= precision {
+                    return Err(Error::Corrupt(format!(
+                        "point transform {point_transform} with {precision}-bit samples"
+                    )));
+                }
+                return Ok(Header {
+                    precision,
+                    width,
+                    height,
+                    components,
+                    predictor,
+                    point_transform,
+                    restart_interval,
+                    tables,
+                    component_tables,
+                    scan_start: next,
+                });
+            }
+            // APPn, COM, DQT, DNL and the rest: not our business.
+            _ => {}
+        }
+        at = next;
+    }
+}
+
+/// T.81's seven prediction rules, over the sample to the left (`a`),
+/// the one above (`b`) and the one above-left (`c`). The halvings are
+/// arithmetic shifts, as the specification defines them.
+#[inline(always)]
+fn predict<const P: u8>(a: i32, b: i32, c: i32) -> i32 {
+    match P {
+        1 => a,
+        2 => b,
+        3 => c,
+        4 => a + b - c,
+        5 => a + ((b - c) >> 1),
+        6 => b + ((a - c) >> 1),
+        _ => (a + b) >> 1,
+    }
+}
+
+/// Decode the whole scan, restart interval by restart interval.
+fn decode_scan<const P: u8>(
+    scan: &[u8],
+    header: &Header,
+    tables: &[&HuffTable],
+    out: &mut [u16],
+) -> Result<()> {
+    let mcus = header.width * header.height;
+    let interval = if header.restart_interval == 0 {
+        mcus
+    } else {
+        header.restart_interval
+    };
+    // The prediction every restart interval (and the frame) starts
+    // from: half of full scale, so the first difference is centred.
+    let initial = 1i32 << (header.precision - header.point_transform - 1);
+
+    let mut pump = BitPumpJpeg::new(scan);
+    // Where `pump`'s slice starts inside `scan`, so the search for the
+    // next RSTn can be expressed in `scan`'s offsets.
+    let mut base = 0usize;
+    let mut mcu = 0usize;
+    // RSTn markers count 0..=7 and wrap; a stream that lost an
+    // interval would otherwise resync on the next marker and come out
+    // shifted by a row with no error.
+    let mut restart_index = 0u8;
+    while mcu < mcus {
+        let end = (mcu + interval).min(mcus);
+        decode_interval::<P>(&mut pump, header, tables, out, mcu, end, initial);
+        mcu = end;
+        if mcu < mcus {
+            // The encoder padded to a byte boundary and wrote RSTn;
+            // the bits after it start a fresh accumulator, and the
+            // predictors reset.
+            base = find_restart(scan, base + pump.byte_pos(), restart_index)?;
+            restart_index = (restart_index + 1) % 8;
+            pump = BitPumpJpeg::new(&scan[base..]);
+        }
+    }
+    Ok(())
+}
+
+/// One restart interval: MCUs `start..end` in raster order. An MCU of
+/// a lossless scan is one sample of each component, so the MCU index
+/// is the pixel index.
+#[allow(clippy::too_many_arguments)]
+fn decode_interval<const P: u8>(
+    pump: &mut BitPumpJpeg<'_>,
+    header: &Header,
+    tables: &[&HuffTable],
+    out: &mut [u16],
+    start: usize,
+    end: usize,
+    initial: i32,
+) {
+    let width = header.width;
+    let ncomp = header.components;
+    let stride = width * ncomp;
+
+    let mut mcu = start;
+    // The first sample of an interval has no usable neighbours: T.81
+    // predicts it from half scale, wherever in the raster it falls.
+    let mut first = true;
+    while mcu < end {
+        let y = mcu / width;
+        let row_end = end.min((y + 1) * width);
+        let mut idx = mcu * ncomp;
+
+        if first || mcu.is_multiple_of(width) {
+            for table in tables.iter().take(ncomp) {
+                let diff = table.decode_diff(pump);
+                // Left of the first column there is nothing, so the
+                // rule is "predict from above" (T.81's predictor 2).
+                let prediction = if first {
+                    initial
+                } else {
+                    out[idx - stride] as i32
+                };
+                out[idx] = (prediction + diff) as u16;
+                idx += 1;
+            }
+            first = false;
+            mcu += 1;
+            if mcu >= row_end {
+                continue;
+            }
+        }
+
+        let count = row_end - mcu;
+        if y == 0 {
+            // The top row has nothing above it: predictor 1, always.
+            for _ in 0..count {
+                for table in tables.iter().take(ncomp) {
+                    let diff = table.decode_diff(pump);
+                    out[idx] = (out[idx - ncomp] as i32 + diff) as u16;
+                    idx += 1;
+                }
+            }
+        } else {
+            for _ in 0..count {
+                for table in tables.iter().take(ncomp) {
+                    let diff = table.decode_diff(pump);
+                    let a = out[idx - ncomp] as i32;
+                    let b = out[idx - stride] as i32;
+                    let c = out[idx - stride - ncomp] as i32;
+                    // Wrapping to sixteen bits is what T.81 means by
+                    // "modulo 65536": the difference was taken that
+                    // way, and the sample fits in `precision` bits
+                    // again once it wraps back.
+                    out[idx] = (predict::<P>(a, b, c) + diff) as u16;
+                    idx += 1;
+                }
+            }
+        }
+        mcu = row_end;
+    }
+}
+
+/// The offset just past the next `RSTn` marker at or after `from`.
+/// Entropy-coded `0xFF` bytes are always stuffed with a `0x00`, so any
+/// other `FF xx` in the scan is a real marker and finding one that is
+/// not a restart means the stream ended early.
+fn find_restart(scan: &[u8], from: usize, expected: u8) -> Result<usize> {
+    let mut at = from;
+    while at + 1 < scan.len() {
+        if scan[at] == 0xFF {
+            match scan[at + 1] {
+                // Stuffing, or fill before a marker.
+                0x00 => at += 2,
+                0xFF => at += 1,
+                marker @ 0xD0..=0xD7 if marker == 0xD0 + expected => return Ok(at + 2),
+                marker @ 0xD0..=0xD7 => {
+                    return Err(Error::Corrupt(format!(
+                        "restart marker RST{} where RST{expected} was due",
+                        marker - 0xD0
+                    )))
+                }
+                marker => {
+                    return Err(Error::Corrupt(format!(
+                        "marker FF{marker:02X} in the scan where a restart marker was due"
+                    )))
+                }
+            }
+        } else {
+            at += 1;
+        }
+    }
+    Err(Error::Corrupt(
+        "the scan ends before its next restart marker".into(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------------------------------------------------------------
+    // A lossless JPEG encoder, so the decoder can be tested against
+    // something other than itself. It is deliberately naive: a fixed
+    // canonical Huffman table given as code-length counts, every
+    // predictor, any precision, one to four components, optional
+    // restart intervals.
+    // ---------------------------------------------------------------
+
+    /// How to encode a frame.
+    #[derive(Clone)]
+    struct Encode {
+        width: usize,
+        height: usize,
+        components: usize,
+        precision: u32,
+        predictor: u8,
+        point_transform: u32,
+        restart_interval: usize,
+        /// Sixteen counts of codes of each length, and the symbols in
+        /// canonical order (all seventeen difference categories).
+        counts: [u8; 16],
+        symbols: Vec<u8>,
+        /// Give each component its own copy of the table under its own
+        /// id, to exercise multi-table DHT segments.
+        table_per_component: bool,
+    }
+
+    impl Encode {
+        fn new(width: usize, height: usize, components: usize, precision: u32) -> Encode {
+            Encode {
+                width,
+                height,
+                components,
+                precision,
+                predictor: 1,
+                point_transform: 0,
+                restart_interval: 0,
+                // 1 + 2 + 3 + 4 + 5 + 2 = 17 symbols, Kraft sum 0.906.
+                counts: [0, 1, 2, 3, 4, 5, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                symbols: (0..17u8).collect(),
+                table_per_component: false,
+            }
+        }
+        /// A complete code with one symbol at every length up to 16,
+        /// so the decoder's slow path for long codes gets used.
+        fn long_codes(mut self) -> Encode {
+            self.counts = [1; 16];
+            self.counts[15] = 2;
+            self
+        }
+    }
+
+    /// MSB-first bit writer that stuffs a zero after every 0xFF, as
+    /// JPEG's entropy coder must.
+    struct BitWriter {
+        out: Vec<u8>,
+        acc: u32,
+        nbits: u32,
+    }
+
+    impl BitWriter {
+        fn new() -> BitWriter {
+            BitWriter {
+                out: Vec::new(),
+                acc: 0,
+                nbits: 0,
+            }
+        }
+        fn put(&mut self, code: u32, len: u32) {
+            assert!(len <= 16);
+            self.acc = (self.acc << len) | (code & ((1u32 << len) - 1));
+            self.nbits += len;
+            while self.nbits >= 8 {
+                let byte = (self.acc >> (self.nbits - 8)) as u8;
+                self.out.push(byte);
+                if byte == 0xFF {
+                    self.out.push(0x00);
+                }
+                self.nbits -= 8;
+            }
+            self.acc &= (1u32 << self.nbits) - 1;
+        }
+        /// Pad to a byte with 1 bits, which is what JPEG requires
+        /// before a marker (a run of 1s cannot be mistaken for data
+        /// because the all-ones code is never assigned).
+        fn pad(&mut self) {
+            if self.nbits > 0 {
+                let n = 8 - self.nbits;
+                self.put((1 << n) - 1, n);
+            }
+        }
+        fn marker(&mut self, marker: u8) {
+            self.pad();
+            self.out.push(0xFF);
+            self.out.push(marker);
+        }
+    }
+
+    /// Canonical code assignment: symbols in order, shortest codes
+    /// first, exactly as a JPEG decoder reconstructs them.
+    fn canonical(counts: &[u8; 16], symbols: &[u8]) -> Vec<(u32, u32)> {
+        let mut table = vec![(0u32, 0u32); 256];
+        let mut code = 0u32;
+        let mut index = 0usize;
+        for len in 1..=16u32 {
+            for _ in 0..counts[len as usize - 1] {
+                table[symbols[index] as usize] = (code, len);
+                code += 1;
+                index += 1;
+            }
+            code <<= 1;
+        }
+        assert_eq!(index, symbols.len(), "counts and symbols disagree");
+        table
+    }
+
+    /// The difference between `sample` and its prediction, as a
+    /// category and the bits that follow it.
+    fn encode_diff(w: &mut BitWriter, codes: &[(u32, u32)], sample: u16, prediction: i32) {
+        // Modulo 65536, mapped into -32768..=32767: exactly what the
+        // decoder undoes by wrapping.
+        let diff = (sample as i32 - prediction) as i16 as i32;
+        let category = if diff == 0 {
+            0
+        } else {
+            32 - (diff.unsigned_abs()).leading_zeros()
+        };
+        assert!(category <= 16);
+        let (code, len) = codes[category as usize];
+        assert!(len > 0, "symbol {category} has no code");
+        w.put(code, len);
+        if category == 0 || category == 16 {
+            // Category 16 is the single value -32768; T.81 writes no
+            // extra bits for it.
+            assert!(category != 16 || diff == -32768);
+            return;
+        }
+        let bits = if diff > 0 {
+            diff as u32
+        } else {
+            (diff + (1 << category) - 1) as u32
+        };
+        w.put(bits, category);
+    }
+
+    /// Encode `samples` (`width * height * components`, interleaved).
+    fn encode(spec: &Encode, samples: &[u16]) -> Vec<u8> {
+        assert_eq!(samples.len(), spec.width * spec.height * spec.components);
+        let codes = canonical(&spec.counts, &spec.symbols);
+        let mut out: Vec<u8> = vec![0xFF, 0xD8];
+
+        // DHT, all tables in the one segment.
+        let ntables = if spec.table_per_component {
+            spec.components
+        } else {
+            1
+        };
+        let mut dht = Vec::new();
+        for id in 0..ntables {
+            dht.push(id as u8);
+            dht.extend_from_slice(&spec.counts);
+            dht.extend_from_slice(&spec.symbols);
+        }
+        out.extend_from_slice(&[0xFF, 0xC4]);
+        out.extend_from_slice(&((dht.len() + 2) as u16).to_be_bytes());
+        out.extend_from_slice(&dht);
+
+        if spec.restart_interval > 0 {
+            out.extend_from_slice(&[0xFF, 0xDD, 0x00, 0x04]);
+            out.extend_from_slice(&(spec.restart_interval as u16).to_be_bytes());
+        }
+
+        // SOF3.
+        out.extend_from_slice(&[0xFF, 0xC3]);
+        out.extend_from_slice(&((8 + spec.components * 3) as u16).to_be_bytes());
+        out.push(spec.precision as u8);
+        out.extend_from_slice(&(spec.height as u16).to_be_bytes());
+        out.extend_from_slice(&(spec.width as u16).to_be_bytes());
+        out.push(spec.components as u8);
+        for c in 0..spec.components {
+            out.extend_from_slice(&[c as u8 + 1, 0x11, 0x00]);
+        }
+
+        // SOS.
+        out.extend_from_slice(&[0xFF, 0xDA]);
+        out.extend_from_slice(&((6 + spec.components * 2) as u16).to_be_bytes());
+        out.push(spec.components as u8);
+        for c in 0..spec.components {
+            let table = if spec.table_per_component { c as u8 } else { 0 };
+            out.extend_from_slice(&[c as u8 + 1, table << 4]);
+        }
+        out.extend_from_slice(&[spec.predictor, 0x00, spec.point_transform as u8]);
+
+        // The scan itself, mirroring the decoder's prediction rules.
+        let ncomp = spec.components;
+        let stride = spec.width * ncomp;
+        let initial = 1i32 << (spec.precision - spec.point_transform - 1);
+        let shifted: Vec<u16> = samples.iter().map(|s| s >> spec.point_transform).collect();
+        let interval = if spec.restart_interval == 0 {
+            spec.width * spec.height
+        } else {
+            spec.restart_interval
+        };
+        let mut w = BitWriter::new();
+        let mut restarts = 0u8;
+        for mcu in 0..spec.width * spec.height {
+            if mcu > 0 && mcu % interval == 0 {
+                w.marker(0xD0 + restarts % 8);
+                restarts += 1;
+            }
+            let first_of_interval = mcu % interval == 0;
+            let x = mcu % spec.width;
+            let y = mcu / spec.width;
+            for c in 0..ncomp {
+                let idx = mcu * ncomp + c;
+                let prediction = if first_of_interval {
+                    initial
+                } else if x == 0 {
+                    shifted[idx - stride] as i32
+                } else if y == 0 {
+                    shifted[idx - ncomp] as i32
+                } else {
+                    let a = shifted[idx - ncomp] as i32;
+                    let b = shifted[idx - stride] as i32;
+                    let cc = shifted[idx - stride - ncomp] as i32;
+                    match spec.predictor {
+                        1 => a,
+                        2 => b,
+                        3 => cc,
+                        4 => a + b - cc,
+                        5 => a + ((b - cc) >> 1),
+                        6 => b + ((a - cc) >> 1),
+                        _ => (a + b) >> 1,
+                    }
+                };
+                encode_diff(&mut w, &codes, shifted[idx], prediction);
+            }
+        }
+        w.pad();
+        out.extend_from_slice(&w.out);
+        out.extend_from_slice(&[0xFF, 0xD9]);
+        out
+    }
+
+    /// xorshift64*, so the tests are random but reproducible without a
+    /// dependency.
+    struct Rng(u64);
+    impl Rng {
+        fn next(&mut self) -> u64 {
+            self.0 ^= self.0 >> 12;
+            self.0 ^= self.0 << 25;
+            self.0 ^= self.0 >> 27;
+            self.0.wrapping_mul(0x2545_F491_4F6C_DD1D)
+        }
+        fn below(&mut self, n: u64) -> u64 {
+            self.next() % n
+        }
+    }
+
+    fn random_image(rng: &mut Rng, len: usize, precision: u32) -> Vec<u16> {
+        let max = 1u64 << precision;
+        (0..len)
+            .map(|i| {
+                // A mix of noise and smooth gradients: pure noise
+                // never exercises the small difference categories,
+                // and pure gradients never exercise the large ones.
+                if i % 3 == 0 {
+                    rng.below(max) as u16
+                } else {
+                    ((i as u64 * 7 + rng.below(8)) % max) as u16
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn round_trip_every_predictor() {
+        let mut rng = Rng(0x1234_5678_9ABC_DEF1);
+        for predictor in 1..=7u8 {
+            for components in 1..=4usize {
+                let mut spec = Encode::new(19, 7, components, 12);
+                spec.predictor = predictor;
+                let samples = random_image(&mut rng, 19 * 7 * components, 12);
+                let stream = encode(&spec, &samples);
+                let got = decode(&stream).expect("decode");
+                assert_eq!(got.width, 19);
+                assert_eq!(got.height, 7);
+                assert_eq!(got.components, components);
+                assert_eq!(got.precision, 12);
+                assert_eq!(
+                    got.data, samples,
+                    "predictor {predictor}, {components} components"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn round_trip_every_precision() {
+        let mut rng = Rng(0xDEAD_BEEF_0BAD_F00D);
+        for precision in 2..=16u32 {
+            let mut spec = Encode::new(23, 5, 2, precision);
+            spec.predictor = 4;
+            let samples = random_image(&mut rng, 23 * 5 * 2, precision);
+            let stream = encode(&spec, &samples);
+            let got = decode(&stream).expect("decode");
+            assert_eq!(got.data, samples, "precision {precision}");
+        }
+    }
+
+    #[test]
+    fn round_trip_sixteen_bit_wraps() {
+        // At sixteen bits the differences are taken modulo 65536 and
+        // the widest of them (category 16) carries no value bits, so
+        // this is the case where the wrap-around rules matter.
+        let mut rng = Rng(0x0F0F_1234_5678_0001);
+        let mut spec = Encode::new(64, 16, 1, 16);
+        spec.predictor = 1;
+        let mut samples = random_image(&mut rng, 64 * 16, 16);
+        // Force a category-16 difference: 0 followed by 32768.
+        samples[10] = 0;
+        samples[11] = 32768;
+        let stream = encode(&spec, &samples);
+        assert_eq!(decode(&stream).unwrap().data, samples);
+    }
+
+    #[test]
+    fn round_trip_with_stuffed_ff_bytes() {
+        // Sixteen-bit noise makes long codes and 0xFF bytes in the
+        // entropy data; the decoder must unstuff them.
+        let mut rng = Rng(0x5555_AAAA_1111_2222);
+        let spec = Encode::new(37, 11, 3, 16).long_codes();
+        let samples = random_image(&mut rng, 37 * 11 * 3, 16);
+        let stream = encode(&spec, &samples);
+        assert!(
+            stream.windows(2).any(|w| w == [0xFF, 0x00]),
+            "the test encoder never emitted a stuffed byte, so this proves nothing"
+        );
+        assert_eq!(decode(&stream).unwrap().data, samples);
+    }
+
+    #[test]
+    fn round_trip_with_long_codes() {
+        let mut rng = Rng(0x9E37_79B9_7F4A_7C15);
+        let mut spec = Encode::new(31, 9, 1, 14).long_codes();
+        spec.predictor = 6;
+        let samples = random_image(&mut rng, 31 * 9, 14);
+        let stream = encode(&spec, &samples);
+        assert_eq!(decode(&stream).unwrap().data, samples);
+    }
+
+    #[test]
+    fn round_trip_with_restart_intervals() {
+        let mut rng = Rng(0xABCD_0123_4567_89AB);
+        for interval in [1usize, 5, 17, 40, 1000] {
+            for predictor in [1u8, 4, 7] {
+                let mut spec = Encode::new(17, 6, 2, 12);
+                spec.predictor = predictor;
+                spec.restart_interval = interval;
+                let samples = random_image(&mut rng, 17 * 6 * 2, 12);
+                let stream = encode(&spec, &samples);
+                let got = decode(&stream).expect("decode with restarts");
+                assert_eq!(
+                    got.data, samples,
+                    "interval {interval}, predictor {predictor}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn round_trip_with_a_table_per_component() {
+        let mut rng = Rng(0x2222_3333_4444_5555);
+        let mut spec = Encode::new(13, 4, 4, 12);
+        spec.table_per_component = true;
+        spec.predictor = 5;
+        let samples = random_image(&mut rng, 13 * 4 * 4, 12);
+        let stream = encode(&spec, &samples);
+        assert_eq!(decode(&stream).unwrap().data, samples);
+    }
+
+    #[test]
+    fn round_trip_with_a_point_transform() {
+        let mut rng = Rng(0x7777_8888_9999_AAAA);
+        let mut spec = Encode::new(21, 5, 1, 14);
+        spec.point_transform = 3;
+        spec.predictor = 4;
+        let samples = random_image(&mut rng, 21 * 5, 14);
+        let stream = encode(&spec, &samples);
+        let got = decode(&stream).unwrap();
+        // The encoder threw the low bits away, so that is what comes
+        // back: the decoder undoes only the shift.
+        let want: Vec<u16> = samples.iter().map(|s| (s >> 3) << 3).collect();
+        assert_eq!(got.data, want);
+    }
+
+    #[test]
+    fn round_trip_odd_shapes() {
+        let mut rng = Rng(0xFEED_FACE_CAFE_BEEF);
+        for (w, h) in [(1usize, 1usize), (1, 9), (9, 1), (2, 2), (255, 3)] {
+            for components in [1usize, 2] {
+                let spec = Encode::new(w, h, components, 12);
+                let samples = random_image(&mut rng, w * h * components, 12);
+                let stream = encode(&spec, &samples);
+                assert_eq!(
+                    decode(&stream).unwrap().data,
+                    samples,
+                    "{w}x{h}x{components}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn header_reads_the_frame_without_the_scan() {
+        let spec = Encode::new(40, 12, 2, 14);
+        let samples = vec![100u16; 40 * 12 * 2];
+        let stream = encode(&spec, &samples);
+        let head = header(&stream).unwrap();
+        assert_eq!(
+            (head.width, head.height, head.components, head.precision),
+            (40, 12, 2, 14)
+        );
+        assert!(head.data.is_empty());
+        // A stream cut off right after SOS still has a readable
+        // header even though it cannot be decoded.
+        let scan_start = parse(&stream, true).unwrap().scan_start;
+        let cut = &stream[..scan_start];
+        assert!(header(cut).is_ok());
+        assert!(decode(cut).is_err());
+    }
+
+    #[test]
+    fn rejects_what_it_is_not() {
+        let spec = Encode::new(8, 8, 1, 12);
+        let samples = vec![7u16; 64];
+        let good = encode(&spec, &samples);
+
+        assert!(decode(&[]).is_err());
+        assert!(decode(&[0xFF, 0xD8]).is_err());
+        assert!(decode(b"not a jpeg at all").is_err());
+
+        // A baseline JPEG (SOF0) is a different process.
+        let mut baseline = good.clone();
+        let sof = baseline.windows(2).position(|w| w == [0xFF, 0xC3]).unwrap();
+        baseline[sof + 1] = 0xC0;
+        assert!(matches!(decode(&baseline), Err(Error::Unsupported(_))));
+
+        // Subsampled components.
+        let mut subsampled = good.clone();
+        subsampled[sof + 11] = 0x21;
+        assert!(matches!(decode(&subsampled), Err(Error::Unsupported(_))));
+
+        // A zero height means DNL.
+        let mut dnl = good.clone();
+        dnl[sof + 5] = 0;
+        dnl[sof + 6] = 0;
+        assert!(matches!(decode(&dnl), Err(Error::Unsupported(_))));
+
+        // Predictor 0 is the differential mode.
+        let mut differential = good.clone();
+        let sos = differential
+            .windows(2)
+            .position(|w| w == [0xFF, 0xDA])
+            .unwrap();
+        differential[sos + 7] = 0;
+        assert!(matches!(decode(&differential), Err(Error::Unsupported(_))));
+
+        // A frame far larger than its scan.
+        let mut huge = good.clone();
+        huge[sof + 5] = 0xFF;
+        huge[sof + 6] = 0xFF;
+        huge[sof + 7] = 0xFF;
+        huge[sof + 8] = 0xFF;
+        assert!(decode(&huge).is_err());
+    }
+
+    #[test]
+    fn truncation_never_panics() {
+        let mut rng = Rng(0x1357_9BDF_0246_8ACE);
+        let mut spec = Encode::new(24, 8, 2, 14);
+        spec.restart_interval = 9;
+        let samples = random_image(&mut rng, 24 * 8 * 2, 14);
+        let stream = encode(&spec, &samples);
+        for cut in 0..stream.len() {
+            let _ = decode(&stream[..cut]);
+            let _ = header(&stream[..cut]);
+        }
+        // Garbage in the entropy data must not hang or panic either.
+        for seed in 0..64u64 {
+            let mut rng = Rng(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1);
+            let mut broken = stream.clone();
+            for _ in 0..8 {
+                let at = rng.below(broken.len() as u64) as usize;
+                broken[at] = rng.below(256) as u8;
+            }
+            let _ = decode(&broken);
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Corpus tests. Gated on SCHIST_RAW_CORPUS, which points at a
+    // directory of real files; they compare against the LibRaw oracle
+    // TIFFs written beside them by `unprocessed_raw -T`.
+    //
+    // The TIFF walking here is deliberately minimal and local: the
+    // crate's own tiff.rs is being written in parallel, and these
+    // tests are about the lossless JPEG decoder alone.
+    // ---------------------------------------------------------------
+
+    fn corpus() -> Option<std::path::PathBuf> {
+        let dir = std::env::var_os("SCHIST_RAW_CORPUS")?;
+        let dir = std::path::PathBuf::from(dir);
+        dir.is_dir().then_some(dir)
+    }
+
+    /// The smallest TIFF reader that can find sensor data.
+    struct MiniTiff<'a> {
+        bytes: &'a [u8],
+        le: bool,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct MiniEntry {
+        kind: u16,
+        count: usize,
+        offset: usize,
+    }
+
+    impl<'a> MiniTiff<'a> {
+        fn new(bytes: &'a [u8]) -> Option<MiniTiff<'a>> {
+            let le = match bytes.get(0..4)? {
+                b"II*\0" => true,
+                b"MM\0*" => false,
+                _ => return None,
+            };
+            Some(MiniTiff { bytes, le })
+        }
+        fn u16(&self, at: usize) -> u16 {
+            let b: [u8; 2] = self.bytes[at..at + 2].try_into().unwrap();
+            if self.le {
+                u16::from_le_bytes(b)
+            } else {
+                u16::from_be_bytes(b)
+            }
+        }
+        fn u32(&self, at: usize) -> u32 {
+            let b: [u8; 4] = self.bytes[at..at + 4].try_into().unwrap();
+            if self.le {
+                u32::from_le_bytes(b)
+            } else {
+                u32::from_be_bytes(b)
+            }
+        }
+        /// Every IFD reachable from IFD0: the main chain and the
+        /// SubIFDs each of them names (one level is enough for DNG).
+        fn ifds(&self) -> Vec<std::collections::BTreeMap<u16, MiniEntry>> {
+            let mut out = Vec::new();
+            let mut next = self.u32(4) as usize;
+            let mut chain = Vec::new();
+            while next != 0 && next + 2 <= self.bytes.len() && chain.len() < 16 {
+                chain.push(next);
+                let n = self.u16(next) as usize;
+                let after = next + 2 + n * 12;
+                if after + 4 > self.bytes.len() {
+                    break;
+                }
+                next = self.u32(after) as usize;
+            }
+            let mut queue = chain;
+            while let Some(at) = queue.pop() {
+                let n = self.u16(at) as usize;
+                let mut map = std::collections::BTreeMap::new();
+                for i in 0..n {
+                    let e = at + 2 + i * 12;
+                    if e + 12 > self.bytes.len() {
+                        break;
+                    }
+                    let tag = self.u16(e);
+                    let kind = self.u16(e + 2);
+                    let count = self.u32(e + 4) as usize;
+                    let size = match kind {
+                        1 | 2 | 6 | 7 => 1,
+                        3 | 8 => 2,
+                        4 | 9 | 11 => 4,
+                        _ => 8,
+                    };
+                    let offset = if count * size <= 4 {
+                        e + 8
+                    } else {
+                        self.u32(e + 8) as usize
+                    };
+                    map.insert(
+                        tag,
+                        MiniEntry {
+                            kind,
+                            count,
+                            offset,
+                        },
+                    );
+                    if tag == 0x014A {
+                        // SubIFDs.
+                        for j in 0..count.min(8) {
+                            let sub = self.u32(offset + j * 4) as usize;
+                            if sub + 2 <= self.bytes.len() {
+                                queue.push(sub);
+                            }
+                        }
+                    }
+                }
+                out.push(map);
+            }
+            out
+        }
+        fn values(&self, e: &MiniEntry) -> Vec<u64> {
+            (0..e.count)
+                .map(|i| match e.kind {
+                    1 | 2 | 6 | 7 => self.bytes[e.offset + i] as u64,
+                    3 | 8 => self.u16(e.offset + i * 2) as u64,
+                    _ => self.u32(e.offset + i * 4) as u64,
+                })
+                .collect()
+        }
+        fn value(&self, map: &std::collections::BTreeMap<u16, MiniEntry>, tag: u16) -> Option<u64> {
+            self.values(map.get(&tag)?).first().copied()
+        }
+    }
+
+    /// The raw IFD of a DNG: compression 7 (lossless JPEG) over a CFA
+    /// or linear-raw photometric, plus its tiles or strips.
+    struct RawIfd {
+        width: usize,
+        height: usize,
+        spp: usize,
+        tile_width: usize,
+        tile_height: usize,
+        pieces: Vec<(usize, usize)>,
+    }
+
+    fn find_raw_ifd(tiff: &MiniTiff<'_>) -> Option<RawIfd> {
+        let mut best: Option<RawIfd> = None;
+        for ifd in tiff.ifds() {
+            let photometric = tiff.value(&ifd, 0x0106).unwrap_or(0);
+            let compression = tiff.value(&ifd, 0x0103).unwrap_or(0);
+            if compression != 7 || !matches!(photometric, 32803 | 34892) {
+                continue;
+            }
+            let width = tiff.value(&ifd, 0x0100)? as usize;
+            let height = tiff.value(&ifd, 0x0101)? as usize;
+            let spp = tiff.value(&ifd, 0x0115).unwrap_or(1) as usize;
+            let (tile_width, tile_height, offsets, counts) = match ifd.get(&0x0144) {
+                Some(off) => (
+                    tiff.value(&ifd, 0x0142)? as usize,
+                    tiff.value(&ifd, 0x0143)? as usize,
+                    tiff.values(off),
+                    tiff.values(ifd.get(&0x0145)?),
+                ),
+                // Strips: a strip is a full-width tile.
+                None => {
+                    let rows = tiff.value(&ifd, 0x0116).unwrap_or(height as u64) as usize;
+                    (
+                        width,
+                        rows.min(height),
+                        tiff.values(ifd.get(&0x0111)?),
+                        tiff.values(ifd.get(&0x0117)?),
+                    )
+                }
+            };
+            let pieces = offsets
+                .iter()
+                .zip(counts.iter())
+                .map(|(o, c)| (*o as usize, *c as usize))
+                .collect();
+            let candidate = RawIfd {
+                width,
+                height,
+                spp,
+                tile_width,
+                tile_height,
+                pieces,
+            };
+            if best
+                .as_ref()
+                .is_none_or(|b| b.width * b.height < width * height)
+            {
+                best = Some(candidate);
+            }
+        }
+        best
+    }
+
+    /// Decode every tile of a raw IFD and lay them out into the full
+    /// frame. Tiles at the right and bottom edges are encoded at full
+    /// size and clipped here, as TIFF requires.
+    fn assemble(bytes: &[u8], raw: &RawIfd) -> Result<Vec<u16>> {
+        let across = raw.width.div_ceil(raw.tile_width);
+        let mut frame = vec![0u16; raw.width * raw.height * raw.spp];
+        for (i, (offset, count)) in raw.pieces.iter().enumerate() {
+            let piece = bytes
+                .get(*offset..*offset + *count)
+                .ok_or_else(|| Error::Corrupt("tile outside the file".into()))?;
+            let image = decode(piece)?;
+            // Whatever the stream calls its width and component
+            // count, a row of it is a row of the tile.
+            assert_eq!(
+                image.width * image.components,
+                raw.tile_width * raw.spp,
+                "tile {i} decodes {} samples a row, tile is {} wide",
+                image.width * image.components,
+                raw.tile_width
+            );
+            let tx = (i % across) * raw.tile_width;
+            let ty = (i / across) * raw.tile_height;
+            let keep = (raw.width - tx).min(raw.tile_width) * raw.spp;
+            for row in 0..image.height {
+                if ty + row >= raw.height {
+                    break;
+                }
+                let src = row * raw.tile_width * raw.spp;
+                let dst = ((ty + row) * raw.width + tx) * raw.spp;
+                frame[dst..dst + keep].copy_from_slice(&image.data[src..src + keep]);
+            }
+        }
+        Ok(frame)
+    }
+
+    fn oracle(path: &std::path::Path) -> Option<(usize, usize, Vec<u16>)> {
+        let tiff = path.with_extension(format!(
+            "{}.tiff",
+            path.extension().and_then(|e| e.to_str()).unwrap_or("")
+        ));
+        let image = image::open(&tiff).ok()?.into_luma16();
+        let (w, h) = (image.width() as usize, image.height() as usize);
+        Some((w, h, image.into_raw()))
+    }
+
+    /// Decode a DNG's raw IFD and compare it with LibRaw's unpacking.
+    fn check_dng(path: &std::path::Path) -> bool {
+        let Ok(bytes) = std::fs::read(path) else {
+            return false;
+        };
+        let Some(tiff) = MiniTiff::new(&bytes) else {
+            return false;
+        };
+        let Some(raw) = find_raw_ifd(&tiff) else {
+            println!("{}: no lossless-JPEG raw IFD, skipped", path.display());
+            return false;
+        };
+        let start = std::time::Instant::now();
+        let frame = assemble(&bytes, &raw).expect("decode the raw IFD");
+        let elapsed = start.elapsed();
+        println!(
+            "{}: {}x{}x{} in {} piece(s), {:.3}s ({:.1} MP/s)",
+            path.display(),
+            raw.width,
+            raw.height,
+            raw.spp,
+            raw.pieces.len(),
+            elapsed.as_secs_f64(),
+            (raw.width * raw.height) as f64 / 1e6 / elapsed.as_secs_f64(),
+        );
+
+        let Some((ow, oh, want)) = oracle(path) else {
+            println!("  no oracle TIFF beside it; decoded without error only");
+            return true;
+        };
+        if raw.spp != 1 {
+            println!(
+                "  {} samples a pixel: the greyscale oracle cannot be compared",
+                raw.spp
+            );
+            return true;
+        }
+        // LibRaw's raw_width x raw_height is the raw IFD's size for a
+        // DNG. If a file ever disagrees, compare what overlaps.
+        let cw = ow.min(raw.width);
+        let ch = oh.min(raw.height);
+        if (ow, oh) != (raw.width, raw.height) {
+            println!(
+                "  oracle is {ow}x{oh}, frame is {}x{}: comparing the overlap",
+                raw.width, raw.height
+            );
+        }
+        let mut bad = 0usize;
+        let mut first = None;
+        for y in 0..ch {
+            for x in 0..cw {
+                let got = frame[y * raw.width + x];
+                let expected = want[y * ow + x];
+                if got != expected {
+                    bad += 1;
+                    first.get_or_insert((x, y, got, expected));
+                }
+            }
+        }
+        assert_eq!(
+            bad,
+            0,
+            "{}: {bad} samples differ, first {:?}",
+            path.display(),
+            first
+        );
+        println!("  matches the oracle over {cw}x{ch}");
+        true
+    }
+
+    #[test]
+    fn corpus_dng_tiles_match_libraw() {
+        let Some(dir) = corpus() else { return };
+        let mut checked = 0;
+        // The named files first (the Pentax K-5 is the reference
+        // case), then anything else in the tree that turns out to be
+        // a lossless-JPEG DNG.
+        let mut paths: Vec<std::path::PathBuf> = Vec::new();
+        let mut stack = vec![dir];
+        while let Some(at) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&at) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| e.eq_ignore_ascii_case("dng"))
+                {
+                    paths.push(path);
+                }
+            }
+        }
+        paths.sort();
+        for path in &paths {
+            if check_dng(path) {
+                checked += 1;
+            }
+        }
+        println!("checked {checked} of {} DNGs", paths.len());
+    }
+
+    /// Canon's CR2 keeps its sensor data as one lossless JPEG stream
+    /// in the fourth IFD's strip. The stream's own width is a slice of
+    /// the sensor row and its components are interleaved slices, which
+    /// is the CR2 module's problem, not this one's: here we only check
+    /// that it decodes.
+    #[test]
+    fn corpus_cr2_streams_decode() {
+        let Some(dir) = corpus() else { return };
+        let mut paths: Vec<std::path::PathBuf> = Vec::new();
+        let mut stack = vec![dir];
+        while let Some(at) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&at) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| e.eq_ignore_ascii_case("cr2"))
+                {
+                    paths.push(path);
+                }
+            }
+        }
+        paths.sort();
+        let mut decoded = 0usize;
+        for path in &paths {
+            let bytes = std::fs::read(path).expect("read");
+            let Some(tiff) = MiniTiff::new(&bytes) else {
+                continue;
+            };
+            // IFD3 (the fourth) holds the sensor strip.
+            let ifds = tiff.ifds();
+            let Some(strip) = ifds
+                .iter()
+                .filter_map(|ifd| {
+                    let offset = tiff.value(ifd, 0x0111)? as usize;
+                    let count = tiff.value(ifd, 0x0117)? as usize;
+                    // The sensor strip is by far the largest.
+                    (count > 1 << 20).then_some((offset, count))
+                })
+                .max_by_key(|(_, count)| *count)
+            else {
+                continue;
+            };
+            let piece = &bytes[strip.0..strip.0 + strip.1];
+            let head = match header(piece) {
+                Ok(head) => head,
+                // Canon's sRAW/mRAW frames are subsampled YCbCr; this
+                // decoder says so rather than guessing.
+                Err(Error::Unsupported(why)) => {
+                    println!("{}: skipped, {why}", path.display());
+                    continue;
+                }
+                Err(e) => panic!("{}: {e}", path.display()),
+            };
+            decoded += 1;
+            let start = std::time::Instant::now();
+            let image = decode(piece).expect("decode the CR2 stream");
+            let elapsed = start.elapsed();
+            assert_eq!(image.data.len(), head.width * head.height * head.components);
+            let over = image
+                .data
+                .iter()
+                .filter(|v| **v >= 1 << head.precision)
+                .count();
+            assert_eq!(
+                over, 0,
+                "samples outside the declared {}-bit range",
+                head.precision
+            );
+            let low = image.data.iter().filter(|v| **v < 4096).count();
+            println!(
+                "{}: {}x{}x{} at {} bits, {:.3}s, {:.0}% of samples under 4096",
+                path.display(),
+                head.width,
+                head.height,
+                head.components,
+                head.precision,
+                elapsed.as_secs_f64(),
+                100.0 * low as f64 / image.data.len() as f64,
+            );
+            if head.precision <= 12 {
+                assert!(
+                    low * 10 > image.data.len() * 9,
+                    "a 12-bit body's samples should nearly all be under 4096"
+                );
+            }
+            // Canon's slicing only permutes the samples, so the
+            // oracle's frame must hold exactly the same multiset of
+            // values as the stream decodes to. That checks every
+            // sample without knowing where any of them goes.
+            if let Some((ow, oh, want)) = oracle(path) {
+                if ow * oh == image.data.len() {
+                    let mut mine = vec![0u32; 65536];
+                    let mut theirs = vec![0u32; 65536];
+                    for v in &image.data {
+                        mine[*v as usize] += 1;
+                    }
+                    for v in &want {
+                        theirs[*v as usize] += 1;
+                    }
+                    let differing = mine
+                        .iter()
+                        .zip(theirs.iter())
+                        .filter(|(a, b)| a != b)
+                        .count();
+                    assert_eq!(
+                        differing,
+                        0,
+                        "{}: the histogram differs from LibRaw's",
+                        path.display()
+                    );
+                    println!("  same multiset of values as the oracle ({ow}x{oh})");
+                } else {
+                    println!(
+                        "  oracle is {ow}x{oh} = {} samples, stream is {}",
+                        ow * oh,
+                        image.data.len()
+                    );
+                }
+            }
+        }
+        println!("decoded {decoded} of {} CR2 streams", paths.len());
+    }
+
+    /// Cutting a real stream anywhere must give an error or a frame,
+    /// never a panic and never a hang.
+    #[test]
+    fn corpus_truncation_never_panics() {
+        let Some(dir) = corpus() else { return };
+        let mut streams: Vec<Vec<u8>> = Vec::new();
+        for name in ["_MAR0543.DNG", "PXL_20201121_100251397.dng", "IMG_1361.DNG"] {
+            let path = dir.join(name);
+            let Ok(bytes) = std::fs::read(&path) else {
+                continue;
+            };
+            let Some(tiff) = MiniTiff::new(&bytes) else {
+                continue;
+            };
+            let Some(raw) = find_raw_ifd(&tiff) else {
+                continue;
+            };
+            if let Some((offset, count)) = raw.pieces.first() {
+                if let Some(piece) = bytes.get(*offset..*offset + *count) {
+                    streams.push(piece.to_vec());
+                }
+            }
+        }
+        let path = dir.join("_MG_7191.CR2");
+        if let Ok(bytes) = std::fs::read(&path) {
+            if let Some(tiff) = MiniTiff::new(&bytes) {
+                if let Some((offset, count)) = tiff
+                    .ifds()
+                    .iter()
+                    .filter_map(|ifd| {
+                        Some((
+                            tiff.value(ifd, 0x0111)? as usize,
+                            tiff.value(ifd, 0x0117)? as usize,
+                        ))
+                    })
+                    .max_by_key(|(_, count)| *count)
+                {
+                    if let Some(piece) = bytes.get(offset..offset + count) {
+                        streams.push(piece.to_vec());
+                    }
+                }
+            }
+        }
+        assert!(
+            !streams.is_empty(),
+            "the corpus held no lossless JPEG streams"
+        );
+        let mut rng = Rng(0x0BAD_C0DE_DEAD_BEEF);
+        for stream in &streams {
+            for _ in 0..20 {
+                let cut = rng.below(stream.len() as u64) as usize;
+                let _ = decode(&stream[..cut]);
+                let _ = header(&stream[..cut]);
+            }
+        }
+    }
+}

--- a/crates/codec-raw/src/tiff.rs
+++ b/crates/codec-raw/src/tiff.rs
@@ -1,0 +1,2243 @@
+//! TIFF structure: the container of DNG and most vendor raws.
+//!
+//! Classic and BigTIFF headers in both byte orders, the vendor header
+//! variants that are TIFF under another signature (Olympus `IIRO` /
+//! `IIRS` / `MMOR`, Panasonic `IIU\0`), the IFD chain, SubIFDs, the
+//! Exif IFD, and the GPS IFD. Makernotes are *not* parsed here: each
+//! vendor's is its own dialect, and the vendor module parses it with
+//! [`Tiff::parse_at`] or its own reader.
+//!
+//! Every accessor is bounds-checked and never panics on a hostile
+//! file; a truncated IFD is simply an IFD with fewer entries.
+
+use crate::{Error, Result};
+
+/// TIFF field types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    Byte = 1,
+    Ascii = 2,
+    Short = 3,
+    Long = 4,
+    Rational = 5,
+    SByte = 6,
+    Undefined = 7,
+    SShort = 8,
+    SLong = 9,
+    SRational = 10,
+    Float = 11,
+    Double = 12,
+    Ifd = 13,
+    Long8 = 16,
+    SLong8 = 17,
+    Ifd8 = 18,
+}
+
+impl Kind {
+    pub fn from_u16(v: u16) -> Option<Kind> {
+        Some(match v {
+            1 => Kind::Byte,
+            2 => Kind::Ascii,
+            3 => Kind::Short,
+            4 => Kind::Long,
+            5 => Kind::Rational,
+            6 => Kind::SByte,
+            7 => Kind::Undefined,
+            8 => Kind::SShort,
+            9 => Kind::SLong,
+            10 => Kind::SRational,
+            11 => Kind::Float,
+            12 => Kind::Double,
+            13 => Kind::Ifd,
+            16 => Kind::Long8,
+            17 => Kind::SLong8,
+            18 => Kind::Ifd8,
+            _ => return None,
+        })
+    }
+    /// Bytes per element.
+    pub fn size(self) -> usize {
+        match self {
+            Kind::Byte | Kind::Ascii | Kind::SByte | Kind::Undefined => 1,
+            Kind::Short | Kind::SShort => 2,
+            Kind::Long | Kind::SLong | Kind::Float | Kind::Ifd => 4,
+            Kind::Rational
+            | Kind::SRational
+            | Kind::Double
+            | Kind::Long8
+            | Kind::SLong8
+            | Kind::Ifd8 => 8,
+        }
+    }
+}
+
+/// One IFD entry, with its value decoded eagerly (byte order applied)
+/// and its position kept for the blobs a vendor wants to re-read.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Entry {
+    pub tag: u16,
+    pub kind: Kind,
+    pub count: usize,
+    /// Absolute offset of the value bytes in the file (inside the entry
+    /// when they fit, else where the entry points).
+    pub offset: usize,
+    pub value: Value,
+}
+
+/// Entry values, one vector per type family. Rationals are kept as
+/// pairs; use [`Entry::f64`] for the quotient.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Value {
+    Byte(Vec<u8>),
+    Ascii(String),
+    Short(Vec<u16>),
+    Long(Vec<u32>),
+    Rational(Vec<(u32, u32)>),
+    SByte(Vec<i8>),
+    Undefined(Vec<u8>),
+    SShort(Vec<i16>),
+    SLong(Vec<i32>),
+    SRational(Vec<(i32, i32)>),
+    Float(Vec<f32>),
+    Double(Vec<f64>),
+    Long8(Vec<u64>),
+    SLong8(Vec<i64>),
+}
+
+impl Entry {
+    /// Element `i` as an unsigned integer, for any integer kind
+    /// (`Ifd` counts as `Long`). `None` past the end or for non-integers.
+    pub fn u32(&self, i: usize) -> Option<u32> {
+        // Signed kinds are widened through i64 so a negative value
+        // saturates to 0 rather than wrapping to something enormous:
+        // callers use this for offsets and counts.
+        self.u64(i).map(|v| v.min(u32::MAX as u64) as u32)
+    }
+
+    pub fn u64(&self, i: usize) -> Option<u64> {
+        let signed = |v: i64| -> u64 { v.max(0) as u64 };
+        Some(match &self.value {
+            Value::Byte(v) | Value::Undefined(v) => *v.get(i)? as u64,
+            Value::Short(v) => *v.get(i)? as u64,
+            Value::Long(v) => *v.get(i)? as u64,
+            Value::Long8(v) => *v.get(i)?,
+            Value::SByte(v) => signed(*v.get(i)? as i64),
+            Value::SShort(v) => signed(*v.get(i)? as i64),
+            Value::SLong(v) => signed(*v.get(i)? as i64),
+            Value::SLong8(v) => signed(*v.get(i)?),
+            // Rationals, floats and text are not integers: a caller
+            // that wants their numeric value asks for `f64`.
+            Value::Ascii(_)
+            | Value::Rational(_)
+            | Value::SRational(_)
+            | Value::Float(_)
+            | Value::Double(_) => return None,
+        })
+    }
+
+    /// Element `i` as a float: rationals divided out, integers widened.
+    pub fn f64(&self, i: usize) -> Option<f64> {
+        Some(match &self.value {
+            Value::Rational(v) => {
+                let (n, d) = *v.get(i)?;
+                // A zero denominator is EXIF's way of saying "unknown"
+                // (Nikon writes 0/0 for an unset lens aperture).
+                if d == 0 {
+                    return None;
+                }
+                n as f64 / d as f64
+            }
+            Value::SRational(v) => {
+                let (n, d) = *v.get(i)?;
+                if d == 0 {
+                    return None;
+                }
+                n as f64 / d as f64
+            }
+            Value::Float(v) => *v.get(i)? as f64,
+            Value::Double(v) => *v.get(i)?,
+            Value::SByte(v) => *v.get(i)? as f64,
+            Value::SShort(v) => *v.get(i)? as f64,
+            Value::SLong(v) => *v.get(i)? as f64,
+            Value::SLong8(v) => *v.get(i)? as f64,
+            Value::Byte(v) | Value::Undefined(v) => *v.get(i)? as f64,
+            Value::Short(v) => *v.get(i)? as f64,
+            Value::Long(v) => *v.get(i)? as f64,
+            Value::Long8(v) => *v.get(i)? as f64,
+            Value::Ascii(_) => return None,
+        })
+    }
+
+    /// The string of an ASCII entry, NUL-terminated and trimmed.
+    pub fn str(&self) -> Option<&str> {
+        match &self.value {
+            // TIFF ASCII is NUL-terminated and cameras pad with spaces
+            // ("NIKON CORPORATION\0", "Canon EOS 50D\0"); some write
+            // several NUL-separated strings in one entry, of which the
+            // first is the one anybody means.
+            Value::Ascii(s) => Some(s.split('\0').next().unwrap_or("").trim()),
+            _ => None,
+        }
+    }
+
+    /// Every integer element widened, for offset/count lists.
+    ///
+    /// BigTIFF offsets can exceed 32 bits; use [`Entry::u64s`] there.
+    pub fn u32s(&self) -> Vec<u32> {
+        self.u64s()
+            .into_iter()
+            .map(|v| v.min(u32::MAX as u64) as u32)
+            .collect()
+    }
+
+    /// The same as [`Entry::u32s`] without the 32-bit ceiling.
+    pub fn u64s(&self) -> Vec<u64> {
+        (0..self.count).map_while(|i| self.u64(i)).collect()
+    }
+
+    /// The raw bytes of a `Byte`/`Undefined` entry (or the ASCII bytes).
+    pub fn bytes(&self) -> Option<&[u8]> {
+        match &self.value {
+            Value::Byte(v) | Value::Undefined(v) => Some(v),
+            Value::Ascii(s) => Some(s.as_bytes()),
+            _ => None,
+        }
+    }
+}
+
+/// One image file directory with the directories it points to.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct Ifd {
+    /// Absolute offset of this IFD.
+    pub offset: usize,
+    pub entries: Vec<Entry>,
+    /// Tag 0x014A, in order.
+    pub sub_ifds: Vec<Ifd>,
+    /// Tag 0x8769.
+    pub exif: Option<Box<Ifd>>,
+    /// Tag 0x8825.
+    pub gps: Option<Box<Ifd>>,
+}
+
+impl Ifd {
+    pub fn get(&self, tag: u16) -> Option<&Entry> {
+        self.entries.iter().find(|e| e.tag == tag)
+    }
+    pub fn has(&self, tag: u16) -> bool {
+        self.get(tag).is_some()
+    }
+    /// This IFD, then its SubIFDs (depth-first), then Exif, then GPS.
+    pub fn walk(&self) -> Vec<&Ifd> {
+        let mut out = vec![self];
+        for sub in &self.sub_ifds {
+            out.extend(sub.walk());
+        }
+        if let Some(exif) = &self.exif {
+            out.extend(exif.walk());
+        }
+        if let Some(gps) = &self.gps {
+            out.extend(gps.walk());
+        }
+        out
+    }
+}
+
+/// A parsed TIFF: the header and every IFD reachable from it.
+#[derive(Debug, Clone)]
+pub struct Tiff<'a> {
+    bytes: &'a [u8],
+    little_endian: bool,
+    big_tiff: bool,
+    /// Where this TIFF's offsets are measured from: 0 for a plain
+    /// file, the header position for an embedded one, the makernote's
+    /// own start for the dialects that number from there.
+    base: usize,
+    /// The IFD chain from the header (IFD0, IFD1, ...).
+    pub ifds: Vec<Ifd>,
+}
+
+/// Limits that stop a hostile or truncated file from making the parser
+/// loop or allocate without bound. Real raws are far below all of
+/// them: the fattest IFD in the sample corpus has a few hundred
+/// entries and the largest eagerly decoded value is a makernote of a
+/// few hundred kilobytes.
+const MAX_IFDS_PER_CHAIN: usize = 32;
+const MAX_IFDS_TOTAL: usize = 256;
+const MAX_ENTRIES: usize = 4096;
+const MAX_SUB_IFDS: usize = 32;
+const MAX_DEPTH: usize = 4;
+const MAX_VALUE_BYTES: usize = 32 << 20;
+const VALUE_BUDGET: usize = 64 << 20;
+
+/// The mechanics of walking IFDs, shared by every entry point.
+struct Parser<'a> {
+    bytes: &'a [u8],
+    le: bool,
+    big: bool,
+    base: usize,
+    ifds_left: usize,
+    value_budget: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(bytes: &'a [u8], le: bool, big: bool, base: usize) -> Parser<'a> {
+        Parser {
+            bytes,
+            le,
+            big,
+            base,
+            ifds_left: MAX_IFDS_TOTAL,
+            value_budget: VALUE_BUDGET,
+        }
+    }
+
+    fn u16(&self, at: usize) -> Option<u16> {
+        let b: [u8; 2] = self.bytes.get(at..at.checked_add(2)?)?.try_into().ok()?;
+        Some(if self.le {
+            u16::from_le_bytes(b)
+        } else {
+            u16::from_be_bytes(b)
+        })
+    }
+
+    fn u32(&self, at: usize) -> Option<u32> {
+        let b: [u8; 4] = self.bytes.get(at..at.checked_add(4)?)?.try_into().ok()?;
+        Some(if self.le {
+            u32::from_le_bytes(b)
+        } else {
+            u32::from_be_bytes(b)
+        })
+    }
+
+    fn u64(&self, at: usize) -> Option<u64> {
+        let b: [u8; 8] = self.bytes.get(at..at.checked_add(8)?)?.try_into().ok()?;
+        Some(if self.le {
+            u64::from_le_bytes(b)
+        } else {
+            u64::from_be_bytes(b)
+        })
+    }
+
+    /// An offset field as the file stores it: 4 bytes classic, 8 in
+    /// BigTIFF. Kept raw because 0 means "no more" for the next-IFD
+    /// pointer, which `base` must not turn into a real position.
+    fn offset_raw(&self, at: usize) -> Option<u64> {
+        if self.big {
+            self.u64(at)
+        } else {
+            self.u32(at).map(|v| v as u64)
+        }
+    }
+
+    /// A file offset turned into a position in `bytes`.
+    fn absolute(&self, raw: u64) -> Option<usize> {
+        usize::try_from(raw).ok()?.checked_add(self.base)
+    }
+
+    /// Follow a chain of IFDs from `start`. `ancestors` holds every
+    /// IFD offset already on the path here, so a file whose next-IFD
+    /// pointer loops back (a real corruption, and a favourite of
+    /// fuzzers) simply ends the chain.
+    fn chain(&mut self, start: usize, ancestors: &[usize], depth: usize) -> Vec<Ifd> {
+        let mut visited: Vec<usize> = ancestors.to_vec();
+        let mut out = Vec::new();
+        let mut at = start;
+        while out.len() < MAX_IFDS_PER_CHAIN {
+            if self.ifds_left == 0 || visited.contains(&at) {
+                break;
+            }
+            visited.push(at);
+            self.ifds_left -= 1;
+            let Some((ifd, next)) = self.ifd(at, &visited, depth) else {
+                break;
+            };
+            out.push(ifd);
+            if next == 0 {
+                break;
+            }
+            match self.absolute(next) {
+                Some(next) => at = next,
+                None => break,
+            }
+        }
+        out
+    }
+
+    /// One IFD, ignoring any next-IFD pointer: SubIFDs, Exif and GPS
+    /// are single directories, not chains.
+    fn one(&mut self, at: usize, ancestors: &[usize], depth: usize) -> Option<Ifd> {
+        if depth > MAX_DEPTH || self.ifds_left == 0 || ancestors.contains(&at) {
+            return None;
+        }
+        self.ifds_left -= 1;
+        let mut path = ancestors.to_vec();
+        path.push(at);
+        self.ifd(at, &path, depth).map(|(ifd, _)| ifd)
+    }
+
+    /// One IFD and the raw next-IFD pointer that follows it.
+    fn ifd(&mut self, at: usize, path: &[usize], depth: usize) -> Option<(Ifd, u64)> {
+        let (count, header, entry_size) = if self.big {
+            (self.u64(at)? as usize, 8, 20)
+        } else {
+            (self.u16(at)? as usize, 2, 12)
+        };
+        // A count past the cap is either corruption or a file we would
+        // spend forever on; keep what fits and stop the chain there
+        // (the next-IFD pointer would be somewhere else entirely).
+        let clamped = count.min(MAX_ENTRIES);
+        let mut entries = Vec::with_capacity(clamped.min(256));
+        for i in 0..clamped {
+            let at = match at.checked_add(header + i * entry_size) {
+                Some(at) => at,
+                None => break,
+            };
+            // A truncated IFD is an IFD with fewer entries.
+            let (Some(tag), Some(kind), Some(count)) = (
+                self.u16(at),
+                self.u16(at + 2),
+                if self.big {
+                    self.u64(at + 4)
+                } else {
+                    self.u32(at + 4).map(|v| v as u64)
+                },
+            ) else {
+                break;
+            };
+            // An unknown field type carries an unknown element size, so
+            // the value cannot be found at all: drop the entry.
+            let Some(kind) = Kind::from_u16(kind) else {
+                continue;
+            };
+            let value_field = at + 4 + if self.big { 8 } else { 4 };
+            let Ok(count) = usize::try_from(count) else {
+                continue;
+            };
+            let Some(total) = count.checked_mul(kind.size()) else {
+                continue;
+            };
+            // Values up to the size of the offset field live inside the
+            // entry; anything larger is pointed at.
+            let offset = if total <= if self.big { 8 } else { 4 } {
+                value_field
+            } else {
+                match self
+                    .offset_raw(value_field)
+                    .and_then(|raw| self.absolute(raw))
+                {
+                    Some(offset) => offset,
+                    None => continue,
+                }
+            };
+            let value = self.value(kind, total, offset);
+            entries.push(Entry {
+                tag,
+                kind,
+                count,
+                offset,
+                value,
+            });
+        }
+
+        let mut ifd = Ifd {
+            offset: at,
+            entries,
+            ..Default::default()
+        };
+        self.children(&mut ifd, path, depth);
+
+        let next = if count > clamped {
+            0
+        } else {
+            at.checked_add(header + count * entry_size)
+                .and_then(|at| self.offset_raw(at))
+                .unwrap_or(0)
+        };
+        Some((ifd, next))
+    }
+
+    /// The directories an IFD points at: SubIFDs (0x014A), Exif
+    /// (0x8769) and GPS (0x8825).
+    fn children(&mut self, ifd: &mut Ifd, path: &[usize], depth: usize) {
+        // SubIFDs is LONG in the DNG specification but IFD (type 13) in
+        // plenty of real files, and holds one offset or many.
+        let subs: Vec<u64> = ifd
+            .get(tags::SUB_IFDS)
+            .filter(|e| matches!(e.kind, Kind::Long | Kind::Ifd | Kind::Long8 | Kind::Ifd8))
+            .map(|e| e.u64s())
+            .unwrap_or_default();
+        for raw in subs.into_iter().take(MAX_SUB_IFDS) {
+            let Some(at) = self.absolute(raw) else {
+                continue;
+            };
+            if let Some(sub) = self.one(at, path, depth + 1) {
+                ifd.sub_ifds.push(sub);
+            }
+        }
+        for (tag, slot) in [(tags::EXIF_IFD, 0), (tags::GPS_IFD, 1)] {
+            let Some(raw) = ifd.get(tag).and_then(|e| e.u64(0)) else {
+                continue;
+            };
+            let Some(at) = self.absolute(raw) else {
+                continue;
+            };
+            if let Some(child) = self.one(at, path, depth + 1) {
+                if slot == 0 {
+                    ifd.exif = Some(Box::new(child));
+                } else {
+                    ifd.gps = Some(Box::new(child));
+                }
+            }
+        }
+    }
+
+    /// Decode one entry's value. Anything that does not lie inside the
+    /// file, or that would blow the parser's memory budget, becomes an
+    /// empty value of the right kind: the tag is still visible (a
+    /// decoder can see that the file claims it) but reads nothing.
+    fn value(&mut self, kind: Kind, total: usize, at: usize) -> Value {
+        let empty = empty_value(kind);
+        if total > MAX_VALUE_BYTES || total > self.value_budget {
+            return empty;
+        }
+        let Some(end) = at.checked_add(total) else {
+            return empty;
+        };
+        let Some(raw) = self.bytes.get(at..end) else {
+            return empty;
+        };
+        self.value_budget -= total;
+        decode_value(kind, raw, self.le)
+    }
+}
+
+fn empty_value(kind: Kind) -> Value {
+    match kind {
+        Kind::Byte => Value::Byte(Vec::new()),
+        Kind::Ascii => Value::Ascii(String::new()),
+        Kind::Short => Value::Short(Vec::new()),
+        Kind::Long | Kind::Ifd => Value::Long(Vec::new()),
+        Kind::Rational => Value::Rational(Vec::new()),
+        Kind::SByte => Value::SByte(Vec::new()),
+        Kind::Undefined => Value::Undefined(Vec::new()),
+        Kind::SShort => Value::SShort(Vec::new()),
+        Kind::SLong => Value::SLong(Vec::new()),
+        Kind::SRational => Value::SRational(Vec::new()),
+        Kind::Float => Value::Float(Vec::new()),
+        Kind::Double => Value::Double(Vec::new()),
+        Kind::Long8 | Kind::Ifd8 => Value::Long8(Vec::new()),
+        Kind::SLong8 => Value::SLong8(Vec::new()),
+    }
+}
+
+/// Turn `raw` (a whole number of elements of `kind`) into a
+/// [`Value`], byte order applied.
+fn decode_value(kind: Kind, raw: &[u8], le: bool) -> Value {
+    macro_rules! ints {
+        ($t:ty, $n:literal) => {
+            raw.chunks_exact($n)
+                .map(|c| {
+                    let b: [u8; $n] = c.try_into().unwrap_or([0; $n]);
+                    if le {
+                        <$t>::from_le_bytes(b)
+                    } else {
+                        <$t>::from_be_bytes(b)
+                    }
+                })
+                .collect()
+        };
+    }
+    // Rationals are two 32-bit halves each, numerator first.
+    macro_rules! rationals {
+        ($t:ty) => {
+            raw.chunks_exact(8)
+                .map(|c| {
+                    let n: [u8; 4] = c[0..4].try_into().unwrap_or([0; 4]);
+                    let d: [u8; 4] = c[4..8].try_into().unwrap_or([0; 4]);
+                    if le {
+                        (<$t>::from_le_bytes(n), <$t>::from_le_bytes(d))
+                    } else {
+                        (<$t>::from_be_bytes(n), <$t>::from_be_bytes(d))
+                    }
+                })
+                .collect()
+        };
+    }
+    match kind {
+        Kind::Byte => Value::Byte(raw.to_vec()),
+        Kind::Undefined => Value::Undefined(raw.to_vec()),
+        // Not necessarily UTF-8: cameras have shipped Latin-1 and
+        // Shift-JIS in Artist and Copyright. Lossy keeps the string
+        // usable instead of dropping it.
+        // A lossy conversion can triple the size (every bad byte becomes
+        // a 3-byte replacement), so over-long strings are cut at the
+        // value cap to keep the budget honest.
+        Kind::Ascii => {
+            let mut text = String::from_utf8_lossy(raw).into_owned();
+            if text.len() > MAX_VALUE_BYTES {
+                let mut cut = MAX_VALUE_BYTES;
+                while !text.is_char_boundary(cut) {
+                    cut -= 1;
+                }
+                text.truncate(cut);
+            }
+            Value::Ascii(text)
+        }
+        Kind::SByte => Value::SByte(raw.iter().map(|b| *b as i8).collect()),
+        Kind::Short => Value::Short(ints!(u16, 2)),
+        Kind::SShort => Value::SShort(ints!(i16, 2)),
+        Kind::Long | Kind::Ifd => Value::Long(ints!(u32, 4)),
+        Kind::SLong => Value::SLong(ints!(i32, 4)),
+        Kind::Float => Value::Float(ints!(f32, 4)),
+        Kind::Double => Value::Double(ints!(f64, 8)),
+        Kind::Long8 | Kind::Ifd8 => Value::Long8(ints!(u64, 8)),
+        Kind::SLong8 => Value::SLong8(ints!(i64, 8)),
+        Kind::Rational => Value::Rational(rationals!(u32)),
+        Kind::SRational => Value::SRational(rationals!(i32)),
+    }
+}
+
+/// The byte order and flavour a TIFF header names.
+fn header(bytes: &[u8], base: usize) -> Result<(bool, bool)> {
+    let sig = bytes
+        .get(base..base + 4)
+        .ok_or_else(|| Error::Corrupt("file too short for a TIFF header".into()))?;
+    Ok(match [sig[0], sig[1], sig[2], sig[3]] {
+        [b'I', b'I', 42, 0] => (true, false),
+        [b'M', b'M', 0, 42] => (false, false),
+        // BigTIFF's magic is 43; its header carries the offset size.
+        [b'I', b'I', 43, 0] => (true, true),
+        [b'M', b'M', 0, 43] => (false, true),
+        // Olympus stamps ORF with its own magic (and changed it twice:
+        // "RO" on the E-1 era, "RS" on later bodies) and Panasonic
+        // stamps RW2 with "U\0". Both are ordinary little-endian TIFF
+        // behind the signature, offset to IFD0 at byte 4 as usual.
+        [b'I', b'I', b'R', b'O'] | [b'I', b'I', b'R', b'S'] | [b'I', b'I', b'U', 0] => {
+            (true, false)
+        }
+        // The big-endian Olympus variant, on a handful of bodies.
+        [b'M', b'M', b'O', b'R'] => (false, false),
+        _ => return Err(Error::Corrupt(format!("not a TIFF header: {:02x?}", sig))),
+    })
+}
+
+impl<'a> Tiff<'a> {
+    /// Parse from the header at byte 0. Accepts `II*\0`, `MM\0*`, the
+    /// BigTIFF magics, and the Olympus/Panasonic signatures; the IFD
+    /// chain is followed (bounded, loop-safe), SubIFDs and the Exif and
+    /// GPS IFDs are parsed recursively.
+    pub fn parse(bytes: &'a [u8]) -> Result<Tiff<'a>> {
+        Tiff::parse_embedded(bytes, 0)
+    }
+
+    /// Parse a TIFF whose header sits at `base` inside `bytes` (an
+    /// embedded TIFF, as makernotes and Canon CR3's CMT boxes hold),
+    /// with all offsets inside it relative to `base`.
+    pub fn parse_embedded(bytes: &'a [u8], base: usize) -> Result<Tiff<'a>> {
+        let (le, big) = header(bytes, base)?;
+        let mut parser = Parser::new(bytes, le, big, base);
+        let first = if big {
+            // BigTIFF: u16 offset size (always 8 so far), u16 zero,
+            // then the 64-bit offset to IFD0.
+            match parser.u16(base + 4) {
+                Some(8) => {}
+                Some(other) => {
+                    return Err(Error::Unsupported(format!(
+                        "BigTIFF with {other}-byte offsets"
+                    )))
+                }
+                None => return Err(Error::Corrupt("truncated BigTIFF header".into())),
+            }
+            parser
+                .u64(base + 8)
+                .ok_or_else(|| Error::Corrupt("truncated BigTIFF header".into()))?
+        } else {
+            parser
+                .u32(base + 4)
+                .ok_or_else(|| Error::Corrupt("truncated TIFF header".into()))? as u64
+        };
+        let start = parser
+            .absolute(first)
+            .ok_or_else(|| Error::Corrupt("IFD0 offset out of range".into()))?;
+        let ifds = parser.chain(start, &[], 0);
+        Tiff::finish(bytes, le, big, base, ifds)
+    }
+
+    /// Parse one IFD chain starting at an absolute offset, with a given
+    /// byte order and no header — for makernote IFDs that share the
+    /// file's byte order and offsets (Nikon's after its own header,
+    /// Pentax's, Sony's).
+    pub fn parse_at(bytes: &'a [u8], offset: usize, little_endian: bool) -> Result<Tiff<'a>> {
+        Tiff::parse_at_relative(bytes, offset, 0, little_endian)
+    }
+
+    /// The same, for makernotes whose offsets are relative to their own
+    /// start rather than the file: entries are read from `bytes` but
+    /// every offset has `base` added.
+    pub fn parse_at_relative(
+        bytes: &'a [u8],
+        offset: usize,
+        base: usize,
+        little_endian: bool,
+    ) -> Result<Tiff<'a>> {
+        let mut parser = Parser::new(bytes, little_endian, false, base);
+        let ifds = parser.chain(offset, &[], 0);
+        Tiff::finish(bytes, little_endian, false, base, ifds)
+    }
+
+    /// Every entry point ends here: a TIFF with no IFD at all is not
+    /// one, and `root()` may then assume there is an IFD0.
+    fn finish(
+        bytes: &'a [u8],
+        le: bool,
+        big: bool,
+        base: usize,
+        ifds: Vec<Ifd>,
+    ) -> Result<Tiff<'a>> {
+        if ifds.is_empty() {
+            return Err(Error::Corrupt("no readable IFD".into()));
+        }
+        Ok(Tiff {
+            bytes,
+            little_endian: le,
+            big_tiff: big,
+            base,
+            ifds,
+        })
+    }
+
+    pub fn bytes(&self) -> &'a [u8] {
+        self.bytes
+    }
+    pub fn little_endian(&self) -> bool {
+        self.little_endian
+    }
+    pub fn big_tiff(&self) -> bool {
+        self.big_tiff
+    }
+    /// What this TIFF's stored offsets are relative to; add it to any
+    /// offset read out of an entry's value (`StripOffsets` and friends)
+    /// to get a position in [`Tiff::bytes`].
+    pub fn base(&self) -> usize {
+        self.base
+    }
+    /// IFD0.
+    pub fn root(&self) -> &Ifd {
+        &self.ifds[0]
+    }
+    /// Every IFD in the file, chain order then depth-first.
+    pub fn all(&self) -> Vec<&Ifd> {
+        self.ifds.iter().flat_map(|i| i.walk()).collect()
+    }
+    /// The first entry with `tag` anywhere in the file.
+    pub fn find(&self, tag: u16) -> Option<&Entry> {
+        self.all().into_iter().find_map(|i| i.get(tag))
+    }
+    /// The first IFD anywhere holding `tag`.
+    pub fn find_ifd(&self, tag: u16) -> Option<&Ifd> {
+        self.all().into_iter().find(|i| i.has(tag))
+    }
+    /// The first Exif IFD found.
+    pub fn exif(&self) -> Option<&Ifd> {
+        self.all().into_iter().find_map(|i| i.exif.as_deref())
+    }
+    /// Make (0x010F) and Model (0x0110) from IFD0, empty when absent.
+    pub fn make_model(&self) -> (String, String) {
+        let s = |tag| {
+            self.root()
+                .get(tag)
+                .and_then(|e| e.str())
+                .unwrap_or("")
+                .to_string()
+        };
+        (s(0x010F), s(0x0110))
+    }
+
+    // Byte-order-aware readers at absolute offsets, for decoders that
+    // walk the file themselves.
+    pub fn u8_at(&self, at: usize) -> Option<u8> {
+        self.bytes.get(at).copied()
+    }
+    pub fn u16_at(&self, at: usize) -> Option<u16> {
+        let b: [u8; 2] = self.bytes.get(at..at + 2)?.try_into().ok()?;
+        Some(if self.little_endian {
+            u16::from_le_bytes(b)
+        } else {
+            u16::from_be_bytes(b)
+        })
+    }
+    pub fn u32_at(&self, at: usize) -> Option<u32> {
+        let b: [u8; 4] = self.bytes.get(at..at + 4)?.try_into().ok()?;
+        Some(if self.little_endian {
+            u32::from_le_bytes(b)
+        } else {
+            u32::from_be_bytes(b)
+        })
+    }
+    pub fn u64_at(&self, at: usize) -> Option<u64> {
+        let b: [u8; 8] = self.bytes.get(at..at + 8)?.try_into().ok()?;
+        Some(if self.little_endian {
+            u64::from_le_bytes(b)
+        } else {
+            u64::from_be_bytes(b)
+        })
+    }
+}
+
+/// Strip or tile layout of an image IFD, resolved to absolute byte
+/// ranges, for decoders that read pixel data from a TIFF IFD.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ImageLayout {
+    pub width: usize,
+    pub height: usize,
+    pub bits_per_sample: u32,
+    pub samples_per_pixel: usize,
+    pub compression: u32,
+    pub photometric: u32,
+    /// Each chunk (strip or tile) as `(offset, length)`, in order.
+    pub chunks: Vec<(usize, usize)>,
+    /// Tile dimensions when tiled; `None` for strips (then
+    /// `rows_per_chunk` is RowsPerStrip).
+    pub tile: Option<(usize, usize)>,
+    pub rows_per_chunk: usize,
+}
+
+impl ImageLayout {
+    /// Read ImageWidth/Length, BitsPerSample, SamplesPerPixel,
+    /// Compression, PhotometricInterpretation and the strip or tile
+    /// offsets/byte counts. `Err(Corrupt)` when a chunk lies outside
+    /// the file.
+    pub fn of(tiff: &Tiff<'_>, ifd: &Ifd) -> Result<ImageLayout> {
+        let int = |tag: u16| ifd.get(tag).and_then(|e| e.u32(0));
+        let width = int(tags::IMAGE_WIDTH)
+            .ok_or_else(|| Error::Corrupt("image IFD without ImageWidth".into()))?;
+        let height = int(tags::IMAGE_LENGTH)
+            .ok_or_else(|| Error::Corrupt("image IFD without ImageLength".into()))?;
+        // BitsPerSample is per sample; raw IFDs are single-sample, and
+        // where the tag is missing (old Kodak and Minolta thumbnails)
+        // 8 is the only value that has ever been meant. SamplesPerPixel
+        // and Compression take the TIFF defaults.
+        let bits_per_sample = int(tags::BITS_PER_SAMPLE).unwrap_or(8);
+        let samples_per_pixel = int(tags::SAMPLES_PER_PIXEL).unwrap_or(1) as usize;
+        let compression = int(tags::COMPRESSION).unwrap_or(1);
+        let photometric = int(tags::PHOTOMETRIC).unwrap_or(1);
+
+        let tiled = ifd.has(tags::TILE_OFFSETS);
+        let (offsets, counts) = if tiled {
+            (
+                ifd.get(tags::TILE_OFFSETS)
+                    .map(|e| e.u64s())
+                    .unwrap_or_default(),
+                ifd.get(tags::TILE_BYTE_COUNTS)
+                    .map(|e| e.u64s())
+                    .unwrap_or_default(),
+            )
+        } else {
+            (
+                ifd.get(tags::STRIP_OFFSETS)
+                    .map(|e| e.u64s())
+                    .unwrap_or_default(),
+                ifd.get(tags::STRIP_BYTE_COUNTS)
+                    .map(|e| e.u64s())
+                    .unwrap_or_default(),
+            )
+        };
+        if offsets.is_empty() {
+            return Err(Error::Corrupt(
+                "image IFD with no strip or tile offsets".into(),
+            ));
+        }
+        let file_len = tiff.bytes().len();
+        let base = tiff.base();
+        // A single strip with no byte count runs to the end of the file:
+        // several pre-2005 raws (and Olympus's C-series ORF) omit
+        // StripByteCounts entirely.
+        let counts = if counts.len() == offsets.len() {
+            counts
+        } else if counts.is_empty() && offsets.len() == 1 {
+            let start = base.saturating_add(offsets[0] as usize);
+            if start > file_len {
+                return Err(Error::Corrupt(
+                    "strip offset past the end of the file".into(),
+                ));
+            }
+            vec![(file_len - start) as u64]
+        } else {
+            return Err(Error::Corrupt(format!(
+                "{} chunk offsets but {} byte counts",
+                offsets.len(),
+                counts.len()
+            )));
+        };
+
+        // Reserve for what a real file could hold, not what the count
+        // claims: a strip needs a byte, so the file length bounds it.
+        let mut chunks = Vec::with_capacity(offsets.len().min(file_len));
+        for (offset, count) in offsets.iter().zip(counts.iter()) {
+            let start = usize::try_from(*offset)
+                .ok()
+                .and_then(|o| o.checked_add(base))
+                .ok_or_else(|| Error::Corrupt("chunk offset out of range".into()))?;
+            let len = usize::try_from(*count)
+                .map_err(|_| Error::Corrupt("chunk length out of range".into()))?;
+            let end = start
+                .checked_add(len)
+                .ok_or_else(|| Error::Corrupt("chunk length out of range".into()))?;
+            if end > file_len {
+                return Err(Error::Corrupt(format!(
+                    "chunk {start}..{end} lies outside the {file_len}-byte file"
+                )));
+            }
+            chunks.push((start, len));
+        }
+
+        let tile = tiled.then(|| {
+            (
+                int(tags::TILE_WIDTH).unwrap_or(0) as usize,
+                int(tags::TILE_LENGTH).unwrap_or(0) as usize,
+            )
+        });
+        if let Some((tw, th)) = tile {
+            if tw == 0 || th == 0 {
+                return Err(Error::Corrupt("tiled image without tile dimensions".into()));
+            }
+        }
+        let rows_per_chunk = match tile {
+            Some((_, tile_height)) => tile_height,
+            // RowsPerStrip defaults to "the whole image in one strip",
+            // which is what raw IFDs almost always are anyway.
+            None => int(tags::ROWS_PER_STRIP).unwrap_or(height).max(1) as usize,
+        };
+
+        Ok(ImageLayout {
+            width: width as usize,
+            height: height as usize,
+            bits_per_sample,
+            samples_per_pixel,
+            compression,
+            photometric,
+            chunks,
+            tile,
+            rows_per_chunk,
+        })
+    }
+}
+
+/// Tags used across modules.
+pub mod tags {
+    pub const NEW_SUBFILE_TYPE: u16 = 0x00FE;
+    pub const IMAGE_WIDTH: u16 = 0x0100;
+    pub const IMAGE_LENGTH: u16 = 0x0101;
+    pub const BITS_PER_SAMPLE: u16 = 0x0102;
+    pub const COMPRESSION: u16 = 0x0103;
+    pub const PHOTOMETRIC: u16 = 0x0106;
+    pub const MAKE: u16 = 0x010F;
+    pub const MODEL: u16 = 0x0110;
+    pub const STRIP_OFFSETS: u16 = 0x0111;
+    pub const ORIENTATION: u16 = 0x0112;
+    pub const SAMPLES_PER_PIXEL: u16 = 0x0115;
+    pub const ROWS_PER_STRIP: u16 = 0x0116;
+    pub const STRIP_BYTE_COUNTS: u16 = 0x0117;
+    pub const PLANAR_CONFIGURATION: u16 = 0x011C;
+    pub const SOFTWARE: u16 = 0x0131;
+    pub const DATE_TIME: u16 = 0x0132;
+    pub const SUB_IFDS: u16 = 0x014A;
+    pub const JPEG_INTERCHANGE_FORMAT: u16 = 0x0201;
+    pub const JPEG_INTERCHANGE_FORMAT_LENGTH: u16 = 0x0202;
+    pub const TILE_WIDTH: u16 = 0x0142;
+    pub const TILE_LENGTH: u16 = 0x0143;
+    pub const TILE_OFFSETS: u16 = 0x0144;
+    pub const TILE_BYTE_COUNTS: u16 = 0x0145;
+    pub const CFA_REPEAT_PATTERN_DIM: u16 = 0x828D;
+    pub const CFA_PATTERN: u16 = 0x828E;
+    pub const EXIF_IFD: u16 = 0x8769;
+    pub const GPS_IFD: u16 = 0x8825;
+    pub const EXPOSURE_TIME: u16 = 0x829A;
+    pub const F_NUMBER: u16 = 0x829D;
+    pub const ISO: u16 = 0x8827;
+    pub const DATE_TIME_ORIGINAL: u16 = 0x9003;
+    pub const MAKER_NOTE: u16 = 0x927C;
+    pub const FOCAL_LENGTH: u16 = 0x920A;
+    pub const LENS_MODEL: u16 = 0xA434;
+    pub const DNG_VERSION: u16 = 0xC612;
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    // ---------------------------------------------------------------
+    // Hand-built TIFFs. Everything here is written by hand rather than
+    // by a TIFF library so the tests exercise exactly the bytes a
+    // camera writes, including the shapes libraries refuse to produce.
+    // ---------------------------------------------------------------
+
+    fn w16(le: bool, v: u16) -> [u8; 2] {
+        if le {
+            v.to_le_bytes()
+        } else {
+            v.to_be_bytes()
+        }
+    }
+    fn w32(le: bool, v: u32) -> [u8; 4] {
+        if le {
+            v.to_le_bytes()
+        } else {
+            v.to_be_bytes()
+        }
+    }
+    fn w64(le: bool, v: u64) -> [u8; 8] {
+        if le {
+            v.to_le_bytes()
+        } else {
+            v.to_be_bytes()
+        }
+    }
+
+    enum Payload {
+        /// Value bytes, already in the file's byte order.
+        Raw(Vec<u8>),
+        /// LONG offsets of other IFDs in the same build, filled in once
+        /// their positions are known (SubIFDs, Exif, GPS).
+        Refs(Vec<usize>),
+    }
+
+    struct TestEntry {
+        tag: u16,
+        kind: u16,
+        count: u32,
+        payload: Payload,
+    }
+
+    enum Next {
+        End,
+        Ifd(usize),
+        Raw(u32),
+    }
+
+    struct TestIfd {
+        entries: Vec<TestEntry>,
+        next: Next,
+    }
+
+    fn ifd(entries: Vec<TestEntry>) -> TestIfd {
+        TestIfd {
+            entries,
+            next: Next::End,
+        }
+    }
+
+    fn ascii(tag: u16, text: &str) -> TestEntry {
+        let mut bytes = text.as_bytes().to_vec();
+        bytes.push(0);
+        TestEntry {
+            tag,
+            kind: Kind::Ascii as u16,
+            count: bytes.len() as u32,
+            payload: Payload::Raw(bytes),
+        }
+    }
+    fn shorts(le: bool, tag: u16, values: &[u16]) -> TestEntry {
+        TestEntry {
+            tag,
+            kind: Kind::Short as u16,
+            count: values.len() as u32,
+            payload: Payload::Raw(values.iter().flat_map(|v| w16(le, *v)).collect()),
+        }
+    }
+    fn longs(le: bool, tag: u16, values: &[u32]) -> TestEntry {
+        TestEntry {
+            tag,
+            kind: Kind::Long as u16,
+            count: values.len() as u32,
+            payload: Payload::Raw(values.iter().flat_map(|v| w32(le, *v)).collect()),
+        }
+    }
+    fn rational(le: bool, tag: u16, n: u32, d: u32) -> TestEntry {
+        let mut bytes = w32(le, n).to_vec();
+        bytes.extend_from_slice(&w32(le, d));
+        TestEntry {
+            tag,
+            kind: Kind::Rational as u16,
+            count: 1,
+            payload: Payload::Raw(bytes),
+        }
+    }
+    fn refs(tag: u16, kind: Kind, which: Vec<usize>) -> TestEntry {
+        TestEntry {
+            tag,
+            kind: kind as u16,
+            count: which.len() as u32,
+            payload: Payload::Refs(which),
+        }
+    }
+
+    /// Assemble a classic TIFF: header, the IFDs laid out in order,
+    /// then a heap holding every value too long to sit in an entry.
+    fn build(le: bool, ifds: &[TestIfd]) -> Vec<u8> {
+        let mut offsets = Vec::new();
+        let mut at = 8usize;
+        for ifd in ifds {
+            offsets.push(at);
+            at += 2 + 12 * ifd.entries.len() + 4;
+        }
+        let heap_start = at;
+        let mut heap: Vec<u8> = Vec::new();
+        let mut placed: Vec<Vec<(Vec<u8>, Option<u32>)>> = Vec::new();
+        for ifd in ifds {
+            let mut row = Vec::new();
+            for entry in &ifd.entries {
+                let bytes = match &entry.payload {
+                    Payload::Raw(b) => b.clone(),
+                    Payload::Refs(which) => which
+                        .iter()
+                        .flat_map(|i| w32(le, offsets[*i] as u32))
+                        .collect(),
+                };
+                if bytes.len() <= 4 {
+                    row.push((bytes, None));
+                } else {
+                    let at = (heap_start + heap.len()) as u32;
+                    heap.extend_from_slice(&bytes);
+                    if heap.len() % 2 == 1 {
+                        heap.push(0);
+                    }
+                    row.push((bytes, Some(at)));
+                }
+            }
+            placed.push(row);
+        }
+
+        let mut out = Vec::new();
+        out.extend_from_slice(if le { b"II\x2a\x00" } else { b"MM\x00\x2a" });
+        out.extend_from_slice(&w32(le, offsets[0] as u32));
+        for (i, ifd) in ifds.iter().enumerate() {
+            out.extend_from_slice(&w16(le, ifd.entries.len() as u16));
+            for (entry, (bytes, at)) in ifd.entries.iter().zip(&placed[i]) {
+                out.extend_from_slice(&w16(le, entry.tag));
+                out.extend_from_slice(&w16(le, entry.kind));
+                out.extend_from_slice(&w32(le, entry.count));
+                match at {
+                    Some(at) => out.extend_from_slice(&w32(le, *at)),
+                    None => {
+                        let mut inline = bytes.clone();
+                        inline.resize(4, 0);
+                        out.extend_from_slice(&inline);
+                    }
+                }
+            }
+            let next = match ifd.next {
+                Next::End => 0,
+                Next::Ifd(i) => offsets[i] as u32,
+                Next::Raw(v) => v,
+            };
+            out.extend_from_slice(&w32(le, next));
+        }
+        assert_eq!(out.len(), heap_start);
+        out.extend_from_slice(&heap);
+        out
+    }
+
+    /// One BigTIFF IFD: 64-bit counts, an 8-byte value field, and an
+    /// 8-byte next pointer.
+    fn build_big(le: bool, entries: &[(u16, Kind, u64, Vec<u8>)]) -> Vec<u8> {
+        let ifd_at = 16usize;
+        let heap_start = ifd_at + 8 + 20 * entries.len() + 8;
+        let mut heap: Vec<u8> = Vec::new();
+        let mut out = Vec::new();
+        out.extend_from_slice(if le { b"II\x2b\x00" } else { b"MM\x00\x2b" });
+        out.extend_from_slice(&w16(le, 8));
+        out.extend_from_slice(&w16(le, 0));
+        out.extend_from_slice(&w64(le, ifd_at as u64));
+        out.extend_from_slice(&w64(le, entries.len() as u64));
+        for (tag, kind, count, bytes) in entries {
+            out.extend_from_slice(&w16(le, *tag));
+            out.extend_from_slice(&w16(le, *kind as u16));
+            out.extend_from_slice(&w64(le, *count));
+            if bytes.len() <= 8 {
+                let mut inline = bytes.clone();
+                inline.resize(8, 0);
+                out.extend_from_slice(&inline);
+            } else {
+                out.extend_from_slice(&w64(le, (heap_start + heap.len()) as u64));
+                heap.extend_from_slice(bytes);
+            }
+        }
+        out.extend_from_slice(&w64(le, 0));
+        assert_eq!(out.len(), heap_start);
+        out.extend_from_slice(&heap);
+        out
+    }
+
+    #[test]
+    fn classic_both_byte_orders() {
+        for le in [true, false] {
+            let bytes = build(
+                le,
+                &[ifd(vec![
+                    shorts(le, tags::IMAGE_WIDTH, &[4032]),
+                    longs(le, tags::IMAGE_LENGTH, &[3024]),
+                    ascii(tags::MAKE, "NIKON CORPORATION"),
+                    ascii(tags::MODEL, "NIKON D7200"),
+                    rational(le, tags::EXPOSURE_TIME, 1, 2000),
+                    shorts(le, 0x0102, &[12, 12, 12]),
+                ])],
+            );
+            let tiff = Tiff::parse(&bytes).expect("parses");
+            assert_eq!(tiff.little_endian(), le);
+            assert!(!tiff.big_tiff());
+            assert_eq!(tiff.ifds.len(), 1);
+            assert_eq!(
+                tiff.make_model(),
+                ("NIKON CORPORATION".into(), "NIKON D7200".into())
+            );
+            assert_eq!(
+                tiff.find(tags::IMAGE_WIDTH).and_then(|e| e.u32(0)),
+                Some(4032)
+            );
+            assert_eq!(
+                tiff.find(tags::IMAGE_LENGTH).and_then(|e| e.u32(0)),
+                Some(3024)
+            );
+            assert_eq!(
+                tiff.find(tags::EXPOSURE_TIME).and_then(|e| e.f64(0)),
+                Some(0.0005)
+            );
+            // Three SHORTs are six bytes: they live on the heap, not
+            // in the entry, which is the case inline values get wrong.
+            assert_eq!(tiff.find(0x0102).map(|e| e.u32s()), Some(vec![12, 12, 12]));
+            // A SHORT is not a string and a string is not a number.
+            assert_eq!(tiff.find(tags::IMAGE_WIDTH).and_then(|e| e.str()), None);
+            assert_eq!(tiff.find(tags::MAKE).and_then(|e| e.u32(0)), None);
+        }
+    }
+
+    #[test]
+    fn inline_values_are_not_confused_with_offsets() {
+        for le in [true, false] {
+            // Two SHORTs fit in the entry; three do not. Both must read
+            // back the same way.
+            let bytes = build(
+                le,
+                &[ifd(vec![
+                    shorts(le, 0x1000, &[1, 2]),
+                    shorts(le, 0x1001, &[1, 2, 3]),
+                ])],
+            );
+            let tiff = Tiff::parse(&bytes).unwrap();
+            assert_eq!(tiff.find(0x1000).map(|e| e.u32s()), Some(vec![1, 2]));
+            assert_eq!(tiff.find(0x1001).map(|e| e.u32s()), Some(vec![1, 2, 3]));
+            // The inline one points into the entry itself.
+            let inline = tiff.find(0x1000).unwrap();
+            assert!(inline.offset > 8 && inline.offset < 8 + 2 + 12 * 2);
+        }
+    }
+
+    #[test]
+    fn sub_ifds_exif_and_gps() {
+        let le = true;
+        let bytes = build(
+            le,
+            &[
+                // IFD0 points at three children; they are laid out
+                // after it so their offsets are known at build time.
+                TestIfd {
+                    entries: vec![
+                        ascii(tags::MAKE, "Canon"),
+                        refs(tags::SUB_IFDS, Kind::Long, vec![1, 2]),
+                        refs(tags::EXIF_IFD, Kind::Long, vec![3]),
+                        refs(tags::GPS_IFD, Kind::Long, vec![4]),
+                    ],
+                    next: Next::End,
+                },
+                ifd(vec![
+                    shorts(le, tags::PHOTOMETRIC, &[32803]),
+                    shorts(le, tags::IMAGE_WIDTH, &[100]),
+                ]),
+                ifd(vec![shorts(le, tags::IMAGE_WIDTH, &[200])]),
+                ifd(vec![shorts(le, tags::ISO, &[400])]),
+                ifd(vec![ascii(0x0001, "N")]),
+            ],
+        );
+        let tiff = Tiff::parse(&bytes).unwrap();
+        let root = tiff.root();
+        assert_eq!(root.sub_ifds.len(), 2);
+        assert_eq!(
+            root.sub_ifds[0]
+                .get(tags::IMAGE_WIDTH)
+                .and_then(|e| e.u32(0)),
+            Some(100)
+        );
+        assert_eq!(
+            root.sub_ifds[1]
+                .get(tags::IMAGE_WIDTH)
+                .and_then(|e| e.u32(0)),
+            Some(200)
+        );
+        assert_eq!(
+            tiff.exif()
+                .and_then(|e| e.get(tags::ISO))
+                .and_then(|e| e.u32(0)),
+            Some(400)
+        );
+        assert_eq!(
+            root.gps
+                .as_ref()
+                .and_then(|g| g.get(1))
+                .and_then(|e| e.str()),
+            Some("N")
+        );
+        // walk(): self, SubIFDs depth-first, Exif, GPS.
+        assert_eq!(tiff.all().len(), 5);
+        assert!(tiff.find_ifd(tags::PHOTOMETRIC).is_some());
+    }
+
+    #[test]
+    fn single_sub_ifd_is_inline() {
+        // One SubIFD offset fits in the entry, which is how every DNG
+        // with a single raw IFD writes it; type 13 (IFD) is as common
+        // as type 4 (LONG).
+        let bytes = build(
+            true,
+            &[
+                ifd(vec![refs(tags::SUB_IFDS, Kind::Ifd, vec![1])]),
+                ifd(vec![shorts(true, tags::IMAGE_WIDTH, &[7])]),
+            ],
+        );
+        let tiff = Tiff::parse(&bytes).unwrap();
+        assert_eq!(tiff.root().sub_ifds.len(), 1);
+        assert_eq!(
+            tiff.root().sub_ifds[0]
+                .get(tags::IMAGE_WIDTH)
+                .and_then(|e| e.u32(0)),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn a_loop_in_the_chain_terminates() {
+        let mut ifds = vec![
+            ifd(vec![ascii(tags::MAKE, "A")]),
+            ifd(vec![ascii(tags::MAKE, "B")]),
+        ];
+        ifds[0].next = Next::Ifd(1);
+        ifds[1].next = Next::Ifd(0);
+        let bytes = build(true, &ifds);
+        let tiff = Tiff::parse(&bytes).unwrap();
+        assert_eq!(tiff.ifds.len(), 2);
+        assert_eq!(
+            tiff.ifds[1].get(tags::MAKE).and_then(|e| e.str()),
+            Some("B")
+        );
+    }
+
+    #[test]
+    fn a_self_referential_ifd_terminates() {
+        // An IFD whose next pointer is itself, and a SubIFD pointing
+        // back at IFD0: both are cycles a fuzzer finds in seconds.
+        let mut ifds = vec![ifd(vec![refs(tags::SUB_IFDS, Kind::Long, vec![0])])];
+        ifds[0].next = Next::Raw(8);
+        let bytes = build(true, &ifds);
+        let tiff = Tiff::parse(&bytes).unwrap();
+        assert_eq!(tiff.ifds.len(), 1);
+        assert!(tiff.root().sub_ifds.is_empty());
+    }
+
+    #[test]
+    fn values_past_the_end_of_the_file_are_empty() {
+        let le = true;
+        let mut bytes = build(
+            le,
+            &[ifd(vec![
+                ascii(tags::MAKE, "PENTAX             "),
+                shorts(le, tags::IMAGE_WIDTH, &[10]),
+            ])],
+        );
+        // Point Make's value at the far end of nowhere.
+        let value_field = 8 + 2 + 8;
+        bytes[value_field..value_field + 4].copy_from_slice(&w32(le, 0x7fff_0000));
+        let tiff = Tiff::parse(&bytes).unwrap();
+        let make = tiff.find(tags::MAKE).expect("the entry is still there");
+        assert_eq!(make.str(), Some(""));
+        assert_eq!(make.bytes(), Some(&[][..]));
+        // Its neighbours are unharmed.
+        assert_eq!(
+            tiff.find(tags::IMAGE_WIDTH).and_then(|e| e.u32(0)),
+            Some(10)
+        );
+    }
+
+    #[test]
+    fn an_absurd_count_does_not_allocate() {
+        let le = true;
+        let mut bytes = build(le, &[ifd(vec![shorts(le, 0x1000, &[1, 2, 3])])]);
+        // count = 4 billion SHORTs, offset 8: the range is not in the
+        // file, so the value must come back empty rather than fatal.
+        let count_field = 8 + 2 + 4;
+        bytes[count_field..count_field + 4].copy_from_slice(&w32(le, 0xffff_fff0));
+        let tiff = Tiff::parse(&bytes).unwrap();
+        let entry = tiff.find(0x1000).unwrap();
+        assert_eq!(entry.count, 0xffff_fff0);
+        assert!(entry.u32s().is_empty());
+        assert_eq!(entry.u32(0), None);
+    }
+
+    #[test]
+    fn truncated_ifd_keeps_the_entries_it_has() {
+        let le = true;
+        let bytes = build(
+            le,
+            &[ifd(vec![
+                shorts(le, 0x1000, &[1]),
+                shorts(le, 0x1001, &[2]),
+                shorts(le, 0x1002, &[3]),
+            ])],
+        );
+        // Cut the file in the middle of the third entry.
+        let cut = 8 + 2 + 12 * 2 + 5;
+        let tiff = Tiff::parse(&bytes[..cut]).unwrap();
+        assert_eq!(tiff.root().entries.len(), 2);
+        assert_eq!(tiff.find(0x1001).and_then(|e| e.u32(0)), Some(2));
+    }
+
+    #[test]
+    fn big_tiff_both_byte_orders() {
+        for le in [true, false] {
+            let bytes = build_big(
+                le,
+                &[
+                    (tags::IMAGE_WIDTH, Kind::Long, 1, w32(le, 8192).to_vec()),
+                    (tags::MAKE, Kind::Ascii, 8, b"Leica\0\0\0".to_vec()),
+                    // A LONG8 value is exactly the size of the field.
+                    (
+                        tags::STRIP_OFFSETS,
+                        Kind::Long8,
+                        1,
+                        w64(le, 0x1_0000_0000).to_vec(),
+                    ),
+                    // ... and two of them are not, so they go on the heap.
+                    (
+                        tags::STRIP_BYTE_COUNTS,
+                        Kind::Long8,
+                        2,
+                        [w64(le, 5), w64(le, 6)].concat(),
+                    ),
+                ],
+            );
+            let tiff = Tiff::parse(&bytes).unwrap();
+            assert!(tiff.big_tiff());
+            assert_eq!(tiff.little_endian(), le);
+            assert_eq!(
+                tiff.find(tags::IMAGE_WIDTH).and_then(|e| e.u32(0)),
+                Some(8192)
+            );
+            assert_eq!(tiff.find(tags::MAKE).and_then(|e| e.str()), Some("Leica"));
+            // Past 4 GB a LONG8 offset must survive as itself.
+            assert_eq!(
+                tiff.find(tags::STRIP_OFFSETS).and_then(|e| e.u64(0)),
+                Some(0x1_0000_0000)
+            );
+            assert_eq!(
+                tiff.find(tags::STRIP_OFFSETS).and_then(|e| e.u32(0)),
+                Some(u32::MAX)
+            );
+            assert_eq!(
+                tiff.find(tags::STRIP_BYTE_COUNTS).map(|e| e.u64s()),
+                Some(vec![5, 6])
+            );
+        }
+    }
+
+    #[test]
+    fn vendor_signatures_are_plain_tiff() {
+        for magic in [b"IIRO", b"IIRS", b"IIU\x00"] {
+            let mut bytes = build(
+                true,
+                &[ifd(vec![ascii(tags::MAKE, "OLYMPUS IMAGING CORP.")])],
+            );
+            bytes[0..4].copy_from_slice(magic);
+            let tiff = Tiff::parse(&bytes).expect("vendor magic parses as TIFF");
+            assert!(tiff.little_endian());
+            assert_eq!(tiff.make_model().0, "OLYMPUS IMAGING CORP.");
+        }
+        let mut bytes = build(
+            false,
+            &[ifd(vec![ascii(tags::MAKE, "OLYMPUS OPTICAL CO.,LTD")])],
+        );
+        bytes[0..4].copy_from_slice(b"MMOR");
+        let tiff = Tiff::parse(&bytes).unwrap();
+        assert!(!tiff.little_endian());
+        assert_eq!(tiff.make_model().0, "OLYMPUS OPTICAL CO.,LTD");
+    }
+
+    #[test]
+    fn nonsense_headers_are_errors() {
+        for bad in [
+            &b""[..],
+            &b"II"[..],
+            &b"II*"[..],
+            &b"XX\x2a\x00\x08\x00\x00\x00"[..],
+            &b"II\x2a\x00"[..], // header cut before the IFD0 offset
+            &[0u8; 64][..],
+        ] {
+            assert!(Tiff::parse(bad).is_err(), "{bad:02x?} should not parse");
+        }
+        // A valid header whose IFD0 offset points nowhere.
+        let bytes = [b'I', b'I', 0x2a, 0x00, 0xf0, 0xff, 0xff, 0x7f];
+        assert!(Tiff::parse(&bytes).is_err());
+    }
+
+    #[test]
+    fn embedded_tiff_offsets_are_relative_to_the_base() {
+        let inner = build(
+            true,
+            &[ifd(vec![
+                ascii(tags::MAKE, "Canon"),
+                ascii(tags::MODEL, "Canon EOS R"),
+            ])],
+        );
+        let base = 137;
+        let mut outer = vec![0xa5; base];
+        outer.extend_from_slice(&inner);
+        let tiff = Tiff::parse_embedded(&outer, base).unwrap();
+        assert_eq!(tiff.base(), base);
+        assert_eq!(tiff.make_model(), ("Canon".into(), "Canon EOS R".into()));
+        // The same bytes read from 0 are not a TIFF at all.
+        assert!(Tiff::parse(&outer).is_err());
+    }
+
+    #[test]
+    fn bare_ifd_chains_for_makernotes() {
+        let le = true;
+        let inner = build(
+            le,
+            &[ifd(vec![
+                shorts(le, 0x0001, &[1]),
+                ascii(0x0002, "makernote"),
+            ])],
+        );
+        // parse_at: the IFD lives at a known offset, no header.
+        let tiff = Tiff::parse_at(&inner, 8, le).unwrap();
+        assert_eq!(
+            tiff.root().get(0x0002).and_then(|e| e.str()),
+            Some("makernote")
+        );
+
+        // parse_at_relative: the same IFD moved bodily into a bigger
+        // file, its internal offsets still counted from its own start.
+        let base = 64;
+        let mut outer = vec![0u8; base];
+        outer.extend_from_slice(&inner);
+        let tiff = Tiff::parse_at_relative(&outer, base + 8, base, le).unwrap();
+        assert_eq!(
+            tiff.root().get(0x0002).and_then(|e| e.str()),
+            Some("makernote")
+        );
+        assert_eq!(tiff.root().get(0x0001).and_then(|e| e.u32(0)), Some(1));
+        // Without the base it reads whatever happens to be there.
+        assert_ne!(
+            Tiff::parse_at(&outer, base + 8, le)
+                .unwrap()
+                .root()
+                .get(0x0002)
+                .and_then(|e| e.str()),
+            Some("makernote")
+        );
+    }
+
+    #[test]
+    fn image_layout_strips_and_tiles() {
+        let le = true;
+        // Two strips of eight bytes each, in a file long enough to
+        // hold them.
+        let mut bytes = build(
+            le,
+            &[ifd(vec![
+                shorts(le, tags::IMAGE_WIDTH, &[4]),
+                shorts(le, tags::IMAGE_LENGTH, &[4]),
+                shorts(le, tags::BITS_PER_SAMPLE, &[16]),
+                shorts(le, tags::COMPRESSION, &[1]),
+                shorts(le, tags::PHOTOMETRIC, &[32803]),
+                shorts(le, tags::ROWS_PER_STRIP, &[2]),
+                longs(le, tags::STRIP_OFFSETS, &[200, 208]),
+                longs(le, tags::STRIP_BYTE_COUNTS, &[8, 8]),
+            ])],
+        );
+        bytes.resize(216, 0);
+        let tiff = Tiff::parse(&bytes).unwrap();
+        let layout = ImageLayout::of(&tiff, tiff.root()).unwrap();
+        assert_eq!((layout.width, layout.height), (4, 4));
+        assert_eq!(layout.bits_per_sample, 16);
+        assert_eq!(layout.samples_per_pixel, 1);
+        assert_eq!(layout.photometric, 32803);
+        assert_eq!(layout.chunks, vec![(200, 8), (208, 8)]);
+        assert_eq!(layout.tile, None);
+        assert_eq!(layout.rows_per_chunk, 2);
+
+        // The same image as four tiles.
+        let mut bytes = build(
+            le,
+            &[ifd(vec![
+                shorts(le, tags::IMAGE_WIDTH, &[4]),
+                shorts(le, tags::IMAGE_LENGTH, &[4]),
+                shorts(le, tags::TILE_WIDTH, &[2]),
+                shorts(le, tags::TILE_LENGTH, &[2]),
+                longs(le, tags::TILE_OFFSETS, &[100, 108, 116, 124]),
+                longs(le, tags::TILE_BYTE_COUNTS, &[8, 8, 8, 8]),
+            ])],
+        );
+        bytes.resize(132, 0);
+        let tiff = Tiff::parse(&bytes).unwrap();
+        let layout = ImageLayout::of(&tiff, tiff.root()).unwrap();
+        assert_eq!(layout.tile, Some((2, 2)));
+        assert_eq!(layout.rows_per_chunk, 2);
+        assert_eq!(layout.chunks.len(), 4);
+    }
+
+    #[test]
+    fn image_layout_rejects_chunks_outside_the_file() {
+        let le = true;
+        let bytes = build(
+            le,
+            &[ifd(vec![
+                shorts(le, tags::IMAGE_WIDTH, &[4]),
+                shorts(le, tags::IMAGE_LENGTH, &[4]),
+                longs(le, tags::STRIP_OFFSETS, &[100]),
+                longs(le, tags::STRIP_BYTE_COUNTS, &[1 << 20]),
+            ])],
+        );
+        let tiff = Tiff::parse(&bytes).unwrap();
+        assert!(matches!(
+            ImageLayout::of(&tiff, tiff.root()),
+            Err(Error::Corrupt(_))
+        ));
+
+        // No dimensions at all is not an image IFD.
+        let bytes = build(le, &[ifd(vec![ascii(tags::MAKE, "Sony")])]);
+        let tiff = Tiff::parse(&bytes).unwrap();
+        assert!(ImageLayout::of(&tiff, tiff.root()).is_err());
+    }
+
+    #[test]
+    fn image_layout_single_strip_without_byte_counts() {
+        // Old ORF and a few converters omit StripByteCounts; the strip
+        // then runs to the end of the file.
+        let le = true;
+        let mut bytes = build(
+            le,
+            &[ifd(vec![
+                shorts(le, tags::IMAGE_WIDTH, &[2]),
+                shorts(le, tags::IMAGE_LENGTH, &[2]),
+                longs(le, tags::STRIP_OFFSETS, &[64]),
+            ])],
+        );
+        bytes.resize(72, 0);
+        let tiff = Tiff::parse(&bytes).unwrap();
+        let layout = ImageLayout::of(&tiff, tiff.root()).unwrap();
+        assert_eq!(layout.chunks, vec![(64, 8)]);
+    }
+
+    // ---------------------------------------------------------------
+    // Corpus tests. They need real files: set SCHIST_RAW_CORPUS to a
+    // directory of raws (with the `<file>.json` exiftool sidecars the
+    // sample fetcher writes) and they compare against exiftool.
+    // Without it they skip, silently.
+    // ---------------------------------------------------------------
+
+    pub(crate) fn corpus() -> Option<std::path::PathBuf> {
+        std::env::var_os("SCHIST_RAW_CORPUS").map(std::path::PathBuf::from)
+    }
+
+    /// Every sample in the corpus, ignoring the oracle sidecars beside
+    /// them (`<file>.json`, `<file>.tiff`, `<file>.identify.txt`).
+    pub(crate) fn samples(root: &std::path::Path) -> Vec<std::path::PathBuf> {
+        let mut out = Vec::new();
+        let mut stack = vec![root.to_path_buf()];
+        while let Some(dir) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                    continue;
+                }
+                let name = path
+                    .file_name()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string();
+                if name.ends_with(".json") || name.ends_with(".txt") || name.ends_with(".tiff") {
+                    continue;
+                }
+                out.push(path);
+            }
+        }
+        out.sort();
+        out
+    }
+
+    /// The exiftool sidecar for a sample, as a flat map of its
+    /// group-prefixed keys ("EXIF:Make") to rendered values.
+    pub(crate) fn sidecar(
+        path: &std::path::Path,
+    ) -> Option<std::collections::HashMap<String, String>> {
+        let mut json = path.as_os_str().to_os_string();
+        json.push(".json");
+        let text = std::fs::read_to_string(std::path::PathBuf::from(json)).ok()?;
+        Some(json_object(&text))
+    }
+
+    /// A dependency-light reader for exiftool's `-j` output: the keys
+    /// of the first object, with scalars rendered as text and nested
+    /// values flattened to their elements. Enough for an oracle, not a
+    /// general JSON parser.
+    fn json_object(text: &str) -> std::collections::HashMap<String, String> {
+        let bytes = text.as_bytes();
+        let mut at = 0usize;
+        let mut out = std::collections::HashMap::new();
+        while at < bytes.len() && bytes[at] != b'{' {
+            at += 1;
+        }
+        if at == bytes.len() {
+            return out;
+        }
+        at += 1;
+        loop {
+            skip_ws(bytes, &mut at);
+            match bytes.get(at) {
+                Some(b'}') | None => break,
+                Some(b',') => {
+                    at += 1;
+                    continue;
+                }
+                Some(b'"') => {}
+                _ => break,
+            }
+            let Some(key) = json_string(bytes, &mut at) else {
+                break;
+            };
+            skip_ws(bytes, &mut at);
+            if bytes.get(at) != Some(&b':') {
+                break;
+            }
+            at += 1;
+            let Some(value) = json_value(bytes, &mut at) else {
+                break;
+            };
+            out.insert(key, value);
+        }
+        out
+    }
+
+    fn skip_ws(bytes: &[u8], at: &mut usize) {
+        while matches!(bytes.get(*at), Some(b' ' | b'\t' | b'\n' | b'\r')) {
+            *at += 1;
+        }
+    }
+
+    fn json_string(bytes: &[u8], at: &mut usize) -> Option<String> {
+        if bytes.get(*at) != Some(&b'"') {
+            return None;
+        }
+        *at += 1;
+        let mut out = String::new();
+        loop {
+            match *bytes.get(*at)? {
+                b'"' => {
+                    *at += 1;
+                    return Some(out);
+                }
+                b'\\' => {
+                    *at += 1;
+                    let escape = *bytes.get(*at)?;
+                    *at += 1;
+                    out.push(match escape {
+                        b'n' => '\n',
+                        b't' => '\t',
+                        b'r' => '\r',
+                        b'u' => {
+                            let hex = std::str::from_utf8(bytes.get(*at..*at + 4)?).ok()?;
+                            *at += 4;
+                            char::from_u32(u32::from_str_radix(hex, 16).ok()?).unwrap_or('?')
+                        }
+                        other => other as char,
+                    });
+                }
+                other => {
+                    // exiftool's JSON is UTF-8; take bytes as they come
+                    // and let lossy handling deal with anything odd.
+                    let start = *at;
+                    let mut end = *at + 1;
+                    while end < bytes.len() && bytes[end] & 0xc0 == 0x80 {
+                        end += 1;
+                    }
+                    if end > start + 1 {
+                        out.push_str(&String::from_utf8_lossy(&bytes[start..end]));
+                        *at = end;
+                    } else {
+                        out.push(other as char);
+                        *at += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    fn json_value(bytes: &[u8], at: &mut usize) -> Option<String> {
+        skip_ws(bytes, at);
+        match *bytes.get(*at)? {
+            b'"' => json_string(bytes, at),
+            b'{' | b'[' => {
+                // Consume the nested value, rendering its scalars
+                // separated by spaces (arrays of ISO values, mostly).
+                let open = bytes[*at];
+                let close = if open == b'{' { b'}' } else { b']' };
+                *at += 1;
+                let mut parts: Vec<String> = Vec::new();
+                loop {
+                    skip_ws(bytes, at);
+                    match bytes.get(*at) {
+                        None => return Some(parts.join(" ")),
+                        Some(c) if *c == close => {
+                            *at += 1;
+                            return Some(parts.join(" "));
+                        }
+                        Some(b',') | Some(b':') => {
+                            *at += 1;
+                        }
+                        _ => {
+                            let part = json_value(bytes, at)?;
+                            parts.push(part);
+                        }
+                    }
+                }
+            }
+            _ => {
+                let start = *at;
+                while matches!(bytes.get(*at), Some(c) if !matches!(c, b',' | b'}' | b']' | b'\n'))
+                {
+                    *at += 1;
+                }
+                Some(
+                    String::from_utf8_lossy(&bytes[start..*at])
+                        .trim()
+                        .to_string(),
+                )
+            }
+        }
+    }
+
+    /// The value of the first of `keys` present, matched exactly (bar
+    /// case). The group prefix matters: exiftool reports several ISOs
+    /// per file — "EXIF:ISO" is the tag, "MakerNotes:ISO" is what the
+    /// vendor's own block says (Nikon writes one where the EXIF tag is
+    /// absent), and "Composite:ISO" is exiftool's own arithmetic from
+    /// the makernote (Canon's 519 against an EXIF 500). Only the tags
+    /// this crate's shared TIFF code can see are fair comparisons.
+    pub(crate) fn oracle<'a>(
+        json: &'a std::collections::HashMap<String, String>,
+        keys: &[&str],
+    ) -> Option<&'a String> {
+        for key in keys {
+            for (have, value) in json {
+                if have.eq_ignore_ascii_case(key) && !value.is_empty() {
+                    return Some(value);
+                }
+            }
+        }
+        None
+    }
+
+    /// A TIFF-shaped file, by the signatures [`Tiff::parse`] accepts.
+    fn is_tiff_shaped(bytes: &[u8]) -> bool {
+        matches!(
+            bytes.get(0..4),
+            Some(b"II\x2a\x00" | b"MM\x00\x2a" | b"II\x2b\x00" | b"MM\x00\x2b")
+                | Some(b"IIRO" | b"IIRS" | b"MMOR" | b"IIU\x00")
+        )
+    }
+
+    #[test]
+    fn corpus_tiff_files_parse_and_match_exiftool() {
+        let Some(root) = corpus() else { return };
+        let mut checked = 0;
+        let mut previews = 0;
+        let mut problems: Vec<String> = Vec::new();
+        for path in samples(&root) {
+            let Ok(bytes) = std::fs::read(&path) else {
+                continue;
+            };
+            if !is_tiff_shaped(&bytes) {
+                continue;
+            }
+            let name = path
+                .strip_prefix(&root)
+                .unwrap_or(&path)
+                .display()
+                .to_string();
+            let tiff = match Tiff::parse(&bytes) {
+                Ok(tiff) => tiff,
+                Err(e) => {
+                    problems.push(format!("{name}: does not parse: {e}"));
+                    continue;
+                }
+            };
+            checked += 1;
+            let Some(json) = sidecar(&path) else { continue };
+            let (make, model) = tiff.make_model();
+            if let Some(want) = oracle(&json, &["EXIF:Make", "IFD0:Make", "Make"]) {
+                // Cameras pad Make with spaces and NULs; exiftool trims.
+                if make.trim() != want.trim() {
+                    problems.push(format!("{name}: make {make:?}, exiftool {want:?}"));
+                }
+            }
+            if let Some(want) = oracle(&json, &["EXIF:Model", "IFD0:Model", "Model"]) {
+                if model.trim() != want.trim() {
+                    problems.push(format!("{name}: model {model:?}, exiftool {want:?}"));
+                }
+            }
+            // A JPEG exiftool can reach through the standard EXIF tags
+            // must be one largest_jpeg finds too. The makernote-only
+            // previews (Olympus, Epson, Nikon's scanner NEFs) are not
+            // this function's job — their vendor module digs those out
+            // — so only the EXIF group counts here.
+            // Panasonic (and the Leica bodies that write RW2/RWL, and
+            // the Digilux's ".RAW") keeps both the preview and the ISO
+            // in vendor tags of IFD0 — the JPEG's bytes in 0x002E and
+            // the ISO in 0x0017 — which exiftool reports under the
+            // EXIF group all the same. Neither is a tag the shared
+            // helpers are meant to know; `formats::rw2` reads them.
+            let panasonic = crate::probe(&bytes) == Some(crate::Format::Rw2);
+            let has_jpeg = !panasonic
+                && [
+                    "EXIF:JpgFromRaw",
+                    "EXIF:PreviewImage",
+                    "EXIF:ThumbnailImage",
+                    "EXIF:OtherImage",
+                ]
+                .iter()
+                .any(|k| oracle(&json, &[k]).is_some());
+            let jpeg = crate::formats::common::largest_jpeg(&tiff);
+            if let Some(jpeg) = &jpeg {
+                // Starting with FFD8 only proves the offset; decoding
+                // proves the length as well, which is the half that
+                // goes wrong when a tag is read in the wrong order or
+                // an embedded TIFF's base is forgotten.
+                match image::load_from_memory_with_format(jpeg, image::ImageFormat::Jpeg) {
+                    Ok(image) => {
+                        if image.width() == 0 || image.height() == 0 {
+                            problems.push(format!("{name}: preview decodes to nothing"));
+                        }
+                    }
+                    Err(e) => problems.push(format!(
+                        "{name}: preview ({} bytes) will not decode: {e}",
+                        jpeg.len()
+                    )),
+                }
+            }
+            match (&jpeg, has_jpeg) {
+                (Some(jpeg), _) if !jpeg.starts_with(&[0xff, 0xd8]) => {
+                    problems.push(format!("{name}: largest_jpeg is not a JPEG"));
+                }
+                (None, true) => {
+                    problems.push(format!(
+                        "{name}: exiftool finds a preview, largest_jpeg does not"
+                    ));
+                }
+                _ => {}
+            }
+            // And it should be the *largest* one: exiftool prints the
+            // size of every image it can extract ("(Binary data
+            // 1155191 bytes, ...)"), so the biggest it found through
+            // the standard tags is the one to beat.
+            if let Some(jpeg) = jpeg.as_ref().filter(|_| !panasonic) {
+                let biggest = ["EXIF:JpgFromRaw", "EXIF:PreviewImage", "EXIF:OtherImage"]
+                    .iter()
+                    .filter_map(|k| oracle(&json, &[k]))
+                    .filter_map(|v| v.split_whitespace().nth(2)?.parse::<usize>().ok())
+                    .max();
+                if let Some(biggest) = biggest {
+                    if jpeg.len() < biggest {
+                        problems.push(format!(
+                            "{name}: preview {} bytes, exiftool has {biggest}",
+                            jpeg.len()
+                        ));
+                    }
+                }
+            }
+            if jpeg.is_some() {
+                previews += 1;
+            }
+            // ISO, the one shooting field every camera records.
+            // Only the Exif-group value: older Nikon and Kodak bodies
+            // record ISO in the makernote alone, which `metadata`
+            // deliberately does not read (exiftool's bare "ISO" is the
+            // makernote's).
+            if let Some(want) = oracle(&json, &["EXIF:ISO", "IFD0:ISO"]).filter(|_| !panasonic) {
+                let want: Option<f32> = want.split_whitespace().next().and_then(|v| v.parse().ok());
+                let have = crate::formats::common::metadata(&tiff).iso;
+                match (want, have) {
+                    (Some(want), Some(have)) if (want - have).abs() > 0.5 => {
+                        problems.push(format!("{name}: ISO {have}, exiftool {want}"));
+                    }
+                    (Some(want), None) => {
+                        problems.push(format!(
+                            "{name}: exiftool has ISO {want}, metadata() has none"
+                        ));
+                    }
+                    _ => {}
+                }
+            }
+            // Every IFD that says it holds CFA data must resolve to
+            // strips or tiles inside the file: that is the path a
+            // decoder takes to the sensor samples.
+            for ifd in tiff.all() {
+                if ifd.get(tags::PHOTOMETRIC).and_then(|e| e.u32(0)) != Some(32803) {
+                    continue;
+                }
+                match ImageLayout::of(&tiff, ifd) {
+                    Ok(layout) => {
+                        if layout.chunks.is_empty() {
+                            problems.push(format!("{name}: CFA IFD with no chunks"));
+                        }
+                        if layout.width == 0 || layout.height == 0 {
+                            problems.push(format!(
+                                "{name}: CFA IFD is {}x{}",
+                                layout.width, layout.height
+                            ));
+                        }
+                        if !matches!(layout.bits_per_sample, 8 | 10 | 12 | 14 | 16) {
+                            problems.push(format!(
+                                "{name}: CFA IFD at {} bits",
+                                layout.bits_per_sample
+                            ));
+                        }
+                    }
+                    // One sample lies about its strip: the CF132 back
+                    // writes the *uncompressed* size (4096 x 5456 x 2
+                    // bytes) into StripByteCounts, half again as much
+                    // as the whole file. Refusing it is the contract
+                    // working; the Hasselblad module has to resolve
+                    // that strip itself.
+                    Err(_) if name.ends_with("RAW_HASSELBLAD_IXPRESS_CF132.3FR") => {
+                        eprintln!("{name}: StripByteCounts is the uncompressed size, so no layout");
+                    }
+                    Err(e) => problems.push(format!("{name}: CFA IFD has no usable layout: {e}")),
+                }
+            }
+            // Exposure and aperture, where the file records them.
+            for (key, what, have) in [
+                (
+                    "EXIF:FNumber",
+                    "FNumber",
+                    crate::formats::common::metadata(&tiff).f_number,
+                ),
+                (
+                    "EXIF:FocalLength",
+                    "FocalLength",
+                    crate::formats::common::metadata(&tiff).focal_length,
+                ),
+            ] {
+                let Some(want) = oracle(&json, &[key]) else {
+                    continue;
+                };
+                // exiftool prints focal length as "50.0 mm".
+                let Some(want) = want
+                    .trim_start_matches("f/")
+                    .split_whitespace()
+                    .next()
+                    .and_then(|v| v.parse::<f32>().ok())
+                else {
+                    continue;
+                };
+                // A zero focal length (Samsung EX1) is "not recorded".
+                if want == 0.0 {
+                    continue;
+                }
+                match have {
+                    // exiftool prints "4.5 mm" for a 445/100 rational,
+                    // so allow its rounding to one decimal place.
+                    Some(have) if (want - have).abs() > 0.06 => {
+                        problems.push(format!("{name}: {what} {have}, exiftool {want}"));
+                    }
+                    None => problems.push(format!(
+                        "{name}: exiftool has {what} {want}, metadata() has none"
+                    )),
+                    _ => {}
+                }
+            }
+        }
+        assert!(checked > 0, "corpus held no TIFF-shaped files");
+        assert!(
+            problems.is_empty(),
+            "{} problems:\n{}",
+            problems.len(),
+            problems.join("\n")
+        );
+        eprintln!("corpus: {checked} TIFF-shaped files parsed, {previews} with a preview JPEG");
+    }
+
+    /// Samples `crate::probe` gets wrong today, with the reason. The
+    /// fix belongs in `lib.rs`, which this worker does not own; the
+    /// test reports them and fails on anything *not* on the list.
+    const KNOWN_PROBE_GAPS: &[(&str, &str)] = &[
+        (
+            "Dimage_Z2-RAW_MINOLTA_DIMAGE_Z2.MRW",
+            "a headerless sensor dump with no \\0MRM container; only a file-size table could name it",
+        ),
+        (
+            "Nikon/Nikon_COOLSCAN_V_ED-Image21-600pixels.nef",
+            "a scanner NEF: RGB (photometric 2) throughout, no CFA data, so probe_tiff \
+             refuses it. Arguably correct — there is no sensor mosaic to decode",
+        ),
+    ];
+
+    #[test]
+    fn corpus_probe_recognises_every_sample() {
+        let Some(root) = corpus() else { return };
+        let mut problems = Vec::new();
+        let mut known = Vec::new();
+        let mut counts: std::collections::BTreeMap<String, usize> =
+            std::collections::BTreeMap::new();
+        for path in samples(&root) {
+            let Ok(bytes) = std::fs::read(&path) else {
+                continue;
+            };
+            let name = path
+                .strip_prefix(&root)
+                .unwrap_or(&path)
+                .display()
+                .to_string();
+            let ext = path
+                .extension()
+                .map(|e| e.to_string_lossy().to_ascii_uppercase())
+                .unwrap_or_default();
+            let want = match ext.as_str() {
+                "DNG" | "GPR" => Some(crate::Format::Dng),
+                "NEF" | "NRW" => Some(crate::Format::Nef),
+                "ARW" | "SR2" | "SRF" => Some(crate::Format::Arw),
+                "CR2" => Some(crate::Format::Cr2),
+                "CRW" => Some(crate::Format::Crw),
+                "CR3" => Some(crate::Format::Cr3),
+                "RAF" => Some(crate::Format::Raf),
+                "ORF" => Some(crate::Format::Orf),
+                "RW2" | "RWL" => Some(crate::Format::Rw2),
+                "PEF" => Some(crate::Format::Pef),
+                "SRW" => Some(crate::Format::Srw),
+                "MRW" => Some(crate::Format::Mrw),
+                "DCR" | "KDC" => Some(crate::Format::Kodak),
+                "ERF" => Some(crate::Format::Erf),
+                "MEF" => Some(crate::Format::Mef),
+                "IIQ" => Some(crate::Format::Iiq),
+                "3FR" | "FFF" => Some(crate::Format::Hasselblad),
+                "MOS" => Some(crate::Format::Mos),
+                "X3F" => Some(crate::Format::X3f),
+                // .TIF and .RAW samples are vendor raws wearing a
+                // generic extension; they are checked by hand below.
+                _ => None,
+            };
+            let got = crate::probe(&bytes);
+            *counts.entry(format!("{ext} -> {got:?}")).or_default() += 1;
+            let Some(want) = want else { continue };
+            if got == Some(want) {
+                continue;
+            }
+            // Files exiftool itself rejects are not raws at all: three
+            // of the raw.pixls.us ".CRW" samples are CHDK sensor dumps
+            // with no container (exiftool: "File format error"), and
+            // probe is right to say None.
+            let unreadable = sidecar(&path)
+                .map(|json| oracle(&json, &["ExifTool:Error"]).is_some())
+                .unwrap_or(false);
+            if unreadable && got.is_none() {
+                known.push(format!(
+                    "{name}: not a container at all (exiftool cannot read it either)"
+                ));
+                continue;
+            }
+            let lower = name.to_ascii_lowercase();
+            match KNOWN_PROBE_GAPS
+                .iter()
+                .find(|(which, _)| lower.ends_with(&which.to_ascii_lowercase()))
+            {
+                Some((_, why)) => known.push(format!("{name}: probe says {got:?}; {why}")),
+                None => problems.push(format!(
+                    "{name}: probe says {got:?}, extension says {want:?}"
+                )),
+            }
+        }
+        for (what, n) in &counts {
+            eprintln!("probe: {n:3} x {what}");
+        }
+        for note in &known {
+            eprintln!("probe gap: {note}");
+        }
+        assert!(
+            problems.is_empty(),
+            "{} problems:\n{}",
+            problems.len(),
+            problems.join("\n")
+        );
+    }
+
+    #[test]
+    fn truncated_corpus_files_never_panic() {
+        let Some(root) = corpus() else { return };
+        let samples = samples(&root);
+        // A spread of containers rather than the whole corpus: eight
+        // files x 20 cuts is enough to catch a missing bounds check.
+        let mut chosen: Vec<std::path::PathBuf> = Vec::new();
+        for want in [
+            "NEF", "CR2", "CR3", "ORF", "RW2", "ARW", "DNG", "PEF", "RAF", "3FR",
+        ] {
+            if let Some(path) = samples.iter().find(|p| {
+                p.extension()
+                    .map(|e| e.to_string_lossy().to_ascii_uppercase() == want)
+                    .unwrap_or(false)
+            }) {
+                chosen.push(path.clone());
+            }
+        }
+        assert!(!chosen.is_empty(), "corpus held nothing to truncate");
+        // A tiny LCG so the cut points are spread but reproducible.
+        let mut seed = 0x2545_f491_4f6c_dd1du64;
+        for path in chosen {
+            let Ok(bytes) = std::fs::read(&path) else {
+                continue;
+            };
+            for _ in 0..20 {
+                seed = seed
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                let cut = (seed >> 11) as usize % bytes.len().max(1);
+                let head = &bytes[..cut];
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let _ = crate::probe(head);
+                    if let Ok(tiff) = Tiff::parse(head) {
+                        for ifd in tiff.all() {
+                            let _ = ImageLayout::of(&tiff, ifd);
+                            for entry in &ifd.entries {
+                                let _ = entry.u32(0);
+                                let _ = entry.f64(0);
+                                let _ = entry.str();
+                                let _ = entry.u32s();
+                                let _ = entry.bytes();
+                            }
+                        }
+                        let _ = crate::formats::common::largest_jpeg(&tiff);
+                        let _ = crate::formats::common::metadata(&tiff);
+                        let _ = crate::formats::common::orientation(&tiff);
+                    }
+                    let _ = crate::bmff::parse(head);
+                }));
+                assert!(
+                    result.is_ok(),
+                    "panic on {} truncated to {cut} bytes",
+                    path.display()
+                );
+            }
+        }
+    }
+}

--- a/crates/gallery/src/meta.rs
+++ b/crates/gallery/src/meta.rs
@@ -359,6 +359,13 @@ mod raw_tests {
             .filter_map(|e| e.ok())
             .map(|e| e.path())
             .filter(|p| p.is_file())
+            // The LibRaw/exiftool oracle sidecars live beside the raws.
+            .filter(|p| {
+                !matches!(
+                    p.extension().and_then(|e| e.to_str()),
+                    Some("tiff" | "json" | "txt" | "png" | "ppm" | "pgm" | "sh")
+                )
+            })
             .collect();
         paths.sort();
         for path in paths {

--- a/crates/gallery/src/meta.rs
+++ b/crates/gallery/src/meta.rs
@@ -59,7 +59,43 @@ pub fn photo_meta(cache: &Option<PathBuf>, original: &Path) -> PhotoMeta {
 pub fn exif_of(path: &Path) -> Option<exif::Exif> {
     let file = std::fs::File::open(path).ok()?;
     let mut reader = std::io::BufReader::new(file);
-    exif::Reader::new().read_from_container(&mut reader).ok()
+    exif::Reader::new()
+        .read_from_container(&mut reader)
+        .ok()
+        .or_else(|| raw_exif(path))
+}
+
+/// The EXIF of the camera raws whose container the reader does not
+/// know. Olympus and Panasonic files are TIFF under a private signature,
+/// so putting the standard one back gives a TIFF the reader parses
+/// whole; a Fuji RAF names, in its header, where the camera's JPEG sits
+/// inside it, and that JPEG carries the EXIF. Nikon, Sony, Pentax,
+/// Canon CR2 and DNG are plain TIFF and never get here; Canon CR3 is
+/// not handled and has no capture time or position in the gallery.
+fn raw_exif(path: &Path) -> Option<exif::Exif> {
+    let mut bytes = std::fs::read(path).ok()?;
+    let head: [u8; 4] = bytes.get(0..4)?.try_into().ok()?;
+    match &head {
+        b"IIRO" | b"IIRS" | b"IIU\0" => {
+            bytes[2..4].copy_from_slice(b"*\0");
+            exif::Reader::new().read_raw(bytes).ok()
+        }
+        b"MMOR" => {
+            bytes[2..4].copy_from_slice(b"\0*");
+            exif::Reader::new().read_raw(bytes).ok()
+        }
+        _ if bytes.starts_with(b"FUJIFILMCCD-RAW") => {
+            let field = |at: usize| -> Option<usize> {
+                Some(u32::from_be_bytes(bytes.get(at..at + 4)?.try_into().ok()?) as usize)
+            };
+            let (at, len) = (field(84)?, field(88)?);
+            let jpeg = bytes.get(at..at.checked_add(len)?)?;
+            exif::Reader::new()
+                .read_from_container(&mut std::io::Cursor::new(jpeg))
+                .ok()
+        }
+        _ => None,
+    }
 }
 
 /// Latitude and longitude in degrees, from the GPS IFD.
@@ -305,4 +341,50 @@ fn summarize(data: exif::Exif) -> Option<ExifSummary> {
         exposure_bias,
     };
     (!summary.is_empty()).then_some(summary)
+}
+
+#[cfg(test)]
+mod raw_tests {
+    /// Every camera file in `SCHIST_RAW_CORPUS` should yield a make and
+    /// a capture time — the TIFF-shaped ones through the reader as it
+    /// is, Olympus/Panasonic/Fuji through the container shims. Canon
+    /// CR3 is the known exception. Skipped without the variable.
+    #[test]
+    fn corpus_exif() {
+        let Ok(dir) = std::env::var("SCHIST_RAW_CORPUS") else {
+            return;
+        };
+        let mut paths: Vec<_> = std::fs::read_dir(dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.is_file())
+            .collect();
+        paths.sort();
+        for path in paths {
+            let summary = super::exif_summary(&path);
+            eprintln!(
+                "{}: make={:?} model={:?} taken={:?} gps={:?} exposure={:?}",
+                path.display(),
+                summary.as_ref().and_then(|s| s.make.clone()),
+                summary.as_ref().and_then(|s| s.model.clone()),
+                summary.as_ref().and_then(|s| s.taken.clone()),
+                summary.as_ref().and_then(|s| s.gps),
+                summary.as_ref().and_then(|s| s.exposure.clone()),
+            );
+            let ext = path
+                .extension()
+                .map(|e| e.to_string_lossy().to_ascii_lowercase())
+                .unwrap_or_default();
+            if ext != "cr3" {
+                let summary = summary.expect("EXIF read");
+                assert!(summary.make.is_some(), "{}: no make", path.display());
+                assert!(
+                    summary.taken.is_some(),
+                    "{}: no capture time",
+                    path.display()
+                );
+            }
+        }
+    }
 }

--- a/crates/preview/src/lib.rs
+++ b/crates/preview/src/lib.rs
@@ -18,7 +18,9 @@
 //!    result is scaled down in bands, so peak memory follows the
 //!    requested size rather than the document's.
 //!
-//! Everything else (PNG, JPEG, WebP, TIFF) decodes and scales directly.
+//! A camera raw is the same shape: the JPEG the camera embedded, else
+//! the developed sensor data. Everything else (PNG, JPEG, WebP, TIFF)
+//! decodes and scales directly.
 
 use anyhow::{bail, Context as _, Result};
 use image::RgbaImage;
@@ -113,6 +115,13 @@ pub fn render(bytes: &[u8], max_edge: u32) -> Result<Preview> {
             let doc = schist_codecs_common::HeifCodec.import(bytes)?;
             return composite_preview(doc, max_edge);
         }
+        // Camera raws likewise, and before the generic decoder for a
+        // second reason: most of them are TIFF containers, which it
+        // would open and hand back the thumbnail IFD of.
+        #[cfg(not(target_arch = "wasm32"))]
+        if schist_codecs_common::RawCodec.probe(bytes) {
+            return raw_preview(bytes, max_edge);
+        }
         let img = image::load_from_memory(bytes)
             .context("no Schist codec and no image decoder recognized this file")?
             .into_rgba8();
@@ -188,6 +197,44 @@ fn affinity_preview(bytes: &[u8], max_edge: u32) -> Result<Preview> {
         Err(e) => match embedded {
             Some(img) => {
                 log::info!("affinity: import failed ({e}); falling back to the embedded thumbnail");
+                Ok(Preview::from_image(fit(img, max_edge), Source::Embedded))
+            }
+            None => Err(e),
+        },
+    }
+}
+
+/// Camera raw: the camera's own JPEG, else the developed sensor data.
+///
+/// The embedded preview is the camera's render of the same capture and
+/// is often full size, while developing the raw takes seconds, so the
+/// preview wins whenever it is big enough for the size asked for — and
+/// stands in when development fails, the way the PSD thumbnail does.
+/// A missing LibRaw is reported as it is, so a caller can tell it from
+/// a broken file.
+#[cfg(not(target_arch = "wasm32"))]
+fn raw_preview(bytes: &[u8], max_edge: u32) -> Result<Preview> {
+    let embedded = match schist_codecs_common::raw::embedded_preview(bytes) {
+        Ok(img) => img,
+        Err(e) if schist_codecs_common::raw::is_missing_library_error(&e) => return Err(e),
+        Err(e) => {
+            log::info!("raw: embedded preview did not decode: {e}");
+            None
+        }
+    };
+    if let Some(img) = &embedded {
+        if img.width().max(img.height()) >= max_edge {
+            return Ok(Preview::from_image(
+                fit(img.clone(), max_edge),
+                Source::Embedded,
+            ));
+        }
+    }
+    match schist_codecs_common::RawCodec.import(bytes) {
+        Ok(doc) => composite_preview(doc, max_edge),
+        Err(e) => match embedded {
+            Some(img) => {
+                log::info!("raw: developing failed ({e}); falling back to the embedded preview");
                 Ok(Preview::from_image(fit(img, max_edge), Source::Embedded))
             }
             None => Err(e),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,7 @@ crates/app              GPUI shell: window, canvas, panels, dialogs, keymap
 ├── crates/text-engine  font discovery, layout, glyph rasterization
 ├── crates/colormgmt    ICC profiles, display transforms, dithering
 ├── crates/codec-psd    PSD/PSB reader and writer
+├── crates/codec-raw    camera raw decoding and development, clean-room pure Rust
 ├── crates/plugin-host-wasm  sandboxed third-party plugins
 ├── crates/plugin-host-8bf   Photoshop .8bf filter plug-ins (unshipped)
 └── crates/plugin-sdk   what plugin authors compile against

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ plugins/                first-party features, each optional at compile time
 ├── tools-vector        shapes, pen
 ├── tools-type          text layers
 ├── filters-core        blur, sharpen, noise
-├── codecs-common       PNG/JPEG/WebP/TIFF/HEIC
+├── codecs-common       PNG/JPEG/WebP/TIFF/HEIC/camera raw
 └── commands-core       menu commands and their keybindings
 ```
 

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -116,7 +116,10 @@ photo's own format when that format is lossy — a JPEG stays a JPEG,
 byte-for-byte when it is unedited (re-encoding would only cost a
 generation) and at quality 92 when it is not. Everything else becomes
 a PNG, as does anything lossy nothing here can write back: an edited
-HEIC lands as a PNG. The writer is hand-rolled: it deflates each
+HEIC lands as a PNG. A camera raw is the other way round — the capture
+is worth more than any rendering of it, and nothing writes one — so an
+unedited raw goes in byte-for-byte under its own extension, and only an
+edited one becomes a PNG. The writer is hand-rolled: it deflates each
 entry and keeps the smaller of deflated and stored (a JPEG or PNG is
 already compressed and usually stays as it is), and it streams one
 photo at a time, so a whole bucket never has to fit in memory.
@@ -203,7 +206,11 @@ thumbnails are cached as PNGs under the state directory keyed by path,
 mtime and size, so the second launch is instant. HEIC thumbnails need
 the same libheif the editor uses; when they start failing for want of
 it, the gallery raises the managed-download offer once, and retries the
-failed thumbnails after it installs.
+failed thumbnails after it installs. Camera raws need the system's
+LibRaw the same way (there is no download offer for it); their
+thumbnails come from the JPEG the camera embedded, turned upright,
+rather than from developing the sensor data, which takes seconds a
+file.
 
 The grid is virtualised: rows of cells only really exist within a
 viewport's height of the screen, and everything further collapses to

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -133,9 +133,9 @@ in turn requires both entitlements in
 The JIT one: the plugin host compiles every plugin with Cranelift at load
 time, and without it a notarized build dies as soon as it loads one. And
 library validation off: HEIC import dlopen's libheif — Homebrew's, or the
-decode-only build the app offers to download — and the hardened runtime
-otherwise refuses to load any library not signed by this Team ID, which no
-copy of libheif is.
+decode-only build the app offers to download — and camera raw import
+dlopen's Homebrew's LibRaw; the hardened runtime otherwise refuses to load
+any library not signed by this Team ID, which no copy of either is.
 
 Windows builds are not signed — there is no certificate for them yet, so
 the installer triggers SmartScreen on first download.

--- a/docs/web.md
+++ b/docs/web.md
@@ -104,6 +104,7 @@ Compiled out entirely, with the reason:
 | Photoshop `.8bf` plug-ins | helper subprocesses and dlopen |
 | Third-party wasm plug-ins | wasmtime is a JIT; a wasm module cannot host one |
 | HEIC import | libheif is dlopen'd |
+| Camera raw import | LibRaw is dlopen'd |
 | Auto-update | a web deployment updates by serving newer files |
 | Crash reporting (Sentry) | blocking transport; panics go to the console instead |
 | Font downloads | the Google Fonts catalogue trick needs a spoofed legacy user agent to be served TTFs |

--- a/docs/web.md
+++ b/docs/web.md
@@ -104,7 +104,7 @@ Compiled out entirely, with the reason:
 | Photoshop `.8bf` plug-ins | helper subprocesses and dlopen |
 | Third-party wasm plug-ins | wasmtime is a JIT; a wasm module cannot host one |
 | HEIC import | libheif is dlopen'd |
-| Camera raw import | LibRaw is dlopen'd |
+| Camera raw import | the plugin wraps a dlopen'd LibRaw fallback; the pure-Rust `schist-codec-raw` decoder itself would build for wasm and is a candidate for a future web-only path |
 | Auto-update | a web deployment updates by serving newer files |
 | Crash reporting (Sentry) | blocking transport; panics go to the console instead |
 | Font downloads | the Google Fonts catalogue trick needs a spoofed legacy user agent to be served TTFs |

--- a/packaging/linux/aur/PKGBUILD
+++ b/packaging/linux/aur/PKGBUILD
@@ -13,6 +13,10 @@ license=(MIT)
 # window and no further. vulkan-swrast satisfies it in software.
 depends=(fontconfig freetype2 hicolor-icon-theme libxcb libxkbcommon
          libxkbcommon-x11 vulkan-driver vulkan-icd-loader wayland)
+# Both dlopen'd at run time; the app starts and opens everything else
+# without them.
+optdepends=('libheif: HEIC import'
+            'libraw: camera raw import')
 # clang + mold: the repo's .cargo/config.toml selects them as the linker.
 makedepends=(cargo clang mold)
 # !lto: makepkg's -flto=auto produces GCC-bitcode objects in ring's C archive

--- a/packaging/linux/packages.sh
+++ b/packaging/linux/packages.sh
@@ -47,8 +47,9 @@ rm -rf "$build"
 
 built=()
 
-# libheif is dlopen'd at run time for HEIC import -- present or not, the
-# app starts -- so it is a weak dependency in all three formats.
+# libheif is dlopen'd at run time for HEIC import, and LibRaw for camera
+# raws -- present or not, the app starts -- so both are weak dependencies
+# in all three formats.
 
 build_deb() {
     local work="$build/deb" out size
@@ -78,7 +79,7 @@ Maintainer: $packager
 Installed-Size: $size
 Depends: libc6, libfontconfig1, libfreetype6, libxcb1, libxkbcommon0,
  libxkbcommon-x11-0, libwayland-client0, libvulkan1, hicolor-icon-theme
-Recommends: libheif1
+Recommends: libheif1, libraw23t64 | libraw23
 Homepage: $url
 Description: $summary
  Schist is a layered image editor that opens and writes Photoshop (PSD and
@@ -161,6 +162,7 @@ Requires:       libwayland-client
 Requires:       vulkan-loader
 Requires:       hicolor-icon-theme
 Recommends:     libheif
+Recommends:     LibRaw
 
 %description
 Schist is a layered image editor that opens and writes Photoshop (PSD and
@@ -226,6 +228,7 @@ EOF
         echo "depend = $dep" >> "$work/.PKGINFO"
     done
     echo "optdepend = libheif: HEIC import" >> "$work/.PKGINFO"
+    echo "optdepend = libraw: camera raw import" >> "$work/.PKGINFO"
     # Recorded in the .MTREE below, so it is set before that is written.
     chmod 644 "$work/.PKGINFO"
 

--- a/packaging/linux/schist.desktop
+++ b/packaging/linux/schist.desktop
@@ -7,4 +7,4 @@ Exec=schist %f
 Icon=com.infrawrench.schist
 Terminal=false
 Categories=Graphics;2DGraphics;RasterGraphics;
-MimeType=image/vnd.adobe.photoshop;application/x-affinity-photo;application/x-affinity-designer;application/x-affinity-publisher;application/x-affinity-document;image/png;image/jpeg;image/tiff;image/webp;image/heif;image/heic;
+MimeType=image/vnd.adobe.photoshop;application/x-affinity-photo;application/x-affinity-designer;application/x-affinity-publisher;application/x-affinity-document;image/png;image/jpeg;image/tiff;image/webp;image/heif;image/heic;image/x-dcraw;image/x-adobe-dng;image/x-canon-cr2;image/x-canon-cr3;image/x-canon-crw;image/x-fuji-raf;image/x-nikon-nef;image/x-nikon-nrw;image/x-olympus-orf;image/x-panasonic-rw2;image/x-panasonic-rw;image/x-pentax-pef;image/x-sony-arw;image/x-sony-sr2;image/x-sony-srf;image/x-minolta-mrw;image/x-sigma-x3f;image/x-kodak-dcr;image/x-kodak-kdc;

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -118,6 +118,7 @@
                 <string>org.webmproject.webp</string>
                 <string>public.heic</string>
                 <string>public.heif</string>
+                <string>public.camera-raw-image</string>
             </array>
         </dict>
     </array>

--- a/plugins/codecs-common/Cargo.toml
+++ b/plugins/codecs-common/Cargo.toml
@@ -20,6 +20,9 @@ schist-compositor.workspace = true
 # libheif to open, so the codec (and its loader) stay off the wasm build.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libloading.workspace = true
+# The pure-Rust raw decoder; LibRaw stays as the fallback for what it
+# does not cover yet.
+schist-codec-raw.workspace = true
 
 [dev-dependencies]
 crc32fast.workspace = true

--- a/plugins/codecs-common/examples/rawdev.rs
+++ b/plugins/codecs-common/examples/rawdev.rs
@@ -1,0 +1,45 @@
+//! Develop a camera raw file the way the codec does and write it as a
+//! PNG, for looking at: `rawdev <raw> <out.png>`. With `--preview` the
+//! embedded camera JPEG is written instead, turned upright the way the
+//! gallery shows it.
+
+use schist_plugin_api::CodecPlugin as _;
+
+fn main() {
+    let mut args: Vec<String> = std::env::args().skip(1).collect();
+    let preview = args
+        .iter()
+        .position(|a| a == "--preview")
+        .map(|i| args.remove(i));
+    let [path, out] = args.as_slice() else {
+        eprintln!("usage: rawdev [--preview] <raw> <out.png>");
+        std::process::exit(2);
+    };
+    let bytes = std::fs::read(path).expect("read");
+    let started = std::time::Instant::now();
+    if preview.is_some() {
+        let img = schist_codecs_common::raw::embedded_preview(&bytes)
+            .expect("preview")
+            .expect("this file embeds no preview");
+        println!(
+            "preview {}x{} in {:.2?}",
+            img.width(),
+            img.height(),
+            started.elapsed()
+        );
+        img.save(out).expect("write");
+        return;
+    }
+    let doc = schist_codecs_common::RawCodec
+        .import(&bytes)
+        .expect("develop");
+    println!(
+        "developed {}x{} ({:?}) in {:.2?}",
+        doc.width,
+        doc.height,
+        doc.depth,
+        started.elapsed()
+    );
+    let png = schist_codecs_common::PngCodec.export(&doc).expect("png");
+    std::fs::write(out, png).expect("write");
+}

--- a/plugins/codecs-common/src/lib.rs
+++ b/plugins/codecs-common/src/lib.rs
@@ -1,14 +1,16 @@
 //! Common raster format codecs (PNG, JPEG, WebP, TIFF) via the `image`
-//! crate, HEIC/HEIF via the system's libheif, wrapped as
-//! `CodecPlugin`s, plus layered Affinity import/export. For the simple
-//! formats, import produces a single "Background" layer and export
-//! flattens through the compositor.
+//! crate, HEIC/HEIF via the system's libheif, camera raws via the
+//! system's LibRaw, wrapped as `CodecPlugin`s, plus layered Affinity
+//! import/export. For the simple formats, import produces a single
+//! "Background" layer and export flattens through the compositor.
 
 pub use affinity::AffinityCodec;
 use anyhow::Context as _;
 #[cfg(not(target_arch = "wasm32"))]
 pub use heif::HeifCodec;
 use image::ImageFormat;
+#[cfg(not(target_arch = "wasm32"))]
+pub use raw::RawCodec;
 use schist_color::Depth;
 use schist_core::{blit_rgba8, blit_rgba_f32, Document, IntRect, Layer};
 use schist_plugin_api::{CodecPlugin, ExportOptions, PluginManifest, PluginRegistry};
@@ -16,6 +18,8 @@ use schist_plugin_api::{CodecPlugin, ExportOptions, PluginManifest, PluginRegist
 mod affinity;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod heif;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod raw;
 
 /// A single-"Background"-layer document from decoded RGBA8 pixels.
 fn flat_document(
@@ -148,7 +152,7 @@ fn import_with(format: ImageFormat, bytes: &[u8], title: &str) -> anyhow::Result
 }
 
 /// `flat_document` for a source that carries more than 8 bits a channel.
-fn deep_document(
+pub(crate) fn deep_document(
     title: &str,
     w: u32,
     h: u32,
@@ -395,6 +399,12 @@ impl PluginManifest for CommonCodecsPlugin {
         registry.register_codec(Box::new(PngCodec));
         registry.register_codec(Box::new(JpegCodec));
         registry.register_codec(Box::new(WebPCodec));
+        // Before TIFF: most raws (NEF, ARW, PEF, DNG...) are TIFF
+        // containers, and probing goes in registration order. The raw
+        // probe only claims files holding sensor data, so an ordinary
+        // TIFF still falls through to its own codec.
+        #[cfg(not(target_arch = "wasm32"))]
+        registry.register_codec(Box::new(RawCodec));
         registry.register_codec(Box::new(TiffCodec));
         #[cfg(not(target_arch = "wasm32"))]
         registry.register_codec(Box::new(HeifCodec));
@@ -572,6 +582,25 @@ mod tests {
             "codec.heif"
         );
         assert_eq!(reg.codec_for(b"", Some("heic")).unwrap().id(), "codec.heif");
+        // A raw in a TIFF container goes to the raw codec, not TIFF's;
+        // a plain TIFF header with nothing behind it still goes to TIFF.
+        assert_eq!(
+            reg.codec_for(&raw::tests::synthetic_dng(8, 8), None)
+                .unwrap()
+                .id(),
+            "codec.raw"
+        );
+        assert_eq!(
+            reg.codec_for(b"II*\x00\x08\x00\x00\x00", None)
+                .unwrap()
+                .id(),
+            "codec.tiff"
+        );
+        assert_eq!(
+            reg.codec_for(b"FUJIFILMCCD-RAW ", None).unwrap().id(),
+            "codec.raw"
+        );
+        assert_eq!(reg.codec_for(b"", Some("NEF")).unwrap().id(), "codec.raw");
         // AVIF shares the container but is not claimed.
         assert!(reg
             .codec_for(b"\x00\x00\x00\x18ftypavif....", None)

--- a/plugins/codecs-common/src/raw.rs
+++ b/plugins/codecs-common/src/raw.rs
@@ -1,0 +1,984 @@
+//! Camera raw import via LibRaw, loaded at runtime.
+//!
+//! A raw file is a sensor dump in one of some dozens of vendor
+//! containers: most are TIFF with a proprietary compression (Nikon,
+//! Sony, Pentax, DNG), Canon's CR3 is ISO-BMFF, and Fuji, Olympus and
+//! Panasonic use private headers. LibRaw reads all of them and develops
+//! the sensor data — black level, white balance, demosaic, the camera
+//! matrix — into a picture. Every pure-Rust raw decoder is LGPL too, so
+//! this makes the same choice HEIC did: nothing links at build time,
+//! nothing is bundled, and the library is dlopen'd on first import,
+//! looked for in two places:
+//!
+//! 1. The managed directory (`SCHIST_LIBRAW_DIR`, else
+//!    `$XDG_DATA_HOME/schist/libraw`), for a copy put there by hand on a
+//!    machine without a system package, or without root to install one.
+//!    There is no consented download of a prebuilt yet, as HEIC has; the
+//!    directory is the hook for one.
+//! 2. The system's LibRaw: Homebrew on macOS, every Linux distro. The
+//!    reentrant build (`libraw_r`) is preferred, and calls into the
+//!    plain one are serialised, because thumbnails decode on several
+//!    threads at once.
+//!
+//! Import only: a raw is a capture, and nothing writes one.
+//!
+//! The development is a plain one: camera white balance, the sensor
+//! matrix to sRGB, 16 bits a channel so the shadows survive being
+//! pushed, and an exposure lift with a soft shoulder (`expose_and_encode`)
+//! in place of dcraw's automatic brightening, which stretches the
+//! histogram until 1% of the pixels clip. The result lands near the
+//! camera's own JPEG in brightness with the highlights still there.
+
+use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
+use std::marker::PhantomData;
+use std::path::PathBuf;
+use std::sync::{Mutex, MutexGuard};
+
+use anyhow::Context as _;
+use schist_color::Depth;
+use schist_core::Document;
+use schist_plugin_api::CodecPlugin;
+
+/// `enum LibRaw_image_formats`
+const IMAGE_JPEG: c_int = 1;
+const IMAGE_BITMAP: c_int = 2;
+/// `enum LibRaw_errors`: the answers that mean "there is no embedded
+/// preview", as opposed to a broken file.
+const NO_THUMBNAIL: c_int = -5;
+const UNSUPPORTED_THUMBNAIL: c_int = -6;
+/// `output_color`: sRGB primaries. The curve is applied here, not by
+/// LibRaw (see `expose_and_encode`), so the developed pixels come out
+/// linear and leave as sRGB, needing no profile.
+const OUTPUT_SRGB: c_int = 1;
+
+/// `libraw_processed_image_t`, returned by `dcraw_make_mem_image` and
+/// `dcraw_make_mem_thumb`. `data` is the start of the pixels (or the
+/// JPEG bytes), `data_size` long, following the header in the same
+/// allocation.
+#[repr(C)]
+struct ProcessedImage {
+    kind: c_int,
+    height: u16,
+    width: u16,
+    colors: u16,
+    bits: u16,
+    data_size: c_uint,
+    data: [u8; 1],
+}
+
+/// The leading fields of `libraw_data_t`: the processed-image pointer
+/// and `libraw_image_sizes_t`. They have led the struct, in this order,
+/// since before the C setters existed, so reading them by layout is as
+/// stable as the API itself; nothing further in — the part that shifts
+/// between versions — is touched.
+#[repr(C)]
+struct DataHead {
+    image: *mut c_void,
+    raw_height: u16,
+    raw_width: u16,
+    height: u16,
+    width: u16,
+    top_margin: u16,
+    left_margin: u16,
+    iheight: u16,
+    iwidth: u16,
+    raw_pitch: c_uint,
+    pixel_aspect: f64,
+    /// The camera's orientation tag in dcraw's encoding: 3 is 180°, 5
+    /// is 90° counter-clockwise, 6 is 90° clockwise. Development
+    /// applies it; the embedded preview is stored unrotated.
+    flip: c_int,
+}
+
+macro_rules! libraw_fns {
+    ($( $field:ident : fn($($arg:ty),*) $(-> $ret:ty)? ; )*) => {
+        struct LibRaw {
+            /// Symbols below point into this mapping; never dropped
+            /// before them (the struct only lives in a static).
+            _lib: libloading::Library,
+            /// Present when the loaded build is not the reentrant one:
+            /// the plain library keeps state that is shared between
+            /// handles, so its calls take turns.
+            serial: Option<Mutex<()>>,
+            $( $field: unsafe extern "C" fn($($arg),*) $(-> $ret)?, )*
+        }
+
+        impl LibRaw {
+            fn from_library(lib: libloading::Library, reentrant: bool) -> Result<Self, String> {
+                unsafe {
+                    Ok(Self {
+                        $( $field: {
+                            let name = concat!("libraw_", stringify!($field), "\0");
+                            *lib.get(name.as_bytes())
+                                .map_err(|err| format!("missing symbol {name}: {err}"))?
+                        }, )*
+                        serial: (!reentrant).then(|| Mutex::new(())),
+                        _lib: lib,
+                    })
+                }
+            }
+        }
+    };
+}
+
+libraw_fns! {
+    init: fn(c_uint) -> *mut c_void;
+    close: fn(*mut c_void);
+    open_buffer: fn(*mut c_void, *const c_void, usize) -> c_int;
+    unpack: fn(*mut c_void) -> c_int;
+    unpack_thumb: fn(*mut c_void) -> c_int;
+    dcraw_process: fn(*mut c_void) -> c_int;
+    dcraw_make_mem_image: fn(*mut c_void, *mut c_int) -> *mut ProcessedImage;
+    dcraw_make_mem_thumb: fn(*mut c_void, *mut c_int) -> *mut ProcessedImage;
+    dcraw_clear_mem: fn(*mut ProcessedImage);
+    strerror: fn(c_int) -> *const c_char;
+    version: fn() -> *const c_char;
+    set_output_bps: fn(*mut c_void, c_int);
+    set_output_color: fn(*mut c_void, c_int);
+    set_gamma: fn(*mut c_void, c_int, f32);
+    set_no_auto_bright: fn(*mut c_void, c_int);
+    set_user_mul: fn(*mut c_void, c_int, f32);
+    get_cam_mul: fn(*mut c_void, c_int) -> f32;
+}
+
+/// Library names to try, in order, and whether each is the reentrant
+/// build. Sonames back to 0.19: the C setters used here exist from
+/// there, and 0.20 is where CR3 support starts.
+#[cfg(target_os = "linux")]
+const LIBRARY_CANDIDATES: &[(&str, bool)] = &[
+    ("libraw_r.so.23", true),
+    ("libraw_r.so.20", true),
+    ("libraw_r.so.19", true),
+    ("libraw_r.so", true),
+    ("libraw.so.23", false),
+    ("libraw.so.20", false),
+    ("libraw.so.19", false),
+    ("libraw.so", false),
+];
+#[cfg(target_os = "macos")]
+const LIBRARY_CANDIDATES: &[(&str, bool)] = &[
+    ("libraw_r.dylib", true),
+    ("libraw.dylib", false),
+    // Homebrew's prefix is not on the default search path for app
+    // bundles launched from Finder.
+    ("/opt/homebrew/lib/libraw_r.dylib", true),
+    ("/opt/homebrew/lib/libraw.dylib", false),
+    ("/usr/local/lib/libraw_r.dylib", true),
+    ("/usr/local/lib/libraw.dylib", false),
+];
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+const LIBRARY_CANDIDATES: &[(&str, bool)] = &[
+    ("libraw_r.dll", true),
+    ("raw_r.dll", true),
+    ("libraw.dll", false),
+    ("raw.dll", false),
+    ("libraw-23.dll", false),
+];
+
+/// The app and the tests match on this phrase to recognise "this
+/// machine has no LibRaw" (as opposed to a broken file); keep it out of
+/// other error messages.
+const NOT_AVAILABLE: &str = "LibRaw is not available";
+
+/// The loaded library. A failed load is deliberately not cached, so a
+/// library installed later is picked up without a restart.
+static LOADED: Mutex<Option<&'static LibRaw>> = Mutex::new(None);
+
+/// True when an `import` error means no LibRaw could be loaded.
+pub fn is_missing_library_error(err: &anyhow::Error) -> bool {
+    format!("{err:#}").contains(NOT_AVAILABLE)
+}
+
+/// Where a hand-installed library is looked for before the system's.
+pub fn managed_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("SCHIST_LIBRAW_DIR") {
+        return PathBuf::from(dir);
+    }
+    let base = if cfg!(windows) {
+        std::env::var("LOCALAPPDATA")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("."))
+    } else {
+        std::env::var("XDG_DATA_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
+                    .join(".local/share")
+            })
+    };
+    base.join("schist/libraw")
+}
+
+fn libraw() -> anyhow::Result<&'static LibRaw> {
+    let mut loaded = LOADED.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(lib) = *loaded {
+        return Ok(lib);
+    }
+
+    // The managed directory first, by every bare library name; then
+    // the candidates as given, which the system loader resolves.
+    let managed = managed_dir();
+    let candidates: Vec<(std::ffi::OsString, bool)> = LIBRARY_CANDIDATES
+        .iter()
+        .filter(|(name, _)| !name.contains('/'))
+        .map(|(name, reentrant)| (managed.join(name).into_os_string(), *reentrant))
+        .chain(
+            LIBRARY_CANDIDATES
+                .iter()
+                .map(|(name, reentrant)| (name.into(), *reentrant)),
+        )
+        .collect();
+
+    let mut errors = Vec::new();
+    for (name, reentrant) in &candidates {
+        let lib = match unsafe { libloading::Library::new(name) } {
+            Ok(lib) => lib,
+            Err(err) => {
+                errors.push(format!("{}: {err}", name.to_string_lossy()));
+                continue;
+            }
+        };
+        match LibRaw::from_library(lib, *reentrant) {
+            Ok(lib) => {
+                let version = unsafe { CStr::from_ptr((lib.version)()) }.to_string_lossy();
+                log::info!(
+                    "raw: loaded LibRaw {version} from {}{}",
+                    name.to_string_lossy(),
+                    if *reentrant { "" } else { " (serialised)" }
+                );
+                let lib = &*Box::leak(Box::new(lib));
+                *loaded = Some(lib);
+                return Ok(lib);
+            }
+            Err(err) => errors.push(format!("{}: {err}", name.to_string_lossy())),
+        }
+    }
+    // The outer message is what the status line shows; the dlopen
+    // detail behind it is for the log.
+    Err(anyhow::anyhow!(errors.join("; "))).context(format!(
+        "{NOT_AVAILABLE}: opening camera raw files needs the LibRaw library \
+         (Linux: install libraw; macOS: brew install libraw)"
+    ))
+}
+
+fn check(lib: &LibRaw, code: c_int, what: &str) -> anyhow::Result<()> {
+    if code == 0 {
+        return Ok(());
+    }
+    let message = unsafe {
+        let ptr = (lib.strerror)(code);
+        if ptr.is_null() {
+            format!("error {code}")
+        } else {
+            CStr::from_ptr(ptr).to_string_lossy().into_owned()
+        }
+    };
+    anyhow::bail!("{what}: {message}")
+}
+
+/// One LibRaw processor with a file opened in it. Holds the
+/// serialisation lock for the non-reentrant build as long as it lives,
+/// and closes (frees) the processor when dropped, so early error returns
+/// leak nothing.
+struct Handle<'a> {
+    lib: &'a LibRaw,
+    ptr: *mut c_void,
+    _guard: Option<MutexGuard<'a, ()>>,
+    /// `open_buffer` reads from the caller's bytes for the handle's
+    /// whole life; nothing is copied.
+    _bytes: PhantomData<&'a [u8]>,
+}
+
+impl<'a> Handle<'a> {
+    fn open(lib: &'a LibRaw, bytes: &'a [u8]) -> anyhow::Result<Self> {
+        let guard = lib
+            .serial
+            .as_ref()
+            .map(|m| m.lock().unwrap_or_else(|e| e.into_inner()));
+        let ptr = unsafe { (lib.init)(0) };
+        anyhow::ensure!(!ptr.is_null(), "libraw_init failed");
+        let handle = Handle {
+            lib,
+            ptr,
+            _guard: guard,
+            _bytes: PhantomData,
+        };
+        check(
+            lib,
+            unsafe { (lib.open_buffer)(ptr, bytes.as_ptr().cast(), bytes.len()) },
+            "reading raw file",
+        )?;
+        Ok(handle)
+    }
+
+    /// The camera orientation, dcraw's encoding (see `DataHead::flip`).
+    fn flip(&self) -> c_int {
+        unsafe { (*self.ptr.cast::<DataHead>()).flip }
+    }
+}
+
+impl Drop for Handle<'_> {
+    fn drop(&mut self) {
+        unsafe { (self.lib.close)(self.ptr) }
+    }
+}
+
+/// A `libraw_processed_image_t`, freed when dropped.
+struct Processed<'a> {
+    lib: &'a LibRaw,
+    ptr: *mut ProcessedImage,
+}
+
+impl Processed<'_> {
+    fn header(&self) -> &ProcessedImage {
+        unsafe { &*self.ptr }
+    }
+
+    fn data(&self) -> &[u8] {
+        unsafe {
+            std::slice::from_raw_parts(
+                std::ptr::addr_of!((*self.ptr).data).cast::<u8>(),
+                (*self.ptr).data_size as usize,
+            )
+        }
+    }
+}
+
+impl Drop for Processed<'_> {
+    fn drop(&mut self) {
+        unsafe { (self.lib.dcraw_clear_mem)(self.ptr) }
+    }
+}
+
+/// Widen a processed bitmap — 1 or 3 samples a pixel, 8 or 16 bits —
+/// to straight RGBA, as f32 in 0..=1.
+fn bitmap_to_rgba_f32(img: &Processed<'_>) -> anyhow::Result<(u32, u32, Vec<f32>)> {
+    let head = img.header();
+    anyhow::ensure!(head.kind == IMAGE_BITMAP, "developed image is not a bitmap");
+    let (w, h) = (head.width as usize, head.height as usize);
+    let colors = head.colors as usize;
+    anyhow::ensure!(w > 0 && h > 0, "zero-sized image");
+    anyhow::ensure!(
+        colors == 1 || colors == 3,
+        "unexpected channel count {colors}"
+    );
+    let data = img.data();
+    let mut out = Vec::with_capacity(w * h * 4);
+    let mut push = |px: &[f32]| {
+        match px {
+            [v] => out.extend_from_slice(&[*v, *v, *v, 1.0]),
+            [r, g, b] => out.extend_from_slice(&[*r, *g, *b, 1.0]),
+            _ => unreachable!(),
+        };
+    };
+    match head.bits {
+        16 => {
+            anyhow::ensure!(data.len() >= w * h * colors * 2, "short pixel data");
+            let samples = data.as_chunks::<2>().0;
+            for px in samples[..w * h * colors].chunks_exact(colors) {
+                let px: Vec<f32> = px
+                    .iter()
+                    .map(|s| u16::from_ne_bytes(*s) as f32 / 65535.0)
+                    .collect();
+                push(&px);
+            }
+        }
+        8 => {
+            anyhow::ensure!(data.len() >= w * h * colors, "short pixel data");
+            for px in data[..w * h * colors].chunks_exact(colors) {
+                let px: Vec<f32> = px.iter().map(|s| *s as f32 / 255.0).collect();
+                push(&px);
+            }
+        }
+        bits => anyhow::bail!("unexpected sample depth {bits}"),
+    }
+    Ok((w as u32, h as u32, out))
+}
+
+/// Develop the sensor data into a 16-bit sRGB document.
+fn develop(lib: &LibRaw, bytes: &[u8]) -> anyhow::Result<Document> {
+    let handle = Handle::open(lib, bytes)?;
+    let lr = handle.ptr;
+    unsafe {
+        check(lib, (lib.unpack)(lr), "unpacking sensor data")?;
+        (lib.set_output_bps)(lr, 16);
+        (lib.set_output_color)(lr, OUTPUT_SRGB);
+        // Linear light out (dcraw's `-g 1 1`), untouched by the
+        // histogram stretch: exposure and the sRGB curve are applied
+        // below, where the highlights can roll off instead of clip.
+        (lib.set_gamma)(lr, 0, 1.0);
+        (lib.set_gamma)(lr, 1, 1.0);
+        (lib.set_no_auto_bright)(lr, 1);
+        // The camera's as-shot white balance, when the file carries one
+        // (a fourth multiplier of zero is normal: three-colour sensors
+        // have no second green). Without it LibRaw assumes daylight,
+        // which is wrong indoors and under most skies.
+        let mul: [f32; 4] = std::array::from_fn(|i| (lib.get_cam_mul)(lr, i as c_int));
+        if mul[..3].iter().all(|m| m.is_finite() && *m > 0.0) {
+            for (i, m) in mul.iter().enumerate() {
+                (lib.set_user_mul)(lr, i as c_int, *m);
+            }
+        }
+        check(lib, (lib.dcraw_process)(lr), "developing")?;
+        let mut errc = 0;
+        let img = (lib.dcraw_make_mem_image)(lr, &mut errc);
+        if img.is_null() {
+            check(lib, errc, "reading developed image")?;
+            anyhow::bail!("reading developed image: no image");
+        }
+        let img = Processed { lib, ptr: img };
+        let (w, h, mut rgba) = bitmap_to_rgba_f32(&img)?;
+        drop(img);
+        expose_and_encode(&mut rgba);
+        crate::deep_document("Raw", w, h, &rgba, Depth::Sixteen, None)
+            .context("assembling document")
+    }
+}
+
+/// Bring linear developed pixels up to display brightness and encode
+/// them as sRGB, in place.
+///
+/// A raw's linear values sit where the sensor put them, which is a stop
+/// or more under the camera's own JPEG: cameras expose to protect the
+/// highlights and lift the picture afterwards. dcraw's answer is to
+/// stretch the histogram until 1% of the samples clip. This does the
+/// lift without the clipping: the gain that brings the 99th percentile
+/// of the brightest channel to white — capped at +2 EV, and never a
+/// darkening, so an exposed-to-the-right frame is left alone — and
+/// above the knee an exponential shoulder (the one HDR captures get)
+/// that compresses the top towards white instead of cutting it off.
+fn expose_and_encode(rgba: &mut [f32]) {
+    const KNEE: f32 = 0.85;
+    const MAX_GAIN: f32 = 4.0;
+    const BINS: usize = 4096;
+
+    let pixels = rgba.as_chunks_mut::<4>().0;
+    if pixels.is_empty() {
+        return;
+    }
+    let mut histogram = vec![0u32; BINS];
+    for px in pixels.iter() {
+        let brightest = px[0].max(px[1]).max(px[2]).clamp(0.0, 1.0);
+        histogram[((brightest * (BINS - 1) as f32) as usize).min(BINS - 1)] += 1;
+    }
+    let total = pixels.len() as u64;
+    let mut seen = 0u64;
+    let mut p99 = 1.0f32;
+    for (bin, count) in histogram.iter().enumerate() {
+        seen += *count as u64;
+        if seen * 100 >= total * 99 {
+            p99 = bin as f32 / (BINS - 1) as f32;
+            break;
+        }
+    }
+    let gain = if p99 > 0.0 {
+        (1.0 / p99).clamp(1.0, MAX_GAIN)
+    } else {
+        1.0
+    };
+
+    // The shoulder leaves everything in 0..=1, and the tiles hold 16
+    // bits, so the curve is a table over that range rather than a
+    // `powf` per sample.
+    let curve: Vec<f32> = (0..=u16::MAX)
+        .map(|i| srgb_encode(i as f32 / u16::MAX as f32))
+        .collect();
+    for px in pixels.iter_mut() {
+        for c in px.iter_mut().take(3) {
+            let v = (*c * gain).max(0.0);
+            let v = if v <= KNEE {
+                v
+            } else {
+                KNEE + (1.0 - KNEE) * (1.0 - (-(v - KNEE) / (1.0 - KNEE)).exp())
+            };
+            *c = curve[(v.min(1.0) * u16::MAX as f32 + 0.5) as usize];
+        }
+    }
+}
+
+/// The sRGB transfer curve, linear light to signal.
+fn srgb_encode(v: f32) -> f32 {
+    if v <= 0.003_130_8 {
+        12.92 * v
+    } else {
+        1.055 * v.powf(1.0 / 2.4) - 0.055
+    }
+}
+
+/// The camera's own preview — most raws embed a JPEG, often full size —
+/// as straight RGBA, turned upright. `None` when the file has no usable
+/// one. Orders of magnitude cheaper than developing, which is what a
+/// thumbnail wants.
+pub fn embedded_preview(bytes: &[u8]) -> anyhow::Result<Option<image::RgbaImage>> {
+    let lib = libraw()?;
+    let handle = Handle::open(lib, bytes)?;
+    let lr = handle.ptr;
+    let img = unsafe {
+        let code = (lib.unpack_thumb)(lr);
+        if code == NO_THUMBNAIL || code == UNSUPPORTED_THUMBNAIL {
+            return Ok(None);
+        }
+        check(lib, code, "reading embedded preview")?;
+        let mut errc = 0;
+        let img = (lib.dcraw_make_mem_thumb)(lr, &mut errc);
+        if img.is_null() {
+            if errc == NO_THUMBNAIL || errc == UNSUPPORTED_THUMBNAIL {
+                return Ok(None);
+            }
+            check(lib, errc, "reading embedded preview")?;
+            return Ok(None);
+        }
+        Processed { lib, ptr: img }
+    };
+    let decoded = match img.header().kind {
+        IMAGE_JPEG => image::load_from_memory_with_format(img.data(), image::ImageFormat::Jpeg)
+            .context("decoding embedded preview")?
+            .into_rgba8(),
+        IMAGE_BITMAP => {
+            let (w, h, rgba) = bitmap_to_rgba_f32(&img)?;
+            let bytes: Vec<u8> = rgba
+                .iter()
+                .map(|v| (v.clamp(0.0, 1.0) * 255.0 + 0.5) as u8)
+                .collect();
+            image::RgbaImage::from_raw(w, h, bytes).context("buffer size")?
+        }
+        _ => return Ok(None),
+    };
+    drop(img);
+    // Development turns the picture the camera's way; the preview is
+    // the sensor's orientation and has to be turned here.
+    let upright = match handle.flip() {
+        3 => image::imageops::rotate180(&decoded),
+        5 => image::imageops::rotate270(&decoded),
+        6 => image::imageops::rotate90(&decoded),
+        _ => decoded,
+    };
+    Ok(Some(upright))
+}
+
+/// Whether a TIFF-structured file holds sensor data: an IFD — the first,
+/// one it chains to, or one of its SubIFDs — whose photometric
+/// interpretation is CFA or LinearRaw, or a DNGVersion tag. This is
+/// what tells a NEF, ARW, PEF, SRW, DNG or 3FR from the TIFFs the same
+/// cameras' converters write, which carry the same Make and Model.
+fn tiff_is_raw(bytes: &[u8]) -> Option<bool> {
+    let le = match bytes.get(0..4)? {
+        b"II*\0" => true,
+        b"MM\0*" => false,
+        _ => return Some(false),
+    };
+    let u16_at = |at: usize| -> Option<u16> {
+        let b: [u8; 2] = bytes.get(at..at + 2)?.try_into().ok()?;
+        Some(if le {
+            u16::from_le_bytes(b)
+        } else {
+            u16::from_be_bytes(b)
+        })
+    };
+    let u32_at = |at: usize| -> Option<u32> {
+        let b: [u8; 4] = bytes.get(at..at + 4)?.try_into().ok()?;
+        Some(if le {
+            u32::from_le_bytes(b)
+        } else {
+            u32::from_be_bytes(b)
+        })
+    };
+    const PHOTOMETRIC: u16 = 0x0106;
+    const SUB_IFDS: u16 = 0x014A;
+    const DNG_VERSION: u16 = 0xC612;
+    const CFA: u16 = 32803;
+    const LINEAR_RAW: u16 = 34892;
+
+    let mut queue = vec![u32_at(4)? as usize];
+    let mut visited = 0;
+    while let Some(ifd) = queue.pop() {
+        // A dozen IFDs is more than any raw uses on the way to its
+        // sensor data; the cap keeps a corrupt chain from looping.
+        if visited >= 12 {
+            break;
+        }
+        visited += 1;
+        let Some(count) = u16_at(ifd) else { continue };
+        let count = count.min(512) as usize;
+        for i in 0..count {
+            let entry = ifd + 2 + i * 12;
+            let (Some(tag), Some(kind), Some(n)) =
+                (u16_at(entry), u16_at(entry + 2), u32_at(entry + 4))
+            else {
+                break;
+            };
+            match tag {
+                // A SHORT value sits left-justified in the value field
+                // in either byte order.
+                PHOTOMETRIC if kind == 3 => {
+                    if matches!(u16_at(entry + 8), Some(CFA | LINEAR_RAW)) {
+                        return Some(true);
+                    }
+                }
+                DNG_VERSION => return Some(true),
+                SUB_IFDS if kind == 4 || kind == 13 => {
+                    let n = n.min(8) as usize;
+                    let at = if n == 1 {
+                        entry + 8
+                    } else {
+                        u32_at(entry + 8)? as usize
+                    };
+                    for j in 0..n {
+                        if let Some(off) = u32_at(at + j * 4) {
+                            queue.push(off as usize);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        if let Some(next) = u32_at(ifd + 2 + count * 12) {
+            if next != 0 {
+                queue.push(next as usize);
+            }
+        }
+    }
+    Some(false)
+}
+
+/// Camera raw files, import only.
+pub struct RawCodec;
+
+impl CodecPlugin for RawCodec {
+    fn id(&self) -> &'static str {
+        "codec.raw"
+    }
+    fn name(&self) -> &'static str {
+        "Camera Raw"
+    }
+    fn extensions(&self) -> &'static [&'static str] {
+        &[
+            "dng", "nef", "nrw", "arw", "srf", "sr2", "cr2", "cr3", "crw", "raf", "orf", "rw2",
+            "rwl", "pef", "srw", "erf", "kdc", "dcr", "mrw", "mos", "iiq", "3fr", "fff", "mef",
+            "x3f", "raw",
+        ]
+    }
+    fn probe(&self, bytes: &[u8]) -> bool {
+        let at = |offset: usize, want: &[u8]| bytes.get(offset..offset + want.len()) == Some(want);
+        // The vendors with their own containers: Fuji, Olympus,
+        // Panasonic/Leica, old Canon, Sigma, Minolta, and Canon's CR3
+        // (ISO-BMFF, brand "crx "). CR2 is TIFF with its own mark.
+        at(0, b"FUJIFILMCCD-RAW")
+            || at(0, b"IIRO")
+            || at(0, b"IIRS")
+            || at(0, b"MMOR")
+            || at(0, b"IIU\0")
+            || at(6, b"HEAPCCDR")
+            || at(0, b"FOVb")
+            || at(0, b"\0MRM")
+            || (at(4, b"ftyp") && at(8, b"crx "))
+            || (at(0, b"II*\0") && at(8, b"CR"))
+            || tiff_is_raw(bytes).unwrap_or(false)
+    }
+    fn import(&self, bytes: &[u8]) -> anyhow::Result<Document> {
+        let lib = libraw()?;
+        develop(lib, bytes)
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use super::*;
+
+    /// A DNG built by hand: an uncompressed 16-bit RGGB mosaic whose
+    /// left half is a flat grey and whose right half is red, with a
+    /// neutral as-shot white balance and the sRGB matrix as the camera
+    /// matrix, so the developed picture's colours are predictable.
+    pub(crate) fn synthetic_dng(width: u16, height: u16) -> Vec<u8> {
+        const BYTE: u16 = 1;
+        const ASCII: u16 = 2;
+        const SHORT: u16 = 3;
+        const LONG: u16 = 4;
+        const RATIONAL: u16 = 5;
+        const SRATIONAL: u16 = 10;
+        let short = |v: u16| v.to_le_bytes().to_vec();
+        let long = |v: u32| v.to_le_bytes().to_vec();
+        let shorts = |v: &[u16]| v.iter().flat_map(|s| s.to_le_bytes()).collect::<Vec<_>>();
+        let rationals = |v: &[(i32, i32)]| {
+            v.iter()
+                .flat_map(|(n, d)| [n.to_le_bytes(), d.to_le_bytes()].concat())
+                .collect::<Vec<_>>()
+        };
+
+        let (w, h) = (width as usize, height as usize);
+        let mut pixels = Vec::with_capacity(w * h * 2);
+        for y in 0..h {
+            for x in 0..w {
+                let red_site = y % 2 == 0 && x % 2 == 0;
+                let value: u16 = if x < w / 2 {
+                    20000
+                } else if red_site {
+                    40000
+                } else {
+                    8000
+                };
+                pixels.extend(value.to_le_bytes());
+            }
+        }
+
+        // XYZ (D65) to linear sRGB, as ColorMatrix1 (XYZ to camera).
+        let srgb_from_xyz: [i32; 9] = [32406, -15372, -4986, -9689, 18758, 415, 557, -2040, 10570];
+        let matrix: Vec<(i32, i32)> = srgb_from_xyz.iter().map(|v| (*v, 10000)).collect();
+
+        // Tags in ascending order, as TIFF requires. The strip offset
+        // is patched in once the layout is known.
+        let entries: Vec<(u16, u16, u32, Vec<u8>)> = vec![
+            (0x00FE, LONG, 1, long(0)),
+            (0x0100, LONG, 1, long(width as u32)),
+            (0x0101, LONG, 1, long(height as u32)),
+            (0x0102, SHORT, 1, short(16)),
+            (0x0103, SHORT, 1, short(1)),
+            (0x0106, SHORT, 1, short(32803)),
+            (0x010F, ASCII, 7, b"Schist\0".to_vec()),
+            (0x0110, ASCII, 10, b"Synthetic\0".to_vec()),
+            (0x0111, LONG, 1, long(0)),
+            (0x0115, SHORT, 1, short(1)),
+            (0x0116, LONG, 1, long(height as u32)),
+            (0x0117, LONG, 1, long((w * h * 2) as u32)),
+            (0x011C, SHORT, 1, short(1)),
+            (0x828D, SHORT, 2, shorts(&[2, 2])),
+            (0x828E, BYTE, 4, vec![0, 1, 1, 2]),
+            (0xC612, BYTE, 4, vec![1, 4, 0, 0]),
+            (0xC614, ASCII, 17, b"Schist Synthetic\0".to_vec()),
+            (0xC61A, SHORT, 1, short(0)),
+            (0xC61D, LONG, 1, long(65535)),
+            (0xC621, SRATIONAL, 9, rationals(&matrix)),
+            (0xC628, RATIONAL, 3, rationals(&[(1, 1), (1, 1), (1, 1)])),
+            (0xC65A, SHORT, 1, short(21)),
+        ];
+        let ifd_at = 8usize;
+        let ifd_len = 2 + entries.len() * 12 + 4;
+        let extra_at = ifd_at + ifd_len;
+        let mut extra = Vec::new();
+        let mut placed = Vec::new();
+        for (tag, kind, count, payload) in &entries {
+            if payload.len() <= 4 {
+                let mut field = payload.clone();
+                field.resize(4, 0);
+                placed.push((*tag, *kind, *count, field));
+            } else {
+                placed.push((*tag, *kind, *count, long((extra_at + extra.len()) as u32)));
+                extra.extend_from_slice(payload);
+            }
+        }
+        let strip_at = extra_at + extra.len();
+        for (tag, _, _, field) in &mut placed {
+            if *tag == 0x0111 {
+                *field = long(strip_at as u32);
+            }
+        }
+        let mut out = Vec::new();
+        out.extend_from_slice(b"II*\0");
+        out.extend(long(ifd_at as u32));
+        out.extend(short(placed.len() as u16));
+        for (tag, kind, count, field) in &placed {
+            out.extend(short(*tag));
+            out.extend(short(*kind));
+            out.extend(long(*count));
+            out.extend_from_slice(field);
+        }
+        out.extend(long(0));
+        assert_eq!(out.len(), extra_at);
+        out.extend(extra);
+        assert_eq!(out.len(), strip_at);
+        out.extend(pixels);
+        out
+    }
+
+    #[test]
+    fn probe_recognises_the_vendor_containers() {
+        let cases: &[(&str, Vec<u8>)] = &[
+            ("raf", b"FUJIFILMCCD-RAW 0201FF393103".to_vec()),
+            ("orf", b"IIRO\x08\0\0\0rest".to_vec()),
+            ("orf big-endian", b"MMOR\0\0\0\x08rest".to_vec()),
+            ("rw2", b"IIU\0\x18\0\0\0rest".to_vec()),
+            ("crw", b"II\x1a\0\0\0HEAPCCDR".to_vec()),
+            ("x3f", b"FOVb\0\0\0\0".to_vec()),
+            ("mrw", b"\0MRM\0\0\0\0".to_vec()),
+            ("cr3", b"\0\0\0\x18ftypcrx \0\0\0\x01".to_vec()),
+            ("cr2", b"II*\0\x10\0\0\0CR\x02\0".to_vec()),
+        ];
+        for (name, bytes) in cases {
+            assert!(RawCodec.probe(bytes), "{name} should probe as raw");
+        }
+        assert!(!RawCodec.probe(b"\x89PNG\r\n\x1a\n"));
+        assert!(
+            !RawCodec.probe(b"II*\0\x08\0\0\0"),
+            "a truncated TIFF is not a raw"
+        );
+        assert!(
+            !RawCodec.probe(b"\0\0\0\x18ftypheic"),
+            "HEIC is another codec's"
+        );
+    }
+
+    #[test]
+    fn probe_tells_a_mosaic_tiff_from_a_plain_one() {
+        assert!(RawCodec.probe(&synthetic_dng(8, 8)), "a DNG is a raw");
+
+        let img = image::RgbaImage::from_pixel(4, 4, image::Rgba([1, 2, 3, 255]));
+        let mut plain = std::io::Cursor::new(Vec::new());
+        img.write_to(&mut plain, image::ImageFormat::Tiff).unwrap();
+        let plain = plain.into_inner();
+        assert!(crate::TiffCodec.probe(&plain));
+        assert!(!RawCodec.probe(&plain), "an RGB TIFF is not a raw");
+    }
+
+    /// The developed picture, or None (skip, like the HEIC tests) when
+    /// this machine has no LibRaw.
+    fn develop_or_skip(bytes: &[u8]) -> Option<Document> {
+        match RawCodec.import(bytes) {
+            Err(err) if is_missing_library_error(&err) => {
+                eprintln!("skipping: {err:#}");
+                None
+            }
+            result => Some(result.unwrap()),
+        }
+    }
+
+    #[test]
+    fn develops_a_synthetic_dng() {
+        let Some(doc) = develop_or_skip(&synthetic_dng(64, 32)) else {
+            return;
+        };
+        assert_eq!((doc.width, doc.height), (64, 32));
+        assert_eq!(doc.depth, Depth::Sixteen, "raws keep 16 bits");
+        assert!(doc.icc_profile.is_none(), "developed to sRGB, no profile");
+        let tiles = &doc.tree.layers[0].as_raster().unwrap().tiles;
+        // Grey in, grey out: the as-shot balance is neutral and the
+        // matrix is sRGB's own.
+        let grey = tiles.pixel(12, 12);
+        assert!(
+            (grey.r - grey.g).abs() < 0.03 && (grey.g - grey.b).abs() < 0.03,
+            "left half should be neutral, got {:?}",
+            (grey.r, grey.g, grey.b)
+        );
+        // 20000/65535 linear is 0.59 in sRGB before the exposure lift,
+        // and the lift is bounded by the red half's brightest channel,
+        // so the grey lands between that and just under white.
+        assert!(
+            (0.55..0.97).contains(&grey.g),
+            "left half should be a light grey, got {}",
+            grey.g
+        );
+        let red = tiles.pixel(52, 12);
+        assert!(
+            red.r > red.g + 0.2 && red.r > red.b + 0.2,
+            "right half should be red, got {:?}",
+            (red.r, red.g, red.b)
+        );
+        assert_eq!(tiles.pixel(12, 12).a, 1.0);
+    }
+
+    #[test]
+    fn exposure_lifts_a_dark_frame_and_rolls_the_top_off() {
+        // 99% of the frame at 0.2 linear, 1% at 0.9: the lift is the
+        // full +2 EV, the bulk lands at 0.8, and the bright percent
+        // compresses towards white without reaching it.
+        let mut px = [0.2f32, 0.2, 0.2, 1.0].repeat(99);
+        px.extend([0.9, 0.9, 0.9, 1.0]);
+        expose_and_encode(&mut px);
+        let bulk = px[0];
+        let bright = px[99 * 4];
+        assert!((bulk - srgb_encode(0.8)).abs() < 0.01, "bulk {bulk}");
+        assert!(bright > bulk && bright < 1.0, "bright {bright}");
+        assert_eq!(px[3], 1.0, "alpha untouched");
+    }
+
+    #[test]
+    fn exposure_leaves_a_bright_frame_alone() {
+        // Exposed to the right already: nothing is darkened, and the
+        // shoulder keeps white white.
+        let mut px = [0.95f32, 0.5, 0.1, 1.0].repeat(50);
+        expose_and_encode(&mut px);
+        assert!(px[0] > srgb_encode(0.9) && px[0] <= 1.0, "red {}", px[0]);
+        assert!((px[1] - srgb_encode(0.5)).abs() < 0.03, "green {}", px[1]);
+        let mut white = vec![1.0f32, 1.0, 1.0, 1.0];
+        expose_and_encode(&mut white);
+        assert!(white[0] > 0.95, "white {}", white[0]);
+    }
+
+    #[test]
+    fn a_dng_without_a_preview_yields_none() {
+        match embedded_preview(&synthetic_dng(64, 32)) {
+            Err(err) if is_missing_library_error(&err) => eprintln!("skipping: {err:#}"),
+            Ok(None) => {}
+            Ok(Some(img)) => panic!(
+                "no preview was embedded, got {}x{}",
+                img.width(),
+                img.height()
+            ),
+            Err(err) => panic!("{err:#}"),
+        }
+    }
+
+    #[test]
+    fn a_broken_raw_is_an_error_not_a_missing_library() {
+        let mut bytes = synthetic_dng(64, 32);
+        bytes.truncate(bytes.len() / 2);
+        match RawCodec.import(&bytes) {
+            Err(err) if is_missing_library_error(&err) => eprintln!("skipping: {err:#}"),
+            Err(err) => assert!(!is_missing_library_error(&err), "{err:#}"),
+            Ok(_) => panic!("half a file should not develop"),
+        }
+    }
+
+    /// Every file in `SCHIST_RAW_CORPUS` (a directory of real camera
+    /// files) must probe as raw, develop, and yield an upright preview
+    /// when it embeds one. Skipped without the variable or LibRaw.
+    #[test]
+    fn corpus_sweep() {
+        let Ok(dir) = std::env::var("SCHIST_RAW_CORPUS") else {
+            return;
+        };
+        let mut entries: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| p.is_file())
+            .collect();
+        entries.sort();
+        for path in entries {
+            let bytes = std::fs::read(&path).unwrap();
+            assert!(
+                RawCodec.probe(&bytes),
+                "{} should probe as raw",
+                path.display()
+            );
+            let started = std::time::Instant::now();
+            let Some(doc) = develop_or_skip(&bytes) else {
+                return;
+            };
+            let developed = started.elapsed();
+            let started = std::time::Instant::now();
+            let preview = embedded_preview(&bytes).unwrap();
+            eprintln!(
+                "{}: {}x{} developed in {:.2?}; preview {} in {:.2?}",
+                path.display(),
+                doc.width,
+                doc.height,
+                developed,
+                preview
+                    .as_ref()
+                    .map(|p| format!("{}x{}", p.width(), p.height()))
+                    .unwrap_or_else(|| "none".into()),
+                started.elapsed()
+            );
+            if let Some(preview) = preview {
+                let landscape = |w: u32, h: u32| w >= h;
+                assert_eq!(
+                    landscape(preview.width(), preview.height()),
+                    landscape(doc.width, doc.height),
+                    "{}: preview orientation disagrees with the developed picture",
+                    path.display()
+                );
+            }
+        }
+    }
+}

--- a/plugins/codecs-common/src/raw.rs
+++ b/plugins/codecs-common/src/raw.rs
@@ -1,4 +1,5 @@
-//! Camera raw import via LibRaw, loaded at runtime.
+//! Camera raw import: the pure-Rust `schist-codec-raw` decoder first,
+//! then LibRaw, loaded at runtime, for whatever it declines.
 //!
 //! A raw file is a sensor dump in one of some dozens of vendor
 //! containers: most are TIFF with a proprietary compression (Nikon,
@@ -511,7 +512,29 @@ fn srgb_encode(v: f32) -> f32 {
 /// one. Orders of magnitude cheaper than developing, which is what a
 /// thumbnail wants.
 pub fn embedded_preview(bytes: &[u8]) -> anyhow::Result<Option<image::RgbaImage>> {
-    let lib = libraw()?;
+    let choice = decoder_choice();
+    // The native answer, kept so a machine without LibRaw still gets
+    // it: "this file embeds no preview" is a definitive answer, and a
+    // native error is a better diagnosis than "no LibRaw".
+    let mut native_answer = None;
+    if choice != Decoder::LibRaw {
+        match guarded(|| native::embedded_preview(bytes)) {
+            Ok(Some(img)) => return Ok(Some(img)),
+            answer if choice == Decoder::Native => return answer,
+            Ok(None) => native_answer = Some(Ok(None)),
+            Err(err) => {
+                log::info!("raw: native preview declined ({err:#}); trying LibRaw");
+                native_answer = Some(Err(err));
+            }
+        }
+    }
+    let lib = match (libraw(), native_answer) {
+        (Ok(lib), _) => lib,
+        (Err(missing), Some(answer)) => {
+            return answer.map_err(|err| err.context(format!("{missing}")));
+        }
+        (Err(missing), None) => return Err(missing),
+    };
     let handle = Handle::open(lib, bytes)?;
     let lr = handle.ptr;
     let img = unsafe {
@@ -557,91 +580,6 @@ pub fn embedded_preview(bytes: &[u8]) -> anyhow::Result<Option<image::RgbaImage>
     Ok(Some(upright))
 }
 
-/// Whether a TIFF-structured file holds sensor data: an IFD — the first,
-/// one it chains to, or one of its SubIFDs — whose photometric
-/// interpretation is CFA or LinearRaw, or a DNGVersion tag. This is
-/// what tells a NEF, ARW, PEF, SRW, DNG or 3FR from the TIFFs the same
-/// cameras' converters write, which carry the same Make and Model.
-fn tiff_is_raw(bytes: &[u8]) -> Option<bool> {
-    let le = match bytes.get(0..4)? {
-        b"II*\0" => true,
-        b"MM\0*" => false,
-        _ => return Some(false),
-    };
-    let u16_at = |at: usize| -> Option<u16> {
-        let b: [u8; 2] = bytes.get(at..at + 2)?.try_into().ok()?;
-        Some(if le {
-            u16::from_le_bytes(b)
-        } else {
-            u16::from_be_bytes(b)
-        })
-    };
-    let u32_at = |at: usize| -> Option<u32> {
-        let b: [u8; 4] = bytes.get(at..at + 4)?.try_into().ok()?;
-        Some(if le {
-            u32::from_le_bytes(b)
-        } else {
-            u32::from_be_bytes(b)
-        })
-    };
-    const PHOTOMETRIC: u16 = 0x0106;
-    const SUB_IFDS: u16 = 0x014A;
-    const DNG_VERSION: u16 = 0xC612;
-    const CFA: u16 = 32803;
-    const LINEAR_RAW: u16 = 34892;
-
-    let mut queue = vec![u32_at(4)? as usize];
-    let mut visited = 0;
-    while let Some(ifd) = queue.pop() {
-        // A dozen IFDs is more than any raw uses on the way to its
-        // sensor data; the cap keeps a corrupt chain from looping.
-        if visited >= 12 {
-            break;
-        }
-        visited += 1;
-        let Some(count) = u16_at(ifd) else { continue };
-        let count = count.min(512) as usize;
-        for i in 0..count {
-            let entry = ifd + 2 + i * 12;
-            let (Some(tag), Some(kind), Some(n)) =
-                (u16_at(entry), u16_at(entry + 2), u32_at(entry + 4))
-            else {
-                break;
-            };
-            match tag {
-                // A SHORT value sits left-justified in the value field
-                // in either byte order.
-                PHOTOMETRIC if kind == 3 => {
-                    if matches!(u16_at(entry + 8), Some(CFA | LINEAR_RAW)) {
-                        return Some(true);
-                    }
-                }
-                DNG_VERSION => return Some(true),
-                SUB_IFDS if kind == 4 || kind == 13 => {
-                    let n = n.min(8) as usize;
-                    let at = if n == 1 {
-                        entry + 8
-                    } else {
-                        u32_at(entry + 8)? as usize
-                    };
-                    for j in 0..n {
-                        if let Some(off) = u32_at(at + j * 4) {
-                            queue.push(off as usize);
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-        if let Some(next) = u32_at(ifd + 2 + count * 12) {
-            if next != 0 {
-                queue.push(next as usize);
-            }
-        }
-    }
-    Some(false)
-}
-
 /// Camera raw files, import only.
 pub struct RawCodec;
 
@@ -660,25 +598,131 @@ impl CodecPlugin for RawCodec {
         ]
     }
     fn probe(&self, bytes: &[u8]) -> bool {
-        let at = |offset: usize, want: &[u8]| bytes.get(offset..offset + want.len()) == Some(want);
-        // The vendors with their own containers: Fuji, Olympus,
-        // Panasonic/Leica, old Canon, Sigma, Minolta, and Canon's CR3
-        // (ISO-BMFF, brand "crx "). CR2 is TIFF with its own mark.
-        at(0, b"FUJIFILMCCD-RAW")
-            || at(0, b"IIRO")
-            || at(0, b"IIRS")
-            || at(0, b"MMOR")
-            || at(0, b"IIU\0")
-            || at(6, b"HEAPCCDR")
-            || at(0, b"FOVb")
-            || at(0, b"\0MRM")
-            || (at(4, b"ftyp") && at(8, b"crx "))
-            || (at(0, b"II*\0") && at(8, b"CR"))
-            || tiff_is_raw(bytes).unwrap_or(false)
+        // The native crate's probe knows every container, including
+        // the ones (Phase One, Leaf, Samsung, Kodak) whose TIFFs carry
+        // no CFA photometric and are told apart by maker.
+        schist_codec_raw::probe(bytes).is_some()
     }
     fn import(&self, bytes: &[u8]) -> anyhow::Result<Document> {
-        let lib = libraw()?;
+        let choice = decoder_choice();
+        let native = match choice {
+            Decoder::LibRaw => None,
+            _ => Some(guarded(|| native::develop_document(bytes))),
+        };
+        let native_err = match native {
+            Some(Ok(doc)) => return Ok(doc),
+            Some(Err(err)) if choice == Decoder::Native => return Err(err),
+            Some(Err(err)) => {
+                log::info!("raw: native decoder declined ({err:#}); trying LibRaw");
+                Some(err)
+            }
+            None => None,
+        };
+        // With no LibRaw to fall back on, the native decoder's
+        // diagnosis is the useful one; the missing library is context.
+        let lib = match (libraw(), native_err) {
+            (Ok(lib), _) => lib,
+            (Err(missing), Some(native_err)) => {
+                return Err(native_err.context(format!("{missing}")));
+            }
+            (Err(missing), None) => return Err(missing),
+        };
         develop(lib, bytes)
+    }
+}
+
+/// Run the native decoder with a panic turned into an error. The
+/// crate promises never to panic on hostile input, and its tests fuzz
+/// for that; this is the belt to those braces, since a panic here
+/// would take the whole editor down with the file.
+fn guarded<T>(f: impl FnOnce() -> anyhow::Result<T>) -> anyhow::Result<T> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(result) => result,
+        Err(payload) => {
+            let what = payload
+                .downcast_ref::<&str>()
+                .map(|s| s.to_string())
+                .or_else(|| payload.downcast_ref::<String>().cloned())
+                .unwrap_or_else(|| "unknown panic".into());
+            Err(anyhow::anyhow!("native raw decoder panicked: {what}"))
+        }
+    }
+}
+
+/// Which decoder `import` and `embedded_preview` use. The default tries
+/// the native crate and falls back to LibRaw; `SCHIST_RAW_DECODER`
+/// (`native` or `libraw`) pins one, for comparing them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Decoder {
+    Auto,
+    Native,
+    LibRaw,
+}
+
+fn decoder_choice() -> Decoder {
+    match std::env::var("SCHIST_RAW_DECODER").as_deref() {
+        Ok("native") => Decoder::Native,
+        Ok("libraw") => Decoder::LibRaw,
+        _ => Decoder::Auto,
+    }
+}
+
+/// The pure-Rust path.
+mod native {
+    use super::expose_and_encode;
+    use anyhow::Context as _;
+    use schist_codec_raw::{DevelopOptions, Orientation};
+    use schist_color::Depth;
+    use schist_core::Document;
+
+    /// Decode and develop through `schist-codec-raw`, then the same
+    /// exposure and encoding as the LibRaw path. A camera the table
+    /// has no colour matrix for is declined (`Err`), so the caller can
+    /// let LibRaw, which may know it, render the colours rather than
+    /// show raw camera RGB.
+    pub(super) fn develop_document(bytes: &[u8]) -> anyhow::Result<Document> {
+        let raw = schist_codec_raw::decode(bytes).context("decoding")?;
+        anyhow::ensure!(
+            raw.color_matrix.is_some(),
+            "no colour matrix for {} {}",
+            raw.make,
+            raw.model
+        );
+        let developed =
+            schist_codec_raw::develop(&raw, &DevelopOptions::default()).context("developing")?;
+        let (w, h) = (developed.width as u32, developed.height as u32);
+        let mut rgba = Vec::with_capacity(developed.rgb.len() / 3 * 4);
+        for px in developed.rgb.as_chunks::<3>().0 {
+            rgba.extend_from_slice(&[px[0], px[1], px[2], 1.0]);
+        }
+        expose_and_encode(&mut rgba);
+        crate::deep_document("Raw", w, h, &rgba, Depth::Sixteen, None)
+            .context("assembling document")
+    }
+
+    /// The embedded JPEG, decoded and turned upright.
+    pub(super) fn embedded_preview(bytes: &[u8]) -> anyhow::Result<Option<image::RgbaImage>> {
+        let Some(jpeg) = schist_codec_raw::preview(bytes).context("finding preview")? else {
+            return Ok(None);
+        };
+        let img = image::load_from_memory_with_format(&jpeg, image::ImageFormat::Jpeg)
+            .context("decoding embedded preview")?
+            .into_rgba8();
+        let upright = match schist_codec_raw::orientation(bytes) {
+            Orientation::Rotate180 => image::imageops::rotate180(&img),
+            Orientation::Rotate90CW => image::imageops::rotate90(&img),
+            Orientation::Rotate270CW => image::imageops::rotate270(&img),
+            Orientation::MirrorHorizontal => image::imageops::flip_horizontal(&img),
+            Orientation::MirrorVertical => image::imageops::flip_vertical(&img),
+            Orientation::Transpose => {
+                image::imageops::rotate270(&image::imageops::flip_horizontal(&img))
+            }
+            Orientation::Transverse => {
+                image::imageops::rotate90(&image::imageops::flip_horizontal(&img))
+            }
+            Orientation::Normal => img,
+        };
+        Ok(Some(upright))
     }
 }
 
@@ -929,6 +973,151 @@ pub(crate) mod tests {
         }
     }
 
+    /// The native decoder against LibRaw over `SCHIST_RAW_CORPUS`
+    /// (recursive): each file developed both ways, compared as PSNR
+    /// of the encoded 8-bit pictures after downscaling to 512 px, with
+    /// a table printed. Decline (`Unsupported`, no matrix) is counted,
+    /// not failed, and so is a crop-policy size difference; a file both
+    /// decode that lands under 18 dB fails (the corpus sits at a
+    /// median of 33 dB — the two develop pipelines differ in demosaic
+    /// and tone, so this is a smoke test for gross errors, not parity).
+    #[test]
+    fn native_agrees_with_libraw() {
+        let Ok(dir) = std::env::var("SCHIST_RAW_CORPUS") else {
+            return;
+        };
+        if std::env::var("SCHIST_RAW_COMPARE").is_err() {
+            return;
+        }
+        fn walk(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+            for entry in std::fs::read_dir(dir).into_iter().flatten().flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, out);
+                } else if !matches!(
+                    path.extension()
+                        .and_then(|e| e.to_str())
+                        .map(|e| e.to_ascii_lowercase())
+                        .as_deref(),
+                    Some("tiff" | "json" | "txt" | "png" | "ppm" | "pgm" | "sh")
+                ) {
+                    out.push(path);
+                }
+            }
+        }
+        let mut files = Vec::new();
+        walk(std::path::Path::new(&dir), &mut files);
+        files.sort();
+        let thumb = |doc: &Document| -> Option<image::RgbaImage> {
+            let rect = doc.canvas_rect();
+            let rgba = schist_compositor::composite_region_rgba8(doc, rect);
+            let img = image::RgbaImage::from_raw(rect.width() as u32, rect.height() as u32, rgba)?;
+            Some(image::imageops::resize(
+                &img,
+                512,
+                512 * img.height() / img.width().max(1),
+                image::imageops::FilterType::Triangle,
+            ))
+        };
+        let mut rows = Vec::new();
+        let (mut declined, mut failed) = (0, Vec::new());
+        for path in &files {
+            let bytes = std::fs::read(path).unwrap();
+            if !RawCodec.probe(&bytes) {
+                continue;
+            }
+            let name = path
+                .strip_prefix(&dir)
+                .unwrap_or(path)
+                .display()
+                .to_string();
+            let started = std::time::Instant::now();
+            let native = native::develop_document(&bytes);
+            let native_time = started.elapsed();
+            let lib = match libraw() {
+                Ok(lib) => lib,
+                Err(_) => return,
+            };
+            let started = std::time::Instant::now();
+            let reference = develop(lib, &bytes);
+            let libraw_time = started.elapsed();
+            match (native, reference) {
+                (Ok(a), Ok(b)) => {
+                    let (Some(a), Some(b)) = (thumb(&a), thumb(&b)) else {
+                        continue;
+                    };
+                    // The two decoders crop differently by a few
+                    // pixels (the file's own active area versus
+                    // LibRaw's per-model margins), which is policy, not
+                    // a decoding error: compare the common centre.
+                    // Anything further apart is a real disagreement.
+                    let (w, h) = (a.width().min(b.width()), a.height().min(b.height()));
+                    if a.width().abs_diff(b.width()) * 100 > w
+                        || a.height().abs_diff(b.height()) * 100 > h
+                    {
+                        // Beyond a percent it is a policy difference
+                        // worth reading, not a decode error: Panasonic
+                        // aspect-mode files (we honour the camera's 1:1
+                        // or 16:9 crop, LibRaw shows the whole sensor),
+                        // the Hasselblad backs' active area.
+                        rows.push(format!(
+                            "{name:60} SIZE MISMATCH native {:?} libraw {:?}",
+                            a.dimensions(),
+                            b.dimensions()
+                        ));
+                        continue;
+                    }
+                    let centre = |img: &image::RgbaImage| {
+                        image::imageops::crop_imm(
+                            img,
+                            (img.width() - w) / 2,
+                            (img.height() - h) / 2,
+                            w,
+                            h,
+                        )
+                        .to_image()
+                    };
+                    let (a, b) = (centre(&a), centre(&b));
+                    let mse: f64 = a
+                        .as_raw()
+                        .iter()
+                        .zip(b.as_raw())
+                        .map(|(x, y)| {
+                            let d = *x as f64 - *y as f64;
+                            d * d
+                        })
+                        .sum::<f64>()
+                        / a.as_raw().len() as f64;
+                    let psnr = 10.0 * (255.0f64 * 255.0 / mse.max(1e-9)).log10();
+                    rows.push(format!(
+                        "{name:60} {psnr:5.1} dB   native {:5.2?}  libraw {:5.2?}",
+                        native_time, libraw_time
+                    ));
+                    if psnr < 18.0 {
+                        failed.push(name.clone());
+                    }
+                }
+                (Err(err), _) => {
+                    declined += 1;
+                    rows.push(format!("{name:60} declined: {err:#}"));
+                }
+                (Ok(_), Err(err)) => rows.push(format!("{name:60} native only (LibRaw: {err})")),
+            }
+        }
+        for row in &rows {
+            eprintln!("{row}");
+        }
+        eprintln!(
+            "{} files, {declined} declined by native, {} below 20 dB",
+            rows.len(),
+            failed.len()
+        );
+        assert!(
+            failed.is_empty(),
+            "native and LibRaw disagree on: {failed:?}"
+        );
+    }
+
     /// Every file in `SCHIST_RAW_CORPUS` (a directory of real camera
     /// files) must probe as raw, develop, and yield an upright preview
     /// when it embeds one. Skipped without the variable or LibRaw.
@@ -937,14 +1126,46 @@ pub(crate) mod tests {
         let Ok(dir) = std::env::var("SCHIST_RAW_CORPUS") else {
             return;
         };
-        let mut entries: Vec<_> = std::fs::read_dir(&dir)
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .map(|e| e.path())
-            .filter(|p| p.is_file())
-            .collect();
+        fn walk(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+            for entry in std::fs::read_dir(dir).into_iter().flatten().flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    walk(&path, out);
+                } else {
+                    out.push(path);
+                }
+            }
+        }
+        let mut entries = Vec::new();
+        walk(std::path::Path::new(&dir), &mut entries);
         entries.sort();
         for path in entries {
+            // The oracle sidecars (`.tiff`, `.json`, `.identify.txt`)
+            // live beside the samples and are not raws; nor are the
+            // headerless dumps and scanner files the probe declines.
+            let sidecar = matches!(
+                path.extension().and_then(|e| e.to_str()),
+                Some("tiff" | "json" | "txt" | "png" | "ppm" | "pgm" | "sh")
+            );
+            if sidecar {
+                continue;
+            }
+            if !RawCodec.probe(&std::fs::read(&path).unwrap()) {
+                eprintln!("{}: not probed as raw, skipped", path.display());
+                continue;
+            }
+            // A sample with no `.tiff` sidecar is one LibRaw's own
+            // tools could not unpack (Foveon, GoPro, ProRAW...): the
+            // fallback cannot help there, so only files with an oracle
+            // are required to develop.
+            let oracle = path.with_file_name(format!(
+                "{}.tiff",
+                path.file_name().unwrap().to_string_lossy()
+            ));
+            if !oracle.exists() {
+                eprintln!("{}: no LibRaw oracle, skipped", path.display());
+                continue;
+            }
             let bytes = std::fs::read(&path).unwrap();
             assert!(
                 RawCodec.probe(&bytes),
@@ -970,7 +1191,12 @@ pub(crate) mod tests {
                     .unwrap_or_else(|| "none".into()),
                 started.elapsed()
             );
-            if let Some(preview) = preview {
+            // A square-mode frame (the D-LUX 5's 2752x2754 with a
+            // 1920x1920 preview) has no orientation to disagree on.
+            // Nor does a thumbnail-sized one: a few backs store those
+            // the sensor's way round (Phase One's 409x545).
+            let square = doc.width.abs_diff(doc.height) * 50 < doc.width.max(doc.height);
+            if let Some(preview) = preview.filter(|p| !square && p.width().max(p.height()) >= 640) {
                 let landscape = |w: u32, h: u32| w >= h;
                 assert_eq!(
                     landscape(preview.width(), preview.height()),


### PR DESCRIPTION
Two commits: the first adds camera raw import through a runtime-loaded LibRaw; the second adds `crates/codec-raw`, a **pure-Rust, clean-room raw decoder** that the plugin now tries first, falling back to LibRaw for whatever it declines. Most files no longer need LibRaw at all; nothing regresses where it is still needed.

## Commit 1 — LibRaw via dlopen (the HEIC pattern)

- LibRaw is dlopen'd at runtime (system copy; `libraw_r` preferred, plain build serialised). Every pure-Rust raw crate is LGPL/AGPL, hence no static link.
- Develop: camera as-shot WB, sRGB, 16-bit, an exposure lift (99th percentile to white, capped +2 EV) with a soft shoulder instead of dcraw's 1%-clip stretch.
- Thumbnails/Quick Look use the embedded camera JPEG, turned upright. Unedited raws archive verbatim. ORF/RW2/RAF EXIF via container shims. Packaging: weak LibRaw deps, raw MIME types, `public.camera-raw-image`.

## Commit 2 — `schist-codec-raw`

Written by a fan-out of 4 foundation + 10 vendor Opus workers under a clean-room rule (specs, ExifTool tag docs, real files and LibRaw's *output* as oracle; no copyleft decoder source read or fetched), then 4 adversarial review passes (~30k mutated files) whose findings are fixed here.

### Support ("exact" = every sample matches LibRaw's unpacked frame)

| container | status |
|---|---|
| DNG | 26/26 exact incl. ProRAW/linear where LibRaw fails; uncompressed, lossless JPEG, deflate, lossy, float; GoPro VC-5 declined |
| Sony ARW/SR2/SRF | 24/24, every generation incl. ARW 1.0 and ARW 4 lossless |
| Nikon NEF/NRW | 36 files / 20 bodies incl. all six D850 variants (Huffman trees reconstructed from oracle data); Z 8/9 HE declined |
| Canon CR2 / CRW | 14/14 CR2; sRAW/mRAW and compressed CRW declined |
| Canon CR3 | container, ColorData (found in the CTMD track), previews exact; **CRX pixels not decoded** → LibRaw |
| Fujifilm RAF | 9 bodies exact uncompressed; **compressed RAF declined** → LibRaw |
| Olympus ORF / Panasonic RW2 | 12/12 (four layouts) and 29/31; RawFormat 8 declined |
| Pentax PEF / Samsung SRW | 10/10 and 15/17; NX1/NX500 codec declined |
| Minolta / Kodak / Epson / Mamiya | 15 bodies; Kodak 65000 reverse-engineered; Epson as-shot WB unknown (declines colour) |
| Hasselblad / Phase One / Leaf | 7/7, 5/11 ("IIQ S" declined), 3/3 |
| Sigma X3F | metadata + preview only |

Colour: DNG carries its matrix; others use `cameras.rs` (189 bodies; 64 read from real DNGs, the rest recalled Adobe D65 values cross-checked against each body's own WB presets, with a duplicate-matrix guard). No matrix → the plugin prefers LibRaw.

Native vs LibRaw's own development over the 103 corpus files both handle: median 33 dB, p10 25 dB, worst 19.6 dB (a CHDK DNG). `SCHIST_RAW_COMPARE=1 SCHIST_RAW_CORPUS=… cargo test -p schist-codecs-common native_agrees_with_libraw -- --nocapture` prints the table; `SCHIST_RAW_DECODER=native|libraw` pins a decoder.

### Robustness

Every decoder sizes its frame through `frame_samples` (400 MP ceiling, overflow-checked) and requires the file to hold at least a bit per sample; `validate` is overflow-safe; the plugin wraps native calls in `catch_unwind`. Reviewer fuzzing: 0 panics after fixes.

### For a human to judge (licensing)

- Reviewers noted the Olympus and Panasonic bit-level decoders use the same magic constants any correct decoder must (format-determined; prose is independent), and the bit-pump type names coincide with rawspeed's. Both flagged, neither judged a copy.
- The recalled camera matrices are Adobe's published profile values; ~35 entries have no independent check yet.

### Known gaps / follow-ups

- CRX (Canon CR3) and Fuji compressed are the two big codecs still on LibRaw; both workers pinned the entropy layers and documented where they stopped in the module docs.
- Nikon bodies without CropArea get their masked right-hand columns trimmed by a data-driven detector; one flat test-chart frame slips through.
- No prebuilt/download offer for LibRaw yet (Windows has no system LibRaw), and CR3 has no EXIF in the gallery.
- The pure-Rust crate would build for wasm; a web-only raw path is a follow-up.

## Test plan

- [x] `cargo test --workspace`, `cargo fmt --check`, `clippy --workspace --all-targets -D warnings`
- [x] Crate: 296 tests incl. per-format corpus tests against LibRaw oracles (`SCHIST_RAW_CORPUS=/tmp/rawsamples`)
- [x] Plugin sweep over the full corpus (native → LibRaw fallback), gallery EXIF corpus
- [x] Native-vs-LibRaw PSNR table as above
- [ ] macOS smoke test with Homebrew's LibRaw under the signed bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
