### PR TITLE
feat(gallery): scope a search to the bucket on show

### DIFF
--- a/crates/app/src/workspace/library.rs
+++ b/crates/app/src/workspace/library.rs
@@ -238,6 +238,11 @@ pub struct Library {
     /// The place the current query named, when it named one — shown on
     /// the results header.
     pub search_place: Option<String>,
+    /// The bucket the current results — or the query in flight — were
+    /// ranked within: a search made while viewing a bucket is scoped
+    /// to it. Compared against `bucket_filter` each frame, so the
+    /// search follows when the viewed bucket changes.
+    pub search_scoped: Option<usize>,
     /// Bumped per query so a slow embedding cannot land on a newer one.
     search_seq: u64,
     /// Answered queries, so the engine is only asked once per string.
@@ -401,6 +406,7 @@ impl Library {
             search_selected: false,
             search_results: None,
             search_place: None,
+            search_scoped: None,
             search_seq: 0,
             query_cache: FxHashMap::default(),
             index_gen: 0,
@@ -615,6 +621,10 @@ impl Library {
             })).collect::<Vec<_>>(),
             "search": (!self.search.is_empty()).then_some(&self.search),
             "search_results": self.search_results.as_ref().map(|r| r.len()),
+            "search_bucket": self
+                .search_scoped
+                .and_then(|i| self.buckets.get(i))
+                .map(|b| b.name.clone()),
             "map_filter": self.map_filter_label(),
             "index": {"embedded": indexed, "total": total,
                       "search_models_installed": schist_neural::embed::ready()},
@@ -1091,6 +1101,16 @@ impl Library {
             }
             self.save();
         }
+    }
+
+    /// What a search is confined to: the viewed bucket's contents
+    /// (hand-picked photos and the rule's matches), so the bucket
+    /// filters first and the query ranks what is left. `None` while
+    /// no bucket is on show — the whole index.
+    pub fn search_scope(&self) -> Option<FxHashSet<PathBuf>> {
+        self.bucket_filter
+            .and_then(|i| self.buckets.get(i))
+            .map(|b| b.contents().into_iter().collect())
     }
 
     /// The index as the ranking task sees it, rebuilt only when the
@@ -1908,6 +1928,7 @@ impl Workspace {
                 }
                 // The rules (or the bucket list) changed underneath
                 // the pass: throw it away, the next render re-runs it.
+                let mut viewed_refilled = false;
                 if ws.library.rule_rev == target.1 {
                     for (index, mut matched, by_score) in out {
                         if !by_score {
@@ -1920,12 +1941,20 @@ impl Workspace {
                             });
                         }
                         if let Some(bucket) = ws.library.buckets.get_mut(index) {
-                            bucket.matches = matched;
+                            if bucket.matches != matched {
+                                bucket.matches = matched;
+                                viewed_refilled |= ws.library.bucket_filter == Some(index);
+                            }
                         }
                     }
                     ws.library.smart_synced = Some(target);
                 }
                 ws.library.smart_running = false;
+                // A search scoped to this bucket was ranked over what
+                // it held before the pass; rank it over what it holds now.
+                if viewed_refilled && !ws.library.search.trim().is_empty() {
+                    ws.gallery_search_changed(cx);
+                }
                 cx.notify();
             })
             .ok();
@@ -2236,6 +2265,7 @@ impl Workspace {
         self.library.search_selected = false;
         self.library.search_results = None;
         self.library.search_place = None;
+        self.library.search_scoped = None;
         self.library.search_seq += 1;
         cx.notify();
         true
@@ -2244,11 +2274,14 @@ impl Workspace {
     /// Re-rank for the current query. The engine is consulted at most
     /// once per string — answered queries come from the cache — and the
     /// index rides into the task as a shared snapshot instead of a
-    /// per-keystroke copy of every path and vector.
+    /// per-keystroke copy of every path and vector. Made while viewing
+    /// a bucket, the search is scoped to it: the bucket filters, then
+    /// the query ranks what is left.
     pub(super) fn gallery_search_changed(&mut self, cx: &mut Context<Self>) {
         self.library.search_seq += 1;
         let seq = self.library.search_seq;
         let query = self.library.search.trim().to_string();
+        self.library.search_scoped = self.library.bucket_filter;
         if query.is_empty() {
             self.library.search_results = None;
             self.library.search_place = None;
@@ -2256,6 +2289,7 @@ impl Workspace {
             return;
         }
         let cached = self.library.query_cache.get(&query).cloned();
+        let scope = self.library.search_scope();
         let snapshot = self.library.search_snapshot();
         cx.spawn(async move |this, cx| {
             let ranked = cx
@@ -2278,16 +2312,25 @@ impl Workspace {
                         return None;
                     }
                     // Scores keyed by borrowed path; only what survives
-                    // the cut gets cloned.
+                    // the cut gets cloned. The scope applies before the
+                    // cut, so a bucket's matches are never crowded out
+                    // of the kept two hundred by the rest of the library.
+                    let in_scope = |path: &PathBuf| scope.as_ref().is_none_or(|s| s.contains(path));
                     let mut scored: FxHashMap<&PathBuf, f32> = FxHashMap::default();
                     if let Some(text) = &answer.text {
                         for (path, v) in snapshot.vectors.iter() {
+                            if !in_scope(path) {
+                                continue;
+                            }
                             let s = v.iter().zip(text.iter()).map(|(a, b)| a * b).sum::<f32>();
                             scored.insert(path, s);
                         }
                     }
                     if let Some(place) = &answer.place {
                         for (path, (lat, lon)) in snapshot.positions.iter() {
+                            if !in_scope(path) {
+                                continue;
+                            }
                             let affinity = library_geo::geo_affinity(place, *lat, *lon);
                             if affinity > 0.0 {
                                 *scored.entry(path).or_insert(0.0) += GEO_BOOST * affinity;
@@ -2352,6 +2395,8 @@ impl Workspace {
         self.library.search = query.clone();
         self.library.search_cursor = query.len();
         self.library.search_seq += 1;
+        self.library.search_scoped = self.library.bucket_filter;
+        let scope = self.library.search_scope();
         let answer = match self.library.query_cache.get(&query) {
             Some(answer) => answer.clone(),
             None => {
@@ -2369,14 +2414,21 @@ impl Workspace {
             }
         };
         let snapshot = self.library.search_snapshot();
+        let in_scope = |path: &PathBuf| scope.as_ref().is_none_or(|s| s.contains(path));
         let mut scored: FxHashMap<&PathBuf, f32> = FxHashMap::default();
         if let Some(text) = &answer.text {
             for (path, v) in snapshot.vectors.iter() {
+                if !in_scope(path) {
+                    continue;
+                }
                 scored.insert(path, v.iter().zip(text.iter()).map(|(a, b)| a * b).sum());
             }
         }
         if let Some(place) = &answer.place {
             for (path, (lat, lon)) in snapshot.positions.iter() {
+                if !in_scope(path) {
+                    continue;
+                }
                 let affinity = library_geo::geo_affinity(place, *lat, *lon);
                 if affinity > 0.0 {
                     *scored.entry(path).or_insert(0.0) += GEO_BOOST * affinity;
@@ -2399,6 +2451,21 @@ impl Workspace {
         self.library.search_results = Some(ranked.clone());
         cx.notify();
         ranked
+    }
+
+    /// Keep a live search scoped to the bucket on show: when the
+    /// viewed bucket changes under a query — a click in the sidebar,
+    /// a bucket deleted — re-rank within the new one (or the whole
+    /// library). Called from the gallery's render, like the smart
+    /// buckets' refresh, so nothing that moves `bucket_filter` has to
+    /// remember to.
+    pub(super) fn gallery_search_rescope(&mut self, cx: &mut Context<Self>) {
+        if self.library.search.trim().is_empty()
+            || self.library.search_scoped == self.library.bucket_filter
+        {
+            return;
+        }
+        self.gallery_search_changed(cx);
     }
 
     /// Load both towers off the UI thread before the first keystroke
@@ -3010,6 +3077,31 @@ mod tests {
         // A torn file is a miss, not a crash.
         assert!(parse_index_snapshot(&bytes[..bytes.len() - 3]).is_none());
         assert!(parse_index_snapshot(b"not an index").is_none());
+    }
+
+    #[test]
+    fn a_search_is_scoped_to_the_bucket_on_show() {
+        let mut lib = Library::load();
+        lib.buckets.push(Bucket {
+            name: "Trip".into(),
+            photos: vec![PathBuf::from("/p/a.jpg")],
+            query: Some("beach".into()),
+            area: None,
+            matches: vec![PathBuf::from("/p/b.jpg"), PathBuf::from("/p/a.jpg")],
+        });
+        // No bucket on show: the whole index.
+        assert!(lib.search_scope().is_none());
+        // Viewing one: its hand-picked photos and its rule's matches,
+        // each once.
+        lib.bucket_filter = Some(lib.buckets.len() - 1);
+        let scope = lib.search_scope().expect("scoped");
+        assert_eq!(scope.len(), 2);
+        assert!(scope.contains(&PathBuf::from("/p/a.jpg")));
+        assert!(scope.contains(&PathBuf::from("/p/b.jpg")));
+        // A slot that no longer exists scopes to nothing in
+        // particular — the whole index again, not a crash.
+        lib.bucket_filter = Some(99);
+        assert!(lib.search_scope().is_none());
     }
 
     #[test]

--- a/crates/app/src/workspace/library_mcp.rs
+++ b/crates/app/src/workspace/library_mcp.rs
@@ -52,10 +52,13 @@ pub(super) fn tool_defs() -> Vec<Value> {
             "gallery_search",
             "Search photos by what is in them (\"dog on a beach\"), by where they were taken \
              (\"taken in nyc\"), or both, ranked best first. The gallery's own search box \
-             shows the same results. Content search needs the Search models installed; \
-             places work from EXIF alone.",
+             shows the same results. While a bucket is being viewed (or one is named here, \
+             which views it), the bucket filters first and the query ranks its photos. \
+             Content search needs the Search models installed; places work from EXIF alone.",
             json!({
                 "query": {"type": "string"},
+                "bucket": {"type": "string", "description": "Search within this bucket (by \
+                           name) only; the gallery switches to viewing it."},
                 "limit": {"type": "integer", "minimum": 1, "maximum": 200, "default": 20},
             }),
             &["query"],
@@ -219,7 +222,22 @@ impl Workspace {
                     .and_then(|v| v.as_u64())
                     .unwrap_or(20)
                     .clamp(1, 200) as usize;
+                if let Some(name) = str_arg(args, "bucket") {
+                    let index = self
+                        .library
+                        .buckets
+                        .iter()
+                        .position(|b| b.name.eq_ignore_ascii_case(name))
+                        .ok_or_else(|| anyhow::anyhow!("no bucket named {name:?}"))?;
+                    self.library.bucket_filter = Some(index);
+                    self.library.folder_filter = None;
+                }
                 let ranked = self.gallery_search_now(&query, cx);
+                let bucket = self
+                    .library
+                    .search_scoped
+                    .and_then(|i| self.library.buckets.get(i))
+                    .map(|b| b.name.clone());
                 let all: Vec<&Entry> = self
                     .library
                     .sections
@@ -238,6 +256,7 @@ impl Workspace {
                     .collect();
                 Ok(text(json!({
                     "query": query,
+                    "bucket": bucket,
                     "place": self.library.search_place,
                     "matches": ranked.len(),
                     "photos": rows,

--- a/crates/app/src/workspace/library_view.rs
+++ b/crates/app/src/workspace/library_view.rs
@@ -151,8 +151,10 @@ impl Workspace {
         self.library.begin_thumb_frame();
         self.kick_thumb_loader(cx);
         // Smart buckets re-score whenever the index moved, so they
-        // fill themselves as photos are indexed and imported.
+        // fill themselves as photos are indexed and imported — and a
+        // search follows the bucket on show.
         self.refresh_smart_buckets(cx);
+        self.gallery_search_rescope(cx);
         self.maybe_offer_heif(cx);
         self.gallery_reveal_tick(cx);
         root
@@ -987,7 +989,10 @@ fn grid(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElement {
     // fetch thumbnails, so they cannot also iterate `sections` in place.
     let mut sections: Vec<(String, String, Vec<super::library::Entry>)> =
         if let Some(results) = &ws.library.search_results {
-            // A search flattens the groups into one ranked strip.
+            // A search flattens the groups into one ranked strip. Made
+            // while viewing a bucket, it was ranked within the bucket;
+            // the strip also keeps to the bucket's current contents,
+            // so a photo removed by hand leaves at once.
             let by_path: FxHashMap<&PathBuf, &super::library::Entry> = ws
                 .library
                 .sections
@@ -995,15 +1000,25 @@ fn grid(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElement {
                 .flat_map(|s| s.entries.iter())
                 .map(|e| (&e.path, e))
                 .collect();
+            let bucket = ws
+                .library
+                .bucket_filter
+                .and_then(|i| ws.library.buckets.get(i));
+            let scope: Option<FxHashSet<&PathBuf>> =
+                bucket.map(|b| b.photos.iter().chain(b.matches.iter()).collect());
             let entries: Vec<super::library::Entry> = results
                 .iter()
+                .filter(|(path, _)| scope.as_ref().is_none_or(|s| s.contains(path)))
                 .filter_map(|(path, _)| by_path.get(path).map(|e| (*e).clone()))
                 .filter(|e| ws.library.passes_map(&e.path))
                 .collect();
-            let title = match &ws.library.search_place {
-                Some(place) => format!("Search results · near {place}"),
+            let mut title = match bucket {
+                Some(bucket) => format!("Bucket · {} · Search results", bucket.name),
                 None => "Search results".to_string(),
             };
+            if let Some(place) = &ws.library.search_place {
+                title.push_str(&format!(" · near {place}"));
+            }
             vec![(title, String::new(), entries)]
         } else {
             ws.library.grouped()
@@ -1092,6 +1107,13 @@ fn grid(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElement {
                         .bucket_filter
                         .and_then(|i| ws.library.buckets.get(i))
                     {
+                        Some(_) if ws.library.search_results.is_some() => {
+                            "Nothing in this bucket matches the search. Escape clears it \
+                         to show the whole bucket."
+                        }
+                        None if ws.library.search_results.is_some() => {
+                            "Nothing matches the search. Escape clears it."
+                        }
                         Some(bucket) if bucket.is_smart() => {
                             "Nothing matches this bucket's rule yet — matches appear as \
                          photos are indexed. Dragging photos in works too."

--- a/crates/app/src/workspace/mod.rs
+++ b/crates/app/src/workspace/mod.rs
@@ -13,7 +13,7 @@ use gpui::{
     MouseUpEvent, ParentElement as _, PathBuilder, PinchEvent, Pixels, Point, Render, RenderImage,
     ScrollWheelEvent, SharedString, Styled as _, TouchPhase, Window,
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use schist_color::{ColorMode, Depth, Rgba};
 use schist_compositor::TileCache;
 use schist_core::{blit_rgba8, Document, IntRect, Layer, TileCoord, TILE_SIZE};

--- a/crates/gallery/src/headless.rs
+++ b/crates/gallery/src/headless.rs
@@ -11,9 +11,9 @@ use crate::meta::taken_from_unix;
 use crate::paths::{thumb_cache_path, thumb_source};
 use crate::persist::{BucketFile, LibraryFile};
 use crate::scan::{scan_folders, Entry, Section};
-use crate::search::{rank, SEARCH_KEPT};
+use crate::search::{rank, Ranked, SEARCH_KEPT};
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 pub struct Gallery {
@@ -134,8 +134,30 @@ impl Gallery {
     }
 
     /// The search box's ranking, from the snapshot's embeddings and
-    /// positions. Blocking on the text tower.
-    pub fn search(&self, query: &str) -> (Vec<(PathBuf, f32)>, Option<String>) {
+    /// positions. Blocking on the text tower. Given a bucket, the
+    /// bucket filters first and the query ranks what is left — its
+    /// hand-picked photos, which are all this side can see of it (a
+    /// smart rule's matches live in the app, recomputed per session).
+    /// An unknown bucket name is an error, not a library-wide search.
+    pub fn search(
+        &self,
+        query: &str,
+        bucket: Option<&str>,
+    ) -> anyhow::Result<(Ranked, Option<String>)> {
+        let scope: Option<HashSet<PathBuf>> = match bucket {
+            Some(name) => Some(
+                self.file
+                    .buckets
+                    .iter()
+                    .find(|b| b.name().eq_ignore_ascii_case(name))
+                    .ok_or_else(|| anyhow::anyhow!("no bucket named {name:?}"))?
+                    .photos()
+                    .iter()
+                    .cloned()
+                    .collect(),
+            ),
+            None => None,
+        };
         let text = schist_neural::embed::embed_text(query);
         let place = find_place(query);
         let vectors = self
@@ -146,9 +168,15 @@ impl Gallery {
             .index
             .values()
             .filter_map(|r| r.gps.flatten().map(|g| (&r.path, g)));
-        let mut ranked = rank(text.as_deref(), place.as_ref(), vectors, positions);
+        let mut ranked = rank(
+            text.as_deref(),
+            place.as_ref(),
+            scope.as_ref(),
+            vectors,
+            positions,
+        );
         ranked.truncate(SEARCH_KEPT);
-        (ranked, place.map(|p| p.name))
+        Ok((ranked, place.map(|p| p.name)))
     }
 
     /// The cached thumbnail PNG, when the app has rendered one.

--- a/crates/gallery/src/search.rs
+++ b/crates/gallery/src/search.rs
@@ -2,6 +2,7 @@
 //! buckets and the headless server all do the same way.
 
 use crate::geo::{geo_affinity, GeoMatch};
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 /// The most results a search shows, and the similarity below which a
@@ -14,27 +15,42 @@ pub const SEARCH_FLOOR: f32 = 0.15;
 /// the query names one, without exiling good semantic matches.
 pub const GEO_BOOST: f32 = 0.35;
 
+/// Photos with their scores, best first.
+pub type Ranked = Vec<(PathBuf, f32)>;
+
 /// Two readings of a query, blended: what the photos look like (the
 /// text tower's unit vector against each photo's) and, when it names
 /// somewhere, where they were taken. Everything above the floor, best
 /// first — callers truncate to what they can show.
+///
+/// `scope` confines the search to some photos — a bucket's contents,
+/// when the search is made while viewing one — so the bucket filters
+/// first and the query ranks what is left. `None` searches the lot.
 pub fn rank<'a>(
     text: Option<&[f32]>,
     place: Option<&GeoMatch>,
+    scope: Option<&HashSet<PathBuf>>,
     vectors: impl IntoIterator<Item = (&'a PathBuf, &'a [f32])>,
     positions: impl IntoIterator<Item = (&'a PathBuf, (f64, f64))>,
-) -> Vec<(PathBuf, f32)> {
+) -> Ranked {
     if text.is_none() && place.is_none() {
         return Vec::new();
     }
+    let in_scope = |path: &PathBuf| scope.is_none_or(|s| s.contains(path));
     let mut scored: std::collections::HashMap<&PathBuf, f32> = std::collections::HashMap::new();
     if let Some(text) = text {
         for (path, v) in vectors {
+            if !in_scope(path) {
+                continue;
+            }
             scored.insert(path, v.iter().zip(text.iter()).map(|(a, b)| a * b).sum());
         }
     }
     if let Some(place) = place {
         for (path, (lat, lon)) in positions {
+            if !in_scope(path) {
+                continue;
+            }
             let affinity = geo_affinity(place, lat, lon);
             if affinity > 0.0 {
                 *scored.entry(path).or_insert(0.0) += GEO_BOOST * affinity;
@@ -54,4 +70,49 @@ pub fn rank<'a>(
         .collect();
     ranked.sort_by(|a, b| b.1.total_cmp(&a.1));
     ranked
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn photos() -> Vec<(PathBuf, Vec<f32>)> {
+        vec![
+            (PathBuf::from("/p/best.jpg"), vec![1.0, 0.0]),
+            (PathBuf::from("/p/good.jpg"), vec![0.8, 0.6]),
+            (PathBuf::from("/p/miss.jpg"), vec![0.0, 1.0]),
+        ]
+    }
+
+    fn ranked(scope: Option<&HashSet<PathBuf>>) -> Vec<PathBuf> {
+        let photos = photos();
+        rank(
+            Some(&[1.0, 0.0]),
+            None,
+            scope,
+            photos.iter().map(|(p, v)| (p, v.as_slice())),
+            std::iter::empty(),
+        )
+        .into_iter()
+        .map(|(p, _)| p)
+        .collect()
+    }
+
+    #[test]
+    fn a_scope_filters_before_the_query_ranks() {
+        // Unscoped: everything above the floor, best first.
+        assert_eq!(
+            ranked(None),
+            vec![PathBuf::from("/p/best.jpg"), PathBuf::from("/p/good.jpg")]
+        );
+        // Scoped to a bucket: the bucket filters first, then the
+        // query ranks what is left — the best photo in the library
+        // stays out because it is not in the bucket, and the bucket's
+        // own non-match still fails the floor.
+        let scope: HashSet<PathBuf> =
+            [PathBuf::from("/p/good.jpg"), PathBuf::from("/p/miss.jpg")].into();
+        assert_eq!(ranked(Some(&scope)), vec![PathBuf::from("/p/good.jpg")]);
+        // An empty bucket searches nothing rather than everything.
+        assert!(ranked(Some(&HashSet::new())).is_empty());
+    }
 }

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -53,9 +53,12 @@ mod gallery {
             def("gallery_search",
                 "Search photos by what is in them (\"dog on a beach\"), by where they were taken \
                  (\"taken in nyc\"), or both, ranked best first, over the embeddings the app has \
-                 indexed. Content search needs the Search models installed; places work from \
+                 indexed. With a bucket, the bucket filters first and the query ranks its \
+                 photos. Content search needs the Search models installed; places work from \
                  EXIF alone.",
                 json!({"query": {"type": "string"},
+                       "bucket": {"type": "string",
+                                  "description": "Search within this bucket (by name) only."},
                        "limit": {"type": "integer", "minimum": 1, "maximum": 200, "default": 20}}),
                 &["query"]),
             def("gallery_thumbnail",
@@ -166,7 +169,8 @@ mod gallery {
                     .and_then(|v| v.as_u64())
                     .unwrap_or(20)
                     .clamp(1, 200) as usize;
-                let (ranked, place) = gallery.search(query);
+                let bucket = args.get("bucket").and_then(|v| v.as_str());
+                let (ranked, place) = gallery.search(query, bucket)?;
                 let rows: Vec<Value> = ranked
                     .iter()
                     .take(limit)
@@ -176,9 +180,13 @@ mod gallery {
                         Some(row)
                     })
                     .collect();
-                text(
-                    json!({"query": query, "place": place, "matches": ranked.len(), "photos": rows}),
-                )
+                text(json!({
+                    "query": query,
+                    "bucket": bucket,
+                    "place": place,
+                    "matches": ranked.len(),
+                    "photos": rows,
+                }))
             }
             "gallery_thumbnail" => {
                 let path = PathBuf::from(str_arg(args, "path")?);

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -374,6 +374,19 @@ understood ("Search results · near New York City"). Location search
 works even without the embedding models; with them, "dog in new york"
 blends both readings.
 
+A search made while viewing a bucket stays inside it: the bucket
+filters first — its hand-added photos and, for a smart bucket, its
+rule's current matches — and the query ranks what is left, under a
+"Bucket · <name> · Search results" header. The scoping happens before
+the two-hundred cut, so a bucket's matches are never crowded out by
+the rest of the library, and the search follows the bucket: click
+another bucket (or none) under a live query and it re-ranks there,
+a smart bucket refilling re-ranks too, and Escape clears the query to
+show the whole bucket again. Both `gallery_search` tools take an
+optional `bucket` — the in-app one views the bucket as it searches,
+so the user sees what the agent saw; the headless one sees only the
+hand-added photos, as its `gallery_list` does.
+
 ## What is persisted
 
 `~/.config/schist/library.json`: the watched folders, the recent-files


### PR DESCRIPTION
## Summary

Searching while viewing a bucket used to rank the whole library and ignore the bucket. Now the bucket filters first and the query ranks what is left.

- **Scoped before the cut.** The keystroke search and the AI tool's search restrict scoring to the viewed bucket's contents (hand-added photos plus a smart rule's current matches), so the bucket's photos are never crowded out of the kept 200 by the rest of the library.
- **The search follows the bucket.** The library records which bucket the results were ranked in; each gallery frame compares it to the bucket on show and re-ranks on a change. A viewed smart bucket refilling re-ranks too. Escape clears the query and shows the whole bucket.
- **The grid says so.** Header reads `Bucket · <name> · Search results` (with `· near <place>` when the query named one); a photo removed by hand leaves the strip at once; empty results get their own message in and out of a bucket.
- **MCP.** Both `gallery_search` tools take an optional `bucket`. The in-app one switches the gallery to it as it searches and reports it in the reply and in `gallery_state`; the headless one scopes to the hand-added photos it can see. An unknown name is an error, not a library-wide search.
- The shared `rank()` in `schist-gallery` gains the scope parameter, plus a `Ranked` alias that clears a clippy complexity warning.
- Docs: new paragraph in the Search section of `docs/gallery.md`.

## Test plan

- [x] New unit test in `schist-gallery`: scope filters before the floor; an empty bucket searches nothing
- [x] New unit test in `schist-app`: `search_scope()` returns the bucket's contents deduplicated, and nothing for a stale slot
- [x] Existing gallery tests, clippy on gallery/mcp/app, rustfmt all clean
- [x] Headless GUI check of the sidebar-click re-rank and header text (not done; verified by reading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
