### PR TITLE
feat(gallery): batch Process… dialog and more bulk actions in the right-click menus

### DIFF
--- a/crates/app/src/dialogs/batch.rs
+++ b/crates/app/src/dialogs/batch.rs
@@ -1,0 +1,445 @@
+//! The gallery's batch dialog: one recipe — turn, upscale, colour —
+//! run over every selected photo (or a whole bucket), written as
+//! versioned gallery edits or as flat copies.
+
+use super::*;
+use crate::workspace::{BatchRecipe, BatchTarget, CanvasTransform};
+use schist_core::AdjustmentKind;
+use std::path::PathBuf;
+
+/// The adjustments on offer, in the order Photoshop's menu lists the
+/// ones it has. Curves needs its editor and the fills paint over the
+/// photo, so neither belongs in a batch.
+const KINDS: &[AdjustmentKind] = &[
+    AdjustmentKind::BrightnessContrast,
+    AdjustmentKind::Levels,
+    AdjustmentKind::Exposure,
+    AdjustmentKind::Vibrance,
+    AdjustmentKind::HueSaturation,
+    AdjustmentKind::ColorBalance,
+    AdjustmentKind::BlackWhite,
+    AdjustmentKind::PhotoFilter,
+    AdjustmentKind::ChannelMixer,
+    AdjustmentKind::Invert,
+    AdjustmentKind::Posterize,
+    AdjustmentKind::Threshold,
+];
+
+/// Popup ids for each adjustment step's kind dropdown — a popup is
+/// keyed by a static string, so the steps are capped at this many.
+const STEP_POPUPS: [&str; 6] = [
+    "batch-adj-0",
+    "batch-adj-1",
+    "batch-adj-2",
+    "batch-adj-3",
+    "batch-adj-4",
+    "batch-adj-5",
+];
+
+/// The upscalers on offer: the two that ship inside the binary, so a
+/// batch never stalls on a download.
+const UPSCALERS: &[&str] = &["waifu2x-photo", "waifu2x-art"];
+
+fn section(title: &'static str) -> impl IntoElement {
+    div()
+        .pt_1()
+        .text_size(px(11.0))
+        .text_color(gpui::rgb(ui::palette().text_dim))
+        .child(title)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn batch_dialog(
+    ws: &mut Workspace,
+    state: &DialogState,
+    photos: Vec<PathBuf>,
+    recipe: BatchRecipe,
+    target: BatchTarget,
+    codec_id: &'static str,
+    options: schist_plugin_api::ExportOptions,
+    cx: &mut Context<Workspace>,
+) -> impl IntoElement {
+    let n = photos.len();
+    let edited = photos
+        .iter()
+        .filter(|p| schist_gallery::backing_psd(p).is_some_and(|s| s.exists()))
+        .count();
+    let note = match (target, edited) {
+        (BatchTarget::Edit, 0) => format!(
+            "{n} photo{} — saved as gallery edits; the originals are never touched.",
+            if n == 1 { "" } else { "s" }
+        ),
+        (BatchTarget::Edit, _) => format!(
+            "{n} photo{}, {edited} already edited — the recipe goes on top of the edit, \
+             and the previous edit is kept as a version.",
+            if n == 1 { "" } else { "s" }
+        ),
+        (_, 0) => format!(
+            "{n} photo{} — flat copies; the originals are never touched.",
+            if n == 1 { "" } else { "s" }
+        ),
+        (_, _) => format!(
+            "{n} photo{}, {edited} already edited — the copies are made from the edits.",
+            if n == 1 { "" } else { "s" }
+        ),
+    };
+
+    let mut body = div().flex().flex_col().gap_1().child(
+        div()
+            .text_size(px(11.0))
+            .text_color(gpui::rgb(ui::palette().text_dim))
+            .pb_1()
+            .child(SharedString::from(note)),
+    );
+
+    // Turn.
+    let rotations: Vec<(SharedString, Option<CanvasTransform>)> = vec![
+        ("None".into(), None),
+        ("90\u{b0} Clockwise".into(), Some(CanvasTransform::Cw90)),
+        (
+            "90\u{b0} Counter Clockwise".into(),
+            Some(CanvasTransform::Ccw90),
+        ),
+        ("180\u{b0}".into(), Some(CanvasTransform::Rotate180)),
+    ];
+    let rotate_label = rotations
+        .iter()
+        .find(|(_, r)| *r == recipe.rotate)
+        .map(|(l, _)| l.clone())
+        .unwrap_or_else(|| "None".into());
+    body = body
+        .child(section("Turn"))
+        .child(ui::field_row(
+            "Rotate",
+            ui::dropdown(
+                &ws.dropdown_scroll,
+                ui::Dropdown {
+                    popup: Popup::Field("batch-rotate"),
+                    is_open: state.open_popup == Some(Popup::Field("batch-rotate")),
+                    current: recipe.rotate,
+                    label: rotate_label,
+                    width: 190.0,
+                    options: rotations,
+                },
+                |ws, value, _cx| {
+                    ws.update_modal(|m| {
+                        if let Modal::BatchProcess { recipe, .. } = m {
+                            recipe.rotate = value;
+                        }
+                    });
+                },
+                cx,
+            ),
+        ))
+        .child(ui::field_row(
+            "Flip",
+            div()
+                .flex()
+                .flex_row()
+                .gap_4()
+                .child(ui::checkbox(
+                    "Horizontal",
+                    recipe.flip_h,
+                    |ws, _cx| {
+                        ws.update_modal(|m| {
+                            if let Modal::BatchProcess { recipe, .. } = m {
+                                recipe.flip_h = !recipe.flip_h;
+                            }
+                        });
+                    },
+                    cx,
+                ))
+                .child(ui::checkbox(
+                    "Vertical",
+                    recipe.flip_v,
+                    |ws, _cx| {
+                        ws.update_modal(|m| {
+                            if let Modal::BatchProcess { recipe, .. } = m {
+                                recipe.flip_v = !recipe.flip_v;
+                            }
+                        });
+                    },
+                    cx,
+                )),
+        ));
+
+    // Size.
+    let mut upscalers: Vec<(SharedString, Option<&'static str>)> = vec![("None".into(), None)];
+    upscalers.extend(UPSCALERS.iter().map(|id| {
+        (
+            SharedString::from(schist_tools_transform::Resample::Neural(id).display_name()),
+            Some(*id),
+        )
+    }));
+    let upscale_label = upscalers
+        .iter()
+        .find(|(_, u)| *u == recipe.upscale)
+        .map(|(l, _)| l.clone())
+        .unwrap_or_else(|| "None".into());
+    body = body.child(section("Size")).child(ui::field_row(
+        "Upscale",
+        ui::dropdown(
+            &ws.dropdown_scroll,
+            ui::Dropdown {
+                popup: Popup::Field("batch-upscale"),
+                is_open: state.open_popup == Some(Popup::Field("batch-upscale")),
+                current: recipe.upscale,
+                label: upscale_label,
+                width: 190.0,
+                options: upscalers,
+            },
+            |ws, value, _cx| {
+                ws.update_modal(|m| {
+                    if let Modal::BatchProcess { recipe, .. } = m {
+                        recipe.upscale = value;
+                    }
+                });
+            },
+            cx,
+        ),
+    ));
+
+    // Colour: each step is an adjustment layer, its sliders under it.
+    body = body.child(section("Colour"));
+    let kind_options: Vec<(SharedString, AdjustmentKind)> = KINDS
+        .iter()
+        .map(|k| (SharedString::from(k.display_name()), *k))
+        .collect();
+    for (i, params) in recipe.adjustments.iter().enumerate() {
+        let Some(popup) = STEP_POPUPS.get(i).copied() else {
+            break;
+        };
+        let kind = params.kind();
+        body = body.child(
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap_2()
+                .child(ui::dropdown(
+                    &ws.dropdown_scroll,
+                    ui::Dropdown {
+                        popup: Popup::Field(popup),
+                        is_open: state.open_popup == Some(Popup::Field(popup)),
+                        current: kind,
+                        label: kind.display_name().into(),
+                        width: 190.0,
+                        options: kind_options.clone(),
+                    },
+                    move |ws, value, _cx| {
+                        ws.update_modal(|m| {
+                            if let Modal::BatchProcess { recipe, .. } = m {
+                                if let Some(step) = recipe.adjustments.get_mut(i) {
+                                    if step.kind() != value {
+                                        *step = schist_adjustments::Params::default_for(value);
+                                    }
+                                }
+                            }
+                        });
+                    },
+                    cx,
+                ))
+                .child(ui::button(
+                    "Remove",
+                    false,
+                    move |ws, _w, _cx| {
+                        ws.update_modal(|m| {
+                            if let Modal::BatchProcess { recipe, .. } = m {
+                                if i < recipe.adjustments.len() {
+                                    recipe.adjustments.remove(i);
+                                }
+                            }
+                        });
+                    },
+                    cx,
+                )),
+        );
+        for spec in params.param_specs() {
+            let key = spec.key;
+            body = body.child(param_slider(
+                SliderSpec {
+                    id: spec.key,
+                    label: spec.label,
+                    value: spec.value,
+                    min: spec.min,
+                    max: spec.max,
+                    suffix: spec.suffix,
+                    ..Default::default()
+                },
+                move |ws, v, _cx| {
+                    ws.update_modal(|m| {
+                        if let Modal::BatchProcess { recipe, .. } = m {
+                            if let Some(step) = recipe.adjustments.get_mut(i) {
+                                step.set_param(key, v);
+                            }
+                        }
+                    });
+                },
+                cx,
+            ));
+        }
+    }
+    if recipe.adjustments.len() < STEP_POPUPS.len() {
+        body = body.child(ui::field_row(
+            "Add",
+            ui::dropdown(
+                &ws.dropdown_scroll,
+                ui::Dropdown {
+                    popup: Popup::Field("batch-adj-add"),
+                    is_open: state.open_popup == Some(Popup::Field("batch-adj-add")),
+                    current: None,
+                    label: "Adjustment\u{2026}".into(),
+                    width: 190.0,
+                    options: kind_options
+                        .iter()
+                        .map(|(l, k)| (l.clone(), Some(*k)))
+                        .collect(),
+                },
+                |ws, value, _cx| {
+                    let Some(kind) = value else { return };
+                    ws.update_modal(|m| {
+                        if let Modal::BatchProcess { recipe, .. } = m {
+                            recipe
+                                .adjustments
+                                .push(schist_adjustments::Params::default_for(kind));
+                        }
+                    });
+                },
+                cx,
+            ),
+        ));
+    }
+
+    // Output.
+    let targets: Vec<(SharedString, BatchTarget)> =
+        [BatchTarget::Edit, BatchTarget::Beside, BatchTarget::Folder]
+            .into_iter()
+            .map(|t| (SharedString::from(t.label()), t))
+            .collect();
+    body = body.child(section("Output")).child(ui::field_row(
+        "Save as",
+        ui::dropdown(
+            &ws.dropdown_scroll,
+            ui::Dropdown {
+                popup: Popup::Field("batch-target"),
+                is_open: state.open_popup == Some(Popup::Field("batch-target")),
+                current: target,
+                label: target.label().into(),
+                width: 190.0,
+                options: targets,
+            },
+            |ws, value, _cx| {
+                ws.update_modal(|m| {
+                    if let Modal::BatchProcess { target, .. } = m {
+                        *target = value;
+                    }
+                });
+            },
+            cx,
+        ),
+    ));
+    if target != BatchTarget::Edit {
+        let codecs: Vec<(SharedString, &'static str)> = ws
+            .registry
+            .codecs()
+            .filter(|c| c.can_export())
+            .map(|c| (SharedString::from(c.name().to_string()), c.id()))
+            .collect();
+        let current_name = codecs
+            .iter()
+            .find(|(_, id)| *id == codec_id)
+            .map(|(n, _)| n.clone())
+            .unwrap_or_else(|| "PNG".into());
+        let supports_quality = ws
+            .registry
+            .codecs()
+            .find(|c| c.id() == codec_id)
+            .map(|c| c.supports_quality())
+            .unwrap_or(false);
+        body = body.child(ui::field_row(
+            "Format",
+            ui::dropdown(
+                &ws.dropdown_scroll,
+                ui::Dropdown {
+                    popup: Popup::Field("batch-format"),
+                    is_open: state.open_popup == Some(Popup::Field("batch-format")),
+                    current: codec_id,
+                    label: current_name,
+                    width: 190.0,
+                    options: codecs,
+                },
+                |ws, value, _cx| {
+                    ws.update_modal(|m| {
+                        if let Modal::BatchProcess { codec, .. } = m {
+                            *codec = value;
+                        }
+                    });
+                },
+                cx,
+            ),
+        ));
+        if supports_quality {
+            body = body.child(param_slider(
+                SliderSpec {
+                    id: "batch-quality",
+                    label: "Quality",
+                    value: options.quality as f32,
+                    min: 1.0,
+                    max: 100.0,
+                    suffix: "",
+                    ..Default::default()
+                },
+                |ws, v, _cx| {
+                    ws.update_modal(|m| {
+                        if let Modal::BatchProcess { options, .. } = m {
+                            options.quality = v.clamp(1.0, 100.0) as u8;
+                        }
+                    });
+                },
+                cx,
+            ));
+        }
+    }
+
+    let run_label = if n == 1 {
+        "Process".to_string()
+    } else {
+        format!("Process {n}")
+    };
+    let actions = div()
+        .flex()
+        .flex_row()
+        .gap_2()
+        .child(ui::button(
+            "Cancel",
+            false,
+            |ws, _w, cx| ws.close_modal(cx),
+            cx,
+        ))
+        .child(ui::button(
+            run_label,
+            true,
+            move |ws, window, cx| {
+                let Some(Modal::BatchProcess {
+                    photos,
+                    recipe,
+                    target,
+                    codec,
+                    options,
+                }) = ws.modal.clone()
+                else {
+                    return;
+                };
+                if recipe.is_empty() {
+                    ws.status =
+                        "Nothing to do: pick a turn, an upscale or an adjustment first".into();
+                    cx.notify();
+                    return;
+                }
+                ws.close_modal(cx);
+                ws.run_batch(photos, recipe, target, codec, options, window, cx);
+            },
+            cx,
+        ));
+    ui::modal_frame("Process Photos", 440.0, body, actions)
+}

--- a/crates/app/src/dialogs/mod.rs
+++ b/crates/app/src/dialogs/mod.rs
@@ -14,6 +14,8 @@ use schist_core::Filter;
 use schist_tools_transform::Resample;
 
 mod adjust;
+#[cfg(not(target_arch = "wasm32"))]
+mod batch;
 mod close;
 mod edit;
 mod export;
@@ -34,6 +36,8 @@ mod size;
 mod update;
 
 use adjust::*;
+#[cfg(not(target_arch = "wasm32"))]
+use batch::*;
 use close::*;
 use edit::*;
 use export::*;
@@ -228,6 +232,18 @@ pub fn render(ws: &mut Workspace, cx: &mut Context<Workspace>) -> Option<gpui::A
         }
         #[cfg(target_arch = "wasm32")]
         Modal::SaveImageAs { .. } => return None,
+        #[cfg(not(target_arch = "wasm32"))]
+        Modal::BatchProcess {
+            photos,
+            recipe,
+            target,
+            codec,
+            options,
+        } => {
+            batch_dialog(ws, &state, photos, recipe, target, codec, options, cx).into_any_element()
+        }
+        #[cfg(target_arch = "wasm32")]
+        Modal::BatchProcess { .. } => return None,
         #[cfg(target_arch = "wasm32")]
         Modal::SearchModels => return None,
         #[cfg(not(target_arch = "wasm32"))]

--- a/crates/app/src/workspace/image_ops.rs
+++ b/crates/app/src/workspace/image_ops.rs
@@ -260,46 +260,7 @@ impl Workspace {
     /// Image ▸ Image Rotation, and the flip entries under Edit ▸ Transform.
     pub fn transform_canvas(&mut self, op: CanvasTransform, cx: &mut Context<Self>) {
         let Some(doc) = self.doc.as_mut() else { return };
-        let (w, h) = (doc.width, doc.height);
-        let swaps = matches!(op, CanvasTransform::Cw90 | CanvasTransform::Ccw90);
-        let (nw, nh) = if swaps { (h, w) } else { (w, h) };
-        // Read every layer's pixels first: the mapping reads from the old
-        // geometry while writing the new one.
-        let ids: Vec<schist_core::LayerId> = doc.tree.iter().map(|l| l.id).collect();
-        let sources: Vec<(schist_core::LayerId, schist_core::TileMap)> = ids
-            .iter()
-            .filter_map(|id| {
-                doc.tree
-                    .find(*id)
-                    .and_then(|l| l.as_raster())
-                    .map(|r| (*id, r.tiles.clone()))
-            })
-            .collect();
-        let mut edit = doc.begin_edit(op.title());
-        edit.set_canvas_size(nw, nh);
-        for (id, src) in &sources {
-            for coord in TileCoord::covering(&IntRect::from_size(nw, nh)) {
-                let trect = coord.rect();
-                let Some(tile) = edit.writable_tile(*id, coord) else {
-                    break;
-                };
-                for y in trect.top..trect.bottom {
-                    for x in trect.left..trect.right {
-                        // Where this destination pixel came from.
-                        let (sx, sy) = match op {
-                            CanvasTransform::Cw90 => (y, nw as i32 - 1 - x),
-                            CanvasTransform::Ccw90 => (nh as i32 - 1 - y, x),
-                            CanvasTransform::Rotate180 => (w as i32 - 1 - x, h as i32 - 1 - y),
-                            CanvasTransform::FlipH => (w as i32 - 1 - x, y),
-                            CanvasTransform::FlipV => (x, h as i32 - 1 - y),
-                        };
-                        let ix = ((y - trect.top) * TILE_SIZE + (x - trect.left)) as usize;
-                        tile.set(ix, src.pixel(sx, sy));
-                    }
-                }
-            }
-        }
-        edit.commit();
+        transform_document(doc, op);
         self.status = op.title().into();
         self.fit_to_view();
         self.after_change(cx);
@@ -400,4 +361,50 @@ impl Workspace {
         self.status = mode.display_name().into();
         self.after_change(cx);
     }
+}
+
+/// Turn or flip a whole document, every raster layer with it, as one
+/// history entry. The gallery's batch run uses this on documents that
+/// never reach the editor.
+pub(super) fn transform_document(doc: &mut Document, op: CanvasTransform) {
+    let (w, h) = (doc.width, doc.height);
+    let swaps = matches!(op, CanvasTransform::Cw90 | CanvasTransform::Ccw90);
+    let (nw, nh) = if swaps { (h, w) } else { (w, h) };
+    // Read every layer's pixels first: the mapping reads from the old
+    // geometry while writing the new one.
+    let ids: Vec<schist_core::LayerId> = doc.tree.iter().map(|l| l.id).collect();
+    let sources: Vec<(schist_core::LayerId, schist_core::TileMap)> = ids
+        .iter()
+        .filter_map(|id| {
+            doc.tree
+                .find(*id)
+                .and_then(|l| l.as_raster())
+                .map(|r| (*id, r.tiles.clone()))
+        })
+        .collect();
+    let mut edit = doc.begin_edit(op.title());
+    edit.set_canvas_size(nw, nh);
+    for (id, src) in &sources {
+        for coord in TileCoord::covering(&IntRect::from_size(nw, nh)) {
+            let trect = coord.rect();
+            let Some(tile) = edit.writable_tile(*id, coord) else {
+                break;
+            };
+            for y in trect.top..trect.bottom {
+                for x in trect.left..trect.right {
+                    // Where this destination pixel came from.
+                    let (sx, sy) = match op {
+                        CanvasTransform::Cw90 => (y, nw as i32 - 1 - x),
+                        CanvasTransform::Ccw90 => (nh as i32 - 1 - y, x),
+                        CanvasTransform::Rotate180 => (w as i32 - 1 - x, h as i32 - 1 - y),
+                        CanvasTransform::FlipH => (w as i32 - 1 - x, y),
+                        CanvasTransform::FlipV => (x, h as i32 - 1 - y),
+                    };
+                    let ix = ((y - trect.top) * TILE_SIZE + (x - trect.left)) as usize;
+                    tile.set(ix, src.pixel(sx, sy));
+                }
+            }
+        }
+    }
+    edit.commit();
 }

--- a/crates/app/src/workspace/library.rs
+++ b/crates/app/src/workspace/library.rs
@@ -180,7 +180,7 @@ pub struct Library {
     /// Thumbnail states, tagged with the mtime they were built from: a
     /// file that changed underneath — a photo still landing off a
     /// camera when its first decode ran, an edit — loads again.
-    thumbs: FxHashMap<PathBuf, (u64, Thumb)>,
+    pub(super) thumbs: FxHashMap<PathBuf, (u64, Thumb)>,
     /// The frame each thumbnail was last visible on — what decides who
     /// goes when the map is over budget. Cells near the viewport
     /// re-stamp every frame, and eviction refuses anything stamped
@@ -193,7 +193,7 @@ pub struct Library {
     ticker: bool,
     /// A gallery open waiting for its decode: (path being loaded, the
     /// original image it is an edit of). Consumed by `finish_load`.
-    pub(super) pending_backing: Option<(PathBuf, PathBuf)>,
+    pub(super) pending_backing: Vec<(PathBuf, PathBuf)>,
     /// Original image path per open document that came from the gallery,
     /// so a save can refresh that image's thumbnail.
     pub(super) edit_backings: FxHashMap<schist_core::DocumentId, PathBuf>,
@@ -380,7 +380,7 @@ impl Library {
             thumb_frame: 0,
             queue: Vec::new(),
             ticker: false,
-            pending_backing: None,
+            pending_backing: Vec::new(),
             edit_backings: FxHashMap::default(),
             map: library_geo::MapState::default(),
             flagged: FxHashMap::default(),
@@ -2802,25 +2802,26 @@ impl Workspace {
             return;
         };
         let target = if psd.exists() { psd } else { original.clone() };
-        self.library.pending_backing = Some((target.clone(), original));
+        self.library
+            .pending_backing
+            .push((target.clone(), original));
         self.load_file(target, cx);
     }
 
     /// Bookkeeping when a load finishes: adopt a gallery edit's backing
     /// arrangement, or record an ordinary open in the recents.
     pub(super) fn finish_load_bookkeeping(&mut self, loaded: &Path) {
+        // Loads finish in any order, so each claims its own entry.
         let claimed = self
             .library
             .pending_backing
-            .as_ref()
-            .is_some_and(|(target, _)| target == loaded);
-        if !claimed {
+            .iter()
+            .position(|(target, _)| target == loaded);
+        let Some(claimed) = claimed else {
             self.note_recent(loaded);
             return;
-        }
-        let Some((_, original)) = self.library.pending_backing.take() else {
-            return;
         };
+        let (_, original) = self.library.pending_backing.remove(claimed);
         let Some(doc) = self.doc.as_mut() else {
             return;
         };
@@ -2846,24 +2847,7 @@ impl Workspace {
         if !backed {
             return;
         }
-        let Some(dir) = path.parent() else { return };
-        let _ = std::fs::create_dir_all(dir);
-        if !path.exists() {
-            return;
-        }
-        let stamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
-        let name = path
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "backing.psd".into());
-        let versions = dir.join("versions");
-        let _ = std::fs::create_dir_all(&versions);
-        if let Err(err) = std::fs::copy(path, versions.join(format!("{stamp}-{name}"))) {
-            log::warn!("could not keep a version of {}: {err}", path.display());
-        }
+        super::library_ops::keep_sidecar_version(path);
     }
 
     /// After a save landed on a gallery sidecar: drop the photo's cached

--- a/crates/app/src/workspace/library_ops.rs
+++ b/crates/app/src/workspace/library_ops.rs
@@ -1,8 +1,9 @@
 //! Bulk actions on gallery photos: move them to a folder (sidecars in
 //! tow — the versioning invariant is that edits live beside their
-//! photo), pack them into a ZIP, upscale them with the built-in
-//! waifu2x. Everything here runs on the background executor with the
-//! tray narrating.
+//! photo), pack them into a ZIP, revert them to their originals, and
+//! run the batch dialog's recipe (turn, upscale, adjust) over them as
+//! versioned edits or flat copies. Everything here runs on the
+//! background executor with the tray narrating.
 
 use super::library::backing_psd;
 use super::*;
@@ -259,33 +260,232 @@ impl Workspace {
         .detach();
     }
 
-    /// Double every photo with the built-in waifu2x, writing
-    /// `<name>@2x.png` beside each original. The model ships in the
-    /// binary, so this needs no download.
-    pub(super) fn upscale_photos(&mut self, paths: Vec<PathBuf>, cx: &mut Context<Self>) {
+    /// Open several photos as editor tabs, each backed by its sidecar
+    /// like a double-click would, up to [`DROP_OPEN_CAP`].
+    pub(super) fn open_photos_in_tabs(&mut self, paths: Vec<PathBuf>, cx: &mut Context<Self>) {
+        let total = paths.len();
+        let opening = total.min(DROP_OPEN_CAP);
+        for path in paths.into_iter().take(DROP_OPEN_CAP) {
+            self.open_from_gallery(path, cx);
+        }
+        if total > opening {
+            self.status = format!(
+                "Opening the first {opening} of {total} photos — the gallery holds the rest"
+            )
+            .into();
+            cx.notify();
+        }
+    }
+
+    /// Ask for a folder, then move the photos there — the menu's route
+    /// to what dragging onto a folder row does.
+    pub(super) fn move_photos_prompt(
+        &mut self,
+        paths: Vec<PathBuf>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if paths.is_empty() {
             return;
         }
-        let total = paths.len();
-        self.status = format!("Upscaling {total} photos\u{2026}").into();
+        let rx = cx.prompt_for_paths(gpui::PathPromptOptions {
+            files: false,
+            directories: true,
+            multiple: false,
+            prompt: Some("Move Here".into()),
+        });
+        cx.spawn_in(window, async move |this, cx| {
+            let Ok(Ok(Some(mut dirs))) = rx.await else {
+                return;
+            };
+            let Some(dest) = dirs.pop() else { return };
+            this.update_in(cx, |ws, _window, cx| ws.move_photos_to(paths, dest, cx))
+                .ok();
+        })
+        .detach();
+    }
+
+    /// Put photos back to their originals: each edit sidecar goes into
+    /// `versions/` (nothing is lost — it is one more version) and the
+    /// gallery shows the untouched photo again.
+    pub(super) fn revert_photos(&mut self, paths: Vec<PathBuf>, cx: &mut Context<Self>) {
+        let mut reverted = 0usize;
+        for path in &paths {
+            let Some(psd) = backing_psd(path).filter(|p| p.exists()) else {
+                continue;
+            };
+            keep_sidecar_version(&psd);
+            match std::fs::remove_file(&psd) {
+                Ok(()) => {
+                    reverted += 1;
+                    self.library.thumbs.remove(path);
+                }
+                Err(err) => log::error!("revert failed for {}: {err:#}", path.display()),
+            }
+        }
+        self.status = match reverted {
+            0 => "Nothing to revert: none of those photos has an edit".into(),
+            1 => "Reverted 1 photo to its original — the edit is kept under versions/".into(),
+            n => format!(
+                "Reverted {n} photos to their originals — the edits are kept under versions/"
+            )
+            .into(),
+        };
+        self.library_rescan(cx);
+        cx.notify();
+    }
+
+    /// Right-click ▸ Process…: the batch dialog over these photos.
+    pub(super) fn open_batch_process(&mut self, photos: Vec<PathBuf>, cx: &mut Context<Self>) {
+        if photos.is_empty() {
+            return;
+        }
+        let codec = self
+            .registry
+            .codecs()
+            .find(|c| c.can_export() && c.extensions().contains(&"jpg"))
+            .or_else(|| {
+                self.registry
+                    .codecs()
+                    .find(|c| c.can_export() && c.extensions().contains(&"png"))
+            })
+            .or_else(|| self.registry.codecs().find(|c| c.can_export()))
+            .map(|c| c.id());
+        let Some(codec) = codec else {
+            self.status = "No format here can save an image".into();
+            cx.notify();
+            return;
+        };
+        self.open_modal(
+            Modal::BatchProcess {
+                photos,
+                recipe: BatchRecipe::default(),
+                target: BatchTarget::Edit,
+                codec,
+                options: schist_plugin_api::ExportOptions {
+                    quality: 92,
+                    ..Default::default()
+                },
+            },
+            cx,
+        );
+    }
+
+    /// The dialog's Run: settle where the results go, then start.
+    #[allow(clippy::too_many_arguments)]
+    pub fn run_batch(
+        &mut self,
+        photos: Vec<PathBuf>,
+        recipe: BatchRecipe,
+        target: BatchTarget,
+        codec_id: &'static str,
+        options: schist_plugin_api::ExportOptions,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if recipe.is_empty() {
+            self.status = "Nothing to do: pick a turn, an upscale or an adjustment first".into();
+            cx.notify();
+            return;
+        }
+        let codecs = self.registry.shared_codecs();
+        let flat = codecs.iter().find(|c| c.id() == codec_id).cloned();
+        match target {
+            BatchTarget::Edit => self.batch_photos(photos, recipe, BatchSink::Edit, cx),
+            BatchTarget::Beside => {
+                let Some(codec) = flat else { return };
+                self.batch_photos(
+                    photos,
+                    recipe,
+                    BatchSink::Copies {
+                        dir: None,
+                        codec,
+                        options,
+                    },
+                    cx,
+                )
+            }
+            BatchTarget::Folder => {
+                let Some(codec) = flat else { return };
+                let rx = cx.prompt_for_paths(gpui::PathPromptOptions {
+                    files: false,
+                    directories: true,
+                    multiple: false,
+                    prompt: Some("Save Copies Here".into()),
+                });
+                cx.spawn_in(window, async move |this, cx| {
+                    let Ok(Ok(Some(mut dirs))) = rx.await else {
+                        return;
+                    };
+                    let Some(dir) = dirs.pop() else { return };
+                    this.update_in(cx, |ws, _window, cx| {
+                        ws.batch_photos(
+                            photos,
+                            recipe,
+                            BatchSink::Copies {
+                                dir: Some(dir),
+                                codec,
+                                options,
+                            },
+                            cx,
+                        )
+                    })
+                    .ok();
+                })
+                .detach();
+            }
+        }
+    }
+
+    /// Run the recipe over every photo, one at a time on the background
+    /// executor — a neural upscale is seconds per megapixel, and a camera
+    /// roll's worth of documents would not fit in memory together.
+    fn batch_photos(
+        &mut self,
+        photos: Vec<PathBuf>,
+        recipe: BatchRecipe,
+        sink: BatchSink,
+        cx: &mut Context<Self>,
+    ) {
+        if photos.is_empty() {
+            return;
+        }
+        let total = photos.len();
+        self.status = format!("Processing {total} photos\u{2026}").into();
         cx.notify();
         let codecs = self.registry.shared_codecs();
+        let recipe = Arc::new(recipe);
+        let sink = Arc::new(sink);
         cx.spawn(async move |this, cx| {
-            for (done, path) in paths.into_iter().enumerate() {
+            let mut failed = 0usize;
+            for (done, path) in photos.into_iter().enumerate() {
                 let job_codecs = codecs.clone();
-                let result = cx
-                    .background_executor()
-                    .spawn(async move { upscale_photo(&job_codecs, &path) })
-                    .await;
+                let job_recipe = recipe.clone();
+                let job_sink = sink.clone();
+                let job_path = path.clone();
+                let result =
+                    cx.background_executor()
+                        .spawn(async move {
+                            process_photo(&job_codecs, &job_path, &job_recipe, &job_sink)
+                        })
+                        .await;
                 let keep = this.update(cx, |ws, cx| {
                     match result {
                         Ok(out) => {
-                            ws.status =
-                                format!("Upscaled {}/{total} — {}", done + 1, out.display()).into()
+                            // The grid renders from the sidecar once it
+                            // exists; the cached thumbnail is the old one.
+                            ws.library.thumbs.remove(&path);
+                            ws.status = format!(
+                                "Processed {}/{total} \u{2014} {}",
+                                done + 1,
+                                out.display()
+                            )
+                            .into();
                         }
                         Err(err) => {
-                            log::error!("upscale failed: {err:#}");
-                            ws.status = format!("Upscale failed: {err}").into();
+                            failed += 1;
+                            log::error!("batch failed for {}: {err:#}", path.display());
+                            ws.status = format!("Processing failed: {err}").into();
                         }
                     }
                     cx.notify();
@@ -295,11 +495,164 @@ impl Workspace {
                 }
             }
             this.update(cx, |ws, cx| {
+                if failed == 0 {
+                    ws.status = format!("Processed {total} photos").into();
+                } else {
+                    ws.status = format!(
+                        "Processed {} of {total} photos \u{2014} the log has the rest",
+                        total - failed
+                    )
+                    .into();
+                }
                 ws.library_rescan(cx);
+                cx.notify();
             })
             .ok();
         })
         .detach();
+    }
+}
+
+/// Where a batch run writes.
+enum BatchSink {
+    /// Each photo's sidecar, versioned.
+    Edit,
+    /// Flat copies: beside the originals when `dir` is None.
+    Copies {
+        dir: Option<PathBuf>,
+        codec: Arc<dyn schist_plugin_api::CodecPlugin>,
+        options: schist_plugin_api::ExportOptions,
+    },
+}
+
+/// Copy a sidecar into its `versions/` directory, stamped, before it
+/// is replaced — every save of an edit is a version, automatically.
+pub(super) fn keep_sidecar_version(path: &Path) {
+    let Some(dir) = path.parent() else { return };
+    let _ = std::fs::create_dir_all(dir);
+    if !path.exists() {
+        return;
+    }
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "backing.psd".into());
+    let versions = dir.join("versions");
+    let _ = std::fs::create_dir_all(&versions);
+    if let Err(err) = std::fs::copy(path, versions.join(format!("{stamp}-{name}"))) {
+        log::warn!("could not keep a version of {}: {err}", path.display());
+    }
+}
+
+/// A path that nothing occupies yet: `name.ext`, else `name-2.ext`,
+/// `name-3.ext`… Batch output never overwrites a file it did not
+/// just write.
+fn unclaimed(dir: &Path, stem: &str, ext: &str) -> PathBuf {
+    let first = dir.join(format!("{stem}.{ext}"));
+    if !first.exists() {
+        return first;
+    }
+    (2..)
+        .map(|n| dir.join(format!("{stem}-{n}.{ext}")))
+        .find(|p| !p.exists())
+        .expect("the counter is unbounded")
+}
+
+/// Run the recipe over one photo and write the result where the sink
+/// says. Blocking and, with an upscale in the recipe, heavy.
+fn process_photo(
+    codecs: &[Arc<dyn schist_plugin_api::CodecPlugin>],
+    path: &Path,
+    recipe: &BatchRecipe,
+    sink: &BatchSink,
+) -> anyhow::Result<PathBuf> {
+    // The edit is the picture the gallery shows, so a recipe applies on
+    // top of it; the original stands in when there is none.
+    let sidecar = backing_psd(path).ok_or_else(|| anyhow::anyhow!("no file name"))?;
+    let source = if sidecar.exists() {
+        sidecar.clone()
+    } else {
+        path.to_path_buf()
+    };
+    let mut doc = super::decode_file(codecs, &source)?;
+    for op in recipe.transforms() {
+        super::image_ops::transform_document(&mut doc, op);
+    }
+    if let Some(id) = recipe.upscale {
+        let (w, h) = (doc.width * 2, doc.height * 2);
+        match schist_tools_transform::plan_neural(&doc, w, h, id) {
+            schist_tools_transform::Plan::NoModel => {
+                anyhow::bail!(
+                    "the {} model would not load",
+                    schist_tools_transform::Resample::Neural(id).display_name()
+                )
+            }
+            schist_tools_transform::Plan::Classical => {
+                schist_tools_transform::resize_image(&mut doc, w, h, schist_core::Filter::Bicubic)
+            }
+            schist_tools_transform::Plan::Neural(plan) => {
+                let up = plan.run();
+                schist_tools_transform::apply_upscaled(&mut doc, up);
+            }
+        }
+    }
+    for params in &recipe.adjustments {
+        let kind = params.kind();
+        let mut layer = schist_core::Layer::new_raster(kind.display_name());
+        layer.kind = schist_core::LayerKind::Adjustment(schist_core::AdjustmentData {
+            kind,
+            raw: Vec::new(),
+            params_json: serde_json::to_string(params).ok(),
+        });
+        doc.push_layer(layer);
+    }
+    let stem = path
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "photo".into());
+    match sink {
+        BatchSink::Edit => {
+            let psd = codecs
+                .iter()
+                .find(|c| c.can_export() && c.extensions().contains(&"psd"))
+                .ok_or_else(|| anyhow::anyhow!("no PSD writer is loaded"))?;
+            if let Some(name) = path.file_name() {
+                doc.title = name.to_string_lossy().into_owned();
+            }
+            let bytes = psd.export(&doc)?;
+            keep_sidecar_version(&sidecar);
+            if let Some(dir) = sidecar.parent() {
+                std::fs::create_dir_all(dir)?;
+            }
+            // A sibling temp file and a rename, so an interrupted run
+            // cannot leave a truncated edit behind.
+            let tmp = sidecar.with_extension("schist-tmp");
+            std::fs::write(&tmp, bytes)?;
+            std::fs::rename(&tmp, &sidecar)?;
+            Ok(sidecar)
+        }
+        BatchSink::Copies {
+            dir,
+            codec,
+            options,
+        } => {
+            let img = flatten(&doc)?;
+            let (bytes, _, _) = flat_export(img, codec, options, 1.0)?;
+            let ext = codec.extensions().first().copied().unwrap_or("png");
+            let out = match dir {
+                Some(dir) => unclaimed(dir, &stem, ext),
+                None => {
+                    let beside = path.parent().unwrap_or(Path::new("."));
+                    unclaimed(beside, &format!("{stem}-edit"), ext)
+                }
+            };
+            std::fs::write(&out, bytes)?;
+            Ok(out)
+        }
     }
 }
 
@@ -622,11 +975,30 @@ fn render_photo_as(
 ) -> anyhow::Result<(u32, u32)> {
     let source = zip_plan(path).source;
     let doc = super::decode_file(codecs, &source)?;
+    let img = flatten(&doc)?;
+    let (bytes, w, h) = flat_export(img, codec, options, scale)?;
+    std::fs::write(out, bytes)?;
+    Ok((w, h))
+}
+
+/// Flatten a document to 8-bit RGBA.
+fn flatten(doc: &schist_core::Document) -> anyhow::Result<image::RgbaImage> {
     let rect = doc.canvas_rect();
     let (w, h) = (rect.width() as u32, rect.height() as u32);
-    let rgba = schist_compositor::composite_region_rgba8(&doc, rect);
-    let img: image::RgbaImage = image::ImageBuffer::from_raw(w, h, rgba)
-        .ok_or_else(|| anyhow::anyhow!("composited buffer had the wrong size"))?;
+    let rgba = schist_compositor::composite_region_rgba8(doc, rect);
+    image::ImageBuffer::from_raw(w, h, rgba)
+        .ok_or_else(|| anyhow::anyhow!("composited buffer had the wrong size"))
+}
+
+/// Shrink a flat picture by `scale` and encode it through `codec`.
+/// Returns the bytes and the size they hold.
+fn flat_export(
+    img: image::RgbaImage,
+    codec: &Arc<dyn schist_plugin_api::CodecPlugin>,
+    options: &schist_plugin_api::ExportOptions,
+    scale: f32,
+) -> anyhow::Result<(Vec<u8>, u32, u32)> {
+    let (w, h) = img.dimensions();
     let (img, w, h) = if scale < 0.999 {
         let nw = ((w as f32 * scale).round() as u32).max(1);
         let nh = ((h as f32 * scale).round() as u32).max(1);
@@ -650,46 +1022,7 @@ fn render_photo_as(
     );
     flat.push_layer(layer);
     let bytes = codec.export_with(&flat, options)?;
-    std::fs::write(out, bytes)?;
-    Ok((w, h))
-}
-
-/// Decode a photo whole, run the built-in waifu2x over it, and write
-/// the double-size PNG beside the original. Blocking and heavy.
-fn upscale_photo(
-    codecs: &[Arc<dyn schist_plugin_api::CodecPlugin>],
-    path: &Path,
-) -> anyhow::Result<PathBuf> {
-    let model = schist_neural::get("waifu2x-photo")
-        .ok_or_else(|| anyhow::anyhow!("the waifu2x model failed to load"))?;
-    let doc = super::decode_file(codecs, path)?;
-    let rect = doc.canvas_rect();
-    let (w, h) = (rect.width() as usize, rect.height() as usize);
-    let rgba = schist_compositor::composite_region_rgba8(&doc, rect);
-    let mut rgb = Vec::with_capacity(w * h * 3);
-    for px in rgba.as_chunks::<4>().0 {
-        rgb.extend([
-            px[0] as f32 / 255.0,
-            px[1] as f32 / 255.0,
-            px[2] as f32 / 255.0,
-        ]);
-    }
-    let out = schist_neural::run_scaled(&model, &rgb, w, h)
-        .ok_or_else(|| anyhow::anyhow!("the model declined the image"))?;
-    let (ow, oh) = (w * 2, h * 2);
-    let mut pixels = Vec::with_capacity(ow * oh * 3);
-    for v in &out {
-        pixels.push((v.clamp(0.0, 1.0) * 255.0).round() as u8);
-    }
-    let stem = path
-        .file_stem()
-        .map(|s| s.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "photo".into());
-    let target = path.with_file_name(format!("{stem}@2x.png"));
-    let img: image::RgbImage = image::ImageBuffer::from_raw(ow as u32, oh as u32, pixels)
-        .ok_or_else(|| anyhow::anyhow!("upscaled buffer had the wrong size"))?;
-    img.save(&target)?;
-    Ok(target)
+    Ok((bytes, w, h))
 }
 
 #[cfg(test)]
@@ -919,6 +1252,118 @@ mod tests {
         let decoded = image::load_from_memory(&bytes).unwrap().to_rgba8();
         assert_eq!(decoded.dimensions(), (w, h));
         assert!(decoded.pixels().all(|p| p.0 == [255, 0, 255, 255]));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A 6x2 document, magenta on the left half and black on the right,
+    /// as a PSD: the batch test's "photo" and, once written, its edit.
+    fn half_magenta(dir: &std::path::Path, name: &str) -> PathBuf {
+        use schist_color::Depth;
+        use schist_core::{Document, IntRect, Layer};
+        let (w, h) = (6u32, 2u32);
+        let mut doc = Document::new("photo", w, h, Depth::Eight);
+        let mut layer = Layer::new_raster("photo");
+        let rgba: Vec<u8> = (0..w * h)
+            .flat_map(|i| {
+                if i % w < 3 {
+                    [255u8, 0, 255, 255]
+                } else {
+                    [0, 0, 0, 255]
+                }
+            })
+            .collect();
+        schist_core::blit_rgba8(
+            &mut layer.as_raster_mut().unwrap().tiles,
+            Depth::Eight,
+            IntRect::from_size(w, h),
+            &rgba,
+        );
+        doc.push_layer(layer);
+        let path = dir.join(name);
+        std::fs::write(&path, schist_codec_psd::write_psd(&doc).unwrap()).unwrap();
+        path
+    }
+
+    /// The batch run, end to end: a turn and an adjustment land in the
+    /// sidecar as a rotated canvas plus a live adjustment layer, the
+    /// original is untouched, a second run versions the first edit, and
+    /// the copies target writes a flat file beside the photo without
+    /// overwriting anything.
+    #[test]
+    fn batch_process_writes_versioned_edits_and_flat_copies() {
+        let dir = std::env::temp_dir().join(format!("schist-batch-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let photo = half_magenta(&dir, "photo.psd");
+        let original_bytes = std::fs::read(&photo).unwrap();
+        let codecs: Vec<Arc<dyn schist_plugin_api::CodecPlugin>> = vec![Arc::new(crate::PsdCodec)];
+
+        let recipe = BatchRecipe {
+            rotate: Some(CanvasTransform::Cw90),
+            adjustments: vec![schist_adjustments::Params::Invert],
+            ..Default::default()
+        };
+        let out = process_photo(&codecs, &photo, &recipe, &BatchSink::Edit).unwrap();
+        assert_eq!(out, dir.join(".schist/photo.psd.psd"));
+        assert_eq!(std::fs::read(&photo).unwrap(), original_bytes);
+        let edit = schist_codec_psd::read_psd(&std::fs::read(&out).unwrap()).unwrap();
+        let rect = edit.canvas_rect();
+        // Turned on its side, with the adjustment kept live on top.
+        assert_eq!((rect.width(), rect.height()), (2, 6));
+        assert!(edit.tree.iter().any(|l| matches!(
+            &l.kind,
+            schist_core::LayerKind::Adjustment(a) if a.kind == schist_core::AdjustmentKind::Invert
+        )));
+        // Clockwise, the magenta left half becomes the top half; inverted
+        // it is green, and the black bottom half is white.
+        let pixels = schist_compositor::composite_region_rgba8(&edit, rect);
+        let px = pixels.as_chunks::<4>().0;
+        assert!(px[..6].iter().all(|p| p[0] < 16 && p[1] > 240 && p[2] < 16));
+        assert!(px[6..]
+            .iter()
+            .all(|p| p[0] > 240 && p[1] > 240 && p[2] > 240));
+
+        // Running again works on the edit and keeps the first as a version.
+        let again = BatchRecipe {
+            flip_v: true,
+            ..Default::default()
+        };
+        process_photo(&codecs, &photo, &again, &BatchSink::Edit).unwrap();
+        let versions: Vec<_> = std::fs::read_dir(dir.join(".schist/versions"))
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(versions.len(), 1);
+        assert!(versions[0].ends_with("-photo.psd.psd"));
+        let edit = schist_codec_psd::read_psd(&std::fs::read(&out).unwrap()).unwrap();
+        let rect = edit.canvas_rect();
+        assert_eq!((rect.width(), rect.height()), (2, 6));
+        let pixels = schist_compositor::composite_region_rgba8(&edit, rect);
+        let px = pixels.as_chunks::<4>().0;
+        // Flipped: white on top now, green below.
+        assert!(px[..6]
+            .iter()
+            .all(|p| p[0] > 240 && p[1] > 240 && p[2] > 240));
+        assert!(px[6..].iter().all(|p| p[0] < 16 && p[1] > 240 && p[2] < 16));
+
+        // Copies go beside the photo, from the edit, and never overwrite.
+        let sink = BatchSink::Copies {
+            dir: None,
+            codec: codecs[0].clone(),
+            options: schist_plugin_api::ExportOptions::default(),
+        };
+        let first = process_photo(&codecs, &photo, &again, &sink).unwrap();
+        assert_eq!(first, dir.join("photo-edit.psd"));
+        let second = process_photo(&codecs, &photo, &again, &sink).unwrap();
+        assert_eq!(second, dir.join("photo-edit-2.psd"));
+        let flat = schist_codec_psd::read_psd(&std::fs::read(&first).unwrap()).unwrap();
+        assert_eq!(flat.tree.layers.len(), 1);
+        let rect = flat.canvas_rect();
+        let pixels = schist_compositor::composite_region_rgba8(&flat, rect);
+        let px = pixels.as_chunks::<4>().0;
+        // The edit was white-over-green; flipped once more it is green
+        // on top again.
+        assert!(px[..6].iter().all(|p| p[0] < 16 && p[1] > 240 && p[2] < 16));
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/app/src/workspace/library_view.rs
+++ b/crates/app/src/workspace/library_view.rs
@@ -2620,7 +2620,18 @@ fn gallery_context_menu(
             let acting = ws.library.selected.clone();
             let n = acting.len();
 
-            {
+            if n > 1 {
+                let open = acting.clone();
+                let opening = n.min(super::DROP_OPEN_CAP);
+                row(
+                    format!("Edit {opening} in tabs"),
+                    &mut rows,
+                    cx,
+                    std::rc::Rc::new(move |ws, _w, cx| {
+                        ws.open_photos_in_tabs(open.clone(), cx);
+                    }),
+                );
+            } else {
                 let open = path.clone();
                 row(
                     "Edit".into(),
@@ -2716,18 +2727,57 @@ fn gallery_context_menu(
                 );
             }
             {
-                let up = acting;
+                // Turn, upscale, colour — one recipe over the lot.
+                let batch = acting.clone();
                 let label = if n > 1 {
-                    format!("Upscale {n} ×2")
+                    format!("Process {n} photos\u{2026}")
                 } else {
-                    "Upscale ×2".to_string()
+                    "Process\u{2026}".to_string()
                 };
                 row(
                     label,
                     &mut rows,
                     cx,
                     std::rc::Rc::new(move |ws, _w, cx| {
-                        ws.upscale_photos(up.clone(), cx);
+                        ws.open_batch_process(batch.clone(), cx);
+                    }),
+                );
+            }
+            sep(&mut rows);
+            {
+                let moving = acting.clone();
+                let label = if n > 1 {
+                    format!("Move {n} to folder\u{2026}")
+                } else {
+                    "Move to folder\u{2026}".to_string()
+                };
+                row(
+                    label,
+                    &mut rows,
+                    cx,
+                    std::rc::Rc::new(move |ws, window, cx| {
+                        ws.move_photos_prompt(moving.clone(), window, cx);
+                    }),
+                );
+            }
+            // Only an edited photo has an original to go back to.
+            let edited = acting
+                .iter()
+                .filter(|p| super::library::backing_psd(p).is_some_and(|s| s.exists()))
+                .count();
+            if edited > 0 {
+                let revert = acting;
+                let label = if edited > 1 {
+                    format!("Revert {edited} to originals")
+                } else {
+                    "Revert to original".to_string()
+                };
+                row(
+                    label,
+                    &mut rows,
+                    cx,
+                    std::rc::Rc::new(move |ws, _w, cx| {
+                        ws.revert_photos(revert.clone(), cx);
                     }),
                 );
             }
@@ -2749,6 +2799,21 @@ fn gallery_context_menu(
                     ws.gallery_edit_bucket(index, cx);
                 }),
             );
+            if !photos.is_empty() {
+                // Into the grid's selection, where the keyboard and
+                // the photo menu can take it from here.
+                let select = photos.clone();
+                row(
+                    format!("Select all ({})", photos.len()),
+                    &mut rows,
+                    cx,
+                    std::rc::Rc::new(move |ws, _w, _cx| {
+                        ws.library.bucket_filter = Some(index);
+                        ws.library.folder_filter = None;
+                        ws.library.selected = select.clone();
+                    }),
+                );
+            }
             sep(&mut rows);
             let (zip, _held) = ws
                 .library
@@ -2764,14 +2829,23 @@ fn gallery_context_menu(
                     }),
                 );
             }
-            {
-                let up = photos;
+            if !photos.is_empty() {
+                let batch = photos.clone();
                 row(
-                    "Upscale all ×2".into(),
+                    format!("Process all\u{2026} ({})", photos.len()),
                     &mut rows,
                     cx,
                     std::rc::Rc::new(move |ws, _w, cx| {
-                        ws.upscale_photos(up.clone(), cx);
+                        ws.open_batch_process(batch.clone(), cx);
+                    }),
+                );
+                let moving = photos;
+                row(
+                    "Move all to folder\u{2026}".into(),
+                    &mut rows,
+                    cx,
+                    std::rc::Rc::new(move |ws, window, cx| {
+                        ws.move_photos_prompt(moving.clone(), window, cx);
                     }),
                 );
             }

--- a/crates/app/src/workspace/mod.rs
+++ b/crates/app/src/workspace/mod.rs
@@ -553,6 +553,71 @@ impl CanvasTransform {
     }
 }
 
+/// What the gallery's batch dialog does to each photo, in the order
+/// it happens: the canvas is turned, then enlarged, then the colour
+/// adjustments go on top as adjustment layers — so an edit keeps them
+/// live in the sidecar, the way a Layer ▸ New Adjustment would.
+#[derive(Debug, Clone, PartialEq, Default)]
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub struct BatchRecipe {
+    /// A quarter or half turn, if any.
+    pub rotate: Option<CanvasTransform>,
+    pub flip_h: bool,
+    pub flip_v: bool,
+    /// A neural ×2 upscaler from the catalogue, if any.
+    pub upscale: Option<&'static str>,
+    /// Adjustment layers, bottom to top.
+    pub adjustments: Vec<schist_adjustments::Params>,
+}
+
+impl BatchRecipe {
+    /// Whether the recipe does anything at all.
+    pub fn is_empty(&self) -> bool {
+        self.rotate.is_none()
+            && !self.flip_h
+            && !self.flip_v
+            && self.upscale.is_none()
+            && self.adjustments.is_empty()
+    }
+
+    /// The canvas transforms, in the order they apply.
+    pub fn transforms(&self) -> Vec<CanvasTransform> {
+        let mut ops = Vec::new();
+        ops.extend(self.rotate);
+        if self.flip_h {
+            ops.push(CanvasTransform::FlipH);
+        }
+        if self.flip_v {
+            ops.push(CanvasTransform::FlipV);
+        }
+        ops
+    }
+}
+
+/// Where a batch run puts its results.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+pub enum BatchTarget {
+    /// Into each photo's `.schist` sidecar, versioned like any save.
+    /// The originals stay untouched and the gallery shows the edits.
+    #[default]
+    Edit,
+    /// A flat copy beside each original, `<name>-edit.<ext>`.
+    Beside,
+    /// Flat copies in a folder chosen when the run starts.
+    Folder,
+}
+
+impl BatchTarget {
+    pub fn label(self) -> &'static str {
+        match self {
+            BatchTarget::Edit => "Gallery edits (versioned)",
+            BatchTarget::Beside => "Copies beside the originals",
+            BatchTarget::Folder => "Copies in a folder\u{2026}",
+        }
+    }
+}
+
 /// Which Select ▸ Modify operation a dialog is running.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ModifyKind {
@@ -1026,6 +1091,15 @@ pub enum Modal {
         options: schist_plugin_api::ExportOptions,
         scale: f32,
         size: Option<(u32, u32)>,
+    },
+    /// The gallery's batch dialog: one recipe run over every photo in
+    /// `photos`, written as versioned edits or as flat copies.
+    BatchProcess {
+        photos: Vec<PathBuf>,
+        recipe: BatchRecipe,
+        target: BatchTarget,
+        codec: &'static str,
+        options: schist_plugin_api::ExportOptions,
     },
     /// Create or edit a gallery bucket: its name, and optionally a
     /// smart rule — a search query and/or a map area (the drawn

--- a/crates/app/src/workspace/modals.rs
+++ b/crates/app/src/workspace/modals.rs
@@ -473,6 +473,7 @@ impl Workspace {
             | Modal::MapFilter
             | Modal::SearchModels
             | Modal::SaveImageAs { .. }
+            | Modal::BatchProcess { .. }
             // Handled above, before the numeric parse, like the other
             // text fields.
             | Modal::BucketName { .. }

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -86,9 +86,9 @@ sidebar **folder**, which moves the files (each photo's `.schist`
 sidecar and versions travel with it), or to a **bucket**. Buckets are
 Picasa's tray with names: persisted baskets photos are dragged into,
 viewed by clicking their sidebar row, and acted on as a group from
-their right-click menu — **Save all as ZIP…** and **Upscale all ×2**
-(the built-in waifu2x, `<name>@2x.png` beside each original, no
-download needed).
+their right-click menu — **Select all**, **Save all as ZIP…**,
+**Process all…** (the batch dialog below) and **Move all to
+folder…**.
 
 A drag that leaves for another window leaves Schist altogether: the
 moment the pointer is over someone else's window, the internal drag is
@@ -123,14 +123,37 @@ photo at a time, so a whole bucket never has to fit in memory.
 
 "+ New bucket" asks for a name (an empty one falls back to "Bucket N")
 and the bucket is born holding the current selection. Photos have
-their own right-click menu too: Edit, Reveal in file manager, Add to
-bucket, Upscale — acting on the whole selection when the click lands
-in it — and one of two ways out: several selected photos offer **Save
+their own right-click menu too: Edit (several selected open as tabs,
+capped at a hundred), Reveal in file manager, Add to bucket, Process…,
+Move to folder…, and Revert to original for edited photos (the edit
+sidecar goes into `versions/` rather than being lost) — acting on the
+whole selection when the click lands in it — and one of two ways out: several selected photos offer **Save
 N as ZIP…**, a single one offers **Save image as…**, a dialog with the
 format (every codec that exports), quality where the format takes
 one, and a scale slider from 10% to 100% that says what it comes to
 in pixels. It saves the photo's edit when it has one, flattened, and
 never touches the original.
+
+**Process…** is the batch dialog, for a selection or a whole bucket:
+one recipe run over every photo. It has a turn (rotate by a quarter or
+half turn, flip either way), a size (the two built-in waifu2x ×2
+upscalers, no download needed), and a colour section where any number
+of adjustments stack up — Brightness/Contrast, Levels, Exposure,
+Vibrance, Hue/Saturation, Color Balance, Black & White, Photo Filter,
+Channel Mixer, Invert, Posterize, Threshold — each with the same
+sliders its adjustment layer has in the editor. The recipe applies in
+that order: turn, enlarge, then the adjustments go on top as
+adjustment layers. Where it lands is the last choice. **Gallery
+edits** writes each photo's `.schist` sidecar exactly as ⌘S would —
+the adjustments stay live layers you can retune in the editor, an
+existing edit is what the recipe applies to, and the previous sidecar
+is kept under `versions/` — so the originals are never touched and
+the grid shows the results. **Copies beside the originals** flattens
+each result to `<name>-edit.<ext>` in the photo's folder (never
+overwriting: a second run gets `-2`), and **Copies in a folder…** asks
+where; both take a format and, where it applies, a quality. Photos are
+processed one at a time on the background executor with the tray
+counting, since an upscale is seconds per megapixel.
 
 ## The AI panel
 


### PR DESCRIPTION
## Summary

- The gallery's photo and bucket right-click menus' **Upscale ×2** row becomes **Process…**, a batch dialog that runs one recipe over the selection or a whole bucket: a turn (rotate 90°/180°, flips), a neural ×2 upscale (the two built-in waifu2x models), and any number of colour adjustments (Brightness/Contrast, Levels, Exposure, Vibrance, Hue/Saturation, Color Balance, Black & White, Photo Filter, Channel Mixer, Invert, Posterize, Threshold) with the same sliders their adjustment layers have in the editor.
- Output goes to **gallery edits** (each photo's `.schist` sidecar, written like a ⌘S: adjustments stay live layers, the previous edit is kept under `versions/`), **copies beside the originals** (`<name>-edit.<ext>`, never overwriting), or **copies in a folder…**; both copy modes take a format and quality.
- New photo rows: **Edit N in tabs**, **Move to folder…**, **Revert to original** (the sidecar is moved into `versions/`, not deleted). New bucket rows: **Select all**, **Process all…**, **Move all to folder…**.
- Fixes a latent bug: opening several gallery photos at once used a single pending-backing slot, so every load but the last lost its sidecar link and a plain save would have overwritten the original.
- `transform_canvas` is factored into a document-level `transform_document`, and sidecar versioning into `keep_sidecar_version`, so the batch engine runs without a workspace. `docs/gallery.md` describes the new menus and dialog.

## Test plan

- [x] New unit test `batch_process_writes_versioned_edits_and_flat_copies`: rotate + invert land in the sidecar as a turned canvas with a live adjustment layer, the original bytes are untouched, a second run versions the first edit, copies land beside the photo without collisions.
- [x] `cargo test -p schist-app library_ops` (7 passed), `cargo clippy -p schist-app --all-targets -- -D warnings`, `cargo fmt --check`.
- [x] Headless Xvfb run on a seeded library: menu → dialog → Hue/Saturation +140° over three photos → recoloured thumbnails with "edited" badges; Revert to original restored them and left three files under `versions/`.
- [ ] The neural upscale path in the batch reuses the editor's Image Size code but was not run headlessly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
