### PR TITLE
feat(raw): native raw import on the web build, LibRaw prompt on the desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ sample against LibRaw across some 250 camera files), which covers most
 bodies; what it declines — Canon CR3 pixels, Fuji's compressed RAF, a
 few odd codecs, and cameras with no colour matrix in its table yet —
 falls back to the system's LibRaw, loaded at runtime (`brew install
-libraw`, or the distro's package). HEIC decodes through libheif the
+libraw`, or the distro's package); the browser build, which cannot load
+one, refuses those few files and opens everything else. HEIC decodes through libheif the
 same way: the system's copy if installed, otherwise Schist offers to
 download a hash-pinned, decode-only build (with its LGPL license texts)
 from [libheif-prebuilt](https://github.com/IAmJSD/libheif-prebuilt) —

--- a/crates/app/src/dialogs/mod.rs
+++ b/crates/app/src/dialogs/mod.rs
@@ -173,6 +173,10 @@ pub fn render(ws: &mut Workspace, cx: &mut Context<Workspace>) -> Option<gpui::A
         #[cfg(target_arch = "wasm32")]
         Modal::HeifSupport { .. } => return None,
         #[cfg(not(target_arch = "wasm32"))]
+        Modal::LibRawSupport { path } => libraw_support(path, cx).into_any_element(),
+        #[cfg(target_arch = "wasm32")]
+        Modal::LibRawSupport { .. } => return None,
+        #[cfg(not(target_arch = "wasm32"))]
         Modal::CameraImport { sources } => {
             crate::workspace::camera_import_dialog(&sources, cx).into_any_element()
         }

--- a/crates/app/src/dialogs/open.rs
+++ b/crates/app/src/dialogs/open.rs
@@ -123,6 +123,68 @@ pub(super) fn heif_support(
     )
 }
 
+/// A raw file Schist's own decoder declines needs LibRaw, and this
+/// machine has none. There is no download offer yet (no prebuilt to
+/// pin, unlike libheif), so this says where the library comes from
+/// and retries the open once it is there.
+#[cfg(not(target_arch = "wasm32"))]
+pub(super) fn libraw_support(
+    path: std::path::PathBuf,
+    cx: &mut Context<Workspace>,
+) -> impl IntoElement {
+    let name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string());
+    let how = if cfg!(target_os = "macos") {
+        "Install it with Homebrew: brew install libraw".to_string()
+    } else if cfg!(target_os = "linux") {
+        "Install your distribution's LibRaw package (Debian/Ubuntu: libraw23t64 or \
+         libraw23; Fedora: LibRaw; Arch: libraw)."
+            .to_string()
+    } else {
+        format!(
+            "Put a LibRaw build (libraw.dll) in {}",
+            schist_codecs_common::raw::managed_dir().display()
+        )
+    };
+    ui::modal_frame(
+        "LibRaw Needed",
+        420.0,
+        div()
+            .flex()
+            .flex_col()
+            .gap_2()
+            .text_size(px(12.0))
+            .child(format!(
+                "Schist\u{2019}s own raw decoder does not read \u{201C}{name}\u{201D} \
+                 yet (Canon CR3, Fuji compressed RAF and a few other codecs), and \
+                 the LibRaw library it falls back to for those is not installed."
+            ))
+            .child(how)
+            .child("Then choose Try Again."),
+        div()
+            .flex()
+            .flex_row()
+            .gap_2()
+            .child(ui::button(
+                "Cancel",
+                false,
+                |ws, _window, cx| ws.close_modal(cx),
+                cx,
+            ))
+            .child(ui::button(
+                "Try Again",
+                true,
+                move |ws, _window, cx| {
+                    ws.close_modal(cx);
+                    ws.load_file(path.clone(), cx);
+                },
+                cx,
+            )),
+    )
+}
+
 /// Folders dropped on the window: every image in them as tabs, or the
 /// folders watched in the gallery. The gallery is the answer for
 /// anything bigger than a handful — which is why it is the primary

--- a/crates/app/src/workspace/docs.rs
+++ b/crates/app/src/workspace/docs.rs
@@ -393,6 +393,19 @@ impl Workspace {
                 self.status = "HEIC support is not installed".into();
                 self.open_modal(Modal::HeifSupport { path }, cx);
             }
+            // A raw Schist's own decoder declines needs LibRaw, and
+            // there is none to load: say how to get one and offer a
+            // retry. (The web build refuses these files outright with
+            // a message of its own, through the plain arm below.)
+            #[cfg(not(target_arch = "wasm32"))]
+            Err(err)
+                if schist_codecs_common::raw::is_missing_library_error(&err)
+                    && self.modal.is_none() =>
+            {
+                log::info!("open needs LibRaw: {err:#}");
+                self.status = "LibRaw is not installed".into();
+                self.open_modal(Modal::LibRawSupport { path }, cx);
+            }
             Err(err) => {
                 log::error!("open failed: {err:#}");
                 self.status = format!("Open failed: {err}").into();

--- a/crates/app/src/workspace/mod.rs
+++ b/crates/app/src/workspace/mod.rs
@@ -1020,6 +1020,10 @@ pub enum Modal {
     /// offer to download it (with its LGPL license texts), then retry
     /// opening `path`.
     HeifSupport { path: PathBuf },
+    /// A raw file Schist's own decoder declines (Canon CR3, Fuji's
+    /// compressed RAF...) needs LibRaw, and this machine has none:
+    /// say how to install it, then retry opening `path`.
+    LibRawSupport { path: PathBuf },
     /// More than one camera is reachable: ask which to import from.
     CameraImport { sources: Vec<ImportSource> },
     /// Import options for one camera: the navigable OpenStreetMap view

--- a/crates/app/src/workspace/modals.rs
+++ b/crates/app/src/workspace/modals.rs
@@ -466,6 +466,7 @@ impl Workspace {
             | Modal::DropImage { .. }
             | Modal::DropFolders { .. }
             | Modal::HeifSupport { .. }
+            | Modal::LibRawSupport { .. }
             | Modal::CameraImport { .. }
             | Modal::CameraImportOptions { .. }
             | Modal::CameraImportFailed { .. }

--- a/docs/web.md
+++ b/docs/web.md
@@ -104,7 +104,6 @@ Compiled out entirely, with the reason:
 | Photoshop `.8bf` plug-ins | helper subprocesses and dlopen |
 | Third-party wasm plug-ins | wasmtime is a JIT; a wasm module cannot host one |
 | HEIC import | libheif is dlopen'd |
-| Camera raw import | the plugin wraps a dlopen'd LibRaw fallback; the pure-Rust `schist-codec-raw` decoder itself would build for wasm and is a candidate for a future web-only path |
 | Auto-update | a web deployment updates by serving newer files |
 | Crash reporting (Sentry) | blocking transport; panics go to the console instead |
 | Font downloads | the Google Fonts catalogue trick needs a spoofed legacy user agent to be served TTFs |
@@ -114,6 +113,13 @@ The menu entries for those features are filtered out of the web build
 rather than left to fail.
 
 ## Known gaps
+
+Camera raws open through the pure-Rust `schist-codec-raw` decoder, the
+same one the desktop uses first. The few codecs it declines — Canon CR3
+pixels, Fuji's compressed RAF, a handful of odd ones — go to a runtime
+LibRaw on the desktop; a browser has no library to load, so those files
+are refused with a message saying so (their embedded previews still
+show).
 
 - Text layers can only use the fonts the page ships (IBM Plex Sans
   Regular today — add more in `web/fonts/` and they are picked up by the

--- a/plugins/codecs-common/src/raw.rs
+++ b/plugins/codecs-common/src/raw.rs
@@ -1,25 +1,14 @@
 //! Camera raw import: the pure-Rust `schist-codec-raw` decoder first,
-//! then LibRaw, loaded at runtime, for whatever it declines.
+//! then, off the web, LibRaw loaded at runtime for whatever it declines
+//! (see `libraw`).
 //!
 //! A raw file is a sensor dump in one of some dozens of vendor
 //! containers: most are TIFF with a proprietary compression (Nikon,
 //! Sony, Pentax, DNG), Canon's CR3 is ISO-BMFF, and Fuji, Olympus and
-//! Panasonic use private headers. LibRaw reads all of them and develops
-//! the sensor data — black level, white balance, demosaic, the camera
-//! matrix — into a picture. Every pure-Rust raw decoder is LGPL too, so
-//! this makes the same choice HEIC did: nothing links at build time,
-//! nothing is bundled, and the library is dlopen'd on first import,
-//! looked for in two places:
-//!
-//! 1. The managed directory (`SCHIST_LIBRAW_DIR`, else
-//!    `$XDG_DATA_HOME/schist/libraw`), for a copy put there by hand on a
-//!    machine without a system package, or without root to install one.
-//!    There is no consented download of a prebuilt yet, as HEIC has; the
-//!    directory is the hook for one.
-//! 2. The system's LibRaw: Homebrew on macOS, every Linux distro. The
-//!    reentrant build (`libraw_r`) is preferred, and calls into the
-//!    plain one are serialised, because thumbnails decode on several
-//!    threads at once.
+//! Panasonic use private headers. The native crate reads nearly all of
+//! them exactly; the few codecs it does not (Canon's CRX, Fuji's
+//! compressed RAF, a handful of odd ones) go to LibRaw on the desktop
+//! and are refused, with a message saying why, in the browser.
 //!
 //! Import only: a raw is a capture, and nothing writes one.
 //!
@@ -30,411 +19,36 @@
 //! histogram until 1% of the pixels clip. The result lands near the
 //! camera's own JPEG in brightness with the highlights still there.
 
-use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
-use std::marker::PhantomData;
-use std::path::PathBuf;
-use std::sync::{Mutex, MutexGuard};
-
-use anyhow::Context as _;
-use schist_color::Depth;
 use schist_core::Document;
 use schist_plugin_api::CodecPlugin;
+#[cfg(not(target_arch = "wasm32"))]
+mod libraw;
+#[cfg(not(target_arch = "wasm32"))]
+pub use libraw::managed_dir;
 
-/// `enum LibRaw_image_formats`
-const IMAGE_JPEG: c_int = 1;
-const IMAGE_BITMAP: c_int = 2;
-/// `enum LibRaw_errors`: the answers that mean "there is no embedded
-/// preview", as opposed to a broken file.
-const NO_THUMBNAIL: c_int = -5;
-const UNSUPPORTED_THUMBNAIL: c_int = -6;
-/// `output_color`: sRGB primaries. The curve is applied here, not by
-/// LibRaw (see `expose_and_encode`), so the developed pixels come out
-/// linear and leave as sRGB, needing no profile.
-const OUTPUT_SRGB: c_int = 1;
-
-/// `libraw_processed_image_t`, returned by `dcraw_make_mem_image` and
-/// `dcraw_make_mem_thumb`. `data` is the start of the pixels (or the
-/// JPEG bytes), `data_size` long, following the header in the same
-/// allocation.
-#[repr(C)]
-struct ProcessedImage {
-    kind: c_int,
-    height: u16,
-    width: u16,
-    colors: u16,
-    bits: u16,
-    data_size: c_uint,
-    data: [u8; 1],
-}
-
-/// The leading fields of `libraw_data_t`: the processed-image pointer
-/// and `libraw_image_sizes_t`. They have led the struct, in this order,
-/// since before the C setters existed, so reading them by layout is as
-/// stable as the API itself; nothing further in — the part that shifts
-/// between versions — is touched.
-#[repr(C)]
-struct DataHead {
-    image: *mut c_void,
-    raw_height: u16,
-    raw_width: u16,
-    height: u16,
-    width: u16,
-    top_margin: u16,
-    left_margin: u16,
-    iheight: u16,
-    iwidth: u16,
-    raw_pitch: c_uint,
-    pixel_aspect: f64,
-    /// The camera's orientation tag in dcraw's encoding: 3 is 180°, 5
-    /// is 90° counter-clockwise, 6 is 90° clockwise. Development
-    /// applies it; the embedded preview is stored unrotated.
-    flip: c_int,
-}
-
-macro_rules! libraw_fns {
-    ($( $field:ident : fn($($arg:ty),*) $(-> $ret:ty)? ; )*) => {
-        struct LibRaw {
-            /// Symbols below point into this mapping; never dropped
-            /// before them (the struct only lives in a static).
-            _lib: libloading::Library,
-            /// Present when the loaded build is not the reentrant one:
-            /// the plain library keeps state that is shared between
-            /// handles, so its calls take turns.
-            serial: Option<Mutex<()>>,
-            $( $field: unsafe extern "C" fn($($arg),*) $(-> $ret)?, )*
-        }
-
-        impl LibRaw {
-            fn from_library(lib: libloading::Library, reentrant: bool) -> Result<Self, String> {
-                unsafe {
-                    Ok(Self {
-                        $( $field: {
-                            let name = concat!("libraw_", stringify!($field), "\0");
-                            *lib.get(name.as_bytes())
-                                .map_err(|err| format!("missing symbol {name}: {err}"))?
-                        }, )*
-                        serial: (!reentrant).then(|| Mutex::new(())),
-                        _lib: lib,
-                    })
-                }
-            }
-        }
-    };
-}
-
-libraw_fns! {
-    init: fn(c_uint) -> *mut c_void;
-    close: fn(*mut c_void);
-    open_buffer: fn(*mut c_void, *const c_void, usize) -> c_int;
-    unpack: fn(*mut c_void) -> c_int;
-    unpack_thumb: fn(*mut c_void) -> c_int;
-    dcraw_process: fn(*mut c_void) -> c_int;
-    dcraw_make_mem_image: fn(*mut c_void, *mut c_int) -> *mut ProcessedImage;
-    dcraw_make_mem_thumb: fn(*mut c_void, *mut c_int) -> *mut ProcessedImage;
-    dcraw_clear_mem: fn(*mut ProcessedImage);
-    strerror: fn(c_int) -> *const c_char;
-    version: fn() -> *const c_char;
-    set_output_bps: fn(*mut c_void, c_int);
-    set_output_color: fn(*mut c_void, c_int);
-    set_gamma: fn(*mut c_void, c_int, f32);
-    set_no_auto_bright: fn(*mut c_void, c_int);
-    set_user_mul: fn(*mut c_void, c_int, f32);
-    get_cam_mul: fn(*mut c_void, c_int) -> f32;
-}
-
-/// Library names to try, in order, and whether each is the reentrant
-/// build. Sonames back to 0.19: the C setters used here exist from
-/// there, and 0.20 is where CR3 support starts.
-#[cfg(target_os = "linux")]
-const LIBRARY_CANDIDATES: &[(&str, bool)] = &[
-    ("libraw_r.so.23", true),
-    ("libraw_r.so.20", true),
-    ("libraw_r.so.19", true),
-    ("libraw_r.so", true),
-    ("libraw.so.23", false),
-    ("libraw.so.20", false),
-    ("libraw.so.19", false),
-    ("libraw.so", false),
-];
-#[cfg(target_os = "macos")]
-const LIBRARY_CANDIDATES: &[(&str, bool)] = &[
-    ("libraw_r.dylib", true),
-    ("libraw.dylib", false),
-    // Homebrew's prefix is not on the default search path for app
-    // bundles launched from Finder.
-    ("/opt/homebrew/lib/libraw_r.dylib", true),
-    ("/opt/homebrew/lib/libraw.dylib", false),
-    ("/usr/local/lib/libraw_r.dylib", true),
-    ("/usr/local/lib/libraw.dylib", false),
-];
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
-const LIBRARY_CANDIDATES: &[(&str, bool)] = &[
-    ("libraw_r.dll", true),
-    ("raw_r.dll", true),
-    ("libraw.dll", false),
-    ("raw.dll", false),
-    ("libraw-23.dll", false),
-];
-
-/// The app and the tests match on this phrase to recognise "this
-/// machine has no LibRaw" (as opposed to a broken file); keep it out of
-/// other error messages.
-const NOT_AVAILABLE: &str = "LibRaw is not available";
-
-/// The loaded library. A failed load is deliberately not cached, so a
-/// library installed later is picked up without a restart.
-static LOADED: Mutex<Option<&'static LibRaw>> = Mutex::new(None);
-
-/// True when an `import` error means no LibRaw could be loaded.
+/// True when an `import` error means no LibRaw could be loaded — the
+/// case an install (or, one day, a consented download) fixes, as
+/// opposed to a broken file. Never true on the web, which has no
+/// library to load.
 pub fn is_missing_library_error(err: &anyhow::Error) -> bool {
-    format!("{err:#}").contains(NOT_AVAILABLE)
-}
-
-/// Where a hand-installed library is looked for before the system's.
-pub fn managed_dir() -> PathBuf {
-    if let Ok(dir) = std::env::var("SCHIST_LIBRAW_DIR") {
-        return PathBuf::from(dir);
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        libraw::is_missing_library_error(err)
     }
-    let base = if cfg!(windows) {
-        std::env::var("LOCALAPPDATA")
-            .or_else(|_| std::env::var("USERPROFILE"))
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from("."))
-    } else {
-        std::env::var("XDG_DATA_HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| {
-                PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
-                    .join(".local/share")
-            })
-    };
-    base.join("schist/libraw")
-}
-
-fn libraw() -> anyhow::Result<&'static LibRaw> {
-    let mut loaded = LOADED.lock().unwrap_or_else(|e| e.into_inner());
-    if let Some(lib) = *loaded {
-        return Ok(lib);
-    }
-
-    // The managed directory first, by every bare library name; then
-    // the candidates as given, which the system loader resolves.
-    let managed = managed_dir();
-    let candidates: Vec<(std::ffi::OsString, bool)> = LIBRARY_CANDIDATES
-        .iter()
-        .filter(|(name, _)| !name.contains('/'))
-        .map(|(name, reentrant)| (managed.join(name).into_os_string(), *reentrant))
-        .chain(
-            LIBRARY_CANDIDATES
-                .iter()
-                .map(|(name, reentrant)| (name.into(), *reentrant)),
-        )
-        .collect();
-
-    let mut errors = Vec::new();
-    for (name, reentrant) in &candidates {
-        let lib = match unsafe { libloading::Library::new(name) } {
-            Ok(lib) => lib,
-            Err(err) => {
-                errors.push(format!("{}: {err}", name.to_string_lossy()));
-                continue;
-            }
-        };
-        match LibRaw::from_library(lib, *reentrant) {
-            Ok(lib) => {
-                let version = unsafe { CStr::from_ptr((lib.version)()) }.to_string_lossy();
-                log::info!(
-                    "raw: loaded LibRaw {version} from {}{}",
-                    name.to_string_lossy(),
-                    if *reentrant { "" } else { " (serialised)" }
-                );
-                let lib = &*Box::leak(Box::new(lib));
-                *loaded = Some(lib);
-                return Ok(lib);
-            }
-            Err(err) => errors.push(format!("{}: {err}", name.to_string_lossy())),
-        }
-    }
-    // The outer message is what the status line shows; the dlopen
-    // detail behind it is for the log.
-    Err(anyhow::anyhow!(errors.join("; "))).context(format!(
-        "{NOT_AVAILABLE}: opening camera raw files needs the LibRaw library \
-         (Linux: install libraw; macOS: brew install libraw)"
-    ))
-}
-
-fn check(lib: &LibRaw, code: c_int, what: &str) -> anyhow::Result<()> {
-    if code == 0 {
-        return Ok(());
-    }
-    let message = unsafe {
-        let ptr = (lib.strerror)(code);
-        if ptr.is_null() {
-            format!("error {code}")
-        } else {
-            CStr::from_ptr(ptr).to_string_lossy().into_owned()
-        }
-    };
-    anyhow::bail!("{what}: {message}")
-}
-
-/// One LibRaw processor with a file opened in it. Holds the
-/// serialisation lock for the non-reentrant build as long as it lives,
-/// and closes (frees) the processor when dropped, so early error returns
-/// leak nothing.
-struct Handle<'a> {
-    lib: &'a LibRaw,
-    ptr: *mut c_void,
-    _guard: Option<MutexGuard<'a, ()>>,
-    /// `open_buffer` reads from the caller's bytes for the handle's
-    /// whole life; nothing is copied.
-    _bytes: PhantomData<&'a [u8]>,
-}
-
-impl<'a> Handle<'a> {
-    fn open(lib: &'a LibRaw, bytes: &'a [u8]) -> anyhow::Result<Self> {
-        let guard = lib
-            .serial
-            .as_ref()
-            .map(|m| m.lock().unwrap_or_else(|e| e.into_inner()));
-        let ptr = unsafe { (lib.init)(0) };
-        anyhow::ensure!(!ptr.is_null(), "libraw_init failed");
-        let handle = Handle {
-            lib,
-            ptr,
-            _guard: guard,
-            _bytes: PhantomData,
-        };
-        check(
-            lib,
-            unsafe { (lib.open_buffer)(ptr, bytes.as_ptr().cast(), bytes.len()) },
-            "reading raw file",
-        )?;
-        Ok(handle)
-    }
-
-    /// The camera orientation, dcraw's encoding (see `DataHead::flip`).
-    fn flip(&self) -> c_int {
-        unsafe { (*self.ptr.cast::<DataHead>()).flip }
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = err;
+        false
     }
 }
 
-impl Drop for Handle<'_> {
-    fn drop(&mut self) {
-        unsafe { (self.lib.close)(self.ptr) }
-    }
-}
-
-/// A `libraw_processed_image_t`, freed when dropped.
-struct Processed<'a> {
-    lib: &'a LibRaw,
-    ptr: *mut ProcessedImage,
-}
-
-impl Processed<'_> {
-    fn header(&self) -> &ProcessedImage {
-        unsafe { &*self.ptr }
-    }
-
-    fn data(&self) -> &[u8] {
-        unsafe {
-            std::slice::from_raw_parts(
-                std::ptr::addr_of!((*self.ptr).data).cast::<u8>(),
-                (*self.ptr).data_size as usize,
-            )
-        }
-    }
-}
-
-impl Drop for Processed<'_> {
-    fn drop(&mut self) {
-        unsafe { (self.lib.dcraw_clear_mem)(self.ptr) }
-    }
-}
-
-/// Widen a processed bitmap — 1 or 3 samples a pixel, 8 or 16 bits —
-/// to straight RGBA, as f32 in 0..=1.
-fn bitmap_to_rgba_f32(img: &Processed<'_>) -> anyhow::Result<(u32, u32, Vec<f32>)> {
-    let head = img.header();
-    anyhow::ensure!(head.kind == IMAGE_BITMAP, "developed image is not a bitmap");
-    let (w, h) = (head.width as usize, head.height as usize);
-    let colors = head.colors as usize;
-    anyhow::ensure!(w > 0 && h > 0, "zero-sized image");
-    anyhow::ensure!(
-        colors == 1 || colors == 3,
-        "unexpected channel count {colors}"
-    );
-    let data = img.data();
-    let mut out = Vec::with_capacity(w * h * 4);
-    let mut push = |px: &[f32]| {
-        match px {
-            [v] => out.extend_from_slice(&[*v, *v, *v, 1.0]),
-            [r, g, b] => out.extend_from_slice(&[*r, *g, *b, 1.0]),
-            _ => unreachable!(),
-        };
-    };
-    match head.bits {
-        16 => {
-            anyhow::ensure!(data.len() >= w * h * colors * 2, "short pixel data");
-            let samples = data.as_chunks::<2>().0;
-            for px in samples[..w * h * colors].chunks_exact(colors) {
-                let px: Vec<f32> = px
-                    .iter()
-                    .map(|s| u16::from_ne_bytes(*s) as f32 / 65535.0)
-                    .collect();
-                push(&px);
-            }
-        }
-        8 => {
-            anyhow::ensure!(data.len() >= w * h * colors, "short pixel data");
-            for px in data[..w * h * colors].chunks_exact(colors) {
-                let px: Vec<f32> = px.iter().map(|s| *s as f32 / 255.0).collect();
-                push(&px);
-            }
-        }
-        bits => anyhow::bail!("unexpected sample depth {bits}"),
-    }
-    Ok((w as u32, h as u32, out))
-}
-
-/// Develop the sensor data into a 16-bit sRGB document.
-fn develop(lib: &LibRaw, bytes: &[u8]) -> anyhow::Result<Document> {
-    let handle = Handle::open(lib, bytes)?;
-    let lr = handle.ptr;
-    unsafe {
-        check(lib, (lib.unpack)(lr), "unpacking sensor data")?;
-        (lib.set_output_bps)(lr, 16);
-        (lib.set_output_color)(lr, OUTPUT_SRGB);
-        // Linear light out (dcraw's `-g 1 1`), untouched by the
-        // histogram stretch: exposure and the sRGB curve are applied
-        // below, where the highlights can roll off instead of clip.
-        (lib.set_gamma)(lr, 0, 1.0);
-        (lib.set_gamma)(lr, 1, 1.0);
-        (lib.set_no_auto_bright)(lr, 1);
-        // The camera's as-shot white balance, when the file carries one
-        // (a fourth multiplier of zero is normal: three-colour sensors
-        // have no second green). Without it LibRaw assumes daylight,
-        // which is wrong indoors and under most skies.
-        let mul: [f32; 4] = std::array::from_fn(|i| (lib.get_cam_mul)(lr, i as c_int));
-        if mul[..3].iter().all(|m| m.is_finite() && *m > 0.0) {
-            for (i, m) in mul.iter().enumerate() {
-                (lib.set_user_mul)(lr, i as c_int, *m);
-            }
-        }
-        check(lib, (lib.dcraw_process)(lr), "developing")?;
-        let mut errc = 0;
-        let img = (lib.dcraw_make_mem_image)(lr, &mut errc);
-        if img.is_null() {
-            check(lib, errc, "reading developed image")?;
-            anyhow::bail!("reading developed image: no image");
-        }
-        let img = Processed { lib, ptr: img };
-        let (w, h, mut rgba) = bitmap_to_rgba_f32(&img)?;
-        drop(img);
-        expose_and_encode(&mut rgba);
-        crate::deep_document("Raw", w, h, &rgba, Depth::Sixteen, None)
-            .context("assembling document")
-    }
+/// What a browser says about a file only LibRaw could develop: the
+/// native crate has declined it, and there is no library to load.
+#[cfg(target_arch = "wasm32")]
+fn web_refusal(err: anyhow::Error) -> anyhow::Error {
+    err.context(
+        "this raw file needs LibRaw, which the web build cannot load; the desktop app opens it",
+    )
 }
 
 /// Bring linear developed pixels up to display brightness and encode
@@ -510,7 +124,8 @@ fn srgb_encode(v: f32) -> f32 {
 /// The camera's own preview — most raws embed a JPEG, often full size —
 /// as straight RGBA, turned upright. `None` when the file has no usable
 /// one. Orders of magnitude cheaper than developing, which is what a
-/// thumbnail wants.
+/// thumbnail wants. The native crate finds it in every container; the
+/// LibRaw fallback only matters where that fails.
 pub fn embedded_preview(bytes: &[u8]) -> anyhow::Result<Option<image::RgbaImage>> {
     let choice = decoder_choice();
     // The native answer, kept so a machine without LibRaw still gets
@@ -528,56 +143,18 @@ pub fn embedded_preview(bytes: &[u8]) -> anyhow::Result<Option<image::RgbaImage>
             }
         }
     }
-    let lib = match (libraw(), native_answer) {
-        (Ok(lib), _) => lib,
-        (Err(missing), Some(answer)) => {
-            return answer.map_err(|err| err.context(format!("{missing}")));
-        }
-        (Err(missing), None) => return Err(missing),
-    };
-    let handle = Handle::open(lib, bytes)?;
-    let lr = handle.ptr;
-    let img = unsafe {
-        let code = (lib.unpack_thumb)(lr);
-        if code == NO_THUMBNAIL || code == UNSUPPORTED_THUMBNAIL {
-            return Ok(None);
-        }
-        check(lib, code, "reading embedded preview")?;
-        let mut errc = 0;
-        let img = (lib.dcraw_make_mem_thumb)(lr, &mut errc);
-        if img.is_null() {
-            if errc == NO_THUMBNAIL || errc == UNSUPPORTED_THUMBNAIL {
-                return Ok(None);
-            }
-            check(lib, errc, "reading embedded preview")?;
-            return Ok(None);
-        }
-        Processed { lib, ptr: img }
-    };
-    let decoded = match img.header().kind {
-        IMAGE_JPEG => image::load_from_memory_with_format(img.data(), image::ImageFormat::Jpeg)
-            .context("decoding embedded preview")?
-            .into_rgba8(),
-        IMAGE_BITMAP => {
-            let (w, h, rgba) = bitmap_to_rgba_f32(&img)?;
-            let bytes: Vec<u8> = rgba
-                .iter()
-                .map(|v| (v.clamp(0.0, 1.0) * 255.0 + 0.5) as u8)
-                .collect();
-            image::RgbaImage::from_raw(w, h, bytes).context("buffer size")?
-        }
-        _ => return Ok(None),
-    };
-    drop(img);
-    // Development turns the picture the camera's way; the preview is
-    // the sensor's orientation and has to be turned here.
-    let upright = match handle.flip() {
-        3 => image::imageops::rotate180(&decoded),
-        5 => image::imageops::rotate270(&decoded),
-        6 => image::imageops::rotate90(&decoded),
-        _ => decoded,
-    };
-    Ok(Some(upright))
+    #[cfg(target_arch = "wasm32")]
+    {
+        return native_answer.unwrap_or(Ok(None)).map_err(web_refusal);
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    match libraw::embedded_preview(bytes) {
+        Err(missing) if is_missing_library_error(&missing) => match native_answer {
+            Some(answer) => answer.map_err(|err| err.context(format!("{missing}"))),
+            None => Err(missing),
+        },
+        answer => answer,
+    }
 }
 
 /// Camera raw files, import only.
@@ -618,16 +195,22 @@ impl CodecPlugin for RawCodec {
             }
             None => None,
         };
+        #[cfg(target_arch = "wasm32")]
+        {
+            return Err(web_refusal(native_err.unwrap_or_else(|| {
+                anyhow::anyhow!("the native decoder was disabled")
+            })));
+        }
         // With no LibRaw to fall back on, the native decoder's
         // diagnosis is the useful one; the missing library is context.
-        let lib = match (libraw(), native_err) {
-            (Ok(lib), _) => lib,
-            (Err(missing), Some(native_err)) => {
-                return Err(native_err.context(format!("{missing}")));
-            }
-            (Err(missing), None) => return Err(missing),
-        };
-        develop(lib, bytes)
+        #[cfg(not(target_arch = "wasm32"))]
+        match libraw::develop_document(bytes) {
+            Err(missing) if is_missing_library_error(&missing) => match native_err {
+                Some(native_err) => Err(native_err.context(format!("{missing}"))),
+                None => Err(missing),
+            },
+            result => result,
+        }
     }
 }
 
@@ -892,7 +475,7 @@ pub(crate) mod tests {
             return;
         };
         assert_eq!((doc.width, doc.height), (64, 32));
-        assert_eq!(doc.depth, Depth::Sixteen, "raws keep 16 bits");
+        assert_eq!(doc.depth, schist_color::Depth::Sixteen, "raws keep 16 bits");
         assert!(doc.icc_profile.is_none(), "developed to sRGB, no profile");
         let tiles = &doc.tree.layers[0].as_raster().unwrap().tiles;
         // Grey in, grey out: the as-shot balance is neutral and the
@@ -982,6 +565,7 @@ pub(crate) mod tests {
     /// median of 33 dB — the two develop pipelines differ in demosaic
     /// and tone, so this is a smoke test for gross errors, not parity).
     #[test]
+    #[cfg(not(target_arch = "wasm32"))]
     fn native_agrees_with_libraw() {
         let Ok(dir) = std::env::var("SCHIST_RAW_CORPUS") else {
             return;
@@ -1034,12 +618,11 @@ pub(crate) mod tests {
             let started = std::time::Instant::now();
             let native = native::develop_document(&bytes);
             let native_time = started.elapsed();
-            let lib = match libraw() {
-                Ok(lib) => lib,
-                Err(_) => return,
-            };
             let started = std::time::Instant::now();
-            let reference = develop(lib, &bytes);
+            let reference = match libraw::develop_document(&bytes) {
+                Err(err) if is_missing_library_error(&err) => return,
+                reference => reference,
+            };
             let libraw_time = started.elapsed();
             match (native, reference) {
                 (Ok(a), Ok(b)) => {

--- a/plugins/codecs-common/src/raw/libraw.rs
+++ b/plugins/codecs-common/src/raw/libraw.rs
@@ -1,0 +1,481 @@
+//! The LibRaw fallback: the library, loaded at runtime, that develops
+//! the files the native crate declines.
+//!
+//! Every pure-Rust raw decoder is LGPL, so LibRaw is dlopen'd rather
+//! than linked, the way HEIC's libheif is, and looked for in two
+//! places:
+//!
+//! 1. The managed directory (`SCHIST_LIBRAW_DIR`, else
+//!    `$XDG_DATA_HOME/schist/libraw`), for a copy put there by hand on a
+//!    machine without a system package, or without root to install one.
+//!    There is no consented download of a prebuilt yet, as HEIC has; the
+//!    directory is the hook for one.
+//! 2. The system's LibRaw: Homebrew on macOS, every Linux distro. The
+//!    reentrant build (`libraw_r`) is preferred, and calls into the
+//!    plain one are serialised, because thumbnails decode on several
+//!    threads at once.
+//!
+//! A browser has no dlopen, so none of this exists on the web build;
+//! `super` refuses those files there with a message that says so.
+
+use std::ffi::{c_char, c_int, c_uint, c_void, CStr};
+use std::marker::PhantomData;
+use std::path::PathBuf;
+use std::sync::{Mutex, MutexGuard};
+
+use anyhow::Context as _;
+use schist_color::Depth;
+use schist_core::Document;
+
+use super::expose_and_encode;
+
+/// `enum LibRaw_image_formats`
+const IMAGE_JPEG: c_int = 1;
+const IMAGE_BITMAP: c_int = 2;
+/// `enum LibRaw_errors`: the answers that mean "there is no embedded
+/// preview", as opposed to a broken file.
+const NO_THUMBNAIL: c_int = -5;
+const UNSUPPORTED_THUMBNAIL: c_int = -6;
+/// `output_color`: sRGB primaries. The curve is applied here, not by
+/// LibRaw (see `expose_and_encode`), so the developed pixels come out
+/// linear and leave as sRGB, needing no profile.
+const OUTPUT_SRGB: c_int = 1;
+
+/// `libraw_processed_image_t`, returned by `dcraw_make_mem_image` and
+/// `dcraw_make_mem_thumb`. `data` is the start of the pixels (or the
+/// JPEG bytes), `data_size` long, following the header in the same
+/// allocation.
+#[repr(C)]
+struct ProcessedImage {
+    kind: c_int,
+    height: u16,
+    width: u16,
+    colors: u16,
+    bits: u16,
+    data_size: c_uint,
+    data: [u8; 1],
+}
+
+/// The leading fields of `libraw_data_t`: the processed-image pointer
+/// and `libraw_image_sizes_t`. They have led the struct, in this order,
+/// since before the C setters existed, so reading them by layout is as
+/// stable as the API itself; nothing further in — the part that shifts
+/// between versions — is touched.
+#[repr(C)]
+struct DataHead {
+    image: *mut c_void,
+    raw_height: u16,
+    raw_width: u16,
+    height: u16,
+    width: u16,
+    top_margin: u16,
+    left_margin: u16,
+    iheight: u16,
+    iwidth: u16,
+    raw_pitch: c_uint,
+    pixel_aspect: f64,
+    /// The camera's orientation tag in dcraw's encoding: 3 is 180°, 5
+    /// is 90° counter-clockwise, 6 is 90° clockwise. Development
+    /// applies it; the embedded preview is stored unrotated.
+    flip: c_int,
+}
+
+macro_rules! libraw_fns {
+    ($( $field:ident : fn($($arg:ty),*) $(-> $ret:ty)? ; )*) => {
+        struct LibRaw {
+            /// Symbols below point into this mapping; never dropped
+            /// before them (the struct only lives in a static).
+            _lib: libloading::Library,
+            /// Present when the loaded build is not the reentrant one:
+            /// the plain library keeps state that is shared between
+            /// handles, so its calls take turns.
+            serial: Option<Mutex<()>>,
+            $( $field: unsafe extern "C" fn($($arg),*) $(-> $ret)?, )*
+        }
+
+        impl LibRaw {
+            fn from_library(lib: libloading::Library, reentrant: bool) -> Result<Self, String> {
+                unsafe {
+                    Ok(Self {
+                        $( $field: {
+                            let name = concat!("libraw_", stringify!($field), "\0");
+                            *lib.get(name.as_bytes())
+                                .map_err(|err| format!("missing symbol {name}: {err}"))?
+                        }, )*
+                        serial: (!reentrant).then(|| Mutex::new(())),
+                        _lib: lib,
+                    })
+                }
+            }
+        }
+    };
+}
+
+libraw_fns! {
+    init: fn(c_uint) -> *mut c_void;
+    close: fn(*mut c_void);
+    open_buffer: fn(*mut c_void, *const c_void, usize) -> c_int;
+    unpack: fn(*mut c_void) -> c_int;
+    unpack_thumb: fn(*mut c_void) -> c_int;
+    dcraw_process: fn(*mut c_void) -> c_int;
+    dcraw_make_mem_image: fn(*mut c_void, *mut c_int) -> *mut ProcessedImage;
+    dcraw_make_mem_thumb: fn(*mut c_void, *mut c_int) -> *mut ProcessedImage;
+    dcraw_clear_mem: fn(*mut ProcessedImage);
+    strerror: fn(c_int) -> *const c_char;
+    version: fn() -> *const c_char;
+    set_output_bps: fn(*mut c_void, c_int);
+    set_output_color: fn(*mut c_void, c_int);
+    set_gamma: fn(*mut c_void, c_int, f32);
+    set_no_auto_bright: fn(*mut c_void, c_int);
+    set_user_mul: fn(*mut c_void, c_int, f32);
+    get_cam_mul: fn(*mut c_void, c_int) -> f32;
+}
+
+/// Library names to try, in order, and whether each is the reentrant
+/// build. Sonames back to 0.19: the C setters used here exist from
+/// there, and 0.20 is where CR3 support starts.
+#[cfg(target_os = "linux")]
+const LIBRARY_CANDIDATES: &[(&str, bool)] = &[
+    ("libraw_r.so.23", true),
+    ("libraw_r.so.20", true),
+    ("libraw_r.so.19", true),
+    ("libraw_r.so", true),
+    ("libraw.so.23", false),
+    ("libraw.so.20", false),
+    ("libraw.so.19", false),
+    ("libraw.so", false),
+];
+#[cfg(target_os = "macos")]
+const LIBRARY_CANDIDATES: &[(&str, bool)] = &[
+    ("libraw_r.dylib", true),
+    ("libraw.dylib", false),
+    // Homebrew's prefix is not on the default search path for app
+    // bundles launched from Finder.
+    ("/opt/homebrew/lib/libraw_r.dylib", true),
+    ("/opt/homebrew/lib/libraw.dylib", false),
+    ("/usr/local/lib/libraw_r.dylib", true),
+    ("/usr/local/lib/libraw.dylib", false),
+];
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+const LIBRARY_CANDIDATES: &[(&str, bool)] = &[
+    ("libraw_r.dll", true),
+    ("raw_r.dll", true),
+    ("libraw.dll", false),
+    ("raw.dll", false),
+    ("libraw-23.dll", false),
+];
+
+/// The app and the tests match on this phrase to recognise "this
+/// machine has no LibRaw" (as opposed to a broken file); keep it out of
+/// other error messages.
+const NOT_AVAILABLE: &str = "LibRaw is not available";
+
+/// The loaded library. A failed load is deliberately not cached, so a
+/// library installed later is picked up without a restart.
+static LOADED: Mutex<Option<&'static LibRaw>> = Mutex::new(None);
+
+/// True when an `import` error means no LibRaw could be loaded.
+pub fn is_missing_library_error(err: &anyhow::Error) -> bool {
+    format!("{err:#}").contains(NOT_AVAILABLE)
+}
+
+/// Where a hand-installed library is looked for before the system's.
+pub fn managed_dir() -> PathBuf {
+    if let Ok(dir) = std::env::var("SCHIST_LIBRAW_DIR") {
+        return PathBuf::from(dir);
+    }
+    let base = if cfg!(windows) {
+        std::env::var("LOCALAPPDATA")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from("."))
+    } else {
+        std::env::var("XDG_DATA_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| {
+                PathBuf::from(std::env::var("HOME").unwrap_or_else(|_| ".".into()))
+                    .join(".local/share")
+            })
+    };
+    base.join("schist/libraw")
+}
+
+fn libraw() -> anyhow::Result<&'static LibRaw> {
+    let mut loaded = LOADED.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(lib) = *loaded {
+        return Ok(lib);
+    }
+
+    // The managed directory first, by every bare library name; then
+    // the candidates as given, which the system loader resolves.
+    let managed = managed_dir();
+    let candidates: Vec<(std::ffi::OsString, bool)> = LIBRARY_CANDIDATES
+        .iter()
+        .filter(|(name, _)| !name.contains('/'))
+        .map(|(name, reentrant)| (managed.join(name).into_os_string(), *reentrant))
+        .chain(
+            LIBRARY_CANDIDATES
+                .iter()
+                .map(|(name, reentrant)| (name.into(), *reentrant)),
+        )
+        .collect();
+
+    let mut errors = Vec::new();
+    for (name, reentrant) in &candidates {
+        let lib = match unsafe { libloading::Library::new(name) } {
+            Ok(lib) => lib,
+            Err(err) => {
+                errors.push(format!("{}: {err}", name.to_string_lossy()));
+                continue;
+            }
+        };
+        match LibRaw::from_library(lib, *reentrant) {
+            Ok(lib) => {
+                let version = unsafe { CStr::from_ptr((lib.version)()) }.to_string_lossy();
+                log::info!(
+                    "raw: loaded LibRaw {version} from {}{}",
+                    name.to_string_lossy(),
+                    if *reentrant { "" } else { " (serialised)" }
+                );
+                let lib = &*Box::leak(Box::new(lib));
+                *loaded = Some(lib);
+                return Ok(lib);
+            }
+            Err(err) => errors.push(format!("{}: {err}", name.to_string_lossy())),
+        }
+    }
+    // The outer message is what the status line shows; the dlopen
+    // detail behind it is for the log.
+    Err(anyhow::anyhow!(errors.join("; "))).context(format!(
+        "{NOT_AVAILABLE}: opening camera raw files needs the LibRaw library \
+         (Linux: install libraw; macOS: brew install libraw)"
+    ))
+}
+
+fn check(lib: &LibRaw, code: c_int, what: &str) -> anyhow::Result<()> {
+    if code == 0 {
+        return Ok(());
+    }
+    let message = unsafe {
+        let ptr = (lib.strerror)(code);
+        if ptr.is_null() {
+            format!("error {code}")
+        } else {
+            CStr::from_ptr(ptr).to_string_lossy().into_owned()
+        }
+    };
+    anyhow::bail!("{what}: {message}")
+}
+
+/// One LibRaw processor with a file opened in it. Holds the
+/// serialisation lock for the non-reentrant build as long as it lives,
+/// and closes (frees) the processor when dropped, so early error returns
+/// leak nothing.
+struct Handle<'a> {
+    lib: &'a LibRaw,
+    ptr: *mut c_void,
+    _guard: Option<MutexGuard<'a, ()>>,
+    /// `open_buffer` reads from the caller's bytes for the handle's
+    /// whole life; nothing is copied.
+    _bytes: PhantomData<&'a [u8]>,
+}
+
+impl<'a> Handle<'a> {
+    fn open(lib: &'a LibRaw, bytes: &'a [u8]) -> anyhow::Result<Self> {
+        let guard = lib
+            .serial
+            .as_ref()
+            .map(|m| m.lock().unwrap_or_else(|e| e.into_inner()));
+        let ptr = unsafe { (lib.init)(0) };
+        anyhow::ensure!(!ptr.is_null(), "libraw_init failed");
+        let handle = Handle {
+            lib,
+            ptr,
+            _guard: guard,
+            _bytes: PhantomData,
+        };
+        check(
+            lib,
+            unsafe { (lib.open_buffer)(ptr, bytes.as_ptr().cast(), bytes.len()) },
+            "reading raw file",
+        )?;
+        Ok(handle)
+    }
+
+    /// The camera orientation, dcraw's encoding (see `DataHead::flip`).
+    fn flip(&self) -> c_int {
+        unsafe { (*self.ptr.cast::<DataHead>()).flip }
+    }
+}
+
+impl Drop for Handle<'_> {
+    fn drop(&mut self) {
+        unsafe { (self.lib.close)(self.ptr) }
+    }
+}
+
+/// A `libraw_processed_image_t`, freed when dropped.
+struct Processed<'a> {
+    lib: &'a LibRaw,
+    ptr: *mut ProcessedImage,
+}
+
+impl Processed<'_> {
+    fn header(&self) -> &ProcessedImage {
+        unsafe { &*self.ptr }
+    }
+
+    fn data(&self) -> &[u8] {
+        unsafe {
+            std::slice::from_raw_parts(
+                std::ptr::addr_of!((*self.ptr).data).cast::<u8>(),
+                (*self.ptr).data_size as usize,
+            )
+        }
+    }
+}
+
+impl Drop for Processed<'_> {
+    fn drop(&mut self) {
+        unsafe { (self.lib.dcraw_clear_mem)(self.ptr) }
+    }
+}
+
+/// Widen a processed bitmap — 1 or 3 samples a pixel, 8 or 16 bits —
+/// to straight RGBA, as f32 in 0..=1.
+fn bitmap_to_rgba_f32(img: &Processed<'_>) -> anyhow::Result<(u32, u32, Vec<f32>)> {
+    let head = img.header();
+    anyhow::ensure!(head.kind == IMAGE_BITMAP, "developed image is not a bitmap");
+    let (w, h) = (head.width as usize, head.height as usize);
+    let colors = head.colors as usize;
+    anyhow::ensure!(w > 0 && h > 0, "zero-sized image");
+    anyhow::ensure!(
+        colors == 1 || colors == 3,
+        "unexpected channel count {colors}"
+    );
+    let data = img.data();
+    let mut out = Vec::with_capacity(w * h * 4);
+    let mut push = |px: &[f32]| {
+        match px {
+            [v] => out.extend_from_slice(&[*v, *v, *v, 1.0]),
+            [r, g, b] => out.extend_from_slice(&[*r, *g, *b, 1.0]),
+            _ => unreachable!(),
+        };
+    };
+    match head.bits {
+        16 => {
+            anyhow::ensure!(data.len() >= w * h * colors * 2, "short pixel data");
+            let samples = data.as_chunks::<2>().0;
+            for px in samples[..w * h * colors].chunks_exact(colors) {
+                let px: Vec<f32> = px
+                    .iter()
+                    .map(|s| u16::from_ne_bytes(*s) as f32 / 65535.0)
+                    .collect();
+                push(&px);
+            }
+        }
+        8 => {
+            anyhow::ensure!(data.len() >= w * h * colors, "short pixel data");
+            for px in data[..w * h * colors].chunks_exact(colors) {
+                let px: Vec<f32> = px.iter().map(|s| *s as f32 / 255.0).collect();
+                push(&px);
+            }
+        }
+        bits => anyhow::bail!("unexpected sample depth {bits}"),
+    }
+    Ok((w as u32, h as u32, out))
+}
+
+/// Develop the sensor data into a 16-bit sRGB document.
+fn develop(lib: &LibRaw, bytes: &[u8]) -> anyhow::Result<Document> {
+    let handle = Handle::open(lib, bytes)?;
+    let lr = handle.ptr;
+    unsafe {
+        check(lib, (lib.unpack)(lr), "unpacking sensor data")?;
+        (lib.set_output_bps)(lr, 16);
+        (lib.set_output_color)(lr, OUTPUT_SRGB);
+        // Linear light out (dcraw's `-g 1 1`), untouched by the
+        // histogram stretch: exposure and the sRGB curve are applied
+        // below, where the highlights can roll off instead of clip.
+        (lib.set_gamma)(lr, 0, 1.0);
+        (lib.set_gamma)(lr, 1, 1.0);
+        (lib.set_no_auto_bright)(lr, 1);
+        // The camera's as-shot white balance, when the file carries one
+        // (a fourth multiplier of zero is normal: three-colour sensors
+        // have no second green). Without it LibRaw assumes daylight,
+        // which is wrong indoors and under most skies.
+        let mul: [f32; 4] = std::array::from_fn(|i| (lib.get_cam_mul)(lr, i as c_int));
+        if mul[..3].iter().all(|m| m.is_finite() && *m > 0.0) {
+            for (i, m) in mul.iter().enumerate() {
+                (lib.set_user_mul)(lr, i as c_int, *m);
+            }
+        }
+        check(lib, (lib.dcraw_process)(lr), "developing")?;
+        let mut errc = 0;
+        let img = (lib.dcraw_make_mem_image)(lr, &mut errc);
+        if img.is_null() {
+            check(lib, errc, "reading developed image")?;
+            anyhow::bail!("reading developed image: no image");
+        }
+        let img = Processed { lib, ptr: img };
+        let (w, h, mut rgba) = bitmap_to_rgba_f32(&img)?;
+        drop(img);
+        expose_and_encode(&mut rgba);
+        crate::deep_document("Raw", w, h, &rgba, Depth::Sixteen, None)
+            .context("assembling document")
+    }
+}
+
+/// Develop `bytes` through LibRaw, loading it first.
+pub(super) fn develop_document(bytes: &[u8]) -> anyhow::Result<Document> {
+    develop(libraw()?, bytes)
+}
+
+/// The embedded preview through LibRaw: its JPEG, or its bitmap
+/// thumbnail, turned upright by the orientation it read.
+pub(super) fn embedded_preview(bytes: &[u8]) -> anyhow::Result<Option<image::RgbaImage>> {
+    let lib = libraw()?;
+    let handle = Handle::open(lib, bytes)?;
+    let lr = handle.ptr;
+    let img = unsafe {
+        let code = (lib.unpack_thumb)(lr);
+        if code == NO_THUMBNAIL || code == UNSUPPORTED_THUMBNAIL {
+            return Ok(None);
+        }
+        check(lib, code, "reading embedded preview")?;
+        let mut errc = 0;
+        let img = (lib.dcraw_make_mem_thumb)(lr, &mut errc);
+        if img.is_null() {
+            if errc == NO_THUMBNAIL || errc == UNSUPPORTED_THUMBNAIL {
+                return Ok(None);
+            }
+            check(lib, errc, "reading embedded preview")?;
+            return Ok(None);
+        }
+        Processed { lib, ptr: img }
+    };
+    let decoded = match img.header().kind {
+        IMAGE_JPEG => image::load_from_memory_with_format(img.data(), image::ImageFormat::Jpeg)
+            .context("decoding embedded preview")?
+            .into_rgba8(),
+        IMAGE_BITMAP => {
+            let (w, h, rgba) = bitmap_to_rgba_f32(&img)?;
+            let bytes: Vec<u8> = rgba
+                .iter()
+                .map(|v| (v.clamp(0.0, 1.0) * 255.0 + 0.5) as u8)
+                .collect();
+            image::RgbaImage::from_raw(w, h, bytes).context("buffer size")?
+        }
+        _ => return Ok(None),
+    };
+    drop(img);
+    // Development turns the picture the camera's way; the preview is
+    // the sensor's orientation and has to be turned here.
+    let upright = match handle.flip() {
+        3 => image::imageops::rotate180(&decoded),
+        5 => image::imageops::rotate270(&decoded),
+        6 => image::imageops::rotate90(&decoded),
+        _ => decoded,
+    };
+    Ok(Some(upright))
+}


### PR DESCRIPTION
## Summary

Follow-up to #94. The raw codec was gated off the wasm build together with the LibRaw fallback, although the native decoder it tries first is pure Rust.

- The LibRaw fallback moves into `plugins/codecs-common/src/raw/libraw.rs`, compiled only off wasm. The raw codec itself now registers on every target, so the browser build opens raws through `schist-codec-raw`.
- **Web:** the few files only LibRaw develops (Canon CR3 pixels, Fuji compressed RAF, a handful of odd codecs) are refused with `this raw file needs LibRaw, which the web build cannot load; the desktop app opens it`, and their embedded previews still show.
- **Desktop:** opening one of those files with no LibRaw installed now raises a "LibRaw Needed" dialog with the platform's install step (Homebrew, the distro package, or the managed directory on Windows) and a Try Again button, instead of a bare status-line error. There is still no download offer, since no prebuilt exists to pin.

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown -p schist-app` with the raw codec unconditional
- [x] clippy `-D warnings` on app/codecs-common/preview, `cargo fmt --check`
- [x] Plugin raw tests incl. the full-corpus sweep (native → LibRaw), app and preview tests
- [ ] Dialog not exercised visually (this box has LibRaw); it mirrors the HEIC consent dialog's structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
