### PR TITLE
feat(raw): decode CR3, compressed RAF, CRW, NX1, IIQ S and Panasonic v8 natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ rest, developed with the camera's white balance to 16-bit sRGB. Raws
 decode through Schist's own clean-room `schist-codec-raw` crate (pure
 Rust, written from the public specifications and verified sample for
 sample against LibRaw across some 250 camera files), which covers most
-bodies; what it declines — Canon CR3 pixels, Fuji's compressed RAF, a
-few odd codecs, and cameras with no colour matrix in its table yet —
+bodies, Canon's CR3 and Fuji's compressed RAF included; what it
+declines — Sigma's Foveon sensor data, GoPro's VC-5, a few old odd
+codecs, and cameras with no colour matrix in its table yet —
 falls back to the system's LibRaw, loaded at runtime (`brew install
 libraw`, or the distro's package); the browser build, which cannot load
 one, refuses those few files and opens everything else. HEIC decodes through libheif the

--- a/crates/codec-raw/README.md
+++ b/crates/codec-raw/README.md
@@ -4,7 +4,12 @@ Camera raw files, decoded and developed in pure Rust, written clean-room
 from the public DNG, TIFF/EP, EXIF and ITU T.81 specifications, published
 format descriptions, and observation of real files against LibRaw's
 `unprocessed_raw` output. Nothing in it derives from dcraw, LibRaw,
-rawspeed, rawler or any other copyleft decoder.
+rawspeed, rawler or any other copyleft decoder: where a codec has no
+public description (Canon's CRX and compressed CRW, Fuji's compressed
+RAF, Samsung's NX1 scheme, Phase One's IIQ S, Panasonic's RawFormat 8),
+it was implemented from a written functional specification produced by
+a separate party who read the reference — the standard clean-room
+arrangement — and verified against the reference's output only.
 
 `decode` reads a file into a `RawImage` (the sensor frame, its filter
 array, levels, white balance, colour matrix, crop, orientation and the
@@ -23,16 +28,16 @@ frame on the files listed, drawn from the raw.pixls.us sample set.
 | Sony ARW / SR2 / SRF | exact on 24, every generation incl. ARW 1.0 and ARW 4 lossless |
 | Nikon NEF / NRW | exact on 36 (20 bodies); Z 8/9 High Efficiency unsupported |
 | Canon CR2 | exact on 14; sRAW/mRAW unsupported |
-| Canon CRW | uncompressed only; the compressed Huffman sets are not publicly documented |
-| Canon CR3 | container, metadata and previews exact; the CRX pixel codec is not decoded |
-| Fujifilm RAF | exact on 9 uncompressed bodies (X-Trans and Bayer); compressed RAF refused |
+| Canon CRW | exact on 4 (compressed and uncompressed) |
+| Canon CR3 | exact on 10: CRX lossless and lossy (cRAW), EOS R through R8, dual-pixel included |
+| Fujifilm RAF | exact on 13: uncompressed, lossless and lossy compressed, X-Trans and Bayer; SuperCCD unsupported |
 | Olympus / OM ORF | exact on 12, four sensor layouts |
-| Panasonic RW2 / Leica RWL | exact on 29; RawFormat 8 (GH6, G9 II) unsupported |
+| Panasonic RW2 / Leica RWL | exact on 31, RawFormat 4 through 8 |
 | Pentax PEF | exact on 10 |
-| Samsung SRW | exact on 15; the NX1/NX500 codec unsupported |
+| Samsung SRW | exact on 17, every compression |
 | Minolta MRW, Kodak DCR/KDC, Epson ERF, Mamiya MEF | exact on 15 bodies; Kodak DC50 unsupported; Epson's as-shot balance is not found in the file |
 | Hasselblad 3FR / FFF | exact on 7 |
-| Phase One IIQ | exact on 5 ("IIQ L" and raw); "IIQ S" unsupported |
+| Phase One IIQ | exact on 11, raw, "IIQ L" and both "IIQ S" formats |
 | Leaf MOS | exact on 3 |
 | Sigma X3F | metadata and preview only |
 

--- a/crates/codec-raw/src/formats/cr3.rs
+++ b/crates/codec-raw/src/formats/cr3.rs
@@ -51,16 +51,25 @@ pub fn decode(bytes: &[u8]) -> Result<RawImage> {
         .ok_or_else(|| Error::Corrupt("CR3 raw track has no sample in the file".into()))?;
     let data = crx::decode(&header, sample)?;
 
+    // The codec's four components are always red, the green on red's
+    // row, the green on blue's row and blue; the CMP1 layout nibble
+    // says which corner of the 2x2 cell each of them lands on, and so
+    // what the pattern at the frame origin is. It is 0 — RGGB — on
+    // every full-size raw track seen; the small "SD" track, which
+    // nothing here decodes, uses 1.
+    let cfa = match header.cfa_layout {
+        1 => Cfa::GRBG,
+        2 => Cfa::GBRG,
+        3 => Cfa::BGGR,
+        _ => Cfa::RGGB,
+    };
     let mut image = RawImage::new(
         Format::Cr3,
         header.width,
         header.height,
         1,
         RawData::U16(data),
-        // Every CR3 body is RGGB at the origin of the full frame, and
-        // the CMP1 layout nibble is 0 to say so on the full-size raw
-        // track. (The small SD track uses 1, but nothing decodes it.)
-        Cfa::RGGB,
+        cfa,
     );
     file.describe(&mut image);
     image.apply_camera_table();
@@ -613,7 +622,7 @@ mod tests {
         let mut p = vec![0u8; 52];
         p[0..2].copy_from_slice(&0xff00u16.to_be_bytes());
         p[2..4].copy_from_slice(&0x0030u16.to_be_bytes());
-        p[4..6].copy_from_slice(&1u16.to_be_bytes());
+        p[4..6].copy_from_slice(&0x0100u16.to_be_bytes());
         p[8..12].copy_from_slice(&width.to_be_bytes());
         p[12..16].copy_from_slice(&height.to_be_bytes());
         p[16..20].copy_from_slice(&width.to_be_bytes());
@@ -683,8 +692,12 @@ mod tests {
             let raw_trak = trak(sample_table(
                 craw_entry(
                     &[
-                        cmp1_box(64, 32, levels, mdat_header),
-                        cdi1_box(64, 32, [4, 2, 59, 29]),
+                        // A tile is half the frame across in each
+                        // direction and the codec will not transform
+                        // one smaller than 22 either way, so the
+                        // smallest legal frame here is 88x88.
+                        cmp1_box(96, 64, levels, mdat_header),
+                        cdi1_box(96, 64, [4, 2, 59, 29]),
                     ]
                     .concat(),
                 ),
@@ -838,22 +851,23 @@ mod tests {
         ))
     }
 
-    /// Files whose CRX variant this decoder knows it cannot do yet,
-    /// with why. Anything else that fails is a bug.
+    /// Files whose CRX variant this decoder knows it cannot do, with
+    /// why. Anything else that fails is a bug.
     ///
-    /// Every CR3 is on this list at the moment: the container, the
-    /// metadata, the preview and every layer of the CRX headers are
-    /// read, but the entropy-coded coefficients are not decoded, so
-    /// `decode` reports the codec as unsupported and only `preview`
-    /// and the metadata below are exercised against real files.
+    /// The list is empty: every CR3 in the corpus decodes, lossless
+    /// and lossy, both record dialects. What CRX still cannot do is
+    /// not represented here because no sample of it exists — the
+    /// signed and decorrelated-colour encodings, which `crx::decode`
+    /// reports as unsupported.
     fn unsupported_reason(_name: &str) -> Option<&'static str> {
-        Some("the CRX entropy coder is not implemented")
+        None
     }
 
     #[test]
     fn corpus_cr3_files_decode_and_match_the_oracle() {
         let Some(root) = corpus() else { return };
         let mut problems: Vec<String> = Vec::new();
+        let mut timings: Vec<(String, std::time::Duration, usize)> = Vec::new();
         let mut decoded = 0;
         let mut skipped = 0;
         for path in samples(&root) {
@@ -920,8 +934,12 @@ mod tests {
                 }
             }
 
+            let started = std::time::Instant::now();
             let image = match decode(&bytes) {
-                Ok(image) => image,
+                Ok(image) => {
+                    timings.push((name.clone(), started.elapsed(), image.width * image.height));
+                    image
+                }
                 Err(Error::Unsupported(why)) => {
                     match unsupported_reason(&name) {
                         Some(_) => skipped += 1,
@@ -995,6 +1013,13 @@ mod tests {
             problems.join("\n")
         );
         eprintln!("corpus: {decoded} CR3 files decoded, {skipped} unsupported variants skipped");
+        for (name, took, pixels) in &timings {
+            eprintln!(
+                "    {:>7.1} ms  {:>5.1} Mpx  {name}",
+                took.as_secs_f64() * 1e3,
+                *pixels as f64 / 1e6
+            );
+        }
     }
 
     /// Levels, white balance, crop, orientation and CFA against

--- a/crates/codec-raw/src/formats/crw.rs
+++ b/crates/codec-raw/src/formats/crw.rs
@@ -23,25 +23,25 @@
 //! # What is decoded
 //!
 //! The oldest bodies — the PowerShot Pro70 generation — store the
-//! sensor uncompressed, ten bits a sample, and those decode here.
+//! sensor uncompressed, ten bits a sample. Everything later — every
+//! EOS CRW and every PowerShot from the G1 on — compresses, and that
+//! codec is implemented here too; see [`decompress`].
 //!
-//! Every EOS CRW and every later PowerShot compresses, and the three
-//! Huffman table sets its decoder picks between are *not* in the file.
-//! Record `0x1835` gives only the index of the set to use; the tables
-//! themselves appear in no specification and in no published format
-//! write-up, only in the source of the copyleft decoders this crate
-//! may not read. They cannot be guessed and may not be copied, so a
-//! compressed image is [`Error::Unsupported`] and the message says
-//! why rather than pretending the file is broken.
+//! Its three Huffman table sets are firmware constants: record
+//! `0x1835` carries only the *index* of the set a frame used, never
+//! the tables. They are written out below as the DHT-style code-length
+//! counts and symbol lists they are, and `set 0`'s assignment is
+//! pinned by a unit test against the code words it must produce.
 //!
-//! [`preview`] still works on those files: the camera's own full-size
+//! [`preview`] works whatever the codec: the camera's own full-size
 //! JPEG is a record like any other, and it is the whole picture.
 //!
 //! Clean-room: written from the public CIFF 1.0 specification and
-//! third-party descriptions of it, ExifTool's tag documentation, and
-//! measurement of the sample files named in this module's tests.
+//! third-party descriptions of it, ExifTool's tag documentation, a
+//! functional description of the entropy coder, and measurement of the
+//! sample files named in this module's tests.
 
-use crate::bits::{BitPump, BitPumpMsb};
+use crate::bits::{BitPump, BitPumpJpeg, BitPumpMsb, HuffTable};
 use crate::{Cfa, CfaColor, Error, Format, Metadata, Orientation, RawData, RawImage, Rect, Result};
 
 /// Records this module reads. The low eleven bits are the identity;
@@ -85,15 +85,38 @@ pub fn decode(bytes: &[u8]) -> Result<RawImage> {
     let image = ciff
         .find(tag::IMAGE_DATA)
         .ok_or_else(|| Error::Corrupt("crw: no image record (0x2005)".into()))?;
-    if ciff.find(tag::DECODER_TABLE).is_some() {
-        return Err(Error::Unsupported(format!(
-            "crw: {model}'s image is Canon's compressed CIFF data; its Huffman \
-             tables are published nowhere this clean-room decoder may read"
-        )));
-    }
-
     let sensor = ciff.sensor_info();
     let info = ciff.image_info();
+
+    // Record 0x1835's presence *is* the compression flag; its first
+    // field is the index of the Huffman table set the frame was coded
+    // with. Nothing else in the file distinguishes the two layouts.
+    let mut raw = if ciff.find(tag::DECODER_TABLE).is_some() {
+        compressed(&ciff, image, sensor, &model)?
+    } else {
+        uncompressed(&ciff, image, sensor, info, &model)?
+    };
+    raw.set_camera(&make, &model);
+    if let Some(info) = info {
+        raw.orientation = info.orientation;
+    }
+    if let Some(wb) = ciff.as_shot_wb() {
+        raw.wb_coeffs = wb;
+    }
+    raw.metadata = ciff.metadata();
+    raw.preview = ciff.jpeg();
+    raw.apply_camera_table();
+    Ok(raw)
+}
+
+/// The ten-bits-a-sample layout of the Pro70 generation.
+fn uncompressed(
+    ciff: &Ciff<'_>,
+    image: Record,
+    sensor: Option<SensorInfo>,
+    info: Option<ImageInfo>,
+    model: &str,
+) -> Result<RawImage> {
     // An uncompressed CIFF says its size in two places and neither is
     // the sensor frame: SensorInfo has it on the bodies that write one,
     // and on the bodies that do not (the Pro70 generation) only the
@@ -117,7 +140,7 @@ pub fn decode(bytes: &[u8]) -> Result<RawImage> {
             image.len
         )));
     }
-    let cfa = uncompressed_cfa(&model).ok_or_else(|| {
+    let cfa = uncompressed_cfa(model).ok_or_else(|| {
         Error::Unsupported(format!(
             "crw: uncompressed CIFF from {model}: this decoder does not know its filter array"
         ))
@@ -125,7 +148,6 @@ pub fn decode(bytes: &[u8]) -> Result<RawImage> {
 
     let data = unpack10(ciff.slice(image)?, width * height);
     let mut raw = RawImage::new(Format::Crw, width, height, 1, RawData::U16(data), cfa);
-    raw.set_camera(&make, &model);
     // Ten bits a sample, and no record says the sensor saturates
     // earlier.
     raw.white_level = 1023.0;
@@ -134,15 +156,6 @@ pub fn decode(bytes: &[u8]) -> Result<RawImage> {
             raw.crop = crop;
         }
     }
-    if let Some(info) = info {
-        raw.orientation = info.orientation;
-    }
-    if let Some(wb) = ciff.as_shot_wb() {
-        raw.wb_coeffs = wb;
-    }
-    raw.metadata = ciff.metadata();
-    raw.preview = ciff.jpeg();
-    raw.apply_camera_table();
     Ok(raw)
 }
 
@@ -189,6 +202,437 @@ fn unpack10(bytes: &[u8], samples: usize) -> Vec<u16> {
     }
     let mut pump = BitPumpMsb::new(&swapped);
     (0..samples).map(|_| pump.get(10) as u16).collect()
+}
+
+// ----------------------------------------------- the compressed codec
+
+/// Rows to a band. The codec decodes eight rows at a time because the
+/// low-bit plane, when there is one, is interleaved a band at a time.
+const BAND: usize = 8;
+/// Samples to a Huffman block. Blocks run straight across row ends,
+/// and `raw_width` is a multiple of eight but rarely of 64, so a row
+/// boundary usually falls inside a block.
+const BLOCK: usize = 64;
+/// The implicit sample to the left of every row: the middle of the
+/// ten-bit range, which is what both predictors are set to whenever a
+/// row starts.
+const EDGE_PREDICTOR: i32 = 512;
+/// Bytes of zero padding between the low-bit plane and the start of
+/// the coded stream. Verified all-zero on every sample; its purpose is
+/// not known, and it is simply skipped.
+const PAD: usize = 514;
+/// How far into the file the low-bit-plane heuristic looks.
+const PROBE_WINDOW: usize = 0x4000;
+
+/// The geometry of one compressed frame: where the picture sits in the
+/// sensor frame, and how far into the masked border the two black
+/// rectangles are set.
+///
+/// None of this is in the file. The image record's own inset rectangle
+/// (`0x1031` fields 5..8) describes a *smaller* picture than the one
+/// the raw converter shows — 3072x2048 against 3088x2056 on the EOS
+/// D60 — so the frame size is used as a key into [`GEOMETRY`] instead,
+/// which is also what puts the black rectangles on the right columns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Geometry {
+    left: usize,
+    top: usize,
+    width: usize,
+    height: usize,
+    /// Insets of the left rectangle (fields 0 and 1) and of the right
+    /// one (2 and 3) into the masked border. Zero everywhere but the
+    /// EOS D60 / 10D / 300D frame, whose left rectangle starts sixteen
+    /// columns further in.
+    mask: [usize; 4],
+}
+
+/// `raw_width, raw_height, left, top, width shrink, height shrink,`
+/// then the four black-rectangle insets. Keyed by the frame size
+/// because a body writes exactly one.
+const GEOMETRY: [[usize; 10]; 8] = [
+    // PowerShot Pro90 IS
+    [1944, 1416, 0, 0, 48, 0, 0, 0, 0, 0],
+    // PowerShot S30, G1
+    [2144, 1560, 4, 8, 52, 2, 0, 0, 0, 0],
+    // EOS D30
+    [2224, 1456, 48, 6, 0, 2, 0, 0, 0, 0],
+    // PowerShot G2, S40, G3, S45
+    [2376, 1728, 12, 6, 52, 2, 0, 0, 0, 0],
+    // PowerShot G5, S50, S60
+    [2672, 1968, 12, 6, 44, 2, 0, 0, 0, 0],
+    // EOS D60, EOS 10D, EOS 300D
+    [3152, 2068, 64, 12, 0, 0, 16, 0, 0, 0],
+    // PowerShot G6, S70
+    [3160, 2344, 44, 12, 4, 4, 0, 0, 0, 0],
+    // PowerShot Pro1
+    [3344, 2484, 4, 6, 52, 6, 0, 0, 0, 0],
+];
+
+fn geometry(width: usize, height: usize) -> Option<Geometry> {
+    let row = GEOMETRY.iter().find(|r| r[0] == width && r[1] == height)?;
+    Some(Geometry {
+        left: row[2],
+        top: row[3],
+        width: width.checked_sub(row[2] + row[4])?,
+        height: height.checked_sub(row[3] + row[5])?,
+        mask: [row[6], row[7], row[8], row[9]],
+    })
+}
+
+/// The frame size the `raw_width == 2672` low-bit correction applies
+/// to; see [`merge_low_bits`].
+const FUDGED_WIDTH: usize = 2672;
+
+const TABLE_A_COUNTS: [[u8; 16]; 3] = [
+    [0, 1, 4, 2, 3, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 2, 2, 3, 1, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 6, 3, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+];
+const TABLE_A_SYMBOLS: [[u8; 13]; 3] = [
+    [
+        0x04, 0x03, 0x05, 0x06, 0x02, 0x07, 0x01, 0x08, 0x09, 0x00, 0x0A, 0x0B, 0xFF,
+    ],
+    [
+        0x03, 0x02, 0x04, 0x01, 0x05, 0x00, 0x06, 0x07, 0x09, 0x08, 0x0A, 0x0B, 0xFF,
+    ],
+    [
+        0x06, 0x05, 0x07, 0x04, 0x08, 0x03, 0x09, 0x02, 0x00, 0x0A, 0x01, 0x0B, 0xFF,
+    ],
+];
+const TABLE_B_COUNTS: [[u8; 16]; 3] = [
+    [0, 2, 2, 2, 1, 4, 2, 1, 2, 5, 1, 1, 0, 0, 0, 139],
+    [0, 2, 2, 1, 4, 1, 4, 1, 3, 3, 1, 0, 0, 0, 0, 140],
+    [0, 0, 6, 2, 1, 3, 3, 2, 5, 1, 2, 2, 8, 10, 0, 117],
+];
+const TABLE_B_SYMBOLS: [[u8; 162]; 3] = [
+    [
+        0x03, 0x04, 0x02, 0x05, 0x01, 0x06, 0x07, 0x08, 0x12, 0x13, 0x11, 0x14, 0x09, 0x15, 0x22,
+        0x00, 0x21, 0x16, 0x0A, 0xF0, 0x23, 0x17, 0x24, 0x31, 0x32, 0x18, 0x19, 0x33, 0x25, 0x41,
+        0x34, 0x42, 0x35, 0x51, 0x36, 0x37, 0x38, 0x29, 0x79, 0x26, 0x1A, 0x39, 0x56, 0x57, 0x28,
+        0x27, 0x52, 0x55, 0x58, 0x43, 0x76, 0x59, 0x77, 0x54, 0x61, 0xF9, 0x71, 0x78, 0x75, 0x96,
+        0x97, 0x49, 0xB7, 0x53, 0xD7, 0x74, 0xB6, 0x98, 0x47, 0x48, 0x95, 0x69, 0x99, 0x91, 0xFA,
+        0xB8, 0x68, 0xB5, 0xB9, 0xD6, 0xF7, 0xD8, 0x67, 0x46, 0x45, 0x94, 0x89, 0xF8, 0x81, 0xD5,
+        0xF6, 0xB4, 0x88, 0xB1, 0x2A, 0x44, 0x72, 0xD9, 0x87, 0x66, 0xD4, 0xF5, 0x3A, 0xA7, 0x73,
+        0xA9, 0xA8, 0x86, 0x62, 0xC7, 0x65, 0xC8, 0xC9, 0xA1, 0xF4, 0xD1, 0xE9, 0x5A, 0x92, 0x85,
+        0xA6, 0xE7, 0x93, 0xE8, 0xC1, 0xC6, 0x7A, 0x64, 0xE1, 0x4A, 0x6A, 0xE6, 0xB3, 0xF1, 0xD3,
+        0xA5, 0x8A, 0xB2, 0x9A, 0xBA, 0x84, 0xA4, 0x63, 0xE5, 0xC5, 0xF3, 0xD2, 0xC4, 0x82, 0xAA,
+        0xDA, 0xE4, 0xF2, 0xCA, 0x83, 0xA3, 0xA2, 0xC3, 0xEA, 0xC2, 0xE2, 0xE3,
+    ],
+    [
+        0x02, 0x03, 0x01, 0x04, 0x05, 0x12, 0x11, 0x06, 0x13, 0x07, 0x08, 0x14, 0x22, 0x09, 0x21,
+        0x00, 0x23, 0x15, 0x31, 0x32, 0x0A, 0x16, 0xF0, 0x24, 0x33, 0x41, 0x42, 0x19, 0x17, 0x25,
+        0x18, 0x51, 0x34, 0x43, 0x52, 0x29, 0x35, 0x61, 0x39, 0x71, 0x62, 0x36, 0x53, 0x26, 0x38,
+        0x1A, 0x37, 0x81, 0x27, 0x91, 0x79, 0x55, 0x45, 0x28, 0x72, 0x59, 0xA1, 0xB1, 0x44, 0x69,
+        0x54, 0x58, 0xD1, 0xFA, 0x57, 0xE1, 0xF1, 0xB9, 0x49, 0x47, 0x63, 0x6A, 0xF9, 0x56, 0x46,
+        0xA8, 0x2A, 0x4A, 0x78, 0x99, 0x3A, 0x75, 0x74, 0x86, 0x65, 0xC1, 0x76, 0xB6, 0x96, 0xD6,
+        0x89, 0x85, 0xC9, 0xF5, 0x95, 0xB4, 0xC7, 0xF7, 0x8A, 0x97, 0xB8, 0x73, 0xB7, 0xD8, 0xD9,
+        0x87, 0xA7, 0x7A, 0x48, 0x82, 0x84, 0xEA, 0xF4, 0xA6, 0xC5, 0x5A, 0x94, 0xA4, 0xC6, 0x92,
+        0xC3, 0x68, 0xB5, 0xC8, 0xE4, 0xE5, 0xE6, 0xE9, 0xA2, 0xA3, 0xE3, 0xC2, 0x66, 0x67, 0x93,
+        0xAA, 0xD4, 0xD5, 0xE7, 0xF8, 0x88, 0x9A, 0xD7, 0x77, 0xC4, 0x64, 0xE2, 0x98, 0xA5, 0xCA,
+        0xDA, 0xE8, 0xF3, 0xF6, 0xA9, 0xB2, 0xB3, 0xF2, 0xD2, 0x83, 0xBA, 0xD3,
+    ],
+    [
+        0x04, 0x05, 0x03, 0x06, 0x02, 0x07, 0x01, 0x08, 0x09, 0x12, 0x13, 0x14, 0x11, 0x15, 0x0A,
+        0x16, 0x17, 0xF0, 0x00, 0x22, 0x21, 0x18, 0x23, 0x19, 0x24, 0x32, 0x31, 0x25, 0x33, 0x38,
+        0x37, 0x34, 0x35, 0x36, 0x39, 0x79, 0x57, 0x58, 0x59, 0x28, 0x56, 0x78, 0x27, 0x41, 0x29,
+        0x77, 0x26, 0x42, 0x76, 0x99, 0x1A, 0x55, 0x98, 0x97, 0xF9, 0x48, 0x54, 0x96, 0x89, 0x47,
+        0xB7, 0x49, 0xFA, 0x75, 0x68, 0xB6, 0x67, 0x69, 0xB9, 0xB8, 0xD8, 0x52, 0xD7, 0x88, 0xB5,
+        0x74, 0x51, 0x46, 0xD9, 0xF8, 0x3A, 0xD6, 0x87, 0x45, 0x7A, 0x95, 0xD5, 0xF6, 0x86, 0xB4,
+        0xA9, 0x94, 0x53, 0x2A, 0xA8, 0x43, 0xF5, 0xF7, 0xD4, 0x66, 0xA7, 0x5A, 0x44, 0x8A, 0xC9,
+        0xE8, 0xC8, 0xE7, 0x9A, 0x6A, 0x73, 0x4A, 0x61, 0xC7, 0xF4, 0xC6, 0x65, 0xE9, 0x72, 0xE6,
+        0x71, 0x91, 0x93, 0xA6, 0xDA, 0x92, 0x85, 0x62, 0xF3, 0xC5, 0xB2, 0xA4, 0x84, 0xBA, 0x64,
+        0xA5, 0xB3, 0xD2, 0x81, 0xE5, 0xD3, 0xAA, 0xC4, 0xCA, 0xF2, 0xB1, 0xE4, 0xD1, 0x83, 0x63,
+        0xEA, 0xC3, 0xE2, 0x82, 0xF1, 0xA3, 0xC2, 0xA1, 0xC1, 0xE3, 0xA2, 0xE1,
+    ],
+];
+
+/// Whether the image record carries a low-bit plane, and with it
+/// whether the frame is twelve bits a sample rather than ten.
+///
+/// Nothing in the file says. What decides it is that the coded stream
+/// is byte-stuffed — inside it every `0xFF` is followed by `0x00` —
+/// while a low-bit plane is two raw bits a pixel and obeys no such
+/// rule. So look at the window the coded stream would occupy if there
+/// were no plane: a `0xFF` followed by anything but `0x00` there means
+/// the window is really plane data, so the plane exists. A window with
+/// no `0xFF` in it at all decides nothing, and a plane is assumed,
+/// which is the behaviour every other decoder of this format has and
+/// therefore what the reference frames were produced with.
+fn has_low_bit_plane(bytes: &[u8], stream_start: usize) -> bool {
+    let end = bytes.len().min(PROBE_WINDOW);
+    let Some(window) = bytes.get(stream_start..end) else {
+        return true;
+    };
+    let mut seen = false;
+    for pair in window.windows(2) {
+        if pair[0] == 0xFF {
+            seen = true;
+            if pair[1] != 0 {
+                return true;
+            }
+        }
+    }
+    !seen
+}
+
+/// The compressed layout: a Huffman-coded stream of ten-bit samples,
+/// optionally over a plane of two extra low bits each.
+fn compressed(
+    ciff: &Ciff<'_>,
+    image: Record,
+    sensor: Option<SensorInfo>,
+    model: &str,
+) -> Result<RawImage> {
+    let sensor = sensor.ok_or_else(|| {
+        Error::Corrupt("crw: compressed image with no sensor record (0x1031)".into())
+    })?;
+    let (width, height) = (sensor.width, sensor.height);
+    let samples = crate::frame_samples(width, height, 1)?;
+    let geometry = geometry(width, height).ok_or_else(|| {
+        Error::Unsupported(format!(
+            "crw: compressed {width}x{height} frame from {model}: no body known to \
+             this decoder writes that size, so its margins are unknown"
+        ))
+    })?;
+
+    // Every offset below is relative to the image record rather than
+    // to the file. A camera puts the record at file offset 26 and
+    // nothing else has ever been seen, but the record knows where it
+    // is and the file's own header length says so too.
+    let plane_len = samples / 4;
+    let low = has_low_bit_plane(ciff.bytes, image.at + PAD).then_some(plane_len);
+    let coded_at = image.at + low.unwrap_or(0) + PAD;
+    let end = image.at + image.len;
+    if coded_at >= end || end > ciff.bytes.len() {
+        return Err(Error::Corrupt(format!(
+            "crw: image record holds {} bytes, too few for a {width}x{height} frame",
+            image.len
+        )));
+    }
+    // A coded stream cannot be shorter than a bit a sample, so the
+    // record's own length bounds the frame a forged header may claim.
+    if (end - coded_at).saturating_mul(8) < samples {
+        return Err(Error::Corrupt(format!(
+            "crw: {} bytes of coded data for {samples} samples",
+            end - coded_at
+        )));
+    }
+    let set = ciff
+        .longs(tag::DECODER_TABLE)
+        .first()
+        .map_or(0, |v| *v as usize)
+        .min(TABLE_A_COUNTS.len() - 1);
+
+    let mut frame = decompress(&ciff.bytes[coded_at..end], set, width, height)?;
+    if let Some(plane_len) = low {
+        let plane = ciff
+            .bytes
+            .get(image.at..image.at + plane_len)
+            .ok_or_else(|| Error::Corrupt("crw: low-bit plane outside the file".into()))?;
+        merge_low_bits(&mut frame, plane, width, height);
+    }
+
+    // The filter array is RGGB over the raw frame on every body that
+    // wrote this codec; the margins are all even, so the picture's own
+    // origin reads RGGB too.
+    let mut raw = RawImage::new(
+        Format::Crw,
+        width,
+        height,
+        1,
+        RawData::U16(frame),
+        Cfa::RGGB,
+    );
+    raw.crop = Rect {
+        x: geometry.left,
+        y: geometry.top,
+        width: geometry.width,
+        height: geometry.height,
+    };
+    // Ten bits a sample without a plane, twelve with; nothing in the
+    // file records a saturation point, so the depth is the ceiling.
+    raw.white_level = if low.is_some() { 4095.0 } else { 1023.0 };
+    if let Some(black) = black_level(&raw.data, width, &geometry) {
+        if black.iter().all(|b| *b < raw.white_level) {
+            raw.black_levels = black;
+        }
+    }
+    Ok(raw)
+}
+
+/// The entropy-coded frame, ten bits a sample.
+///
+/// The stream is one continuous MSB-first bit sequence with JPEG's
+/// byte stuffing (`FF 00` is a data `FF`; `FF` followed by anything
+/// else ends it), never realigned at a band, row or block boundary.
+///
+/// It carries 64-sample blocks of signed differences coded exactly as
+/// JPEG codes AC coefficients: a symbol packing a run of zeros in its
+/// high nibble and a magnitude class in its low one, then that many
+/// bits of value. Two things are peculiar to Canon. Difference 0 of a
+/// block is *second order* — a difference against the previous block's
+/// difference 0, through a carry that runs unbroken for the whole
+/// frame — and the reconstruction keeps two predictors, one per Bayer
+/// column parity, both reset to [`EDGE_PREDICTOR`] at the start of
+/// every row. Because blocks straddle row ends, that reset lands in
+/// the middle of a block more often than not.
+fn decompress(coded: &[u8], set: usize, width: usize, height: usize) -> Result<Vec<u16>> {
+    // Table A codes the first coefficient of a block, table B the
+    // other 63. Both are firmware constants indexed by record 0x1835.
+    let first = HuffTable::new(&TABLE_A_COUNTS[set], &TABLE_A_SYMBOLS[set])?;
+    let rest = HuffTable::new(&TABLE_B_COUNTS[set], &TABLE_B_SYMBOLS[set])?;
+    let mut out = vec![0u16; width * height];
+    let mut pump = BitPumpJpeg::new(coded);
+    let mut carry = 0i32;
+    let mut predictor = [0i32; 2];
+    let mut at = 0usize;
+
+    for row in (0..height).step_by(BAND) {
+        let rows = BAND.min(height - row);
+        // Whole blocks only: a band whose sample count is not a
+        // multiple of 64 simply leaves its tail uncoded.
+        for _ in 0..rows * width / BLOCK {
+            let mut difference = [0i32; BLOCK];
+            let mut i = 0usize;
+            while i < BLOCK {
+                let symbol = if i == 0 {
+                    first.decode(&mut pump)
+                } else {
+                    rest.decode(&mut pump)
+                };
+                // Zero ends the block, except as the first
+                // coefficient, where it is the magnitude class 0.
+                if symbol == 0 && i > 0 {
+                    break;
+                }
+                // 0xFF skips one position. Its nominal run field is
+                // fifteen, but the format does not use it that way.
+                if symbol == 0xFF {
+                    i += 1;
+                    continue;
+                }
+                let run = (symbol >> 4) as usize;
+                let size = (symbol & 15) as u32;
+                i += run;
+                if size == 0 {
+                    i += 1;
+                    continue;
+                }
+                let value = pump.get(size) as i32;
+                // The lossless-JPEG sign convention: the top half of
+                // the range is positive, the bottom half negative.
+                let signed = if value & (1 << (size - 1)) != 0 {
+                    value
+                } else {
+                    value - (1 << size) + 1
+                };
+                // A run can push the index past the end of the block.
+                // Those differences are dropped, but their bits have
+                // been consumed and the stream stays in step.
+                if let Some(slot) = difference.get_mut(i) {
+                    *slot = signed;
+                }
+                i += 1;
+            }
+            difference[0] += carry;
+            carry = difference[0];
+
+            for (i, d) in difference.iter().enumerate() {
+                if at.is_multiple_of(width) {
+                    predictor = [EDGE_PREDICTOR; 2];
+                }
+                let side = i & 1;
+                // The carry is never reset, so a crafted stream can
+                // drive the running value without bound; saturating
+                // keeps a data error a data error rather than a panic.
+                predictor[side] = predictor[side].saturating_add(*d);
+                if let Some(sample) = out.get_mut(at) {
+                    // A sample outside ten bits is a data error the
+                    // format has no way to signal; it is stored as it
+                    // falls rather than clamped, which is what the
+                    // reference frames show.
+                    *sample = predictor[side] as u16;
+                }
+                at += 1;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Fold the two extra bits a sample of a twelve-bit body's low-bit
+/// plane into the ten-bit frame.
+///
+/// The plane is raw two-bit fields, four to a byte, **least
+/// significant pair first**, in raster order over the whole frame; it
+/// is read straight out of the record and never touches the Huffman
+/// reader's position.
+fn merge_low_bits(frame: &mut [u16], plane: &[u8], width: usize, height: usize) {
+    for row in (0..height).step_by(BAND) {
+        // Each band of eight rows consumes `width * 2` bytes, which is
+        // the same as stepping the plane by `row * width / 4`.
+        let from = row * width / 4;
+        let bytes = plane.get(from..).unwrap_or(&[]);
+        let base = row * width;
+        let count = (BAND * width).min(frame.len() - base);
+        for (i, sample) in frame[base..base + count].iter_mut().enumerate() {
+            let low = (bytes.get(i / 4).copied().unwrap_or(0) >> ((i % 4) * 2)) & 3;
+            let mut value = ((*sample as u32) << 2) | low as u32;
+            // Unexplained, and present in every decoder of this
+            // format: on the 2672-wide bodies only, a merged value
+            // under 512 is raised by two. Reproduced because the
+            // reference frames carry it.
+            if width == FUDGED_WIDTH && value < 512 {
+                value += 2;
+            }
+            *sample = value as u16;
+        }
+    }
+}
+
+/// The black level, averaged over the sensor's optically black columns.
+///
+/// No record carries it. Two rectangles are used, both spanning the
+/// picture's rows: one in the masked border to the left of the
+/// picture, one in whatever is left to its right. Each CFA position is
+/// averaged separately.
+///
+/// The result is rejected — leaving the black level at zero — when a
+/// position collected no samples, or when the regions hold as many
+/// exactly-zero samples as the first position has samples at all. That
+/// second test is what makes the EOS D60's all-zero leading rows
+/// harmless: a frame whose masked border is mostly zeros has no black
+/// level worth measuring.
+fn black_level(data: &RawData, width: usize, geometry: &Geometry) -> Option<[f32; 4]> {
+    let RawData::U16(frame) = data else {
+        return None;
+    };
+    let left = (2 + geometry.mask[0])..geometry.left.saturating_sub(2 + geometry.mask[1]);
+    let right = (geometry.left + geometry.width + 2 + geometry.mask[2])
+        ..width.saturating_sub(geometry.mask[3]);
+    let mut sum = [0u64; 4];
+    let mut count = [0usize; 4];
+    let mut zeros = 0usize;
+    for row in geometry.top..geometry.top + geometry.height {
+        for columns in [left.clone(), right.clone()] {
+            for col in columns {
+                if col >= width {
+                    break;
+                }
+                let Some(sample) = frame.get(row * width + col) else {
+                    continue;
+                };
+                let position = (row & 1) * 2 + (col & 1);
+                sum[position] += *sample as u64;
+                count[position] += 1;
+                zeros += usize::from(*sample == 0);
+            }
+        }
+    }
+    if count.contains(&0) || zeros >= count[0] {
+        return None;
+    }
+    Some(std::array::from_fn(|i| sum[i] as f32 / count[i] as f32))
 }
 
 // ----------------------------------------------------------------- CIFF
@@ -564,6 +1008,302 @@ mod tests {
         assert_eq!(unpack10(&[0x21], 2), vec![0x84, 0]);
     }
 
+    // ---------------------------------------- the compressed codec
+
+    /// The canonical code of one symbol in a DHT-style table, as
+    /// `(code, length)`: start at 0 for the shortest length, count up
+    /// within a length, shift left when the length grows.
+    fn canonical(counts: &[u8; 16], symbols: &[u8], want: u8) -> Option<(u32, u32)> {
+        let (mut code, mut index) = (0u32, 0usize);
+        for length in 1..=16u32 {
+            for k in 0..counts[length as usize - 1] as u32 {
+                if symbols[index + k as usize] == want {
+                    return Some((code + k, length));
+                }
+            }
+            index += counts[length as usize - 1] as usize;
+            code = (code + counts[length as usize - 1] as u32) << 1;
+        }
+        None
+    }
+
+    /// Bits MSB-first into whole bytes, with the byte stuffing the
+    /// codec's reader expects: a data `0xFF` is written `FF 00`.
+    #[derive(Default)]
+    struct Stuffed {
+        out: Vec<u8>,
+        cache: u32,
+        bits: u32,
+    }
+
+    impl Stuffed {
+        fn put(&mut self, value: u32, bits: u32) {
+            self.cache = (self.cache << bits) | (value & ((1u64 << bits) - 1) as u32);
+            self.bits += bits;
+            while self.bits >= 8 {
+                self.bits -= 8;
+                let byte = (self.cache >> self.bits) as u8;
+                self.out.push(byte);
+                if byte == 0xFF {
+                    self.out.push(0);
+                }
+            }
+        }
+        /// One Huffman symbol from the named table of set 0.
+        fn symbol(&mut self, first: bool, symbol: u8) {
+            let (counts, symbols): (&[u8; 16], &[u8]) = if first {
+                (&TABLE_A_COUNTS[0], &TABLE_A_SYMBOLS[0])
+            } else {
+                (&TABLE_B_COUNTS[0], &TABLE_B_SYMBOLS[0])
+            };
+            let (code, length) = canonical(counts, symbols, symbol).expect("symbol in the table");
+            self.put(code, length);
+        }
+        /// A run/size symbol and its value bits, in the sign
+        /// convention of section 4.2.
+        fn difference(&mut self, first: bool, run: u8, size: u32, value: i32) {
+            self.symbol(first, (run << 4) | size as u8);
+            if size > 0 {
+                let bits = if value > 0 {
+                    value
+                } else {
+                    value + (1 << size) - 1
+                };
+                self.put(bits as u32, size);
+            }
+        }
+        fn finish(mut self) -> Vec<u8> {
+            if self.bits > 0 {
+                let pad = 8 - self.bits;
+                self.put(0, pad);
+            }
+            self.out
+        }
+    }
+
+    /// The canonical assignment of the three first-coefficient tables,
+    /// spelled out code word by code word. This is the one place the
+    /// firmware tables can be checked without a file: get the code
+    /// assignment wrong and every compressed frame is noise. Only set
+    /// 0 appears in the corpus, so for sets 1 and 2 this is the whole
+    /// of the evidence.
+    #[test]
+    fn the_first_coefficient_tables_have_the_codes_they_must() {
+        const EXPANDED: [[(&str, u8); 13]; 3] = [
+            [
+                ("00", 0x04),
+                ("010", 0x03),
+                ("011", 0x05),
+                ("100", 0x06),
+                ("101", 0x02),
+                ("1100", 0x07),
+                ("1101", 0x01),
+                ("11100", 0x08),
+                ("11101", 0x09),
+                ("11110", 0x00),
+                ("111110", 0x0A),
+                ("1111110", 0x0B),
+                ("1111111", 0xFF),
+            ],
+            [
+                ("00", 0x03),
+                ("01", 0x02),
+                ("100", 0x04),
+                ("101", 0x01),
+                ("1100", 0x05),
+                ("1101", 0x00),
+                ("1110", 0x06),
+                ("11110", 0x07),
+                ("111110", 0x09),
+                ("1111110", 0x08),
+                ("11111110", 0x0A),
+                ("111111110", 0x0B),
+                ("111111111", 0xFF),
+            ],
+            [
+                ("000", 0x06),
+                ("001", 0x05),
+                ("010", 0x07),
+                ("011", 0x04),
+                ("100", 0x08),
+                ("101", 0x03),
+                ("1100", 0x09),
+                ("1101", 0x02),
+                ("1110", 0x00),
+                ("11110", 0x0A),
+                ("111110", 0x01),
+                ("1111110", 0x0B),
+                ("1111111", 0xFF),
+            ],
+        ];
+        for (set, codes) in EXPANDED.iter().enumerate() {
+            for (bits, symbol) in codes {
+                let want = (u32::from_str_radix(bits, 2).unwrap(), bits.len() as u32);
+                assert_eq!(
+                    canonical(&TABLE_A_COUNTS[set], &TABLE_A_SYMBOLS[set], *symbol),
+                    Some(want),
+                    "set {set} table A symbol {symbol:#04x} should be {bits}"
+                );
+            }
+        }
+    }
+
+    /// The six tables build, and each holds exactly the leaves its
+    /// counts promise. A table that over-subscribes its code space is
+    /// rejected by [`HuffTable::new`], which is the check that a
+    /// mistyped count would trip.
+    #[test]
+    fn every_table_set_builds() {
+        for set in 0..3 {
+            assert_eq!(
+                TABLE_A_COUNTS[set]
+                    .iter()
+                    .map(|c| *c as usize)
+                    .sum::<usize>(),
+                TABLE_A_SYMBOLS[set].len()
+            );
+            assert_eq!(
+                TABLE_B_COUNTS[set]
+                    .iter()
+                    .map(|c| *c as usize)
+                    .sum::<usize>(),
+                TABLE_B_SYMBOLS[set].len()
+            );
+            HuffTable::new(&TABLE_A_COUNTS[set], &TABLE_A_SYMBOLS[set]).expect("table A builds");
+            HuffTable::new(&TABLE_B_COUNTS[set], &TABLE_B_SYMBOLS[set]).expect("table B builds");
+        }
+    }
+
+    /// `FF 00` is a data `0xFF`; `FF` followed by anything else ends
+    /// the stream, and everything after it reads as zero.
+    #[test]
+    fn the_reader_unstuffs_and_stops_at_a_marker() {
+        let mut pump = BitPumpJpeg::new(&[0xFF, 0x00, 0xFF, 0x00]);
+        for _ in 0..16 {
+            assert_eq!(pump.get(1), 1);
+        }
+        let mut pump = BitPumpJpeg::new(&[0xFF, 0x01, 0xFF, 0xFF]);
+        assert_eq!(pump.get(8), 0);
+        assert!(pump.at_marker());
+    }
+
+    /// Run/size symbols, end of block, the block-to-block carry and
+    /// the per-row predictor reset, on a stream built here.
+    ///
+    /// Two blocks over a 64-wide, two-row frame, so each block is
+    /// exactly one row and the reset falls on a block boundary.
+    #[test]
+    fn a_block_carries_runs_an_end_marker_and_a_carry() {
+        let mut bits = Stuffed::default();
+        // Block 0: +3 at position 0, then a run of one to position 2
+        // carrying +1, then end of block.
+        bits.difference(true, 0, 2, 3);
+        bits.difference(false, 1, 1, 1);
+        bits.symbol(false, 0x00);
+        // Block 1: a first coefficient of zero, which the carry from
+        // block 0 turns into +3, then end of block.
+        bits.difference(true, 0, 0, 0);
+        bits.symbol(false, 0x00);
+        let frame = decompress(&bits.finish(), 0, 64, 2).expect("decodes");
+        // Row 0: both predictors start at 512; the even one takes +3
+        // then +1, the odd one nothing.
+        assert_eq!(&frame[..5], &[515, 512, 516, 512, 516]);
+        // Row 1 resets both predictors and applies the carried +3 to
+        // the even one only.
+        assert_eq!(&frame[64..68], &[515, 512, 515, 512]);
+    }
+
+    /// `0xFF` skips a single position. Its nominal run field is
+    /// fifteen, and a decoder that honoured it would put the next
+    /// difference fifteen columns further along.
+    #[test]
+    fn the_ff_symbol_skips_one_position_not_sixteen() {
+        let mut bits = Stuffed::default();
+        bits.symbol(true, 0xFF);
+        bits.difference(false, 0, 1, 1);
+        bits.symbol(false, 0x00);
+        let frame = decompress(&bits.finish(), 0, 64, 1).expect("decodes");
+        // Position 0 untouched, position 1 raised by one: the skip
+        // moved the index on by exactly one.
+        assert_eq!(&frame[..4], &[512, 513, 512, 513]);
+    }
+
+    /// A run that reaches past the end of a block loses its
+    /// difference but still spends its bits, so the block that
+    /// follows starts in step.
+    #[test]
+    fn a_run_past_the_end_of_a_block_still_spends_its_bits() {
+        let mut bits = Stuffed::default();
+        // Position 0, then a run of 15 from position 49 lands on 64.
+        bits.difference(true, 0, 1, 1);
+        for _ in 0..3 {
+            bits.difference(false, 15, 0, 0);
+        }
+        bits.difference(false, 15, 1, 1);
+        // No end-of-block symbol: the index has already run past 63,
+        // so the block finishes on the run itself.
+        // The next block must decode as a plain +1 at position 0.
+        bits.difference(true, 0, 1, 1);
+        bits.symbol(false, 0x00);
+        let frame = decompress(&bits.finish(), 0, 64, 2).expect("decodes");
+        assert_eq!(frame[0], 513);
+        // Carry: block 1's own difference 0 is +1 on top of block 0's.
+        assert_eq!(frame[64], 514);
+    }
+
+    /// The low-bit plane's four samples a byte, least significant pair
+    /// first. The numbers are the EOS D60's row 8: ten-bit 55 55 55 52
+    /// becoming twelve-bit 222 221 221 208.
+    #[test]
+    fn the_low_bit_plane_is_read_least_significant_pair_first() {
+        let mut frame = vec![55u16, 55, 55, 52];
+        let byte = 2 | (1 << 2) | (1 << 4);
+        merge_low_bits(&mut frame, &[byte], 4, 1);
+        assert_eq!(frame, vec![222, 221, 221, 208]);
+    }
+
+    /// The 2672-wide bodies raise a merged value under 512 by two.
+    /// Unexplained, but every frame of theirs carries it.
+    #[test]
+    fn the_2672_wide_bodies_get_the_low_bit_fudge() {
+        let mut frame = vec![100u16, 200];
+        merge_low_bits(&mut frame, &[0], FUDGED_WIDTH, 1);
+        assert_eq!(frame, vec![402, 800]);
+        let mut frame = vec![100u16, 200];
+        merge_low_bits(&mut frame, &[0], 2376, 1);
+        assert_eq!(frame, vec![400, 800]);
+    }
+
+    /// The heuristic that decides whether there is a low-bit plane.
+    #[test]
+    fn the_low_bit_probe_reads_the_stuffing_rule() {
+        let mut file = vec![0u8; PROBE_WINDOW];
+        // Coded data: every 0xFF followed by a zero.
+        file[600] = 0xFF;
+        assert!(!has_low_bit_plane(&file, 540));
+        // Plane data: an 0xFF followed by something else.
+        file[601] = 1;
+        assert!(has_low_bit_plane(&file, 540));
+        // No 0xFF at all decides nothing, and a plane is assumed.
+        assert!(has_low_bit_plane(&vec![0u8; PROBE_WINDOW], 540));
+    }
+
+    /// The per-frame-size geometry, on the two bodies the corpus has.
+    #[test]
+    fn geometry_is_keyed_by_the_frame_size() {
+        let g2 = geometry(2376, 1728).expect("PowerShot G2");
+        assert_eq!((g2.left, g2.top, g2.width, g2.height), (12, 6, 2312, 1720));
+        let d60 = geometry(3152, 2068).expect("EOS D60");
+        assert_eq!(
+            (d60.left, d60.top, d60.width, d60.height),
+            (64, 12, 3088, 2056)
+        );
+        // The D60 frame is the only one whose left black rectangle is
+        // set in: columns 18..=61 rather than 2..=61.
+        assert_eq!(d60.mask, [16, 0, 0, 0]);
+        assert_eq!(geometry(1000, 1000), None);
+    }
+
     #[test]
     fn hostile_input_is_an_error_not_a_panic() {
         for bytes in [
@@ -581,8 +1321,16 @@ mod tests {
 
     // ---------------------------------------------------------- corpus
 
-    /// Compressed CIFF is refused on purpose: see this module's header.
-    /// Everything the corpus holds but the Pro70 is compressed.
+    /// Files this module knowingly declines, with the reason. A
+    /// corpus file that fails for any other reason fails the test.
+    ///
+    /// Nothing is on it today: every CIFF in the corpus decodes. The
+    /// list stays because the two open cases — an uncompressed body
+    /// other than the Pro70, whose filter array nothing records, and a
+    /// compressed frame of a size no body in [`GEOMETRY`] writes —
+    /// are refusals rather than bugs.
+    const UNSUPPORTED: &[&str] = &["filter array", "no body known"];
+
     fn corpus() -> Option<PathBuf> {
         std::env::var_os("SCHIST_RAW_CORPUS").map(PathBuf::from)
     }
@@ -611,13 +1359,141 @@ mod tests {
         Some((width, height, image.into_raw()))
     }
 
+    /// The ten-bit frame of a compressed sample, before its low-bit
+    /// plane (if any) is merged, with where its coded stream began and
+    /// whether a plane was found.
+    fn ten_bit_frame(bytes: &[u8]) -> (Vec<u16>, usize, bool) {
+        let ciff = Ciff::parse(bytes).expect("CIFF");
+        let image = ciff.find(tag::IMAGE_DATA).expect("image record");
+        let sensor = ciff.sensor_info().expect("sensor record");
+        let (width, height) = (sensor.width, sensor.height);
+        let plane = has_low_bit_plane(bytes, image.at + PAD);
+        let coded_at = image.at + PAD + if plane { width * height / 4 } else { 0 };
+        let end = image.at + image.len;
+        let set = ciff
+            .longs(tag::DECODER_TABLE)
+            .first()
+            .map_or(0, |v| *v as usize)
+            .min(TABLE_A_COUNTS.len() - 1);
+        let frame = decompress(&bytes[coded_at..end], set, width, height).expect("decodes");
+        (frame, coded_at, plane)
+    }
+
+    fn sample(path: &str) -> Option<Vec<u8>> {
+        let dir = corpus()?;
+        let path = dir.join("Canon").join(path);
+        std::fs::read(path).ok()
+    }
+
+    /// The PowerShot G2: ten bits a sample, no low-bit plane, and a
+    /// row of dense non-zero differences.
+    #[test]
+    fn the_g2_decodes_its_first_band_sample_for_sample() {
+        let Some(bytes) = sample("PowerShot_G2-RAW_CANON_G2.CRW") else {
+            return;
+        };
+        let (frame, coded_at, plane) = ten_bit_frame(&bytes);
+        assert!(!plane, "the G2 is a ten-bit body");
+        assert_eq!(coded_at, 540);
+        assert_eq!(
+            &bytes[coded_at..coded_at + 16],
+            &[
+                0xE8, 0x7F, 0xE8, 0x7B, 0xFD, 0xEB, 0x8C, 0x4A, 0x50, 0xF7, 0x8C, 0x63, 0x3E, 0xE5,
+                0x8F, 0x58
+            ]
+        );
+        let width = 2376;
+        assert_eq!(
+            &frame[..16],
+            &[32, 31, 32, 31, 32, 31, 32, 32, 31, 31, 33, 33, 30, 33, 31, 32]
+        );
+        assert_eq!(
+            &frame[64..80],
+            &[32, 31, 32, 30, 31, 31, 32, 31, 32, 30, 33, 32, 30, 32, 31, 32]
+        );
+        assert_eq!(
+            &frame[width..width + 16],
+            &[32, 32, 32, 34, 34, 32, 32, 33, 34, 32, 32, 30, 32, 33, 32, 33]
+        );
+        // Band 0 emits exactly 8 * 2376 samples, so the two predictors
+        // at the end of it are the last two samples of row 7.
+        assert_eq!(&frame[8 * width - 2..8 * width], &[32, 32]);
+    }
+
+    /// The EOS D60: twelve bits a sample, so a low-bit plane sits in
+    /// front of a coded stream whose very first bytes are stuffed.
+    #[test]
+    fn the_d60_decodes_its_first_two_bands_sample_for_sample() {
+        let Some(bytes) = sample("EOS_D60-CRW_0099.CRW") else {
+            return;
+        };
+        let (mut frame, coded_at, plane) = ten_bit_frame(&bytes);
+        assert!(plane, "the D60 is a twelve-bit body");
+        assert_eq!(coded_at, 540 + 3152 * 2068 / 4);
+        assert_eq!(
+            &bytes[coded_at..coded_at + 8],
+            // Two stuffed pairs in the first eight bytes.
+            &[0xF9, 0xFF, 0x00, 0xFE, 0x9F, 0xFF, 0x00, 0xDF]
+        );
+        let width = 3152;
+        // Block 0's differences are -512, -512 and block 1's +512,
+        // which the carry cancels, so the frame opens with seven
+        // entirely blank rows.
+        assert!(
+            frame[..7 * width].iter().all(|s| *s == 0),
+            "rows 0..6 should be blank"
+        );
+        assert!(frame[7 * width..8 * width].iter().any(|s| *s != 0));
+        // Both predictors stand at 55 at the end of band 0.
+        assert_eq!(&frame[8 * width - 2..8 * width], &[55, 55]);
+        assert_eq!(
+            &frame[8 * width..8 * width + 16],
+            &[55, 55, 55, 55, 55, 55, 55, 52, 55, 55, 55, 54, 55, 55, 55, 55]
+        );
+        assert_eq!(
+            &frame[8 * width + 64..8 * width + 80],
+            &[55, 55, 55, 54, 55, 55, 55, 55, 54, 55, 55, 55, 55, 55, 55, 55]
+        );
+        // Band 1 leaves the two predictors far apart, which is what
+        // proves they are kept independently.
+        assert_eq!(&frame[16 * width - 2..16 * width], &[455, 381]);
+
+        let plane = &bytes[26..26 + 3152 * 2068 / 4];
+        merge_low_bits(&mut frame, plane, width, 2068);
+        assert_eq!(
+            &frame[8 * width..8 * width + 16],
+            &[222, 221, 221, 221, 221, 221, 221, 208, 221, 221, 221, 218, 221, 220, 221, 221]
+        );
+        assert_eq!(
+            &frame[8 * width + 64..8 * width + 80],
+            &[221, 221, 221, 219, 220, 221, 220, 221, 219, 221, 220, 221, 222, 221, 221, 220]
+        );
+    }
+
+    /// The EOS 10D writes the same geometry and the same opening
+    /// blocks as the D60 but ends band 0 with its two predictors at
+    /// different values: an implementation that shared one predictor
+    /// between the column parities would pass the D60 and fail here.
+    #[test]
+    fn the_10d_ends_its_first_band_with_two_different_predictors() {
+        let Some(bytes) = sample("EOS_10D-CRW_7673.CRW") else {
+            return;
+        };
+        let (frame, coded_at, plane) = ten_bit_frame(&bytes);
+        assert!(plane);
+        assert_eq!(coded_at, 540 + 3152 * 2068 / 4);
+        let width = 3152;
+        assert!(frame[..7 * width].iter().all(|s| *s == 0));
+        assert_eq!(&frame[8 * width - 2..8 * width], &[51, 54]);
+    }
+
     #[test]
     fn corpus_decodes_what_it_can_and_refuses_the_rest() {
         let Some(dir) = corpus() else { return };
         let mut files = Vec::new();
         crw_files(&dir, &mut files);
         files.sort();
-        let (mut uncompressed, mut decoded) = (0, 0);
+        let (mut ciffs, mut decoded) = (0, 0);
         for path in &files {
             let name = path
                 .file_name()
@@ -643,12 +1519,11 @@ mod tests {
                 Some(Format::Crw),
                 "{name} probes as CRW"
             );
-            // An image record with no decoder-table index beside it is
-            // one this module is meant to decode, so a refusal on one
-            // of those would be a bug rather than the documented gap.
+            // Every CIFF with an image record is one this module is
+            // meant to decode, compressed or not.
             let ciff = Ciff::parse(&bytes).unwrap_or_else(|e| panic!("{name}: {e}"));
-            if ciff.find(tag::DECODER_TABLE).is_none() && ciff.find(tag::IMAGE_DATA).is_some() {
-                uncompressed += 1;
+            if ciff.find(tag::IMAGE_DATA).is_some() {
+                ciffs += 1;
             }
 
             // The camera's own JPEG comes out of any CRW that has one,
@@ -661,9 +1536,10 @@ mod tests {
                 Ok(raw) => raw,
                 Err(Error::Unsupported(why)) => {
                     assert!(
-                        why.contains("compressed") || why.contains("filter array"),
+                        UNSUPPORTED.iter().any(|allowed| why.contains(allowed)),
                         "{name}: {why}"
                     );
+                    eprintln!("crw: {name} is unsupported: {why}");
                     continue;
                 }
                 Err(why) => panic!("{name}: {why}"),
@@ -700,9 +1576,13 @@ mod tests {
                 wrong.iter().map(|i| want[*i]).collect::<Vec<_>>(),
             );
         }
+        eprintln!(
+            "crw: {decoded} of {ciffs} CIFF files decoded, {} files seen",
+            files.len()
+        );
         assert_eq!(
-            decoded, uncompressed,
-            "every uncompressed CIFF in the corpus should decode"
+            decoded, ciffs,
+            "every CIFF in the corpus with an image record should decode"
         );
     }
 

--- a/crates/codec-raw/src/formats/crx.rs
+++ b/crates/codec-raw/src/formats/crx.rs
@@ -1,117 +1,111 @@
 //! Canon's CRX codec: the wavelet-and-Golomb scheme inside a CR3.
 //!
-//! A CRX image is a grid of *tiles*. Each tile holds one *plane* per
-//! colour-filter position — a Bayer frame is split into its four 2x2
-//! sub-planes, so a plane is half the tile wide and half as tall — and
-//! each plane holds one *subband* per wavelet band. With zero wavelet
-//! levels (what Canon's "RAW" quality writes) a plane is a single LL
-//! band and the coefficients are the sensor samples themselves; with
-//! levels (what "CRAW" writes) there are `3 * levels + 1` bands and a
-//! 5/3-style integer lifting wavelet to invert, with a per-band
-//! quantiser in the lossy case.
+//! A CRX image is a grid of *tiles*. Each tile holds one *component*
+//! per colour-filter position — a Bayer frame is split into its four
+//! 2x2 sub-planes, so a component is half the frame wide and half as
+//! tall — and each component holds one *subband* per wavelet band.
+//! With zero wavelet levels (what Canon's "RAW" quality writes) a
+//! component is a single LL band whose coefficients are the sensor
+//! samples themselves; with levels (what "CRAW" writes) there are
+//! `3 * levels + 1` bands, a quantiser per band and a 5/3 integer
+//! lifting wavelet to invert.
+//!
+//! Every subband is an independently addressed bitstream with its own
+//! entropy-coder state, so tiles, components and bands can all be
+//! decoded in parallel; only the wavelet joins them back up.
 //!
 //! The shapes and sizes come from two places: the `CMP1` box in the
 //! track's sample entry ([`ImageHeader`]), and a header of small
 //! tag/size records in front of the sample data in `mdat`
-//! ([`parse_tiles`]). Nothing about the layouts here is guessed from
-//! another decoder's source: the record tags and field positions were
-//! read off real files and cross-checked against the public CR3 notes.
+//! ([`parse_tiles`]).
+//!
+//! ## The entropy coder in one page
+//!
+//! Bits are read most-significant first straight down the bytes, with
+//! no stuffing and no alignment anywhere. A coefficient magnitude `m`
+//! is a Golomb-Rice code with a running parameter `K`: `m >> K` in
+//! unary (that many zeros, then a one), then the low `K` bits. A
+//! unary prefix of 41 or more zeros is an escape and the magnitude is
+//! a flat 21-bit field instead — which is how every lossless band
+//! opens, because its first residual is `black - 8192`. `m` folds to
+//! a signed residual as `d = -(m & 1) ^ (m >> 1)`.
+//!
+//! `K` adapts after every symbol from the magnitude (blended with the
+//! gradient one column to the right on the line above, where the line
+//! decoder says so) and carries across line boundaries; see [`adapt`].
+//!
+//! Sitting under all of that is a run mode: at a position where the
+//! neighbourhood says the next samples are probably a repeat, one bit
+//! says whether a run is present and an exponential/remainder code
+//! gives its length. A zero-length run is normal and frequent — it
+//! costs one bit and means "no run here". It is the single thing a
+//! partial implementation misses: the flag bit is then read as the
+//! start of the next symbol's unary prefix and everything after it is
+//! noise.
+//!
+//! Two line coders use those pieces. Mode A ([`Coder::mode_a_line`])
+//! codes the LL band, predicting from the left on line 0 and from
+//! Canon's own four-way gradient selector after that. Mode B
+//! ([`Coder::mode_b_line`]) codes the detail bands, where the sample
+//! *is* the residual, runs are tested against a zero neighbourhood
+//! and `K` is steered by a per-column memory of what the line above
+//! used.
 
-//! ## What is known about the coefficient bitstream
-//!
-//! [`decode`] does not decode coefficients yet, and this is what was
-//! established about them from the corpus, so the next hand does not
-//! start from nothing. All of it was checked against
-//! `unprocessed_raw`'s output for `EOS R RAW`, tile 0 plane 0 — a
-//! lossless zero-level band, 1722 by 2273 coefficients — and none of
-//! it comes from another decoder.
-//!
-//! Bits are read most-significant first, straight down the bytes
-//! ([`crate::bits::BitPumpMsb`]), from the band's first byte. A
-//! coefficient is coded as its prediction residual `d`, folded to a
-//! non-negative `m`: `m = 2d` for `d >= 0`, `m = -2d - 1` for `d < 0`.
-//! `m` is then a Rice code with a running parameter `k`: the quotient
-//! `m >> k` in unary — that many zero bits, then a one — followed by
-//! the low `k` bits of `m`. `k` starts at 0 at the head of a band. A
-//! quotient reaching 42 escapes: 42 zeros, a one, then `m` in a
-//! 21-bit field.
-//!
-//! `k` is updated after every coefficient from
-//!
-//! ```text
-//! s = m + (the folded magnitude one to the right on the line above)
-//! raise k while s >= 6 << k, by at most two;
-//! if it did not rise and s < (1 << k) - 1, lower it by one.
-//! ```
-//!
-//! On the first line, which has no line above, `s = 2m` — the same
-//! rule with the coefficient standing in for its own neighbour. `k`
-//! carries across the line boundary. An accumulator scheme in the
-//! manner of JPEG-LS was tried and does not reproduce the stream, and
-//! neither does a `k` read only from the line above: it is a running
-//! state that the line above steers.
-//!
-//! The first line predicts from the left, with `1 << (bits - 1)`
-//! standing in for the pixel before the first — which is why every
-//! lossless band opens with the escape, its first residual being
-//! about `black - 8192`. Later lines predict with the gradient median
-//! of the left, above and above-left neighbours (`min(a, b)` when
-//! `c >= max(a, b)`, `max(a, b)` when `c <= min(a, b)`, else
-//! `a + b - c`).
-//!
-//! That decodes the whole of line 0 exactly, and line 1 exactly up to
-//! its 53rd coefficient. There it wants `k` to fall and then rise
-//! again over two coefficients that the rule above holds steady, and
-//! wants `min(a, b)` where the gradient median gives `max(a, b)` —
-//! two symptoms at one spot, which is what a mode switch looks like:
-//! most likely the zero-run mode that the magnitudes of the line
-//! above select into. Finding that is all that stands between this
-//! and lossless CR3 frames.
-
+use crate::bits::{BitPump, BitPumpMsb};
 use crate::{Error, Result};
+use rayon::prelude::*;
 
 /// The `CMP1` box: what shape the coded image is.
-///
-/// The first four bytes are a marker (0xff00 or 0xff10) and the size
-/// of the rest, then a version that says which of the two record
-/// dialects the `mdat` header speaks (see [`parse_tiles`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImageHeader {
-    /// 1 on the EOS R / RP / M50 / 90D generation, 2 from the R5 on.
-    pub version: u8,
+    /// `0x0100` on the EOS R / RP / M50 / 90D generation, `0x0200`
+    /// from the R5 on. It selects which dialect the `mdat` index
+    /// speaks and where the quantiser lives (see [`parse_tiles`]).
+    pub version: u16,
     /// The whole coded frame, which is also the raw sensor frame.
     pub width: usize,
     pub height: usize,
-    /// One tile of it. Tiles divide the frame left to right, top to
-    /// bottom; the last tile in a row or column is whatever is left.
+    /// One tile of it, in frame coordinates. Tiles divide the frame
+    /// left to right, top to bottom; the last tile in a row or column
+    /// is whatever is left.
     pub tile_width: usize,
     pub tile_height: usize,
     /// Bits per sensor sample, 14 on every body seen.
     pub bits: u32,
-    /// Planes per tile: 4, the Bayer sub-planes, in the order
-    /// top-left, top-right, bottom-left, bottom-right.
+    /// Components per tile: 4, the Bayer sub-planes, in the semantic
+    /// order R, G on R's row, G on B's row, B. (A single 8-bit
+    /// non-Bayer plane is also allowed by the format.)
     pub planes: usize,
-    /// Which 2x2 phase the frame starts on. 0 everywhere on the
-    /// full-size raw track; the small "SD" raw track uses 1.
+    /// Which 2x2 phase those four sit on; see [`cfa_position`]. 0 on
+    /// every full-size raw track, 1 on the small "SD" one.
     pub cfa_layout: u8,
+    /// 0 for the normal Bayer path, 1 for a signed one and 3 for a
+    /// decorrelated-colour one. Only 0 has ever been seen.
+    pub enc_type: u8,
     /// Wavelet levels: 0 for lossless RAW, 3 for cRAW so far.
-    pub levels: u32,
-    /// Whether the wavelet runs across tile columns / rows, which the
-    /// encoder only sets when there is both a wavelet and more than
-    /// one tile in that direction.
+    pub levels: usize,
+    /// Whether the wavelet runs across tile columns / rows. The
+    /// encoder only sets these when there is both a wavelet and more
+    /// than one tile in that direction; the decoder derives the tile
+    /// neighbour flags from the grid instead and only reports them.
     pub tile_cols_linked: bool,
     pub tile_rows_linked: bool,
     /// Bytes of tag/size records in front of the sample data.
     pub mdat_header_size: usize,
+    /// Precision of the green sum in the `enc_type == 3`
+    /// reconstruction; `bits` unless an extended header says
+    /// otherwise.
+    pub median_bits: u32,
 }
 
 impl ImageHeader {
-    /// Parse the payload of a `CMP1` box (the 52 bytes after its
-    /// 8-byte box header).
+    /// Parse the payload of a `CMP1` box (the bytes after its 8-byte
+    /// box header; 52 of them on every body seen).
     pub fn parse(payload: &[u8]) -> Result<ImageHeader> {
-        if payload.len() < 32 {
+        if payload.len() < 36 {
             return Err(Error::Corrupt(format!("CMP1 is {} bytes", payload.len())));
         }
+        let u16_at = |at: usize| u16::from_be_bytes([payload[at], payload[at + 1]]);
         let u32_at = |at: usize| {
             u32::from_be_bytes([
                 payload[at],
@@ -120,35 +114,34 @@ impl ImageHeader {
                 payload[at + 3],
             ])
         };
-        // Byte 4 is the record dialect of the mdat header — 1 or 2,
-        // with the byte after it zero — and byte 24 onwards is a run
-        // of small fields, one or two to the byte. Everything wider
-        // than a byte in here is big-endian.
-        let version = payload[4];
+        let version = u16_at(4);
         let width = u32_at(8) as usize;
         let height = u32_at(12) as usize;
         let tile_width = u32_at(16) as usize;
         let tile_height = u32_at(20) as usize;
         let bits = payload[24] as u32;
+        // Two fields to the byte from here on: a count in the high
+        // nibble, a code in the low one.
         let planes = (payload[25] >> 4) as usize;
         let cfa_layout = payload[25] & 0xf;
-        let levels = (payload[26] & 0xf) as u32;
+        let enc_type = payload[26] >> 4;
+        let levels = (payload[26] & 0xf) as usize;
         let flags = payload[27];
         let mdat_header_size = u32_at(28) as usize;
+        // The extended header carries a second precision for the
+        // decorrelated-colour path. No file in the corpus sets it.
+        let median_bits = if payload[32] & 0x80 != 0
+            && planes == 4
+            && payload.len() > 56
+            && payload[56] & 0x40 != 0
+            && payload.len() > 84
+        {
+            payload[84] as u32
+        } else {
+            bits
+        };
 
-        if width == 0 || height == 0 || tile_width == 0 || tile_height == 0 {
-            return Err(Error::Corrupt("CMP1 with a zero dimension".into()));
-        }
-        // Everything downstream indexes a u16 buffer of width*height
-        // and slices tiles out of it; a frame that cannot be allocated
-        // is a file lying about itself, not a decode we should attempt.
-        if width > 1 << 17 || height > 1 << 17 {
-            return Err(Error::Corrupt(format!("CMP1 frame {width}x{height}")));
-        }
-        if !(1..=16).contains(&bits) {
-            return Err(Error::Corrupt(format!("CMP1 says {bits} bits a sample")));
-        }
-        Ok(ImageHeader {
+        let header = ImageHeader {
             version,
             width,
             height,
@@ -157,78 +150,199 @@ impl ImageHeader {
             bits,
             planes,
             cfa_layout,
+            enc_type,
             levels,
             tile_cols_linked: flags & 0x80 != 0,
             tile_rows_linked: flags & 0x40 != 0,
             mdat_header_size,
-        })
+            median_bits,
+        };
+        header.validate()?;
+        Ok(header)
+    }
+
+    /// The constraints a conforming stream satisfies. They are worth
+    /// checking up front: everything downstream sizes buffers from
+    /// these numbers, and a file that breaks one of them is lying
+    /// about itself rather than using a variant we do not know.
+    fn validate(&self) -> Result<()> {
+        let bad = |what: String| Err(Error::Corrupt(what));
+        // The frame ceiling first: every allocation below is sized
+        // from these two fields.
+        crate::frame_samples(self.width, self.height, 1)?;
+        if self.bits == 0 {
+            return bad("CRX with no bits a sample".into());
+        }
+        if !matches!(self.version, 0x0100 | 0x0200) {
+            return Err(Error::Unsupported(format!(
+                "CRX header version {:#06x}",
+                self.version
+            )));
+        }
+        if self.mdat_header_size == 0 {
+            return bad("CRX with no mdat index".into());
+        }
+        if self.levels > 3 {
+            return bad(format!("CRX with {} wavelet levels", self.levels));
+        }
+        match self.enc_type {
+            1 if self.bits > 15 => return bad(format!("CRX enc 1 with {} bits", self.bits)),
+            0 | 3 if self.bits > 14 => {
+                return bad(format!("CRX enc {} with {} bits", self.enc_type, self.bits))
+            }
+            0 | 1 | 3 => {}
+            other => return bad(format!("CRX encoding {other}")),
+        }
+        if self.planes == 1 {
+            if self.cfa_layout != 0 || self.enc_type != 0 || self.bits != 8 {
+                return bad("CRX single plane that is not 8-bit greyscale".into());
+            }
+        } else if self.planes != 4 {
+            return bad(format!("CRX with {} planes", self.planes));
+        } else if self.cfa_layout > 3 || self.bits == 8 {
+            return bad(format!(
+                "CRX Bayer frame, layout {}, {} bits",
+                self.cfa_layout, self.bits
+            ));
+        } else if (self.width | self.height | self.tile_width | self.tile_height) & 1 != 0 {
+            return bad("CRX Bayer frame with an odd dimension".into());
+        }
+        if self.width == 0
+            || self.height == 0
+            || self.tile_width == 0
+            || self.tile_height == 0
+            || self.tile_width > self.width
+            || self.tile_height > self.height
+        {
+            return bad(format!(
+                "CRX frame {}x{} in tiles of {}x{}",
+                self.width, self.height, self.tile_width, self.tile_height
+            ));
+        }
+        let (pw, ph) = self.plane_size();
+        let (tw, th) = self.tile_size();
+        // The wavelet needs a couple of coefficients at every level
+        // and the frame has to fit the 15-bit coordinates the tile
+        // records carry, so both ends are bounded.
+        if tw < 22 || th < 22 || pw > 0x7fff || ph > 0x7fff {
+            return bad(format!("CRX plane {pw}x{ph} in tiles of {tw}x{th}"));
+        }
+        let (cols, rows) = self.tile_grid();
+        if cols > 255 || rows > 255 || pw - tw * (cols - 1) < 22 || ph - th * (rows - 1) < 22 {
+            return bad(format!("CRX tile grid {cols}x{rows}"));
+        }
+        Ok(())
+    }
+
+    /// The frame in the *plane domain*: a Bayer frame's four
+    /// components are each half the frame across, and every tile and
+    /// band shape below is expressed in those halved coordinates.
+    pub fn plane_size(&self) -> (usize, usize) {
+        match self.planes {
+            1 => (self.width, self.height),
+            _ => (self.width / 2, self.height / 2),
+        }
+    }
+
+    /// One tile, in the plane domain.
+    pub fn tile_size(&self) -> (usize, usize) {
+        match self.planes {
+            1 => (self.tile_width, self.tile_height),
+            _ => (self.tile_width / 2, self.tile_height / 2),
+        }
     }
 
     /// Tiles across and down.
     pub fn tile_grid(&self) -> (usize, usize) {
-        (
-            self.width.div_ceil(self.tile_width),
-            self.height.div_ceil(self.tile_height),
-        )
+        let (pw, ph) = self.plane_size();
+        let (tw, th) = self.tile_size();
+        (pw.div_ceil(tw.max(1)), ph.div_ceil(th.max(1)))
     }
 
-    /// Bands in one plane: one LL band, then HL/LH/HH per level.
+    /// Bands in one component: one LL band, then HL/LH/HH per level.
     pub fn bands(&self) -> usize {
-        3 * self.levels as usize + 1
+        3 * self.levels + 1
     }
 }
 
-/// One subband's slice of a plane's data.
+/// Tile neighbour flags. They are derived from the tile's place in
+/// the grid, never from the header's "linked" bits, and they say on
+/// which sides the tile's bands carry a few extra coefficients so the
+/// wavelet has real data at an internal seam instead of a symmetric
+/// extension.
+const RIGHT: u8 = 1;
+const LEFT: u8 = 2;
+const BELOW: u8 = 4;
+const ABOVE: u8 = 8;
+
+/// One subband's slice of a component's data.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Band {
     /// Where the band's bits are, inside the whole `mdat` sample.
     pub data: std::ops::Range<usize>,
-    /// Index within the plane, 0 for LL.
+    /// Bytes at the end of that range which are not bitstream.
+    pub trailing: usize,
+    /// Index within the component, 0 for LL.
     pub index: usize,
-    /// The twelve bits under the band counter in the record's flags.
-    /// Every band of a lossless frame carries 32 here; in a version-1
-    /// cRAW frame it grows with the wavelet level (32 for the level-3
-    /// bands, up to 256 for the finest), which is what a quantiser
-    /// looks like. Version 2 leaves it zero and puts a quantiser
-    /// table at the front of the tile instead.
-    pub q_step: u32,
-    /// The whole flags word as written, for a caller that wants to
-    /// report on the bits whose meaning is not established here.
-    pub flags: u32,
+    /// Version 1: the band's quantiser exponent, 4 (unity) when
+    /// lossless. Version 2 leaves it 4 and scales the tile's
+    /// quantiser map instead.
+    pub q_param: i32,
+    /// Version 1: whether a quantiser delta precedes every line.
+    pub q_per_line: bool,
+    /// Version 2: the band's scaling of the tile's quantiser map.
+    pub q_step_base: i32,
+    pub q_step_mult: i32,
 }
 
-/// One Bayer sub-plane of a tile.
+impl Band {
+    /// The bytes that actually hold the entropy-coded bitstream.
+    fn bitstream<'a>(&self, sample: &'a [u8]) -> &'a [u8] {
+        let end = self.data.end.saturating_sub(self.trailing);
+        sample.get(self.data.start..end).unwrap_or(&[])
+    }
+}
+
+/// One component — one Bayer sub-plane — of a tile.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Plane {
     pub data: std::ops::Range<usize>,
     pub index: usize,
-    /// Bit 27 of the flags, set in every file seen.
-    pub extra_flag: bool,
-    /// The whole flags word as written; its top nibble is the plane
-    /// counter and the rest is not established here.
-    pub flags: u32,
+    /// Whether the LL band uses the predictive line coder (Mode A).
+    /// Set in every file seen; when clear the LL band is coded like a
+    /// detail band.
+    pub ref_prev_line: bool,
+    /// The spatial-domain rounding mask, 0 in every file seen. It is
+    /// only legal with no wavelet, where it makes Mode A lossy.
+    pub round_mask: i32,
+    pub round_bits: u32,
     pub bands: Vec<Band>,
 }
 
-/// One tile of the frame.
+/// One tile of the frame. Its position and size are in the plane
+/// domain (see [`ImageHeader::plane_size`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Tile {
     pub data: std::ops::Range<usize>,
     /// Position in the tile grid.
     pub col: usize,
     pub row: usize,
-    /// Pixels of the frame this tile covers.
+    /// Where this tile sits in a component, and how big it is.
     pub x: usize,
     pub y: usize,
     pub width: usize,
     pub height: usize,
-    /// Version 2 only: the quantiser table that precedes the plane
-    /// data inside the tile, in bytes.
-    pub qp_table_size: usize,
+    /// Which sides have a neighbour: `RIGHT | LEFT | BELOW | ABOVE`.
+    pub neighbours: u8,
+    /// Version 2 only: the quantiser map's bitstream at the front of
+    /// the tile, and a few bytes after it whose meaning is unknown
+    /// (4 on an R5, 7 on an R8) which are simply skipped.
+    pub qp_size: usize,
+    pub extra_size: usize,
     pub planes: Vec<Plane>,
 }
 
-/// A record in the `mdat` header: a big-endian tag, a big-endian
+/// A record in the `mdat` index: a big-endian tag, a big-endian
 /// payload length, then the payload.
 struct Record<'a> {
     tag: u16,
@@ -256,6 +370,12 @@ fn records(header: &[u8]) -> Result<Vec<Record<'_>>> {
     Ok(out)
 }
 
+fn be16(b: &[u8], at: usize) -> Result<u32> {
+    b.get(at..at + 2)
+        .map(|s| u16::from_be_bytes([s[0], s[1]]) as u32)
+        .ok_or_else(|| Error::Corrupt("short CRX header record".into()))
+}
+
 fn be32(b: &[u8], at: usize) -> Result<u32> {
     b.get(at..at + 4)
         .map(|s| u32::from_be_bytes([s[0], s[1], s[2], s[3]]))
@@ -263,34 +383,40 @@ fn be32(b: &[u8], at: usize) -> Result<u32> {
 }
 
 /// Read the tag/size records in front of a sample and turn them into
-/// the tile / plane / band tree, with each node's byte range inside
-/// `sample` filled in.
+/// the tile / component / band tree, with each node's byte range
+/// inside `sample` filled in.
 ///
-/// The records come in two dialects. Version 1 (EOS R generation) uses
-/// tags 0xff01 tile, 0xff02 plane, 0xff03 band, each with an 8-byte
-/// payload of a size and a flags word. Version 2 (R5 onwards) uses
-/// 0xff11 / 0xff12 / 0xff13, and the tile and band records carry
-/// sixteen bytes: the tile's says how much of the tile is a quantiser
-/// table before the planes start. In both, a node's children tile its
-/// bytes exactly and the tiles tile the sample after the header.
+/// The records come in two dialects. Version 1 (EOS R generation)
+/// uses tags 0xff01 tile, 0xff02 component, 0xff03 band, each with an
+/// 8-byte payload of a size and one packed word. Version 2 (R5
+/// onwards) uses 0xff11 / 0xff12 / 0xff13; its band record is sixteen
+/// bytes carrying a scale rather than an exponent, and its tile
+/// record may be sixteen too, saying how much of the tile is a
+/// quantiser map in front of the components. In both dialects a
+/// node's children tile its bytes exactly, the tiles tile the sample
+/// after the index, and every node carries its own index so a
+/// misparse is caught rather than decoded as noise.
 pub fn parse_tiles(header: &ImageHeader, sample: &[u8]) -> Result<Vec<Tile>> {
     if header.mdat_header_size > sample.len() {
         return Err(Error::Corrupt(format!(
-            "CRX header of {} bytes in a {}-byte sample",
+            "CRX index of {} bytes in a {}-byte sample",
             header.mdat_header_size,
             sample.len()
         )));
     }
-    let (tile_tag, plane_tag, band_tag) = match header.version {
-        1 => (0xff01u16, 0xff02u16, 0xff03u16),
-        2 => (0xff11, 0xff12, 0xff13),
-        other => return Err(Error::Unsupported(format!("CRX header version {other}"))),
+    let v2 = header.version == 0x0200;
+    let (tile_tag, plane_tag, band_tag) = if v2 {
+        (0xff11u16, 0xff12u16, 0xff13u16)
+    } else {
+        (0xff01, 0xff02, 0xff03)
     };
     let (cols, rows) = header.tile_grid();
+    let (pw, ph) = header.plane_size();
+    let (tw, th) = header.tile_size();
     let mut tiles: Vec<Tile> = Vec::new();
     // Where the next node of each kind starts: tiles follow the
-    // header, planes follow the previous plane inside their tile,
-    // bands the previous band inside their plane.
+    // index, components follow the previous component inside their
+    // tile, bands the previous band inside their component.
     let mut tile_at = header.mdat_header_size;
     let mut plane_at = 0usize;
     let mut band_at = 0usize;
@@ -298,86 +424,154 @@ pub fn parse_tiles(header: &ImageHeader, sample: &[u8]) -> Result<Vec<Tile>> {
     for record in records(&sample[..header.mdat_header_size])? {
         if record.tag == tile_tag {
             let size = be32(record.payload, 0)? as usize;
-            let qp_table_size = if header.version >= 2 {
-                be32(record.payload, 8)? as usize
-            } else {
-                0
-            };
             let index = tiles.len();
             if index >= cols * rows {
                 return Err(Error::Corrupt("more CRX tiles than the grid holds".into()));
             }
+            if be16(record.payload, 4)? as usize != index {
+                return Err(Error::Corrupt("CRX tile out of order".into()));
+            }
+            // The long form is version 2's; the short one is the same
+            // shape as version 1's and carries no quantiser map.
+            let (qp_size, extra_size) = match be16(record.payload, 6)? {
+                0 => (0, 0),
+                0x4000 if record.payload.len() >= 16 => (
+                    be32(record.payload, 8)? as usize,
+                    be16(record.payload, 12)? as usize,
+                ),
+                other => {
+                    return Err(Error::Corrupt(format!(
+                        "CRX tile record flags {other:#06x}"
+                    )))
+                }
+            };
             let (col, row) = (index % cols, index / cols);
-            let x = col * header.tile_width;
-            let y = row * header.tile_height;
             let end = tile_at
                 .checked_add(size)
                 .filter(|end| *end <= sample.len())
                 .ok_or_else(|| Error::Corrupt("CRX tile runs past the sample".into()))?;
+            let mut neighbours = 0;
+            if cols > 1 {
+                neighbours |= if col + 1 < cols { RIGHT } else { 0 };
+                neighbours |= if col > 0 { LEFT } else { 0 };
+            }
+            if rows > 1 {
+                neighbours |= if row + 1 < rows { BELOW } else { 0 };
+                neighbours |= if row > 0 { ABOVE } else { 0 };
+            }
+            let (x, y) = (col * tw, row * th);
             tiles.push(Tile {
                 data: tile_at..end,
                 col,
                 row,
                 x,
                 y,
-                width: header.tile_width.min(header.width - x),
-                height: header.tile_height.min(header.height - y),
-                qp_table_size,
+                width: tw.min(pw - x),
+                height: th.min(ph - y),
+                neighbours,
+                qp_size,
+                extra_size,
                 planes: Vec::new(),
             });
-            // Version 2 puts the quantiser table at the front of the
-            // tile, so the first plane starts after it.
-            plane_at = tile_at + qp_table_size.min(size);
+            // The quantiser map and the unexplained extra bytes sit
+            // at the front of the tile, so the first component starts
+            // after both.
+            plane_at = tile_at
+                .checked_add(qp_size)
+                .and_then(|at| at.checked_add(extra_size))
+                .filter(|at| *at <= end)
+                .ok_or_else(|| Error::Corrupt("CRX quantiser map runs past its tile".into()))?;
             tile_at = end;
         } else if record.tag == plane_tag {
             let size = be32(record.payload, 0)? as usize;
-            let flags = be32(record.payload, 4)?;
+            let packed = *record
+                .payload
+                .get(4)
+                .ok_or_else(|| Error::Corrupt("short CRX component record".into()))?;
             let tile = tiles
                 .last_mut()
-                .ok_or_else(|| Error::Corrupt("CRX plane before any tile".into()))?;
+                .ok_or_else(|| Error::Corrupt("CRX component before any tile".into()))?;
+            let index = tile.planes.len();
+            if (packed >> 4) as usize != index {
+                return Err(Error::Corrupt("CRX component out of order".into()));
+            }
             let end = plane_at
                 .checked_add(size)
                 .filter(|end| *end <= tile.data.end)
-                .ok_or_else(|| Error::Corrupt("CRX plane runs past its tile".into()))?;
+                .ok_or_else(|| Error::Corrupt("CRX component runs past its tile".into()))?;
+            let ref_prev_line = packed & 8 != 0;
+            let round_bits = ((packed >> 1) & 3) as u32;
+            if round_bits != 0 && !(header.levels == 0 && ref_prev_line) {
+                return Err(Error::Corrupt(
+                    "CRX rounded component with a wavelet".into(),
+                ));
+            }
             tile.planes.push(Plane {
                 data: plane_at..end,
-                index: tile.planes.len(),
-                extra_flag: flags & 0x0800_0000 != 0,
-                flags,
+                index,
+                ref_prev_line,
+                round_mask: if round_bits == 0 {
+                    0
+                } else {
+                    1 << (round_bits - 1)
+                },
+                round_bits,
                 bands: Vec::new(),
             });
             band_at = plane_at;
             plane_at = end;
         } else if record.tag == band_tag {
             let size = be32(record.payload, 0)? as usize;
-            let flags = be32(record.payload, 4)?;
             let plane = tiles
                 .last_mut()
                 .and_then(|t| t.planes.last_mut())
-                .ok_or_else(|| Error::Corrupt("CRX band before any plane".into()))?;
+                .ok_or_else(|| Error::Corrupt("CRX band before any component".into()))?;
+            let index = plane.bands.len();
             let end = band_at
                 .checked_add(size)
                 .filter(|end| *end <= plane.data.end)
-                .ok_or_else(|| Error::Corrupt("CRX band runs past its plane".into()))?;
-            plane.bands.push(Band {
+                .ok_or_else(|| Error::Corrupt("CRX band runs past its component".into()))?;
+            let mut band = Band {
                 data: band_at..end,
-                index: plane.bands.len(),
-                // The quantiser sits in the twelve bits under the
-                // band counter; 0x20 is unity and every lossless band
-                // carries exactly that.
-                q_step: (flags >> 16) & 0xfff,
-                flags,
-            });
+                trailing: 0,
+                index,
+                q_param: 4,
+                q_per_line: false,
+                q_step_base: 1,
+                q_step_mult: 0,
+            };
+            if v2 && record.payload.len() >= 16 {
+                if (be16(record.payload, 4)? >> 12) as usize != index {
+                    return Err(Error::Corrupt("CRX band out of order".into()));
+                }
+                band.q_step_mult = be16(record.payload, 6)? as i32;
+                band.q_step_base = be32(record.payload, 8)? as i32;
+                band.trailing = be16(record.payload, 12)? as usize;
+            } else {
+                // One packed word: the band counter, a flag, an
+                // eight-bit exponent and the count of trailing bytes.
+                let word = be32(record.payload, 4)?;
+                if (word >> 28) as usize != index {
+                    return Err(Error::Corrupt("CRX band out of order".into()));
+                }
+                band.q_per_line = word & (1 << 27) != 0;
+                band.q_param = ((word >> 19) & 0xff) as i32;
+                band.trailing = (word & 0x7ffff) as usize;
+            }
+            if band.trailing > size {
+                return Err(Error::Corrupt("CRX band is all trailing bytes".into()));
+            }
+            plane.bands.push(band);
             band_at = end;
         }
-        // Anything else in the header is not a node of the tree; the
-        // parser ignores it rather than failing, so a body that adds a
-        // record still decodes.
+        // Anything else in the index is not a node of the tree; the
+        // parser ignores it rather than failing, so a body that adds
+        // a record still decodes.
     }
 
     if tiles.len() != cols * rows {
         return Err(Error::Corrupt(format!(
-            "CRX header has {} tiles, the grid wants {}",
+            "CRX index has {} tiles, the grid wants {}",
             tiles.len(),
             cols * rows
         )));
@@ -385,7 +579,7 @@ pub fn parse_tiles(header: &ImageHeader, sample: &[u8]) -> Result<Vec<Tile>> {
     for tile in &tiles {
         if tile.planes.len() != header.planes {
             return Err(Error::Corrupt(format!(
-                "CRX tile has {} planes, CMP1 says {}",
+                "CRX tile has {} components, CMP1 says {}",
                 tile.planes.len(),
                 header.planes
             )));
@@ -393,7 +587,7 @@ pub fn parse_tiles(header: &ImageHeader, sample: &[u8]) -> Result<Vec<Tile>> {
         for plane in &tile.planes {
             if plane.bands.len() != header.bands() {
                 return Err(Error::Corrupt(format!(
-                    "CRX plane has {} bands, {} levels wants {}",
+                    "CRX component has {} bands, {} levels wants {}",
                     plane.bands.len(),
                     header.levels,
                     header.bands()
@@ -404,37 +598,1418 @@ pub fn parse_tiles(header: &ImageHeader, sample: &[u8]) -> Result<Vec<Tile>> {
     Ok(tiles)
 }
 
+/// How many extra coefficients a band carries on a side where the
+/// tile has a neighbour, addressed as `EXTRA[levels - 1][dim & 7]`
+/// and read in pairs, one pair per level from the finest.
+///
+/// This is an empirical property of the encoder: it is how many
+/// overlap coefficients get emitted so that the lifting reconstructs
+/// continuously across a tile seam, for each combination of
+/// decomposition depth and tile-dimension residue. There is no
+/// derivation for it here; it is checked against three tile
+/// geometries and both seam directions in the tests.
+const EXTRA: [[[usize; 6]; 8]; 3] = [
+    [
+        [1, 1, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0, 0],
+        [1, 1, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0, 0],
+        [1, 1, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0, 0],
+        [1, 1, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0, 0],
+    ],
+    [
+        [1, 1, 1, 1, 0, 0],
+        [1, 0, 1, 0, 0, 0],
+        [1, 2, 2, 1, 0, 0],
+        [1, 1, 1, 1, 0, 0],
+        [1, 1, 1, 1, 0, 0],
+        [1, 0, 1, 0, 0, 0],
+        [1, 2, 2, 1, 0, 0],
+        [1, 1, 1, 1, 0, 0],
+    ],
+    [
+        [1, 1, 1, 1, 1, 1],
+        [1, 0, 1, 0, 1, 0],
+        [1, 2, 2, 2, 2, 1],
+        [1, 1, 1, 2, 2, 1],
+        [1, 1, 1, 2, 2, 1],
+        [1, 0, 1, 1, 1, 1],
+        [1, 2, 2, 1, 1, 1],
+        [1, 1, 1, 1, 1, 1],
+    ],
+];
+
+/// One subband's shape inside a tile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Shape {
+    pub width: usize,
+    pub height: usize,
+    /// The overlap coefficients at each edge. Only the version-2
+    /// quantiser map cares where they are; the wavelet gets them from
+    /// the widths.
+    pub row_start: usize,
+    pub row_end: usize,
+    pub col_start: usize,
+    pub col_end: usize,
+    /// How far a band column shifts right to land on the quantiser
+    /// map's column, which is pre-downsampled vertically per level
+    /// but not horizontally.
+    pub level_shift: u32,
+    /// Level group, 0 = coarsest. The LL band shares the coarsest.
+    pub group: usize,
+}
+
+/// The shape of every band of one component of `tile`.
+///
+/// Bands are indexed LL first, then each level group from coarsest to
+/// finest as HL, LH, HH. The dyadic split walks the other way — from
+/// the finest, halving the tile each time — and the extra coefficient
+/// counts of [`EXTRA`] widen a band on each side the tile has a
+/// neighbour.
+pub fn band_shapes(levels: usize, tile_w: usize, tile_h: usize, neighbours: u8) -> Vec<Shape> {
+    let mut out = vec![Shape::default(); 3 * levels + 1];
+    if levels == 0 {
+        out[0] = Shape {
+            width: tile_w,
+            height: tile_h,
+            ..Shape::default()
+        };
+        return out;
+    }
+    let across = EXTRA[levels - 1][tile_w & 7];
+    let down = EXTRA[levels - 1][tile_h & 7];
+    let (mut bw, mut bh) = (tile_w, tile_h);
+    for level in 0..levels {
+        let (odd_w, odd_h) = (bw & 1, bh & 1);
+        bw = (bw + odd_w) >> 1;
+        bh = (bh + odd_h) >> 1;
+        let (mut ex_w0, mut ex_w1, mut ex_h0, mut ex_h1) = (0usize, 0usize, 0usize, 0usize);
+        let (mut col_start, mut row_start) = (0usize, 0usize);
+        if neighbours & RIGHT != 0 {
+            ex_w0 = across[2 * level];
+            ex_w1 = across[2 * level + 1];
+        }
+        if neighbours & LEFT != 0 {
+            ex_w0 += 1;
+            col_start = 1;
+        }
+        if neighbours & BELOW != 0 {
+            ex_h0 = down[2 * level];
+            ex_h1 = down[2 * level + 1];
+        }
+        if neighbours & ABOVE != 0 {
+            ex_h0 += 1;
+            row_start = 1;
+        }
+        let hh = 3 * (levels - level);
+        let common = Shape {
+            level_shift: (3 - (level + 1)) as u32,
+            group: levels - 1 - level,
+            ..Shape::default()
+        };
+        out[hh] = Shape {
+            width: bw + ex_w0 - odd_w,
+            height: bh + ex_h0 - odd_h,
+            row_start,
+            row_end: ex_h0 - row_start,
+            col_start,
+            col_end: ex_w0 - col_start,
+            ..common
+        };
+        out[hh - 1] = Shape {
+            width: bw + ex_w1,
+            height: bh + ex_h0 - odd_h,
+            row_start,
+            row_end: ex_h0 - row_start,
+            col_start: 0,
+            col_end: ex_w1,
+            ..common
+        };
+        out[hh - 2] = Shape {
+            width: bw + ex_w0 - odd_w,
+            height: bh + ex_h1,
+            row_start: 0,
+            row_end: ex_h1,
+            col_start,
+            col_end: ex_w0 - col_start,
+            ..common
+        };
+    }
+    let right = if neighbours & RIGHT != 0 {
+        across[2 * levels - 1]
+    } else {
+        0
+    };
+    let below = if neighbours & BELOW != 0 {
+        down[2 * levels - 1]
+    } else {
+        0
+    };
+    out[0] = Shape {
+        width: bw + right,
+        height: bh + below,
+        row_start: 0,
+        row_end: below,
+        col_start: 0,
+        col_end: right,
+        level_shift: (3 - levels) as u32,
+        group: 0,
+    };
+    out
+}
+
+/// The bit reader: most-significant bit first, straight down a band's
+/// bytes, with no stuffing, no padding between symbols and no restart
+/// markers. Each band's reader starts at bit 0 of its own range.
+struct Reader<'a> {
+    pump: BitPumpMsb<'a>,
+    /// Bits in the band's range. The pump itself reads zeros for ever
+    /// past the end, so this is what tells us a decode went wrong.
+    limit: usize,
+    bad: bool,
+}
+
+impl<'a> Reader<'a> {
+    fn new(bytes: &'a [u8]) -> Reader<'a> {
+        Reader {
+            pump: BitPumpMsb::new(bytes),
+            limit: bytes.len() * 8,
+            bad: false,
+        }
+    }
+
+    #[inline(always)]
+    fn get(&mut self, n: u32) -> u32 {
+        if n == 0 {
+            0
+        } else {
+            self.pump.get(n)
+        }
+    }
+
+    #[inline(always)]
+    fn bit(&mut self) -> u32 {
+        self.pump.get(1)
+    }
+
+    /// Count zeros up to the next 1 bit, consuming it.
+    #[inline(always)]
+    fn zeros(&mut self) -> u32 {
+        let mut count = 0;
+        loop {
+            let word = self.pump.peek(24);
+            if word != 0 {
+                let n = word.leading_zeros() - 8;
+                self.pump.consume(n + 1);
+                return count + n;
+            }
+            self.pump.consume(24);
+            count += 24;
+            // Past the end of a truncated or hostile band the pump
+            // feeds zeros for ever; stop rather than count them.
+            if count >= 256 {
+                self.bad = true;
+                return ESCAPE_ZEROS;
+            }
+        }
+    }
+
+    /// A Golomb-Rice magnitude with parameter `k`. A unary prefix of
+    /// `escape` zeros or more means the magnitude follows as a flat
+    /// `wide`-bit field instead.
+    ///
+    /// The threshold is a common off-by-one trap: in the first symbol
+    /// of a line-0 bitstream the escape is preceded by a run-mode
+    /// flag bit that is also 0, so a naive reading sees 42 zeros
+    /// before the 1. Counting from there appears to work on line 0
+    /// and desynchronises later.
+    #[inline(always)]
+    fn golomb(&mut self, k: u32, escape: u32, wide: u32) -> u32 {
+        let z = self.zeros();
+        if z >= escape {
+            self.get(wide)
+        } else if k > 0 {
+            (z << k) | self.get(k)
+        } else {
+            z
+        }
+    }
+
+    /// Whether the band's bitstream was read to its end and no
+    /// further: the encoder pads the last byte, so anything more than
+    /// seven bits either way means the decode went off the rails.
+    fn consumed_exactly(&self) -> bool {
+        !self.bad && self.pump.position() <= self.limit && self.limit - self.pump.position() < 8
+    }
+}
+
+/// The unary prefix length at which a coefficient magnitude escapes
+/// to a flat field, and the width of that field.
+const ESCAPE_ZEROS: u32 = 41;
+const ESCAPE_BITS: u32 = 21;
+/// The same two for both quantiser coders, which are otherwise the
+/// same code. These are format constants, not derivable.
+const Q_ESCAPE_ZEROS: u32 = 23;
+const Q_ESCAPE_BITS: u32 = 8;
+
+/// Fold a magnitude back to a signed residual: `m = 2d` for `d >= 0`
+/// and `m = -2d - 1` for `d < 0`.
+#[inline(always)]
+fn fold(m: u32) -> i32 {
+    ((m >> 1) as i32) ^ -((m & 1) as i32)
+}
+
+/// The adaptive Golomb parameter.
+///
+/// `u` is the magnitude just decoded, sometimes blended with a
+/// neighbour gradient. `K` rises by at most two per symbol and falls
+/// by at most one, and can never go below zero because the test that
+/// lowers it compares against `2^(K-1)`, which is 0 at `K = 0`.
+/// `kmax` of 0 means no clamp — the detail-band coder applies its own
+/// instead.
+#[inline(always)]
+fn adapt(k: u32, u: u32, kmax: u32) -> u32 {
+    let mut next = k as i32;
+    if u < ((1u32 << k) >> 1) {
+        next -= 1;
+    }
+    if (u >> k) > 2 {
+        next += 1;
+    }
+    if (u >> k) > 5 {
+        next += 1;
+    }
+    let mut next = next.max(0) as u32;
+    if kmax != 0 && next >= kmax {
+        next = kmax;
+    }
+    // The rule bounds K by the magnitudes it sees, so this only
+    // matters for a hostile stream: it keeps every shift in range.
+    next.min(30)
+}
+
+/// Canon's four-way predictor: numerically the JPEG-LS gradient median, written as Canon's selector but a
+/// selector between the left neighbour, the one above, and the left
+/// neighbour carried along the gradient of the line above.
+///
+/// It is the single most common reason a partly-working decoder
+/// diverges a few dozen samples into line 1.
+#[inline(always)]
+fn predict(a: i32, b: i32, c: i32) -> i32 {
+    let dh = b.wrapping_sub(c);
+    let negative = dh < 0;
+    let x = (c < a) != negative;
+    let y = (a < b) != negative;
+    match (x, y) {
+        (true, true) => b,
+        (true, false) => a,
+        _ => a.wrapping_add(dh),
+    }
+}
+
+/// How much a continuation bit adds to a run at each run state, and
+/// how wide the remainder field that ends the run is. `RUNLEN[s]` is
+/// always `1 << RUNBITS[s]`.
+const RUNLEN: [usize; 32] = [
+    1, 1, 1, 1, 2, 2, 2, 2, 4, 4, 4, 4, 8, 8, 8, 8, 16, 16, 32, 32, 64, 64, 128, 128, 256, 512,
+    1024, 2048, 4096, 8192, 16384, 32768,
+];
+const RUNBITS: [u32; 32] = [
+    0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 9, 10, 11, 12, 13,
+    14, 15,
+];
+
+/// Which line coder a subband uses (section 9 of the format notes).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    /// The LL band's predictive coder. `round` is 0 in every file
+    /// seen; when it is not, reconstruction is scaled and the run
+    /// tests compare against it instead of against zero, which makes
+    /// a wavelet-free frame lossy in the spatial domain.
+    A { round: i32, round_bits: u32 },
+    /// The detail-band coder.
+    B,
+}
+
+/// What the tests want to see of a band's inner workings. Off unless
+/// a test turns it on, so decoding a real frame does not accumulate
+/// millions of entries.
+#[cfg(test)]
+#[derive(Debug, Default)]
+struct Trace {
+    on: bool,
+    /// `K` after each symbol.
+    k: Vec<u32>,
+    /// Every run, as (line, column, length, state before, after).
+    runs: Vec<(usize, usize, usize, usize, usize)>,
+}
+
+/// One subband's line coder: the bit reader, two padded line buffers
+/// and, for the detail bands, a per-column memory of `K`.
+///
+/// `K` and the run state carry across line boundaries within a band;
+/// nothing carries between bands.
+struct Coder<'a> {
+    r: Reader<'a>,
+    width: usize,
+    /// `width + 2` entries: one padding element on each side, so the
+    /// left, above-left and above-right neighbours are defined at the
+    /// edges. Sample `i` lives at index `i + 1`.
+    cur: Vec<i32>,
+    prev: Vec<i32>,
+    kcol: Vec<u32>,
+    k: u32,
+    /// The run state, 0..31.
+    s: usize,
+    line: usize,
+    #[cfg(test)]
+    trace: Trace,
+}
+
+impl<'a> Coder<'a> {
+    fn new(bytes: &'a [u8], width: usize) -> Coder<'a> {
+        Coder {
+            r: Reader::new(bytes),
+            width,
+            cur: vec![0; width + 2],
+            prev: vec![0; width + 2],
+            kcol: vec![0; width],
+            k: 0,
+            s: 0,
+            line: 0,
+            #[cfg(test)]
+            trace: Trace::default(),
+        }
+    }
+
+    #[inline(always)]
+    fn symbol(&mut self) -> u32 {
+        self.r.golomb(self.k, ESCAPE_ZEROS, ESCAPE_BITS)
+    }
+
+    #[cfg(test)]
+    fn note_k(&mut self) {
+        if self.trace.on {
+            self.trace.k.push(self.k);
+        }
+    }
+
+    #[cfg(not(test))]
+    #[inline(always)]
+    fn note_k(&mut self) {}
+
+    #[cfg(test)]
+    fn note_run(&mut self, column: usize, run: usize, before: usize) {
+        if self.trace.on {
+            self.trace
+                .runs
+                .push((self.line, column, run, before, self.s));
+        }
+    }
+
+    #[cfg(not(test))]
+    #[inline(always)]
+    fn note_run(&mut self, _column: usize, _run: usize, _before: usize) {}
+
+    /// Read a run length, given how many columns are still available.
+    ///
+    /// One bit says whether a run is present at all; then each further
+    /// 1 bit adds the current bucket size and grows the run state, and
+    /// the first 0 bit ends that phase and is followed by a remainder
+    /// field, after which the state shrinks by one. If the growing
+    /// phase reaches or overshoots the limit there is no remainder and
+    /// the state does not shrink.
+    ///
+    /// A zero-length run — one bit, spent to say "no run here" — is
+    /// normal and frequent.
+    fn run(&mut self, limit: usize, at_last_column: bool) -> usize {
+        if self.r.bit() == 0 {
+            return 0;
+        }
+        let mut run = 1usize;
+        // At the very last column of a detail-band line there is
+        // nothing to grow into, so the exponential phase is skipped
+        // rather than read and thrown away.
+        if !at_last_column {
+            while self.r.bit() == 1 {
+                run += RUNLEN[self.s];
+                if run > limit {
+                    return limit;
+                }
+                if self.s < 31 {
+                    self.s += 1;
+                }
+                if run == limit {
+                    return run;
+                }
+            }
+        }
+        if run < limit {
+            run += self.r.get(RUNBITS[self.s]) as usize;
+            if self.s > 0 {
+                self.s -= 1;
+            }
+            if run > limit {
+                // A conforming encoder cannot write this.
+                self.r.bad = true;
+                run = limit;
+            }
+        }
+        run
+    }
+
+    /// Mode A, line 0: predict from the left, with 0 standing in for
+    /// the sample before column 0. Because sensor values are far from
+    /// zero the run test can only fire at column 0, so a real line 0
+    /// holds exactly one run-mode flag bit — the first bit of the
+    /// band, and it is 0.
+    fn mode_a_line0(&mut self, round: i32) {
+        let w = self.width;
+        self.cur[0] = 0;
+        let mut prev = 0i32;
+        let mut i = 0usize;
+        while i + 1 < w {
+            if prev.abs() > round {
+                // The prediction is the left neighbour.
+            } else {
+                let before = self.s;
+                let run = self.run(w - i, false);
+                self.note_run(i, run, before);
+                for _ in 0..run {
+                    self.cur[i + 1] = prev;
+                    i += 1;
+                }
+                if i >= w {
+                    break;
+                }
+            }
+            let m = self.symbol();
+            self.cur[i + 1] = prev.wrapping_add(reconstruct(m, round));
+            self.k = adapt(self.k, m, 15);
+            self.note_k();
+            prev = self.cur[i + 1];
+            i += 1;
+        }
+        if i + 1 == w {
+            let m = self.symbol();
+            self.cur[i + 1] = prev.wrapping_add(reconstruct(m, round));
+            self.k = adapt(self.k, m, 15);
+            self.note_k();
+        }
+        // One past the last sample the buffer holds last + 1, which
+        // guarantees the next line sees a different above-right than
+        // above at the right edge and so cannot start a run there.
+        self.cur[w + 1] = self.cur[w].wrapping_add(1);
+    }
+
+    /// Mode A, lines 1 and later: Canon's four-way gradient predictor,
+    /// with a run whenever the left, above and above-right neighbours
+    /// agree. The symbol decoded straight after a run predicts from
+    /// above rather than from the gradient.
+    fn mode_a_line(&mut self, round: i32, round_bits: u32) {
+        let w = self.width;
+        // The element left of column 0 of this line is the sample
+        // above column 0; the one left of column 0 of the previous
+        // line is whatever that buffer's padding holds, which is 0 on
+        // line 1 and the sample from two lines up after that.
+        self.cur[0] = self.prev[1];
+        if round != 0 {
+            self.prev[0] = self.prev[1];
+        }
+        let mut i = 0usize;
+        // Only the rounded mode uses this; it makes a symbol that
+        // followed a large above-right gradient sticky for one column.
+        let mut reached = false;
+        while i + 1 < w {
+            let flat = if round == 0 {
+                let (a, b, e) = (self.cur[i], self.prev[i + 1], self.prev[i + 2]);
+                a == b && a == e
+            } else {
+                let (a, b, c, e) = (
+                    self.cur[i],
+                    self.prev[i + 1],
+                    self.prev[i],
+                    self.prev[i + 2],
+                );
+                if (e - b).abs() > round {
+                    reached = true;
+                    false
+                } else if reached || (c - a).abs() > round {
+                    reached = false;
+                    false
+                } else {
+                    true
+                }
+            };
+            if flat {
+                let before = self.s;
+                let run = self.run(w - i, false);
+                self.note_run(i, run, before);
+                let a = self.cur[i];
+                for _ in 0..run {
+                    self.cur[i + 1] = a;
+                    i += 1;
+                }
+                if i >= w {
+                    break;
+                }
+            }
+            let (a, b, c, e) = (
+                self.cur[i],
+                self.prev[i + 1],
+                self.prev[i],
+                self.prev[i + 2],
+            );
+            // After a run the prediction is flat — the sample above —
+            // and not the gradient. Getting that wrong shows up as a
+            // wrong prediction and a wrong K at the same column.
+            let prediction = if flat { b } else { predict(a, b, c) };
+            let m = self.symbol();
+            self.cur[i + 1] = prediction.wrapping_add(reconstruct(m, round));
+            let last = i + 1 == w;
+            let u = if last {
+                m
+            } else if round == 0 {
+                blend(m, e.wrapping_sub(b).unsigned_abs())
+            } else {
+                blend(m, scaled_gradient(b, e, round, round_bits).unsigned_abs())
+            };
+            self.k = adapt(self.k, u, 15);
+            self.note_k();
+            if round != 0 && flat && !last {
+                reached = (self.prev[i + 3] - self.prev[i + 2]).abs() > round;
+            }
+            i += 1;
+        }
+        if i + 1 == w {
+            let (a, b, c) = (self.cur[i], self.prev[i + 1], self.prev[i]);
+            let m = self.symbol();
+            self.cur[i + 1] = predict(a, b, c).wrapping_add(reconstruct(m, round));
+            self.k = adapt(self.k, m, 15);
+            self.note_k();
+        }
+        self.cur[w + 1] = self.cur[w].wrapping_add(1);
+    }
+
+    /// Mode B, line 0. Detail-band coefficients cluster hard around
+    /// zero, so this coder predicts nothing — the sample *is* the
+    /// residual — tests for runs against a zero neighbourhood, and
+    /// keeps a per-column memory of `K`. A symbol that follows a run
+    /// folds `m + 1`, which excludes the zero a run would have
+    /// covered from the alphabet.
+    fn mode_b_line0(&mut self) {
+        let w = self.width;
+        self.cur[0] = 0;
+        let mut i = 0usize;
+        while i + 1 < w {
+            let mut biased = false;
+            if self.cur[i] == 0 {
+                let before = self.s;
+                let run = self.run(w - i, false);
+                self.note_run(i, run, before);
+                for _ in 0..run {
+                    self.cur[i + 1] = 0;
+                    self.kcol[i] = 0;
+                    i += 1;
+                }
+                if i >= w {
+                    break;
+                }
+                biased = true;
+            }
+            let m = self.symbol();
+            self.cur[i + 1] = fold(if biased { m + 1 } else { m });
+            self.k = adapt(self.k, m, 15);
+            self.note_k();
+            self.kcol[i] = self.k;
+            i += 1;
+        }
+        if i + 1 == w {
+            let m = self.symbol();
+            self.cur[i + 1] = fold(m);
+            self.k = adapt(self.k, m, 15);
+            self.note_k();
+            self.kcol[i] = self.k;
+        }
+        // Unlike Mode A this mode pads with zero, so the next line's
+        // run test at the right edge sees the zeros it expects.
+        self.cur[w + 1] = 0;
+    }
+
+    /// Mode B, lines 1 and later. `Kcol` is how the line above steers
+    /// this line's parameter: `Kcol[i + 1]` is still the previous
+    /// line's value one column to the right, because this line only
+    /// overwrites `Kcol[i]` after reading it.
+    fn mode_b_line(&mut self) {
+        let w = self.width;
+        let mut i = 0usize;
+        while i + 1 < w {
+            let (a, b, e) = (self.cur[i], self.prev[i + 1], self.prev[i + 2]);
+            if a == 0 && b == 0 && e == 0 {
+                let before = self.s;
+                let run = self.run(w - i, i + 1 == w);
+                self.note_run(i, run, before);
+                for _ in 0..run {
+                    self.cur[i + 1] = 0;
+                    self.kcol[i] = 0;
+                    i += 1;
+                }
+                if i + 1 >= w {
+                    if i + 1 == w {
+                        let m = self.symbol();
+                        self.cur[i + 1] = fold(m + 1);
+                        self.k = adapt(self.k, m, 15);
+                        self.note_k();
+                        self.kcol[i] = self.k;
+                    }
+                    // The run ran to the end of the line; there is no
+                    // trailing symbol.
+                    return;
+                }
+                let m = self.symbol();
+                self.cur[i + 1] = fold(m + 1);
+                self.k = adapt(self.k, m, 0);
+                self.steer(i);
+            } else {
+                let m = self.symbol();
+                self.cur[i + 1] = fold(m);
+                self.k = adapt(self.k, m, 0);
+                self.steer(i);
+            }
+            self.note_k();
+            self.kcol[i] = self.k;
+            i += 1;
+        }
+        if i + 1 == w {
+            let m = self.symbol();
+            self.cur[i + 1] = fold(m);
+            self.k = adapt(self.k, m, 15);
+            self.note_k();
+            self.kcol[i] = self.k;
+        }
+    }
+
+    /// The pull the line above has on `K`, applied where the adapt
+    /// step was left unclamped.
+    #[inline(always)]
+    fn steer(&mut self, i: usize) {
+        if self.kcol[i + 1] as i32 - self.k as i32 <= 1 {
+            self.k = self.k.min(15);
+        } else {
+            self.k += 1;
+        }
+    }
+}
+
+/// Reconstruct a sample's contribution from a magnitude. Without
+/// spatial rounding this is just the folded residual; with it the
+/// residual is scaled, which is what makes that mode lossy.
+#[inline(always)]
+fn reconstruct(m: u32, round: i32) -> i32 {
+    let d = fold(m);
+    if round == 0 {
+        d
+    } else {
+        (2 * round).wrapping_mul(d) + if d < 0 { -1 } else { 0 }
+    }
+}
+
+/// The above-right gradient the rounded mode feeds to `K`, scaled by
+/// the rounding it applies to samples.
+#[inline(always)]
+fn scaled_gradient(b: i32, e: i32, round: i32, round_bits: u32) -> i32 {
+    if e > b {
+        (e - b + round - 1) >> round_bits
+    } else {
+        -((b - e + round) >> round_bits)
+    }
+}
+
+/// The six steps a quantiser exponent cycles through; the exponent's
+/// sixth is the shift. `q = 4` gives 64 >> 6 = 1, unity, which is why
+/// every lossless band and every coarse cRAW band carries 4.
+const QSTEP: [i32; 6] = [0x28, 0x2d, 0x33, 0x39, 0x40, 0x48];
+
+/// An empirical ceiling on a quantiser step. Version 2 clamps to it
+/// explicitly; it also stands in here for the saturating branch of
+/// the exponent mapping, which no real file takes.
+const QSTEP_MAX: i32 = 0x168000;
+
+/// Map a quantiser exponent to its step.
+fn step_of(q: i32) -> i32 {
+    let q = q.clamp(0, 0xff);
+    let (sixths, rest) = (q / 6, (q % 6) as usize);
+    if sixths >= 6 {
+        QSTEP_MAX
+    } else {
+        QSTEP[rest] >> (6 - sixths)
+    }
+}
+
+/// Where a band's coefficients get their scale from.
+enum Quant<'a> {
+    /// One step for the whole band (both versions' common case, and
+    /// unity for everything lossless).
+    Uniform(i32),
+    /// Version 1 with the per-line update flag: a delta to the
+    /// exponent precedes every line, in the band's own bitstream.
+    /// No band in the corpus sets the flag, but it has to be honoured
+    /// because ignoring it would consume the wrong bits.
+    PerLine { exponent: i32, k: u32 },
+    /// Version 2: the tile's quantiser map, scaled by the band.
+    Map {
+        rows: &'a [Vec<i32>],
+        shape: Shape,
+        base: i32,
+        mult: i32,
+    },
+}
+
+impl Quant<'_> {
+    /// Called before each line is decoded, because that is where the
+    /// version-1 delta sits in the bitstream. Returns the step when
+    /// the whole line shares one, otherwise fills `scratch` with a
+    /// step per column.
+    fn begin_line(
+        &mut self,
+        r: &mut Reader,
+        line: usize,
+        scratch: &mut [i32],
+    ) -> Result<Option<i32>> {
+        match self {
+            Quant::Uniform(step) => Ok(Some(*step)),
+            Quant::PerLine { exponent, k } => {
+                let v = r.golomb(*k, Q_ESCAPE_ZEROS, Q_ESCAPE_BITS);
+                *exponent += fold(v);
+                *k = adapt(*k, v, 0);
+                if *k > 7 {
+                    return Err(Error::Corrupt("CRX per-line quantiser ran away".into()));
+                }
+                Ok(Some(step_of(*exponent)))
+            }
+            Quant::Map {
+                rows,
+                shape,
+                base,
+                mult,
+            } => {
+                if rows.is_empty() {
+                    return Err(Error::Corrupt("CRX band with no quantiser map".into()));
+                }
+                // The map is one entry per 8x2 block of the tile, so
+                // a band line indexes it around whatever overlap
+                // coefficients the band carries at its edges.
+                let inner = shape.height.saturating_sub(shape.row_end);
+                let step_row = if line < shape.row_start {
+                    0
+                } else if line < inner {
+                    line - shape.row_end
+                } else {
+                    inner.saturating_sub(shape.row_start + 1)
+                };
+                let row = &rows[step_row.min(rows.len() - 1)];
+                let inner_col = shape.width.saturating_sub(shape.col_end);
+                let last = inner_col.saturating_sub(shape.col_start + 1) >> shape.level_shift;
+                for (i, out) in scratch.iter_mut().enumerate() {
+                    let at = if i < shape.col_start {
+                        0
+                    } else if i < inner_col {
+                        (i - shape.col_start) >> shape.level_shift
+                    } else {
+                        last
+                    };
+                    let s = row[at.min(row.len() - 1)];
+                    // File-controlled base and multiplier: widen so
+                    // a hostile record cannot overflow the sum.
+                    *out = (i64::from(*base) + ((i64::from(s) * i64::from(*mult)) >> 3))
+                        .clamp(1, i64::from(QSTEP_MAX)) as i32;
+                }
+                Ok(None)
+            }
+        }
+    }
+}
+
+/// Decode one subband into `shape.width * shape.height` dequantised
+/// coefficients, row-major.
+///
+/// The quantiser is applied on the way out rather than in the line
+/// buffers, because the line coders predict from — and test runs
+/// against — the coded values, not the scaled ones.
+fn decode_band(bytes: &[u8], shape: Shape, mode: Mode, quant: &mut Quant) -> Result<Vec<i32>> {
+    let (w, h) = (shape.width, shape.height);
+    if w == 0 || h == 0 {
+        return Ok(Vec::new());
+    }
+    // A band with no bitstream at all is a band of zeros.
+    if bytes.is_empty() {
+        return Ok(vec![0; crate::frame_samples(w, h, 1)?]);
+    }
+    let mut coder = Coder::new(bytes, w);
+    run_band(&mut coder, h, mode, quant)
+}
+
+/// `(m + 2 * g) / 2`, the neighbour-blended update term, in 64 bits:
+/// a runaway stream can push the line buffers to values whose
+/// gradient doubles past `u32`.
+#[inline]
+fn blend(m: u32, gradient: u32) -> u32 {
+    ((u64::from(m) + 2 * u64::from(gradient)) >> 1).min(u64::from(u32::MAX)) as u32
+}
+
+/// The body of [`decode_band`], with the coder handed in so a test
+/// can watch what it does.
+fn run_band(coder: &mut Coder, h: usize, mode: Mode, quant: &mut Quant) -> Result<Vec<i32>> {
+    let w = coder.width;
+    let mut out = Vec::with_capacity(crate::frame_samples(w, h, 1)?);
+    let mut scratch = vec![0i32; w];
+    for line in 0..h {
+        coder.line = line;
+        let step = quant.begin_line(&mut coder.r, line, &mut scratch)?;
+        match mode {
+            Mode::A { round, .. } if line == 0 => coder.mode_a_line0(round),
+            Mode::A { round, round_bits } => coder.mode_a_line(round, round_bits),
+            Mode::B if line == 0 => coder.mode_b_line0(),
+            Mode::B => coder.mode_b_line(),
+        }
+        let line = &coder.cur[1..=w];
+        match step {
+            Some(1) => out.extend_from_slice(line),
+            Some(step) => out.extend(line.iter().map(|c| c.wrapping_mul(step))),
+            None => out.extend(
+                line.iter()
+                    .zip(&scratch)
+                    .map(|(c, step)| c.wrapping_mul(*step)),
+            ),
+        }
+        std::mem::swap(&mut coder.cur, &mut coder.prev);
+    }
+    if coder.r.bad {
+        return Err(Error::Corrupt(
+            "CRX band ran off the end of its data".into(),
+        ));
+    }
+    if !coder.r.consumed_exactly() {
+        // Not fatal on its own, but it means something upstream is
+        // wrong: a conforming band is consumed to its last byte.
+        log::debug!(
+            "crx: a {w}x{h} band consumed {} of {} bits",
+            coder.r.pump.position(),
+            coder.r.limit
+        );
+    }
+    Ok(out)
+}
+
+/// The horizontal half of the inverse 5/3 lifting: interleave a
+/// low-pass and a high-pass row back into `out`.
+///
+/// At an outer image edge the high band is extended symmetrically; at
+/// an internal tile seam the neighbouring tile's overlap coefficients
+/// (the extra columns of [`band_shapes`]) stand in for the extension,
+/// which is why a seam reconstructs continuously instead of showing a
+/// narrow vertical band of wrong pixels.
+fn lift_row(low: &[i32], high: &[i32], out: &mut [i32], left: bool, right: bool) {
+    let wd = out.len();
+    if wd == 0 {
+        return;
+    }
+    let l = |i: usize| low.get(i).copied().unwrap_or(0);
+    let h = |i: usize| high.get(i).copied().unwrap_or(0);
+    if wd == 1 {
+        out[0] = l(0);
+        return;
+    }
+    let mut hi = 0usize;
+    if left {
+        // With a left neighbour the high band starts one early: index
+        // 0 is the overlap coefficient, used only here.
+        out[0] = l(0).wrapping_sub((h(0).wrapping_add(h(1)).wrapping_add(2)) >> 2);
+        hi = 1;
+    } else {
+        out[0] = l(0).wrapping_sub((h(0).wrapping_add(1)) >> 1);
+    }
+    let (mut li, mut o, mut i) = (1usize, 0usize, 0usize);
+    while i + 3 < wd {
+        let delta = l(li).wrapping_sub((h(hi).wrapping_add(h(hi + 1)).wrapping_add(2)) >> 2);
+        out[o + 1] = h(hi).wrapping_add((delta.wrapping_add(out[o])) >> 1);
+        out[o + 2] = delta;
+        li += 1;
+        hi += 1;
+        o += 2;
+        i += 2;
+    }
+    if right {
+        let delta = l(li).wrapping_sub((h(hi).wrapping_add(h(hi + 1)).wrapping_add(2)) >> 2);
+        out[o + 1] = h(hi).wrapping_add((delta.wrapping_add(out[o])) >> 1);
+        if wd & 1 == 1 {
+            out[o + 2] = delta;
+        }
+    } else if wd & 1 == 1 {
+        let delta = l(li).wrapping_sub((h(hi).wrapping_add(1)) >> 1);
+        out[o + 1] = h(hi).wrapping_add((delta.wrapping_add(out[o])) >> 1);
+        out[o + 2] = delta;
+    } else {
+        out[o + 1] = out[o].wrapping_add(h(hi));
+    }
+}
+
+/// The vertical half: the same lifting again, a whole row at a time,
+/// over rows that have already been reconstructed horizontally.
+///
+/// The above/below seam cases mirror the left/right ones of
+/// [`lift_row`]; no file in the corpus has a tile above or below
+/// another, so they are written from the format's symmetry and are
+/// unverified.
+#[allow(clippy::too_many_arguments)]
+fn lift_columns(
+    lows: &[i32],
+    highs: &[i32],
+    out: &mut [i32],
+    width: usize,
+    height: usize,
+    above: bool,
+    below: bool,
+) {
+    if width == 0 || height == 0 {
+        return;
+    }
+    let n_low = lows.len() / width;
+    let n_high = highs.len() / width;
+    let low = |m: usize| {
+        let m = m.min(n_low.saturating_sub(1));
+        &lows[m * width..(m + 1) * width]
+    };
+    let high = |m: usize| {
+        let m = m.min(n_high.saturating_sub(1));
+        &highs[m * width..(m + 1) * width]
+    };
+    if n_low == 0 || n_high == 0 {
+        if n_low > 0 {
+            out[..width].copy_from_slice(low(0));
+        }
+        return;
+    }
+    if height == 1 {
+        out[..width].copy_from_slice(low(0));
+        return;
+    }
+    let mut hi = 0usize;
+    {
+        let (l0, h0) = (low(0), high(0));
+        if above {
+            let h1 = high(1);
+            for c in 0..width {
+                out[c] = l0[c].wrapping_sub((h0[c].wrapping_add(h1[c]).wrapping_add(2)) >> 2);
+            }
+            hi = 1;
+        } else {
+            for c in 0..width {
+                out[c] = l0[c].wrapping_sub((h0[c].wrapping_add(1)) >> 1);
+            }
+        }
+    }
+    let (mut li, mut o, mut i) = (1usize, 0usize, 0usize);
+    while i + 3 < height {
+        let (l, h0, h1) = (low(li), high(hi), high(hi + 1));
+        for c in 0..width {
+            let delta = l[c].wrapping_sub((h0[c].wrapping_add(h1[c]).wrapping_add(2)) >> 2);
+            out[(o + 1) * width + c] =
+                h0[c].wrapping_add((delta.wrapping_add(out[o * width + c])) >> 1);
+            out[(o + 2) * width + c] = delta;
+        }
+        li += 1;
+        hi += 1;
+        o += 2;
+        i += 2;
+    }
+    if below {
+        let (l, h0, h1) = (low(li), high(hi), high(hi + 1));
+        for c in 0..width {
+            let delta = l[c].wrapping_sub((h0[c].wrapping_add(h1[c]).wrapping_add(2)) >> 2);
+            out[(o + 1) * width + c] =
+                h0[c].wrapping_add((delta.wrapping_add(out[o * width + c])) >> 1);
+            if height & 1 == 1 {
+                out[(o + 2) * width + c] = delta;
+            }
+        }
+    } else if height & 1 == 1 {
+        let (l, h0) = (low(li), high(hi));
+        for c in 0..width {
+            let delta = l[c].wrapping_sub((h0[c].wrapping_add(1)) >> 1);
+            out[(o + 1) * width + c] =
+                h0[c].wrapping_add((delta.wrapping_add(out[o * width + c])) >> 1);
+            out[(o + 2) * width + c] = delta;
+        }
+    } else {
+        let h0 = high(hi);
+        for c in 0..width {
+            out[(o + 1) * width + c] = out[o * width + c].wrapping_add(h0[c]);
+        }
+    }
+}
+
+/// One level of the inverse wavelet: combine a low-pass image with
+/// the level's HL, LH and HH bands.
+#[allow(clippy::too_many_arguments)]
+fn inverse_level(
+    low: &[i32],
+    low_w: usize,
+    hl: &[i32],
+    hl_w: usize,
+    lh: &[i32],
+    lh_w: usize,
+    hh: &[i32],
+    hh_w: usize,
+    out_w: usize,
+    out_h: usize,
+    neighbours: u8,
+) -> Vec<i32> {
+    let (left, right) = (neighbours & LEFT != 0, neighbours & RIGHT != 0);
+    // Horizontally reconstruct the vertically-low rows (the low-pass
+    // image with HL) and the vertically-high ones (LH with HH), then
+    // lift those against each other down the columns.
+    let horizontal = |a: &[i32], aw: usize, b: &[i32], bw: usize| -> Vec<i32> {
+        let rows = a.len().checked_div(aw).unwrap_or(0);
+        let mut out = vec![0i32; rows * out_w];
+        out.par_chunks_mut(out_w).enumerate().for_each(|(m, row)| {
+            let hi = if bw == 0 {
+                &[][..]
+            } else {
+                b.get(m * bw..(m + 1) * bw).unwrap_or(&[])
+            };
+            lift_row(&a[m * aw..(m + 1) * aw], hi, row, left, right);
+        });
+        out
+    };
+    let lows = horizontal(low, low_w, hl, hl_w);
+    let highs = horizontal(lh, lh_w, hh, hh_w);
+    let mut out = vec![0i32; out_w * out_h];
+    lift_columns(
+        &lows,
+        &highs,
+        &mut out,
+        out_w,
+        out_h,
+        neighbours & ABOVE != 0,
+        neighbours & BELOW != 0,
+    );
+    out
+}
+
+/// Decode one component of one tile to its signed samples, which are
+/// `tile.width * tile.height` values centred on zero.
+fn decode_component(
+    sample: &[u8],
+    header: &ImageHeader,
+    tile: &Tile,
+    plane: &Plane,
+    shapes: &[Shape],
+    steps: Option<&[Vec<Vec<i32>>]>,
+) -> Result<Vec<i32>> {
+    let mut bands: Vec<Vec<i32>> = plane
+        .bands
+        .par_iter()
+        .zip(shapes.par_iter())
+        .map(|(band, shape)| {
+            // Only the LL band can use the predictive coder, and only
+            // when the component says so; everything else is a detail
+            // band whatever its index.
+            let mode = if band.index == 0 && plane.ref_prev_line {
+                Mode::A {
+                    round: plane.round_mask,
+                    round_bits: plane.round_bits,
+                }
+            } else {
+                Mode::B
+            };
+            let mut quant = match steps {
+                Some(steps) if header.levels > 0 => Quant::Map {
+                    rows: steps.get(shape.group).map(Vec::as_slice).unwrap_or(&[]),
+                    shape: *shape,
+                    base: band.q_step_base,
+                    mult: band.q_step_mult,
+                },
+                _ if band.q_per_line => Quant::PerLine {
+                    exponent: band.q_param,
+                    k: 0,
+                },
+                _ => Quant::Uniform(step_of(band.q_param)),
+            };
+            decode_band(band.bitstream(sample), *shape, mode, &mut quant)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    if header.levels == 0 {
+        return Ok(std::mem::take(&mut bands[0]));
+    }
+    let mut low = std::mem::take(&mut bands[0]);
+    let mut low_w = shapes[0].width;
+    for group in 0..header.levels {
+        // Each level's output is the next one's low-pass input; the
+        // last is the component itself.
+        let (out_w, out_h) = if group + 1 < header.levels {
+            (
+                shapes[3 * (group + 1) + 2].width,
+                shapes[3 * (group + 1) + 1].height,
+            )
+        } else {
+            (tile.width, tile.height)
+        };
+        let (hl, lh, hh) = (3 * group + 1, 3 * group + 2, 3 * group + 3);
+        low = inverse_level(
+            &low,
+            low_w,
+            &bands[hl],
+            shapes[hl].width,
+            &bands[lh],
+            shapes[lh].width,
+            &bands[hh],
+            shapes[hh].width,
+            out_w,
+            out_h,
+            tile.neighbours,
+        );
+        low_w = out_w;
+        for band in [hl, lh, hh] {
+            bands[band] = Vec::new();
+        }
+    }
+    Ok(low)
+}
+
+/// Where a component sits in the 2x2 colour-filter cell, as
+/// `(column, row)`.
+///
+/// The four components are always in the semantic order R, G on R's
+/// row, G on B's row, B; `cfa_layout` says which corner each of those
+/// occupies.
+pub fn cfa_position(layout: u8, plane: usize) -> (usize, usize) {
+    const CELL: [[(usize, usize); 4]; 4] = [
+        [(0, 0), (1, 0), (0, 1), (1, 1)],
+        [(1, 0), (0, 0), (1, 1), (0, 1)],
+        [(0, 1), (1, 1), (0, 0), (1, 0)],
+        [(1, 1), (0, 1), (1, 0), (0, 0)],
+    ];
+    CELL[(layout & 3) as usize][plane & 3]
+}
+
 /// Decode one CRX sample into the full frame, `width * height`
-/// samples row-major with the Bayer planes interleaved back.
+/// samples row-major with the components interleaved back onto the
+/// sensor's colour-filter grid.
 pub fn decode(header: &ImageHeader, sample: &[u8]) -> Result<Vec<u16>> {
-    // Parsed even though the coefficients are out of reach, so that a
-    // file whose header does not describe itself is reported as the
-    // corruption it is rather than as an unsupported variant.
     let tiles = parse_tiles(header, sample)?;
-    let bands: usize = tiles
-        .iter()
-        .flat_map(|t| &t.planes)
-        .map(|p| p.bands.len())
-        .sum();
-    Err(Error::Unsupported(format!(
-        "the CRX entropy coder (v{}, {} wavelet levels, {} tile(s), {bands} bands): \
-         the container and every header are read, the coefficients are not",
-        header.version,
-        header.levels,
-        tiles.len(),
-    )))
+    if header.enc_type != 0 {
+        // Encoding 1 is a signed path and 3 a decorrelated-colour one
+        // that has to reconstruct all four components together. No
+        // sample of either exists to check an implementation against,
+        // and the frame this returns cannot carry signed samples.
+        return Err(Error::Unsupported(format!(
+            "CRX encoding {} (only the Bayer path has ever been seen)",
+            header.enc_type
+        )));
+    }
+    // Version 2 puts one quantiser map at the front of each tile,
+    // which every band of that tile scales; version 1 carries an
+    // exponent per band instead.
+    let maps: Vec<Vec<Vec<Vec<i32>>>> = tiles
+        .par_iter()
+        .map(|tile| {
+            if tile.qp_size == 0 || header.levels == 0 {
+                return Ok(Vec::new());
+            }
+            let bytes = sample
+                .get(tile.data.start..tile.data.start + tile.qp_size)
+                .ok_or_else(|| Error::Corrupt("CRX quantiser map outside the sample".into()))?;
+            quantiser_map(bytes, tile.width, tile.height, header.levels)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let median = 1i32 << (header.bits - 1);
+    let white = (1i32 << header.bits) - 1;
+    let mut work: Vec<(usize, usize)> = Vec::new();
+    for (t, tile) in tiles.iter().enumerate() {
+        for p in 0..tile.planes.len() {
+            work.push((t, p));
+        }
+    }
+    // Tiles and components are wholly independent of each other, and
+    // so are the bands inside them; only the wavelet joins a
+    // component's bands back up.
+    let planes: Vec<(usize, usize, Vec<u16>)> = work
+        .par_iter()
+        .map(|(t, p)| {
+            let tile = &tiles[*t];
+            let shapes = band_shapes(header.levels, tile.width, tile.height, tile.neighbours);
+            let steps = if maps[*t].is_empty() {
+                None
+            } else {
+                Some(maps[*t].as_slice())
+            };
+            let data = decode_component(sample, header, tile, &tile.planes[*p], &shapes, steps)?;
+            // The coder's samples are signed and centred on zero; the
+            // level shift and the clamp are the last thing that
+            // happens to them.
+            Ok((
+                *t,
+                *p,
+                data.into_iter()
+                    .map(|v| median.wrapping_add(v).clamp(0, white) as u16)
+                    .collect(),
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let (width, height) = (header.width, header.height);
+    let cell = if header.planes == 1 { 1 } else { 2 };
+    // Each plane scatters its own rows: one pass over the samples,
+    // rather than every frame row scanning every tile of every plane
+    // (which made a 255x255 tile grid take seconds).
+    let mut frame = vec![0u16; crate::frame_samples(width, height, 1)?];
+    for (t, p, data) in &planes {
+        let tile = &tiles[*t];
+        if tile.width == 0 {
+            continue;
+        }
+        let (cx, cy) = if cell == 1 {
+            (0, 0)
+        } else {
+            cfa_position(header.cfa_layout, *p)
+        };
+        for py in 0..tile.height {
+            let fy = cell * (tile.y + py) + cy;
+            if fy >= height {
+                break;
+            }
+            let Some(line) = data
+                .get(py * tile.width..)
+                .and_then(|d| d.get(..tile.width))
+            else {
+                break;
+            };
+            let row = &mut frame[fy * width..][..width];
+            for (x, value) in line.iter().enumerate() {
+                let fx = cell * (tile.x + x) + cx;
+                if let Some(out) = row.get_mut(fx) {
+                    *out = *value;
+                }
+            }
+        }
+    }
+    Ok(frame)
+}
+
+/// Decode a tile's quantiser map and fold it into one step table per
+/// level group, coarsest first.
+///
+/// The map is one exponent per 8x2 block of the tile, coded with a
+/// small predictive Golomb coder of its own. A level's table is the
+/// map with its rows combined in fours, in pairs or not at all, which
+/// is how it comes to match a band that has been downsampled that far
+/// vertically.
+fn quantiser_map(
+    bytes: &[u8],
+    tile_w: usize,
+    tile_h: usize,
+    levels: usize,
+) -> Result<Vec<Vec<Vec<i32>>>> {
+    let (qw, qh) = (tile_w.div_ceil(8), tile_h.div_ceil(2));
+    let base = quantiser_grid(bytes, qw, qh)?;
+    let at = |row: usize, col: usize| base[row.min(qh - 1) * qw + col];
+    let mut out = Vec::with_capacity(levels);
+    for group in 0..levels {
+        let span = 1usize << (levels - 1 - group);
+        let rows = tile_h.div_ceil(2 * span);
+        let mut table = Vec::with_capacity(rows);
+        for r in 0..rows {
+            let mut row = Vec::with_capacity(qw);
+            for c in 0..qw {
+                let value = match span {
+                    1 => at(r, c),
+                    2 => (at(2 * r, c) + at(2 * r + 1, c)) / 2,
+                    // Four rows are averaged with a bias that rounds
+                    // toward zero rather than the plain truncating
+                    // divide two rows get. Nothing explains the
+                    // difference; the entries are positive in
+                    // practice, so the bias never fires.
+                    _ => {
+                        let sum: i32 = (0..span).map(|k| at(span * r + k, c)).sum();
+                        (if sum < 0 { 3 } else { 0 } + sum) >> 2
+                    }
+                };
+                row.push(step_of(value));
+            }
+            table.push(row);
+        }
+        out.push(table);
+    }
+    Ok(out)
+}
+
+/// The quantiser map's own bitstream: row 0 predicts from the left,
+/// later rows use the same four-way gradient predictor as the LL
+/// band's line coder, and there is no run mode. Every entry is
+/// four larger than it is coded.
+fn quantiser_grid(bytes: &[u8], qw: usize, qh: usize) -> Result<Vec<i32>> {
+    if qw == 0 || qh == 0 {
+        return Err(Error::Corrupt("CRX empty quantiser map".into()));
+    }
+    let mut r = Reader::new(bytes);
+    let mut cur = vec![0i32; qw + 2];
+    let mut prev = vec![0i32; qw + 2];
+    let mut out = vec![0i32; qw * qh];
+    let mut k = 0u32;
+    for row in 0..qh {
+        if row == 0 {
+            let mut left = 0i32;
+            for i in 0..qw {
+                let v = r.golomb(k, Q_ESCAPE_ZEROS, Q_ESCAPE_BITS);
+                left = left.wrapping_add(fold(v));
+                cur[i + 1] = left;
+                k = adapt(k, v, 7);
+            }
+        } else {
+            cur[0] = prev[1];
+            for i in 0..qw {
+                let (a, b, c, e) = (cur[i], prev[i + 1], prev[i], prev[i + 2]);
+                let v = r.golomb(k, Q_ESCAPE_ZEROS, Q_ESCAPE_BITS);
+                cur[i + 1] = predict(a, b, c).wrapping_add(fold(v));
+                k = if i + 1 < qw {
+                    adapt(k, blend(v, e.wrapping_sub(b).unsigned_abs()), 7)
+                } else {
+                    adapt(k, v, 7)
+                };
+            }
+        }
+        cur[qw + 1] = cur[qw].wrapping_add(1);
+        out[row * qw..(row + 1) * qw].copy_from_slice(&cur[1..=qw]);
+        std::mem::swap(&mut cur, &mut prev);
+    }
+    if r.bad {
+        return Err(Error::Corrupt("CRX quantiser map ran off its data".into()));
+    }
+    for v in &mut out {
+        *v += 4;
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // ---------------------------------------------------------------
+    // Hand-built streams: the mechanics.
+    // ---------------------------------------------------------------
+
     /// A CMP1 payload shaped like the ones real files carry.
-    fn cmp1(version: u8, w: u32, h: u32, tw: u32, th: u32, levels: u8, hdr: u32) -> Vec<u8> {
+    fn cmp1(version: u16, w: u32, h: u32, tw: u32, th: u32, levels: u8, index: u32) -> Vec<u8> {
         let mut p = vec![0u8; 52];
-        p[0..2].copy_from_slice(&0xff00u16.to_be_bytes());
+        p[0..2].copy_from_slice(&if version == 0x0100 { 0xff00u16 } else { 0xff10 }.to_be_bytes());
         p[2..4].copy_from_slice(&0x0030u16.to_be_bytes());
-        p[4] = version;
+        p[4..6].copy_from_slice(&version.to_be_bytes());
         p[8..12].copy_from_slice(&w.to_be_bytes());
         p[12..16].copy_from_slice(&h.to_be_bytes());
         p[16..20].copy_from_slice(&tw.to_be_bytes());
@@ -442,7 +2017,7 @@ mod tests {
         p[24] = 14;
         p[25] = 0x40;
         p[26] = levels;
-        p[28..32].copy_from_slice(&hdr.to_be_bytes());
+        p[28..32].copy_from_slice(&index.to_be_bytes());
         p
     }
 
@@ -453,93 +2028,836 @@ mod tests {
         out
     }
 
-    fn sizes(size: u32, flags: u32) -> Vec<u8> {
-        let mut out = size.to_be_bytes().to_vec();
-        out.extend_from_slice(&flags.to_be_bytes());
-        out
+    /// Bits, most significant first, as the coder writes them.
+    #[derive(Default)]
+    struct Writer {
+        bytes: Vec<u8>,
+        held: u32,
+        n: u32,
+    }
+
+    impl Writer {
+        fn put(&mut self, value: u32, bits: u32) -> &mut Writer {
+            for i in (0..bits).rev() {
+                self.held = (self.held << 1) | ((value >> i) & 1);
+                self.n += 1;
+                if self.n == 8 {
+                    self.bytes.push(self.held as u8);
+                    self.held = 0;
+                    self.n = 0;
+                }
+            }
+            self
+        }
+        fn zeros(&mut self, n: u32) -> &mut Writer {
+            for _ in 0..n {
+                self.put(0, 1);
+            }
+            self
+        }
+        fn done(&mut self) -> Vec<u8> {
+            while self.n != 0 {
+                self.put(0, 1);
+            }
+            std::mem::take(&mut self.bytes)
+        }
     }
 
     #[test]
     fn image_header_fields() {
-        let header = ImageHeader::parse(&cmp1(1, 6888, 4546, 3444, 4546, 0, 216)).unwrap();
-        assert_eq!(header.version, 1);
+        // The CMP1 payload of Canon/EOS_R-RAW_ISO_100.CR3, byte for
+        // byte, with its 20 zero bytes of tail.
+        let mut payload = vec![
+            0xff, 0x00, 0x00, 0x30, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1a, 0xe8, 0x00, 0x00,
+            0x11, 0xc2, 0x00, 0x00, 0x0d, 0x74, 0x00, 0x00, 0x11, 0xc2, 0x0e, 0x40, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0xd8,
+        ];
+        payload.extend(std::iter::repeat_n(0u8, 20));
+        let header = ImageHeader::parse(&payload).unwrap();
+        assert_eq!(header.version, 0x0100);
         assert_eq!((header.width, header.height), (6888, 4546));
-        assert_eq!(header.tile_grid(), (2, 1));
+        assert_eq!((header.tile_width, header.tile_height), (3444, 4546));
         assert_eq!(header.bits, 14);
         assert_eq!(header.planes, 4);
+        assert_eq!(header.cfa_layout, 0);
+        assert_eq!(header.enc_type, 0);
+        assert_eq!(header.levels, 0);
+        assert!(!header.tile_cols_linked && !header.tile_rows_linked);
+        assert_eq!(header.mdat_header_size, 216);
+        assert_eq!(header.median_bits, 14);
+        // A Bayer frame is coded as four half-size planes, and every
+        // tile and band shape lives in those coordinates.
+        assert_eq!(header.plane_size(), (3444, 2273));
+        assert_eq!(header.tile_size(), (1722, 2273));
+        assert_eq!(header.tile_grid(), (2, 1));
         assert_eq!(header.bands(), 1);
-        let lossy = ImageHeader::parse(&cmp1(1, 6888, 4546, 3444, 4546, 3, 1080)).unwrap();
+        // The same frame in cRAW: three levels, ten bands, and the
+        // flag that says the wavelet spans the tile columns.
+        let mut lossy = cmp1(0x0100, 6888, 4546, 3444, 4546, 3, 1080);
+        lossy[27] = 0x80;
+        let lossy = ImageHeader::parse(&lossy).unwrap();
+        assert_eq!(lossy.levels, 3);
         assert_eq!(lossy.bands(), 10);
+        assert!(lossy.tile_cols_linked && !lossy.tile_rows_linked);
     }
 
     #[test]
-    fn a_short_or_impossible_cmp1_is_corrupt() {
+    fn a_cmp1_that_breaks_its_own_rules_is_rejected() {
         assert!(ImageHeader::parse(&[0u8; 8]).is_err());
-        assert!(ImageHeader::parse(&cmp1(1, 0, 4546, 3444, 4546, 0, 216)).is_err());
-        let mut deep = cmp1(1, 100, 100, 100, 100, 0, 16);
-        deep[24] = 0;
-        assert!(ImageHeader::parse(&deep).is_err());
+        // An unknown dialect, a zero dimension, a tile bigger than the
+        // frame, an odd Bayer frame, a tile too small to transform, a
+        // frame too big for the tile records' coordinates.
+        assert!(matches!(
+            ImageHeader::parse(&cmp1(0x0300, 64, 64, 64, 64, 0, 16)),
+            Err(Error::Unsupported(_))
+        ));
+        assert!(ImageHeader::parse(&cmp1(0x0100, 0, 64, 64, 64, 0, 16)).is_err());
+        assert!(ImageHeader::parse(&cmp1(0x0100, 64, 64, 128, 64, 0, 16)).is_err());
+        assert!(ImageHeader::parse(&cmp1(0x0100, 65, 64, 65, 64, 0, 16)).is_err());
+        assert!(ImageHeader::parse(&cmp1(0x0100, 40, 40, 40, 40, 0, 16)).is_err());
+        assert!(ImageHeader::parse(&cmp1(0x0100, 1 << 17, 64, 64, 64, 0, 16)).is_err());
+        // A header with no index cannot describe anything.
+        assert!(ImageHeader::parse(&cmp1(0x0100, 64, 64, 64, 64, 0, 0)).is_err());
+        // Fourteen bits with eight-bit single-plane rules.
+        let mut single = cmp1(0x0100, 64, 64, 64, 64, 0, 16);
+        single[25] = 0x10;
+        assert!(ImageHeader::parse(&single).is_err());
+    }
+
+    /// The first 120 bytes of the mdat index of
+    /// `Canon/EOS_R-RAW_ISO_100.CR3`, which is tile 0 in full and the
+    /// record that opens tile 1.
+    fn eos_r_index() -> Vec<u8> {
+        let mut index = Vec::new();
+        index.extend(record(0xff01, &hex("00d08d20 0000 0000")));
+        for (size, plane, band) in [
+            (0x0031_8740u32, 0x08u8, 0x0020_0004u32),
+            (0x0036_27c0, 0x18, 0x0020_0000),
+            (0x0036_2110, 0x28, 0x0020_0005),
+            (0x0032_bd10, 0x38, 0x0020_0007),
+        ] {
+            let mut p = size.to_be_bytes().to_vec();
+            p.extend([plane, 0, 0, 0]);
+            index.extend(record(0xff02, &p));
+            let mut b = size.to_be_bytes().to_vec();
+            b.extend(band.to_be_bytes());
+            index.extend(record(0xff03, &b));
+        }
+        index.extend(record(0xff01, &hex("00de2498 0001 0000")));
+        index
+    }
+
+    fn hex(s: &str) -> Vec<u8> {
+        let digits: Vec<u8> = s.bytes().filter(u8::is_ascii_hexdigit).collect();
+        digits
+            .chunks(2)
+            .map(|p| u8::from_str_radix(std::str::from_utf8(p).unwrap(), 16).unwrap())
+            .collect()
     }
 
     #[test]
-    fn tiles_planes_and_bands_tile_their_parents() {
-        // Two tiles of four planes, one band each: the shape of a
-        // lossless EOS R frame, in miniature.
-        let mut hdr = Vec::new();
-        for tile in 0..2u32 {
-            hdr.extend(record(0xff01, &sizes(40, tile << 16)));
-            for plane in 0..4u32 {
-                hdr.extend(record(0xff02, &sizes(10, 0x0800_0000 | (plane << 28))));
-                hdr.extend(record(0xff03, &sizes(10, 0x0020_0000)));
+    fn index_records_of_a_real_lossless_frame() {
+        // Tile 1's four components, invented so the tree adds up; the
+        // rest of the index is the file's own bytes.
+        let mut index = eos_r_index();
+        for plane in 0..4u8 {
+            let size = 0x00de_2498u32 / 4;
+            let mut p = size.to_be_bytes().to_vec();
+            p.extend([plane << 4 | 8, 0, 0, 0]);
+            index.extend(record(0xff02, &p));
+            let mut b = size.to_be_bytes().to_vec();
+            b.extend(0x0020_0004u32.to_be_bytes());
+            index.extend(record(0xff03, &b));
+        }
+        assert_eq!(index.len(), 216);
+        let header = ImageHeader::parse(&cmp1(0x0100, 6888, 4546, 3444, 4546, 0, 216)).unwrap();
+        let mut sample = index.clone();
+        sample.extend(std::iter::repeat_n(0u8, 0x00d0_8d20 + 0x00de_2498));
+        let tiles = parse_tiles(&header, &sample).unwrap();
+
+        assert_eq!(tiles.len(), 2);
+        assert_eq!(tiles[0].data, 216..216 + 0x00d0_8d20);
+        assert_eq!((tiles[0].width, tiles[0].height), (1722, 2273));
+        assert_eq!((tiles[0].x, tiles[0].y), (0, 0));
+        assert_eq!((tiles[1].x, tiles[1].y), (1722, 0));
+        // The neighbour flags come from the grid, never from the
+        // header's linked bits.
+        assert_eq!(tiles[0].neighbours, RIGHT);
+        assert_eq!(tiles[1].neighbours, LEFT);
+        assert_eq!(tiles[0].qp_size, 0);
+        assert_eq!(tiles[0].extra_size, 0);
+        let plane = &tiles[0].planes[0];
+        assert!(plane.ref_prev_line);
+        assert_eq!(plane.round_mask, 0);
+        assert_eq!(plane.data, 216..216 + 0x0031_8740);
+        let band = &plane.bands[0];
+        assert_eq!(band.index, 0);
+        assert!(!band.q_per_line);
+        assert_eq!(band.q_param, 4);
+        assert_eq!(step_of(band.q_param), 1);
+        // Four bytes of the band's range are not bitstream, so the
+        // coder gets 3245884 of the component's 3245888.
+        assert_eq!(band.trailing, 4);
+        assert_eq!(band.bitstream(&sample).len(), 3_245_884);
+        assert_eq!(tiles[0].planes[1].bands[0].trailing, 0);
+        assert_eq!(tiles[0].planes[3].bands[0].trailing, 7);
+    }
+
+    #[test]
+    fn a_version_2_tile_record_carries_a_quantiser_map() {
+        let mut index = Vec::new();
+        let mut tile = 400u32.to_be_bytes().to_vec();
+        tile.extend([0, 0]);
+        tile.extend(0x4000u16.to_be_bytes());
+        tile.extend(40u32.to_be_bytes());
+        tile.extend(4u16.to_be_bytes());
+        tile.extend([0, 0]);
+        index.extend(record(0xff11, &tile));
+        for plane in 0..4u8 {
+            let mut p = 89u32.to_be_bytes().to_vec();
+            p.extend([plane << 4 | 8, 0, 0, 0]);
+            index.extend(record(0xff12, &p));
+            for band in 0..10u16 {
+                let mut b = 8u32.to_be_bytes().to_vec();
+                b.extend((band << 12).to_be_bytes());
+                b.extend(8u16.to_be_bytes());
+                b.extend(0u32.to_be_bytes());
+                b.extend(1u16.to_be_bytes());
+                b.extend([0, 0]);
+                index.extend(record(0xff13, &b));
             }
         }
-        let header = ImageHeader::parse(&cmp1(1, 8, 4, 4, 4, 0, hdr.len() as u32)).unwrap();
-        let mut sample = hdr.clone();
-        sample.extend(std::iter::repeat_n(0u8, 80));
+        let start = index.len();
+        let header =
+            ImageHeader::parse(&cmp1(0x0200, 128, 128, 128, 128, 3, start as u32)).unwrap();
+        let mut sample = index;
+        sample.extend(std::iter::repeat_n(0u8, 400));
         let tiles = parse_tiles(&header, &sample).unwrap();
-        assert_eq!(tiles.len(), 2);
-        assert_eq!(tiles[0].data, hdr.len()..hdr.len() + 40);
-        assert_eq!(tiles[1].data, hdr.len() + 40..hdr.len() + 80);
-        assert_eq!(tiles[1].col, 1);
-        assert_eq!(tiles[0].planes[1].data, hdr.len() + 10..hdr.len() + 20);
-        assert!(tiles[0].planes[0].extra_flag);
-        assert_eq!(tiles[0].planes[0].bands[0].q_step, 32);
-        assert_eq!(
-            tiles[0].planes[3].bands[0].data,
-            hdr.len() + 30..hdr.len() + 40
-        );
+        assert_eq!(tiles[0].qp_size, 40);
+        assert_eq!(tiles[0].extra_size, 4);
+        // The components start after the map and the four bytes whose
+        // meaning nobody knows.
+        assert_eq!(tiles[0].planes[0].data.start, start + 44);
+        let band = &tiles[0].planes[0].bands[3];
+        assert_eq!((band.q_step_base, band.q_step_mult), (0, 8));
+        assert_eq!(band.trailing, 1);
     }
 
     #[test]
-    fn a_header_that_does_not_add_up_is_rejected() {
-        let header = ImageHeader::parse(&cmp1(1, 8, 4, 4, 4, 0, 12)).unwrap();
+    fn an_index_that_does_not_add_up_is_rejected() {
+        let header = ImageHeader::parse(&cmp1(0x0100, 128, 64, 64, 64, 0, 12)).unwrap();
+        let mut short = record(0xff01, &hex("00000008 0000 0000"));
+        short.extend([0u8; 8]);
         // One tile record for a two-tile grid.
-        let hdr = record(0xff01, &sizes(8, 0));
-        let mut sample = hdr.clone();
-        sample.extend([0u8; 8]);
-        assert!(parse_tiles(&header, &sample).is_err());
+        assert!(parse_tiles(&header, &short).is_err());
         // A tile bigger than the sample.
-        let hdr = record(0xff01, &sizes(1 << 20, 0));
-        let mut sample = hdr.clone();
-        sample.extend([0u8; 8]);
-        assert!(parse_tiles(&header, &sample).is_err());
-        // A header longer than the sample it describes.
-        let header = ImageHeader::parse(&cmp1(1, 8, 4, 8, 4, 0, 1 << 20)).unwrap();
+        let mut big = record(0xff01, &hex("00100000 0000 0000"));
+        big.extend([0u8; 8]);
+        assert!(parse_tiles(&header, &big).is_err());
+        // A tile out of order.
+        let mut misnumbered = record(0xff01, &hex("00000008 0007 0000"));
+        misnumbered.extend([0u8; 8]);
+        assert!(parse_tiles(&header, &misnumbered).is_err());
+        // An index longer than the sample it describes.
+        let header = ImageHeader::parse(&cmp1(0x0100, 64, 64, 64, 64, 0, 1 << 20)).unwrap();
         assert!(parse_tiles(&header, &[0u8; 32]).is_err());
     }
 
     #[test]
-    fn an_unknown_record_dialect_is_unsupported() {
-        let header = ImageHeader::parse(&cmp1(7, 8, 4, 8, 4, 0, 0)).unwrap();
-        assert!(matches!(
-            parse_tiles(&header, &[0u8; 8]),
-            Err(Error::Unsupported(_))
-        ));
+    fn band_shapes_of_the_eos_r_craw_tiles() {
+        // Tile 0 of Canon_EOS_R_CRAW_ISO_100.CR3 (1722x2273, a
+        // neighbour on the right) and tile 1 (the same size, a
+        // neighbour on the left).
+        let right = band_shapes(3, 1722, 2273, RIGHT);
+        let widths: Vec<usize> = right.iter().map(|s| s.width).collect();
+        let heights: Vec<usize> = right.iter().map(|s| s.height).collect();
+        assert_eq!(widths, [217, 217, 217, 217, 432, 433, 432, 862, 863, 862]);
+        assert_eq!(
+            heights,
+            [285, 285, 284, 284, 569, 568, 568, 1137, 1136, 1136]
+        );
+        let left = band_shapes(3, 1722, 2273, LEFT);
+        let widths: Vec<usize> = left.iter().map(|s| s.width).collect();
+        assert_eq!(widths, [216, 216, 216, 216, 431, 431, 431, 862, 861, 862]);
+        // Every band of a tile with no vertical neighbour is the same
+        // height whichever side the horizontal seam is on.
+        assert_eq!(
+            left.iter().map(|s| s.height).collect::<Vec<_>>(),
+            heights.clone()
+        );
+        // The level shifts the version-2 quantiser map indexes with.
+        assert_eq!(
+            right.iter().map(|s| s.level_shift).collect::<Vec<_>>(),
+            [0, 0, 0, 0, 1, 1, 1, 2, 2, 2]
+        );
+        assert_eq!(
+            right.iter().map(|s| s.group).collect::<Vec<_>>(),
+            [0, 0, 0, 0, 1, 1, 1, 2, 2, 2]
+        );
+        // A tile with no neighbours at all carries no overlap.
+        let alone = band_shapes(3, 1722, 2273, 0);
+        assert_eq!(
+            alone.iter().map(|s| s.width).collect::<Vec<_>>(),
+            [216, 215, 216, 215, 430, 431, 430, 861, 861, 861]
+        );
+        assert!(alone
+            .iter()
+            .all(|s| s.col_start + s.col_end + s.row_start + s.row_end == 0));
+    }
+
+    #[test]
+    fn band_shapes_of_a_second_tile_geometry() {
+        // Canon/EOS_90D-cRAW-ISO-100.CR3: 1782x2366 with the right
+        // seam, which lands on a different row of the overlap table
+        // (1782 & 7 == 6) from the EOS R's.
+        let shapes = band_shapes(3, 1782, 2366, RIGHT);
+        let got: Vec<(usize, usize)> = shapes.iter().map(|s| (s.width, s.height)).collect();
+        assert_eq!(
+            got,
+            [
+                (224, 296),
+                (224, 296),
+                (224, 296),
+                (224, 296),
+                (447, 592),
+                (447, 591),
+                (447, 591),
+                (892, 1183),
+                (893, 1183),
+                (892, 1183),
+            ]
+        );
+        // With no wavelet there is one band and it is the tile.
+        let flat = band_shapes(0, 1782, 2366, RIGHT);
+        assert_eq!(flat.len(), 1);
+        assert_eq!((flat[0].width, flat[0].height), (1782, 2366));
+    }
+
+    #[test]
+    fn the_escape_needs_forty_one_zeros() {
+        // How every lossless band opens: the run-mode flag, then the
+        // escape, then a flat 21-bit magnitude. A decoder that counts
+        // the flag as part of the unary prefix and escapes at 42 sees
+        // exactly the same thing here and desynchronises later.
+        let bytes = Writer::default()
+            .zeros(1)
+            .zeros(41)
+            .put(1, 1)
+            .put(15367, 21)
+            .done();
+        assert_eq!(bytes.len(), 8);
+        let mut r = Reader::new(&bytes);
+        assert_eq!(r.bit(), 0);
+        assert_eq!(r.golomb(0, ESCAPE_ZEROS, ESCAPE_BITS), 15367);
+        assert_eq!(fold(15367), -7684);
+        assert!(r.consumed_exactly());
+        // Below the threshold it is an ordinary Rice code.
+        let bytes = Writer::default().zeros(3).put(1, 1).put(0b10, 2).done();
+        let mut r = Reader::new(&bytes);
+        assert_eq!(r.golomb(2, ESCAPE_ZEROS, ESCAPE_BITS), 14);
+        // A band of nothing but zero bits must not spin for ever.
+        let mut r = Reader::new(&[0u8; 64]);
+        assert_eq!(r.golomb(0, ESCAPE_ZEROS, ESCAPE_BITS), 0);
+        assert!(r.bad);
+    }
+
+    #[test]
+    fn k_follows_the_magnitudes_of_a_real_line() {
+        // The magnitudes of the first 24 symbols of line 0 of tile 0
+        // component 0 of Canon/EOS_R-RAW_ISO_100.CR3, and the K the
+        // reference has after each of them.
+        let magnitudes = [
+            15367u32, 14, 5, 0, 2, 1, 2, 5, 6, 0, 5, 4, 6, 3, 1, 7, 1, 1, 0, 2, 10, 8, 7, 7,
+        ];
+        let want = [
+            2u32, 3, 3, 2, 2, 1, 1, 1, 2, 1, 1, 1, 2, 2, 1, 2, 1, 1, 0, 0, 2, 2, 2, 2,
+        ];
+        let mut k = 0;
+        let got: Vec<u32> = magnitudes
+            .iter()
+            .map(|m| {
+                k = adapt(k, *m, 15);
+                k
+            })
+            .collect();
+        assert_eq!(got, want);
+        // K rises by at most two and falls by at most one, and never
+        // goes below zero.
+        assert_eq!(adapt(0, 0, 15), 0);
+        assert_eq!(adapt(0, 1 << 20, 15), 2);
+        assert_eq!(adapt(4, 0, 15), 3);
+        assert_eq!(adapt(14, 1 << 20, 15), 15);
+        // Kmax 0 means no clamp; the detail-band coder applies its own.
+        assert_eq!(adapt(14, 1 << 20, 0), 16);
+    }
+
+    #[test]
+    fn the_four_way_predictor_is_the_median_predictor() {
+        // Line 1, column 0 of the EOS R's first band: the left
+        // neighbour is the padding, which is the sample above, and
+        // the above-left is the previous line's padding, still zero.
+        assert_eq!(predict(-7684, -7684, 0), -7684);
+        // Canon writes this as a two-bit selector over the sign of
+        // the gradient above rather than as a median, but the two
+        // agree on every input: a decoder that diverges in line 1 is
+        // missing run mode, not the predictor.
+        let median = |a: i32, b: i32, c: i32| {
+            if c >= a.max(b) {
+                a.min(b)
+            } else if c <= a.min(b) {
+                a.max(b)
+            } else {
+                a + b - c
+            }
+        };
+        for a in -4..=4 {
+            for b in -4..=4 {
+                for c in -4..=4 {
+                    assert_eq!(predict(a, b, c), median(a, b, c), "{a} {b} {c}");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn runs_grow_and_shrink_their_state() {
+        let bits = |value: u32, n: u32| Writer::default().put(value, n).done();
+        // One 0 bit: no run at all, and nothing else is read.
+        let none = bits(0, 1);
+        // 1, then one continuation: length 2, and the state grows and
+        // shrinks straight back.
+        let two = bits(0b110, 3);
+        // Two continuations leave the state one higher.
+        let three = bits(0b1110, 4);
+        // At a state with a remainder field the field is read and
+        // added: state 4 adds 2 per continuation and has one spare
+        // bit, so 1, 0, then a 1 bit of remainder is a run of 2.
+        let remainder = bits(0b101, 3);
+        // A run that reaches the limit stops there, reads no
+        // remainder and leaves the state where the growth put it.
+        let capped = bits(0b11, 2);
+        let run = |bytes: &[u8], state: usize, limit: usize| {
+            let mut coder = Coder::new(bytes, 8);
+            coder.s = state;
+            let run = coder.run(limit, false);
+            (run, coder.s, coder.r.pump.position())
+        };
+        assert_eq!(run(&none, 0, 1000), (0, 0, 1));
+        assert_eq!(run(&two, 0, 1000), (2, 0, 3));
+        assert_eq!(run(&three, 0, 1000), (3, 1, 4));
+        assert_eq!(run(&remainder, 4, 1000), (2, 3, 3));
+        assert_eq!(run(&capped, 0, 2), (2, 1, 2));
+        // Every bucket is a power of two wide.
+        for s in 0..32 {
+            assert_eq!(RUNLEN[s], 1 << RUNBITS[s]);
+        }
+    }
+
+    #[test]
+    fn lifting_interpolates_between_the_low_band() {
+        // With a zero high band the reconstruction is the low band
+        // interleaved with its own midpoints.
+        let mut out = vec![0i32; 4];
+        lift_row(&[10, 20], &[0, 0], &mut out, false, false);
+        assert_eq!(out, [10, 15, 20, 20]);
+        let mut out = vec![0i32; 5];
+        lift_row(&[10, 20, 30], &[0, 0, 0], &mut out, false, false);
+        assert_eq!(out, [10, 15, 20, 25, 30]);
+        // A high band shifts both halves: it is subtracted from the
+        // even samples a quarter at a time and added to the odd ones.
+        let mut out = vec![0i32; 4];
+        lift_row(&[10, 20], &[4, 0], &mut out, false, false);
+        assert_eq!(out, [8, 17, 19, 19]);
+        // One column is the low sample itself.
+        let mut out = vec![0i32; 1];
+        lift_row(&[7], &[3], &mut out, false, false);
+        assert_eq!(out, [7]);
+        // The vertical half does the same thing a row at a time.
+        let mut out = vec![0i32; 4 * 2];
+        lift_columns(
+            &[10, 10, 20, 20],
+            &[0, 0, 0, 0],
+            &mut out,
+            2,
+            4,
+            false,
+            false,
+        );
+        assert_eq!(out, [10, 10, 15, 15, 20, 20, 20, 20]);
+    }
+
+    #[test]
+    fn quantiser_exponents_map_to_the_steps_real_files_use() {
+        // The exponents seen in version-1 cRAW bands.
+        assert_eq!(step_of(4), 1);
+        assert_eq!(step_of(16), 4);
+        assert_eq!(step_of(22), 8);
+        assert_eq!(step_of(26), 12);
+        assert_eq!(step_of(32), 25);
+        // The saturating branch, which no real file takes.
+        assert_eq!(step_of(255), QSTEP_MAX);
+    }
+
+    #[test]
+    fn hostile_samples_are_errors_not_panics() {
+        let mut index = record(0xff01, &hex("00000100 0000 0000"));
+        for plane in 0..4u8 {
+            let mut p = 64u32.to_be_bytes().to_vec();
+            p.extend([plane << 4 | 8, 0, 0, 0]);
+            index.extend(record(0xff02, &p));
+            let mut b = 64u32.to_be_bytes().to_vec();
+            b.extend(0x0020_0000u32.to_be_bytes());
+            index.extend(record(0xff03, &b));
+        }
+        let header =
+            ImageHeader::parse(&cmp1(0x0100, 64, 64, 64, 64, 0, index.len() as u32)).unwrap();
+        for fill in [0x00u8, 0xff, 0x5a] {
+            let mut sample = index.clone();
+            sample.extend(std::iter::repeat_n(fill, 0x100));
+            // Whatever the bits say, this either decodes to something
+            // or reports the file as corrupt; it never panics and
+            // never runs away.
+            match decode(&header, &sample) {
+                Ok(frame) => assert_eq!(frame.len(), 64 * 64),
+                Err(Error::Corrupt(_)) => {}
+                Err(e) => panic!("{e}"),
+            }
+        }
+        // Truncations of the index itself.
+        for cut in 0..index.len() {
+            let _ = parse_tiles(&header, &index[..cut]);
+        }
     }
 
     // ---------------------------------------------------------------
-    // Corpus: the headers of real CRX streams.
+    // Corpus: real CRX streams.
     // ---------------------------------------------------------------
+
+    /// The first sample of a track, from `stsz` and `co64`/`stco`.
+    fn sample_of<'a>(bytes: &'a [u8], stbl: &crate::bmff::Box_) -> Option<&'a [u8]> {
+        let stsz = bytes.get(stbl.child(b"stsz")?.data.clone())?;
+        let be = |b: &[u8], at: usize| -> Option<usize> {
+            Some(u32::from_be_bytes(b.get(at..at + 4)?.try_into().ok()?) as usize)
+        };
+        let size = match be(stsz, 4)? {
+            0 => be(stsz, 12)?,
+            uniform => uniform,
+        };
+        let offset = match (stbl.child(b"co64"), stbl.child(b"stco")) {
+            (Some(co64), _) => {
+                let p = bytes.get(co64.data.clone())?;
+                usize::try_from(u64::from_be_bytes(p.get(8..16)?.try_into().ok()?)).ok()?
+            }
+            (None, Some(stco)) => be(bytes.get(stco.data.clone())?, 8)?,
+            (None, None) => return None,
+        };
+        bytes.get(offset..offset.checked_add(size)?)
+    }
+
+    /// Every CRX stream in a CR3: its header and its sample.
+    fn streams(bytes: &[u8]) -> Vec<(ImageHeader, &[u8])> {
+        let Ok(boxes) = crate::bmff::parse(bytes) else {
+            return Vec::new();
+        };
+        let mut out = Vec::new();
+        for trak in boxes
+            .iter()
+            .filter(|b| &b.kind == b"moov")
+            .flat_map(|m| m.children.iter())
+            .filter(|b| &b.kind == b"trak")
+        {
+            let Some(stbl) = trak.find_all(b"stbl").into_iter().next() else {
+                continue;
+            };
+            let Some(entry) = stbl.child(b"stsd").and_then(|s| s.children.first()) else {
+                continue;
+            };
+            let Some(cmp1) = entry.child(b"CMP1") else {
+                continue;
+            };
+            let Ok(header) = ImageHeader::parse(&bytes[cmp1.data.clone()]) else {
+                continue;
+            };
+            if let Some(sample) = sample_of(bytes, stbl) {
+                out.push((header, sample));
+            }
+        }
+        out
+    }
+
+    /// The largest CRX stream in a CR3 — the full-size raw track.
+    fn raw_stream(bytes: &[u8]) -> Option<(ImageHeader, &[u8])> {
+        streams(bytes)
+            .into_iter()
+            .max_by_key(|(h, _)| h.width * h.height)
+    }
+
+    fn corpus_file(name: &str) -> Option<Vec<u8>> {
+        let root = crate::tiff::tests::corpus()?;
+        std::fs::read(root.join(name)).ok()
+    }
+
+    /// Decode one band of one component of one tile, with the coder's
+    /// workings recorded.
+    fn one_band(
+        header: &ImageHeader,
+        sample: &[u8],
+        tile: usize,
+        plane: usize,
+        band: usize,
+        lines: Option<usize>,
+    ) -> (Vec<i32>, Shape, Trace, bool) {
+        let tiles = parse_tiles(header, sample).expect("the index");
+        let t = &tiles[tile];
+        let shapes = band_shapes(header.levels, t.width, t.height, t.neighbours);
+        let p = &t.planes[plane];
+        let b = &p.bands[band];
+        let mode = if band == 0 && p.ref_prev_line {
+            Mode::A {
+                round: p.round_mask,
+                round_bits: p.round_bits,
+            }
+        } else {
+            Mode::B
+        };
+        let mut quant = if b.q_per_line {
+            Quant::PerLine {
+                exponent: b.q_param,
+                k: 0,
+            }
+        } else {
+            Quant::Uniform(step_of(b.q_param))
+        };
+        let mut coder = Coder::new(b.bitstream(sample), shapes[band].width);
+        coder.trace.on = true;
+        let data = run_band(
+            &mut coder,
+            lines.unwrap_or(shapes[band].height),
+            mode,
+            &mut quant,
+        )
+        .expect("the band");
+        let exact = coder.r.consumed_exactly();
+        (data, shapes[band], std::mem::take(&mut coder.trace), exact)
+    }
+
+    #[test]
+    fn eos_r_lossless_band_matches_the_reference() {
+        let Some(bytes) = corpus_file("Canon/EOS_R-RAW_ISO_100.CR3") else {
+            return;
+        };
+        let (header, sample) = raw_stream(&bytes).expect("a raw track");
+        assert_eq!(header.levels, 0);
+        let (data, shape, trace, exact) = one_band(&header, sample, 0, 0, 0, Some(3));
+        assert_eq!((shape.width, shape.height), (1722, 2273));
+
+        // Line 0: predicted from the left, opening with the escape.
+        #[rustfmt::skip]
+        let line0 = [
+            -7684, -7677, -7680, -7680, -7679, -7680, -7679, -7682, -7679, -7679, -7682, -7680,
+            -7677, -7679, -7680, -7684, -7685, -7686, -7686, -7685, -7680, -7676, -7680, -7684,
+            -7675, -7684, -7680, -7680, -7682, -7685, -7680, -7686, -7675, -7677, -7679, -7677,
+            -7679, -7677, -7677, -7677, -7677, -7677, -7680, -7684, -7682, -7680, -7679, -7680,
+            -7679, -7680, -7684, -7684, -7682, -7682, -7684, -7674, -7677, -7685, -7685, -7679,
+            -7682, -7680, -7682, -7682,
+        ];
+        assert_eq!(&data[..64], &line0);
+        // Line 1: the four-way predictor, and a run at column 52.
+        #[rustfmt::skip]
+        let line1 = [
+            -7676, -7682, -7684, -7684, -7684, -7679, -7676, -7680, -7680, -7680, -7679, -7682,
+            -7680, -7682, -7686, -7677, -7682, -7680, -7682, -7680, -7686, -7684, -7680, -7682,
+            -7680, -7679, -7682, -7679, -7680, -7676, -7680, -7674, -7679, -7677, -7682, -7680,
+            -7684, -7682, -7679, -7679, -7680, -7679, -7685, -7677, -7679, -7682, -7685, -7679,
+            -7679, -7680, -7677, -7682, -7680, -7675, -7676, -7672, -7676, -7680, -7684, -7675,
+            -7686, -7677, -7682, -7682,
+        ];
+        assert_eq!(&data[1722..1722 + 64], &line1);
+        #[rustfmt::skip]
+        let line2 = [
+            -7680, -7677, -7679, -7680, -7675, -7680, -7680, -7684, -7685, -7675, -7684, -7680,
+            -7680, -7676, -7682, -7686,
+        ];
+        assert_eq!(&data[2 * 1722..2 * 1722 + 16], &line2);
+
+        // K after each of the first 64 symbols of lines 0 and 1. Line
+        // 0 spends exactly one symbol a column, so line 1's start at
+        // 1722, and K carries across the boundary rather than
+        // resetting.
+        #[rustfmt::skip]
+        let k0 = [
+            2u32, 3, 3, 2, 2, 1, 1, 1, 2, 1, 1, 1, 2, 2, 1, 2, 1, 1, 0, 0, 2, 2, 2, 2,
+            3, 3, 3, 2, 2, 2, 2, 2, 3, 2, 2, 2, 2, 2, 1, 0, 0, 0, 1, 2, 2, 2, 2, 1,
+            1, 1, 2, 1, 1, 0, 1, 3, 3, 3, 2, 3, 3, 3, 2, 1,
+        ];
+        assert_eq!(&trace.k[..64], &k0);
+        #[rustfmt::skip]
+        let k1 = [
+            3u32, 3, 2, 1, 1, 2, 2, 2, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+            3, 3, 2, 2, 2, 3, 3, 3, 3, 3, 3, 2, 2, 1, 1, 0, 0, 1, 2, 2, 2, 2, 2, 2,
+            1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+        ];
+        assert_eq!(&trace.k[1722..1722 + 64], &k1);
+
+        // Where run mode engages, as (column, length, state before,
+        // after). Line 0 has exactly one — the flag at column 0 — and
+        // line 1's first sixteen are these.
+        let runs: Vec<_> = trace.runs.iter().filter(|r| r.0 == 0).collect();
+        assert_eq!(runs.len(), 1);
+        assert_eq!((runs[0].1, runs[0].2), (0, 0));
+        let line1_runs: Vec<(usize, usize, usize, usize)> = trace
+            .runs
+            .iter()
+            .filter(|r| r.0 == 1)
+            .map(|r| (r.1, r.2, r.3, r.4))
+            .collect();
+        assert_eq!(
+            &line1_runs[..16],
+            &[
+                (52, 0, 0, 0),
+                (213, 2, 0, 0),
+                (216, 0, 0, 0),
+                (238, 0, 0, 0),
+                (250, 1, 0, 0),
+                (259, 0, 0, 0),
+                (275, 0, 0, 0),
+                (279, 0, 0, 0),
+                (305, 0, 0, 0),
+                (311, 1, 0, 0),
+                (387, 3, 0, 1),
+                (417, 0, 1, 1),
+                (504, 0, 1, 1),
+                (567, 1, 1, 0),
+                (631, 0, 0, 0),
+                (657, 0, 0, 0),
+            ]
+        );
+        assert_eq!(line1_runs.len(), 41);
+        assert_eq!(trace.runs.iter().filter(|r| r.0 == 2).count(), 45);
+        // Three lines is not the whole band, so it has not been
+        // consumed yet.
+        assert!(!exact);
+
+        // The whole band, which must land exactly on its last byte.
+        let (data, shape, _, exact) = one_band(&header, sample, 0, 0, 0, None);
+        assert!(exact, "the band did not end on its last byte");
+        assert_eq!(data.len(), shape.width * shape.height);
+    }
+
+    #[test]
+    fn eos_r_craw_bands_match_the_reference() {
+        let Some(bytes) = corpus_file("Canon_EOS_R_CRAW_ISO_100.CR3") else {
+            return;
+        };
+        let (header, sample) = raw_stream(&bytes).expect("a raw track");
+        assert_eq!((header.version, header.levels), (0x0100, 3));
+        let tiles = parse_tiles(&header, sample).unwrap();
+        // Every band of tile 0 component 0, with its declared
+        // bitstream length and its first sixteen dequantised
+        // coefficients.
+        #[rustfmt::skip]
+        let want: [(usize, [i32; 16]); 10] = [
+            (59543,  [-7680, -7678, -7680, -7677, -7680, -7680, -7680, -7678, -7680, -7677, -7678, -7679, -7679, -7678, -7678, -7677]),
+            (53927,  [2, 1, -2, -2, 2, 3, -2, 0, 0, -2, 1, 0, 1, -3, -2, 0]),
+            (46812,  [0, 1, 0, 0, 0, -2, 2, 2, 0, 3, 0, 1, 0, 0, 2, 2]),
+            (51876,  [1, 2, 5, 5, 1, 0, -2, 0, 1, -6, -2, 1, 3, 1, -6, -3]),
+            (136810, [0, 4, 0, 0, 0, 4, 4, 0, -4, -4, -4, -4, 4, 0, 0, 4]),
+            (121881, [0, 0, -4, 0, 0, 4, 0, 0, 0, 0, 4, 0, -4, 0, 0, 0]),
+            (112121, [0, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 0, 0]),
+            (330553, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+            (315674, [0, 0, 0, 0, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 12]),
+            (238244, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]),
+        ];
+        let steps = [1, 1, 1, 1, 4, 4, 8, 12, 12, 25];
+        for (index, (length, head)) in want.iter().enumerate() {
+            let band = &tiles[0].planes[0].bands[index];
+            assert_eq!(
+                band.bitstream(sample).len(),
+                *length,
+                "band {index} bitstream length"
+            );
+            assert_eq!(step_of(band.q_param), steps[index], "band {index} step");
+            let (data, _, _, exact) = one_band(&header, sample, 0, 0, index, None);
+            assert_eq!(&data[..16], head, "band {index} line 0");
+            assert!(exact, "band {index} did not end on its last byte");
+            // Every detail coefficient is a multiple of the step it
+            // was quantised with.
+            if index > 0 {
+                assert!(data.iter().all(|c| c % steps[index] == 0));
+            }
+        }
+        // Band 9's line 0 is one run of 862 zeros.
+        let (_, shape, trace, _) = one_band(&header, sample, 0, 0, 9, Some(1));
+        assert_eq!(shape.width, 862);
+        assert_eq!(trace.runs.len(), 1);
+        assert_eq!(trace.runs[0].2, 862);
+        // Band 1's line 0 opens with a zero-length run and the biased
+        // symbol that follows one, then a run of one at column 8.
+        let (data, _, trace, _) = one_band(&header, sample, 0, 0, 1, Some(1));
+        assert_eq!(data[0], 2);
+        assert_eq!((trace.runs[0].1, trace.runs[0].2), (0, 0));
+        assert_eq!((trace.runs[1].1, trace.runs[1].2), (8, 1));
+    }
+
+    #[test]
+    fn eos_r_craw_inverse_wavelet_matches_the_reference() {
+        let Some(bytes) = corpus_file("Canon_EOS_R_CRAW_ISO_100.CR3") else {
+            return;
+        };
+        let (header, sample) = raw_stream(&bytes).expect("a raw track");
+        let tiles = parse_tiles(&header, sample).unwrap();
+        let tile = &tiles[0];
+        let shapes = band_shapes(header.levels, tile.width, tile.height, tile.neighbours);
+        let data = decode_component(sample, &header, tile, &tile.planes[0], &shapes, None).unwrap();
+        assert_eq!(data.len(), 1722 * 2273);
+        #[rustfmt::skip]
+        let want = [
+            [-7681, -7681, -7680, -7679, -7678, -7678, -7678, -7678, -7677, -7678, -7679, -7680, -7680, -7680, -7680, -7683],
+            [-7681, -7682, -7681, -7681, -7680, -7679, -7677, -7679, -7681, -7681, -7681, -7681, -7680, -7681, -7681, -7678],
+            [-7681, -7682, -7682, -7682, -7681, -7679, -7676, -7680, -7684, -7683, -7682, -7681, -7680, -7681, -7681, -7684],
+            [-7681, -7682, -7682, -7682, -7681, -7680, -7679, -7681, -7683, -7677, -7682, -7681, -7680, -7681, -7681, -7678],
+        ];
+        for (row, want) in want.iter().enumerate() {
+            assert_eq!(&data[row * 1722..row * 1722 + 16], want, "row {row}");
+        }
+    }
+
+    #[test]
+    fn the_first_frame_rows_of_both_eos_r_qualities() {
+        // The level shift and the interleave back onto the Bayer
+        // grid: even columns of even rows are component 0, odd
+        // columns of even rows component 1, and so on.
+        #[rustfmt::skip]
+        let cases: [(&str, [[u16; 16]; 4]); 2] = [
+            ("Canon/EOS_R-RAW_ISO_100.CR3", [
+                [508, 514, 515, 512, 512, 510, 512, 512, 513, 513, 512, 510, 513, 513, 510, 512],
+                [510, 512, 508, 508, 512, 510, 512, 512, 514, 515, 509, 512, 515, 510, 514, 515],
+                [516, 505, 510, 513, 508, 514, 508, 513, 508, 510, 513, 508, 516, 512, 512, 510],
+                [509, 513, 515, 512, 512, 515, 512, 512, 514, 513, 512, 512, 515, 508, 507, 515],
+            ]),
+            ("Canon_EOS_R_CRAW_ISO_100.CR3", [
+                [511, 511, 511, 511, 512, 511, 513, 511, 514, 511, 514, 511, 514, 512, 514, 512],
+                [510, 514, 512, 512, 515, 511, 514, 510, 513, 509, 512, 512, 512, 516, 512, 515],
+                [511, 512, 510, 512, 511, 512, 511, 511, 512, 511, 513, 511, 515, 511, 513, 511],
+                [513, 514, 513, 512, 513, 511, 513, 511, 514, 511, 513, 511, 513, 512, 513, 512],
+            ]),
+        ];
+        for (name, want) in cases {
+            let Some(bytes) = corpus_file(name) else {
+                return;
+            };
+            let (header, sample) = raw_stream(&bytes).expect("a raw track");
+            let frame = decode(&header, sample).unwrap();
+            assert_eq!(frame.len(), header.width * header.height);
+            for (row, want) in want.iter().enumerate() {
+                assert_eq!(
+                    &frame[row * header.width..row * header.width + 16],
+                    want,
+                    "{name} row {row}"
+                );
+            }
+        }
+    }
 
     /// Every CMP1 in the corpus, with the sample its track points at.
     #[test]
@@ -566,48 +2884,7 @@ mod tests {
                 .unwrap_or(&path)
                 .display()
                 .to_string();
-            let Ok(boxes) = crate::bmff::parse(&bytes) else {
-                problems.push(format!("{name}: does not parse"));
-                continue;
-            };
-            for trak in boxes
-                .iter()
-                .filter(|b| &b.kind == b"moov")
-                .flat_map(|m| m.children.iter())
-                .filter(|b| &b.kind == b"trak")
-            {
-                let Some(stbl) = trak.find_all(b"stbl").into_iter().next() else {
-                    continue;
-                };
-                let Some(entry) = stbl.child(b"stsd").and_then(|s| s.children.first()) else {
-                    continue;
-                };
-                let Some(cmp1) = entry.child(b"CMP1") else {
-                    continue;
-                };
-                let header = match ImageHeader::parse(&bytes[cmp1.data.clone()]) {
-                    Ok(header) => header,
-                    Err(e) => {
-                        problems.push(format!("{name}: CMP1: {e}"));
-                        continue;
-                    }
-                };
-                // The sample entry's own VisualSampleEntry width and
-                // height are the frame on the EOS R generation and
-                // the crop on the R5 and later, so they only bound
-                // CMP1's rather than matching it — enough to catch a
-                // field read at the wrong offset.
-                let visual = &bytes[entry.data.clone()];
-                let dim = |at: usize| u16::from_be_bytes([visual[at], visual[at + 1]]) as usize;
-                if dim(24) > header.width || dim(26) > header.height || dim(24) * 2 < header.width {
-                    problems.push(format!(
-                        "{name}: CMP1 {}x{}, sample entry {}x{}",
-                        header.width,
-                        header.height,
-                        dim(24),
-                        dim(26)
-                    ));
-                }
+            for (header, sample) in streams(&bytes) {
                 if header.planes != 4 || header.bits != 14 {
                     problems.push(format!(
                         "{name}: {} planes of {} bits",
@@ -615,26 +2892,22 @@ mod tests {
                     ));
                 }
                 seen.insert(format!(
-                    "v{} levels {} tiles {:?} cfa {}",
+                    "v{:#06x} levels {} enc {} tiles {:?} cfa {}",
                     header.version,
                     header.levels,
+                    header.enc_type,
                     header.tile_grid(),
                     header.cfa_layout
                 ));
-                // Find this track's single sample and check the tree.
-                let Some(sample) = sample_of(&bytes, stbl) else {
-                    problems.push(format!("{name}: no sample table"));
-                    continue;
-                };
                 match parse_tiles(&header, sample) {
                     Err(e) => {
                         problems.push(format!("{name}: {}x{}: {e}", header.width, header.height))
                     }
                     Ok(tiles) => {
                         checked += 1;
-                        // Tiles must fill the sample after the header,
-                        // planes must fill their tile and bands their
-                        // plane, with nothing left over.
+                        // Tiles must fill the sample after the index,
+                        // components must fill their tile and bands
+                        // their component, with nothing left over.
                         let mut at = header.mdat_header_size;
                         for tile in &tiles {
                             if tile.data.start != at {
@@ -642,11 +2915,11 @@ mod tests {
                                     .push(format!("{name}: tile at {} not {at}", tile.data.start));
                             }
                             at = tile.data.end;
-                            let mut plane_at = tile.data.start + tile.qp_table_size;
+                            let mut plane_at = tile.data.start + tile.qp_size + tile.extra_size;
                             for plane in &tile.planes {
                                 if plane.data.start != plane_at {
                                     problems.push(format!(
-                                        "{name}: plane at {} not {plane_at}",
+                                        "{name}: component at {} not {plane_at}",
                                         plane.data.start
                                     ));
                                 }
@@ -668,11 +2941,23 @@ mod tests {
                                     ));
                                 }
                             }
-                            // A version-2 tile pads its end to a word
-                            // or two; a version-1 one is exact.
-                            let slack = tile.data.end - plane_at;
-                            if slack > if header.version >= 2 { 7 } else { 0 } {
-                                problems.push(format!("{name}: planes leave {slack} bytes"));
+                            if plane_at != tile.data.end {
+                                problems.push(format!(
+                                    "{name}: components leave {} bytes",
+                                    tile.data.end - plane_at
+                                ));
+                            }
+                            let shapes = band_shapes(
+                                header.levels,
+                                tile.width,
+                                tile.height,
+                                tile.neighbours,
+                            );
+                            if shapes.len() != header.bands() {
+                                problems.push(format!("{name}: {} shapes", shapes.len()));
+                            }
+                            if shapes.iter().any(|s| s.width == 0 || s.height == 0) {
+                                problems.push(format!("{name}: an empty band shape"));
                             }
                         }
                         if at != sample.len() {
@@ -685,7 +2970,7 @@ mod tests {
                             .iter()
                             .flat_map(|t| &t.planes)
                             .flat_map(|p| &p.bands)
-                            .all(|b| b.q_step == 32);
+                            .all(|b| b.q_param == 4);
                         if header.levels == 0 && !unit {
                             problems.push(format!("{name}: a lossless band with a quantiser"));
                         }
@@ -705,24 +2990,60 @@ mod tests {
         }
     }
 
-    /// The first sample of a track, from `stsz` and `co64`/`stco`.
-    fn sample_of<'a>(bytes: &'a [u8], stbl: &crate::bmff::Box_) -> Option<&'a [u8]> {
-        let stsz = bytes.get(stbl.child(b"stsz")?.data.clone())?;
-        let be = |b: &[u8], at: usize| -> Option<usize> {
-            Some(u32::from_be_bytes(b.get(at..at + 4)?.try_into().ok()?) as usize)
+    /// Every band of every corpus CR3 must be consumed to its last
+    /// byte — the strongest single check that the entropy coder is
+    /// right, because a stream that is decoded wrongly almost never
+    /// lands on the end.
+    #[test]
+    fn corpus_crx_bands_are_consumed_exactly() {
+        let Some(root) = crate::tiff::tests::corpus() else {
+            return;
         };
-        let size = match be(stsz, 4)? {
-            0 => be(stsz, 12)?,
-            uniform => uniform,
-        };
-        let offset = match (stbl.child(b"co64"), stbl.child(b"stco")) {
-            (Some(co64), _) => {
-                let p = bytes.get(co64.data.clone())?;
-                usize::try_from(u64::from_be_bytes(p.get(8..16)?.try_into().ok()?)).ok()?
+        let mut problems: Vec<String> = Vec::new();
+        for path in crate::tiff::tests::samples(&root) {
+            if path
+                .extension()
+                .map(|e| e.to_string_lossy().to_ascii_uppercase())
+                != Some("CR3".into())
+            {
+                continue;
             }
-            (None, Some(stco)) => be(bytes.get(stco.data.clone())?, 8)?,
-            (None, None) => return None,
-        };
-        bytes.get(offset..offset.checked_add(size)?)
+            let Ok(bytes) = std::fs::read(&path) else {
+                continue;
+            };
+            let name = path
+                .strip_prefix(&root)
+                .unwrap_or(&path)
+                .display()
+                .to_string();
+            let Some((header, sample)) = raw_stream(&bytes) else {
+                continue;
+            };
+            if header.enc_type != 0 {
+                continue;
+            }
+            let Ok(tiles) = parse_tiles(&header, sample) else {
+                continue;
+            };
+            for (t, tile) in tiles.iter().enumerate() {
+                for (p, plane) in tile.planes.iter().enumerate() {
+                    for (b, band) in plane.bands.iter().enumerate() {
+                        let (_, _, _, exact) = one_band(&header, sample, t, p, b, None);
+                        if !exact {
+                            problems.push(format!(
+                                "{name}: tile {t} component {p} band {b} ({} bytes)",
+                                band.bitstream(sample).len()
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            problems.is_empty(),
+            "{} bands not consumed exactly:\n{}",
+            problems.len(),
+            problems.join("\n")
+        );
     }
 }

--- a/crates/codec-raw/src/formats/iiq.rs
+++ b/crates/codec-raw/src/formats/iiq.rs
@@ -27,10 +27,13 @@
 //!    little-endian words — the same reader Hasselblad's lossless
 //!    JPEG needs, which is no coincidence: the two formats share an
 //!    ancestor.
-//!  * **5** and **6** — "IIQ S", lossy. Neither is a
-//!    predictor-plus-residual code (the samples land on a coarse,
-//!    non-linear grid that no arrangement of the format-3 machinery
-//!    reproduces), and this module does not decode them.
+//!  * **5** — "IIQ S": format 3's bit stream exactly, carrying an
+//!    eight-bit companded signal that a square law expands back to
+//!    fourteen bits. See [`COMPANDING_DIVISOR`].
+//!  * **6** — the other "IIQ S", and a different codec altogether:
+//!    eight-pixel blocks, each with a per-parity range code and a
+//!    per-block precision, over two parity predictors. See
+//!    [`decode_row_format6`].
 //!
 //! The 14-bit formats are shifted up by two on the way out, so that
 //! every Phase One frame — 16-bit raster or compressed — shares one
@@ -68,6 +71,8 @@ mod p1 {
     /// One `u32` a row: where that row's bits start, counted from the
     /// beginning of the sensor data.
     pub const ROW_OFFSETS: u32 = 0x021C;
+    /// A global black offset. Only the white level is derived from it.
+    pub const T_BLACK: u32 = 0x021D;
     /// The back's name and firmware, ASCII.
     pub const MODEL_FIRMWARE: u32 = 0x0301;
 }
@@ -183,7 +188,7 @@ impl<'a> Directory<'a> {
 /// the difference length in force for each; both are per row, because
 /// every row starts at its own offset in the table and its own bit
 /// boundary.
-fn decode_row(bytes: &[u8], out: &mut [u16]) {
+fn decode_row(bytes: &[u8], out: &mut [u16], expand: Option<&[u16; 256]>) {
     let width = out.len();
     let mut pump = BitPumpMsb32::new(bytes);
     let mut pred = [0i32; 2];
@@ -219,14 +224,30 @@ fn decode_row(bytes: &[u8], out: &mut [u16]) {
             let value = pump.get(bits) as i32;
             pred[parity] += value + 1 - (1 << (bits - 1));
         }
+        let value = pred[parity].clamp(0, 0x3FFF);
+        // Format 5 rides on this stream but carries an eight-bit
+        // signal: everything below 256 is a companded code and comes
+        // back through the square law, and the handful of samples
+        // above it are highlights the predictor ran past.
+        let value = match expand {
+            Some(table) if value < 256 => table[value as usize] as i32,
+            _ => value,
+        };
         // 14-bit samples, shifted to share the 16-bit raster's scale.
-        *sample = (pred[parity].clamp(0, 0x3FFF) as u16) << 2;
+        *sample = (value as u16) << 2;
     }
 }
 
-/// IIQ L: one independent bit stream a row, found through the
-/// row-offset table.
-fn decompress(data: &[u8], offsets: &[u8], width: usize, height: usize) -> Result<Vec<u16>> {
+/// IIQ L and format 5: one independent bit stream a row, found
+/// through the row-offset table. `expand` is the format-5 companding
+/// table, or `None` for format 3.
+fn decompress(
+    data: &[u8],
+    offsets: &[u8],
+    width: usize,
+    height: usize,
+    expand: Option<&[u16; 256]>,
+) -> Result<Vec<u16>> {
     if offsets.len() < height * 4 {
         return Err(Error::Corrupt(format!(
             "Phase One row table holds {} bytes for {height} rows",
@@ -257,7 +278,219 @@ fn decompress(data: &[u8], offsets: &[u8], width: usize, height: usize) -> Resul
             // still worth having, and the bit reader would only see
             // zeros anyway.
             if let Some(bits) = data.get(start..) {
-                decode_row(bits, line);
+                decode_row(bits, line, expand);
+            }
+        });
+    Ok(out)
+}
+
+// ------------------------------------------------------------ format 5
+
+/// The divisor of format 5's square companding law.
+///
+/// A stored sample `v` under 256 stands for `round(v * v / 3.969)`.
+/// The constant is chosen so that `v` = 255 lands exactly on 16383:
+/// the whole eight-bit stored range maps onto the whole fourteen-bit
+/// sample range with fine steps in the shadows and coarse ones in the
+/// highlights. That is the entire lossy part of format 5 — the bit
+/// stream itself is format 3's, and lossless.
+const COMPANDING_DIVISOR: f32 = 3.969;
+
+/// The 256-entry expansion of [`COMPANDING_DIVISOR`], built in 32-bit
+/// float because that is the arithmetic the constant was fitted in.
+fn companding_table() -> [u16; 256] {
+    std::array::from_fn(|v| {
+        let v = v as f32;
+        (v * v / COMPANDING_DIVISOR + 0.5) as u16
+    })
+}
+
+// ------------------------------------------------------------ format 6
+
+/// Pixels to a block of format 6.
+const BLOCK6: usize = 8;
+/// The range code that means "every pixel of this parity in this block
+/// is a raw fourteen-bit absolute value".
+const ESCAPE6: i32 = 9;
+/// Bits of an absolute format-6 sample, and of the tail pixels.
+const ABSOLUTE6: u32 = 14;
+/// The reference's per-row read buffer, and so the most bytes of a row
+/// any decoder of this format will look at.
+fn max_row_bytes(width: usize) -> usize {
+    width * 3 + 2
+}
+
+/// Where each row's bytes are, derived from the row-offset table.
+///
+/// The table is not sorted. On a back that reads its two sensor halves
+/// out in opposite directions — the iXU180 rises to `split_row` and
+/// then falls — a decoder that took "the next entry minus this one" as
+/// the row's length would get negative numbers for half the frame.
+/// Sorting the offsets and taking the gap to the next one in *file*
+/// order is what actually bounds a row.
+fn row_extents(offsets: &[u8], data_len: usize, height: usize) -> Result<Vec<(usize, usize)>> {
+    if offsets.len() < height * 4 {
+        return Err(Error::Corrupt(format!(
+            "Phase One row table holds {} bytes for {height} rows",
+            offsets.len()
+        )));
+    }
+    let starts: Vec<usize> = offsets[..height * 4]
+        .as_chunks::<4>()
+        .0
+        .iter()
+        .map(|b| u32::from_le_bytes(*b) as usize)
+        .collect();
+    let mut order: Vec<usize> = (0..height).collect();
+    order.sort_by_key(|row| starts[*row]);
+    let mut out = vec![(0usize, 0usize); height];
+    for (i, row) in order.iter().enumerate() {
+        let start = starts[*row].min(data_len);
+        let next = order
+            .get(i + 1)
+            .map_or(data_len, |r| starts[*r])
+            .min(data_len);
+        out[*row] = (start, next.saturating_sub(start));
+    }
+    Ok(out)
+}
+
+/// The variable-length code that follows a `00` range prefix, giving
+/// the parity's range outright rather than a step. Four to five bits,
+/// and the values are in no useful order — it is a hand-built code,
+/// not a canonical one.
+fn absolute_range(pump: &mut impl BitPump) -> i32 {
+    let peek = pump.peek(5);
+    let (value, length) = if peek & 0b1_0000 != 0 {
+        // 10 -> 3, 11 -> 2
+        (if peek & 0b0_1000 != 0 { 2 } else { 3 }, 2)
+    } else if peek & 0b0_1000 != 0 {
+        // 010 -> 1, 011 -> 4
+        (if peek & 0b0_0100 != 0 { 4 } else { 1 }, 3)
+    } else if peek & 0b0_0100 != 0 {
+        // 0010 -> 6, 0011 -> 5
+        (if peek & 0b0_0010 != 0 { 5 } else { 6 }, 4)
+    } else {
+        // 00000 -> 9, 00001 -> 8, 00010 -> 0, 00011 -> 7
+        (
+            match peek & 0b11 {
+                0 => 9,
+                1 => 8,
+                2 => 0,
+                _ => 7,
+            },
+            5,
+        )
+    };
+    pump.consume(length);
+    value
+}
+
+/// One row of a format-6 stream.
+///
+/// A row opens with sixteen bits of header, of which only the low
+/// three are used: they give `init_bits`, the number of bits a
+/// difference is transmitted in before any per-block extension.
+///
+/// The row is then blocks of eight pixels. Each block carries a range
+/// code for each column parity — a two-bit step against the previous
+/// block's range, or an escape into an explicit value — and one
+/// precision extension shared by both parities. Together those say how
+/// many bits a difference is sent in (`take`), how many low bits of it
+/// were thrown away (`shift`, the lossy step) and what to subtract to
+/// re-centre it on zero (`bias`). A range of nine is the escape: every
+/// pixel of that parity is a plain fourteen-bit sample instead.
+///
+/// Whatever is left after the last whole block — four pixels on the
+/// iXU180 — is a run of plain fourteen-bit samples that update nothing.
+fn decode_row_format6(bytes: &[u8], out: &mut [u16]) {
+    let width = out.len();
+    if width < BLOCK6 {
+        return;
+    }
+    let mut pump = BitPumpMsb32::new(bytes);
+    let init_bits = (pump.get(16) & 7) as i32;
+    let blocks = ((width - BLOCK6) >> 3) + 1;
+    // Both predictors and both ranges run the length of the row and
+    // reset at its start.
+    let mut previous = [0i32; 2];
+    let mut range = [0i32; 2];
+    let store = |sample: &mut u16, value: i32| {
+        *sample = ((value as i64) << 2).clamp(0, u16::MAX as i64) as u16;
+    };
+    for block in 0..blocks {
+        for side in range.iter_mut() {
+            match pump.get(2) {
+                0b01 => *side -= 1,
+                0b10 => {}
+                0b11 => *side += 1,
+                _ => *side = absolute_range(&mut pump),
+            }
+        }
+        // The relative steps are unbounded — nothing stops a row from
+        // walking its range past 9 or below 0 — so only the
+        // arithmetic below is bounded, and a nonsensical range costs
+        // that row its samples rather than the frame.
+        let extra = if pump.get(1) == 1 {
+            0
+        } else {
+            1 + pump.get(2) as i32
+        };
+        // At most 7 + 4 bits: `init_bits` is three bits wide and the
+        // extension reaches four.
+        let take = (init_bits + extra) as u32;
+        // A range narrower than the precision extension asks for a
+        // negative quantiser, which cannot be meant. It happens on the
+        // IQ140 samples, always with a transmitted value of zero, so
+        // what it should do is unobservable; treating it as no shift
+        // at all is what those frames confirm.
+        let shift: [u32; 2] =
+            std::array::from_fn(|p| range[p].saturating_sub(extra).clamp(0, 24) as u32);
+        let bias: [i32; 2] =
+            std::array::from_fn(|p| (1i32 << (init_bits + range[p] - 1).clamp(0, 30)) - 1);
+        for i in 0..BLOCK6 {
+            let side = i & 1;
+            let value = if range[side] == ESCAPE6 {
+                pump.get(ABSOLUTE6) as i32
+            } else {
+                previous[side]
+                    .wrapping_add((pump.get(take) as i32) << shift[side])
+                    .wrapping_sub(bias[side])
+            };
+            // The predictor keeps the value unshifted and unclamped;
+            // only what goes into the frame is scaled and clipped.
+            previous[side] = value;
+            if let Some(sample) = out.get_mut(block * BLOCK6 + i) {
+                store(sample, value);
+            }
+        }
+    }
+    for sample in out[blocks * BLOCK6..].iter_mut() {
+        let value = pump.get(ABSOLUTE6) as i32;
+        store(sample, value);
+    }
+}
+
+/// Format 6: one independent bit stream a row, bounded by the sorted
+/// row-offset table.
+fn decompress_format6(
+    data: &[u8],
+    offsets: &[u8],
+    width: usize,
+    height: usize,
+) -> Result<Vec<u16>> {
+    let samples = crate::frame_samples(width, height, 1)?;
+    let extents = row_extents(offsets, data.len(), height)?;
+    let cap = max_row_bytes(width);
+    let mut out = vec![0u16; samples];
+    out.par_chunks_exact_mut(width)
+        .zip(extents.par_iter())
+        .for_each(|(line, (start, len))| {
+            // A row longer than the reference's own read buffer is
+            // read only as far as that buffer goes, which is what
+            // keeps a mis-sorted table from reading a whole frame.
+            if let Some(bits) = data.get(*start..*start + (*len).min(cap)) {
+                decode_row_format6(bits, line);
             }
         });
     Ok(out)
@@ -301,24 +534,39 @@ pub fn decode(bytes: &[u8]) -> Result<RawImage> {
     let data = &data[..(raw.length as usize).min(data.len())];
 
     let format = dir.int(p1::FORMAT).unwrap_or(0);
+    // Every compressed format carries 14-bit samples shifted up by
+    // two, so the largest one a row can hold is 0xFFFC; tag 0x021D is
+    // a global offset already inside them. (The reference leaves
+    // format 6 at a flat 0xFFFF, which looks like an oversight rather
+    // than a difference between the codecs, and nothing in the
+    // unpacked frame depends on it.)
+    let compressed_white = 65532.0 - dir.int(p1::T_BLACK).unwrap_or(0) as f32;
     let (samples, white) = match format {
         0 => (unpack(data, width, height)?, 65535.0),
-        3 => {
-            let offsets = dir
-                .blob(p1::ROW_OFFSETS)
-                .ok_or_else(|| Error::Corrupt("IIQ L with no row-offset table".into()))?;
-            // 14 bits shifted up by two: the largest sample a row can
-            // carry is 0x3FFF, so saturation lands here.
-            (decompress(data, offsets, width, height)?, 65532.0)
-        }
-        5 | 6 => {
-            return Err(Error::Unsupported(
-                "Phase One IIQ S (compression 5 and 6): a lossy code this decoder cannot read"
-                    .into(),
-            ))
+        3 | 5 | 6 => {
+            let offsets = dir.blob(p1::ROW_OFFSETS).ok_or_else(|| {
+                Error::Corrupt(format!(
+                    "Phase One format {format} with no row-offset table"
+                ))
+            })?;
+            let samples = match format {
+                6 => decompress_format6(data, offsets, width, height)?,
+                5 => {
+                    let table = companding_table();
+                    decompress(data, offsets, width, height, Some(&table))?
+                }
+                _ => decompress(data, offsets, width, height, None)?,
+            };
+            (samples, compressed_white)
         }
         other => return Err(Error::Unsupported(format!("Phase One compression {other}"))),
     };
+    if white <= 0.0 {
+        return Err(Error::Corrupt(format!(
+            "Phase One black offset {} leaves no range",
+            dir.int(p1::T_BLACK).unwrap_or(0)
+        )));
+    }
 
     // The crop's top-left is where the sensor's active area begins,
     // and that area always reads RGGB; the masked border in front of
@@ -384,20 +632,8 @@ mod tests {
 
     /// Files whose compression this module knowingly declines, with
     /// the reason. Everything else in the corpus must decode.
-    const UNSUPPORTED: &[(&str, &str)] = &[
-        ("H_25-H25_Outdoor_.IIQ", "IIQ S, compression 5"),
-        ("P25+-CF028662.IIQ", "IIQ S, compression 5"),
-        ("P45-230215_3810.TIF", "IIQ S, compression 5"),
-        (
-            "IQ140-Phase_One_IQ140_sample_files_04_Diciembre_2017_005_IIQ_S.TIF",
-            "IIQ S, compression 6",
-        ),
-        (
-            "IQ140-Phase_One_IQ140_sample_files_04_Diciembre_2017_011_Sensor+_IIQ_S.TIF",
-            "IIQ S, compression 6",
-        ),
-        ("iXU180-cap_22908.IIQ", "IIQ S, compression 6"),
-    ];
+    /// Empty: every Phase One compression in the corpus decodes.
+    const UNSUPPORTED: &[(&str, &str)] = &[];
 
     /// A Phase One structure around one directory, for the tests that
     /// do not need a whole file.
@@ -501,7 +737,7 @@ mod tests {
         }
         let bytes = writer.finish();
         let mut out = vec![0u16; 8];
-        decode_row(&bytes, &mut out);
+        decode_row(&bytes, &mut out, None);
         assert_eq!(
             out,
             vec![
@@ -533,7 +769,7 @@ mod tests {
         }
         let bytes = writer.finish();
         let mut out = vec![0u16; 16];
-        decode_row(&bytes, &mut out);
+        decode_row(&bytes, &mut out, None);
         // Each parity climbs by one a step, right through the second
         // group's "keep" selectors.
         let want: Vec<u16> = (0..16).map(|i| ((i / 2 + 1) << 2) as u16).collect();
@@ -554,14 +790,14 @@ mod tests {
         writer.put(4001, 16);
         let bytes = writer.finish();
         let mut out = vec![0u16; 10];
-        decode_row(&bytes, &mut out);
+        decode_row(&bytes, &mut out, None);
         assert_eq!(&out[8..], &[4000 << 2, 4001 << 2]);
     }
 
     #[test]
     fn a_short_row_table_is_corrupt() {
         assert!(matches!(
-            decompress(&[0; 64], &[0; 4], 8, 4),
+            decompress(&[0; 64], &[0; 4], 8, 4, None),
             Err(Error::Corrupt(_))
         ));
     }
@@ -572,7 +808,7 @@ mod tests {
         let mut offsets = Vec::new();
         offsets.extend_from_slice(&0u32.to_le_bytes());
         offsets.extend_from_slice(&u32::MAX.to_le_bytes());
-        let out = decompress(&[0; 64], &offsets, 8, 2).unwrap();
+        let out = decompress(&[0; 64], &offsets, 8, 2, None).unwrap();
         assert_eq!(&out[8..], &[0; 8]);
     }
 
@@ -584,6 +820,269 @@ mod tests {
             let bytes = build(&[(p1::RAW_WIDTH, 4, 8), (p1::RAW_HEIGHT, 4, 8)], &[]);
             let _ = decode(&bytes[..cut.min(bytes.len())]);
         }
+    }
+
+    // ------------------------------------------------- formats 5 and 6
+
+    /// A corpus file by name.
+    fn sample(name: &str) -> Option<Vec<u8>> {
+        let path = corpus::files(&["iiq", "tif"])
+            .into_iter()
+            .find(|p| corpus::name(p) == name)?;
+        std::fs::read(path).ok()
+    }
+
+    /// The sensor data and the row-offset table of a corpus file.
+    fn sensor(bytes: &[u8]) -> (&[u8], &[u8], usize, usize) {
+        let dir = Directory::parse(bytes).expect("Phase One directory");
+        let raw = dir.entry(p1::RAW_DATA).expect("sensor data");
+        let start = raw.value as usize + BASE;
+        let data = &bytes[start..start + raw.length as usize];
+        let offsets = dir.blob(p1::ROW_OFFSETS).expect("row table");
+        let width = dir.int(p1::RAW_WIDTH).unwrap_or(0) as usize;
+        let height = dir.int(p1::RAW_HEIGHT).unwrap_or(0) as usize;
+        (data, offsets, width, height)
+    }
+
+    /// The square companding law, against the table it must produce.
+    ///
+    /// The divisor is an empirical constant whose only justification
+    /// is that it lands `expand[255]` exactly on 16383, so the table
+    /// is the specification and the formula only a way of writing it.
+    #[test]
+    fn the_companding_law_reproduces_its_table() {
+        const EXPAND: [u16; 256] = [
+            0, 0, 1, 2, 4, 6, 9, 12, 16, 20, 25, 30, 36, 43, 49, 57, 64, 73, 82, 91, 101, 111, 122,
+            133, 145, 157, 170, 184, 198, 212, 227, 242, 258, 274, 291, 309, 327, 345, 364, 383,
+            403, 424, 444, 466, 488, 510, 533, 557, 580, 605, 630, 655, 681, 708, 735, 762, 790,
+            819, 848, 877, 907, 938, 969, 1000, 1032, 1064, 1098, 1131, 1165, 1200, 1235, 1270,
+            1306, 1343, 1380, 1417, 1455, 1494, 1533, 1572, 1612, 1653, 1694, 1736, 1778, 1820,
+            1863, 1907, 1951, 1996, 2041, 2086, 2133, 2179, 2226, 2274, 2322, 2371, 2420, 2469,
+            2520, 2570, 2621, 2673, 2725, 2778, 2831, 2885, 2939, 2993, 3049, 3104, 3160, 3217,
+            3274, 3332, 3390, 3449, 3508, 3568, 3628, 3689, 3750, 3812, 3874, 3937, 4000, 4064,
+            4128, 4193, 4258, 4324, 4390, 4457, 4524, 4592, 4660, 4729, 4798, 4868, 4938, 5009,
+            5080, 5152, 5224, 5297, 5371, 5444, 5519, 5594, 5669, 5745, 5821, 5898, 5975, 6053,
+            6132, 6210, 6290, 6370, 6450, 6531, 6612, 6694, 6777, 6859, 6943, 7027, 7111, 7196,
+            7281, 7367, 7454, 7541, 7628, 7716, 7804, 7893, 7983, 8073, 8163, 8254, 8346, 8438,
+            8530, 8623, 8717, 8811, 8905, 9000, 9095, 9191, 9288, 9385, 9482, 9580, 9679, 9778,
+            9878, 9978, 10078, 10179, 10281, 10383, 10485, 10588, 10692, 10796, 10900, 11006,
+            11111, 11217, 11324, 11431, 11538, 11647, 11755, 11864, 11974, 12084, 12195, 12306,
+            12417, 12529, 12642, 12755, 12869, 12983, 13098, 13213, 13328, 13444, 13561, 13678,
+            13796, 13914, 14033, 14152, 14272, 14392, 14512, 14634, 14755, 14878, 15000, 15123,
+            15247, 15371, 15496, 15621, 15747, 15873, 16000, 16127, 16255, 16383,
+        ];
+        assert_eq!(companding_table(), EXPAND);
+        // The two ends are what fix the constant.
+        assert_eq!(EXPAND[0], 0);
+        assert_eq!(EXPAND[255], 16383);
+    }
+
+    /// Row lengths come from sorting the offsets, not from the row
+    /// order: a back that reads its two sensor halves out in opposite
+    /// directions writes a table that falls in the middle.
+    #[test]
+    fn row_lengths_come_from_the_sorted_offsets() {
+        // Four rows written 0, 300, 200, 100: rows 1..3 descend.
+        let mut table = Vec::new();
+        for offset in [0u32, 300, 200, 100] {
+            table.extend_from_slice(&offset.to_le_bytes());
+        }
+        let extents = row_extents(&table, 400, 4).unwrap();
+        assert_eq!(extents, vec![(0, 100), (300, 100), (200, 100), (100, 100)]);
+        // A table too short for the frame is corrupt.
+        assert!(row_extents(&table, 400, 5).is_err());
+    }
+
+    /// The absolute form of a format-6 range code: a hand-built
+    /// prefix code of four to five bits, in no useful order.
+    #[test]
+    fn the_absolute_range_code_decodes_its_ten_values() {
+        for (bits, want) in [
+            ("10", 3),
+            ("11", 2),
+            ("010", 1),
+            ("011", 4),
+            ("0010", 6),
+            ("0011", 5),
+            ("00000", 9),
+            ("00001", 8),
+            ("00010", 0),
+            ("00011", 7),
+        ] {
+            // The code, left-aligned in a 32-bit little-endian word,
+            // padded with ones so a decoder that consumed too few or
+            // too many bits would not accidentally agree.
+            let mut word = u32::from_str_radix(bits, 2).unwrap() << (32 - bits.len());
+            word |= u32::MAX >> bits.len();
+            let stream = word.to_le_bytes();
+            let mut pump = BitPumpMsb32::new(&stream);
+            assert_eq!(absolute_range(&mut pump), want, "code {bits}");
+            assert_eq!(pump.position(), bits.len(), "code {bits} length");
+        }
+    }
+
+    /// The iXU180: format 6, with a row table that reverses at
+    /// `split_row`, escape blocks, both parities carrying independent
+    /// ranges, and a four-pixel tail.
+    #[test]
+    fn the_ixu180_decodes_its_first_rows_sample_for_sample() {
+        let Some(bytes) = sample("iXU180-cap_22908.IIQ") else {
+            return;
+        };
+        let (data, offsets, width, height) = sensor(&bytes);
+        assert_eq!((width, height), (10380, 7816));
+        let extents = row_extents(offsets, data.len(), height).unwrap();
+        // The table's own order rises to row 3887 and then falls, and
+        // the two halves are *interleaved* in the file: sorted by
+        // offset the rows run 0, 7775, 1, 7774, 2, ... So a row's
+        // bytes end where the next offset in file order begins, not
+        // where the next row's offset does.
+        assert_eq!(
+            extents[..5]
+                .iter()
+                .map(|(start, _)| *start)
+                .collect::<Vec<_>>(),
+            vec![0, 9736, 19484, 29244, 38972]
+        );
+        assert_eq!(
+            extents[..5].iter().map(|(_, len)| *len).collect::<Vec<_>>(),
+            vec![4884, 4888, 4892, 4872, 4880]
+        );
+        let lengths: Vec<usize> = extents.iter().map(|(_, l)| *l).collect();
+        assert_eq!(lengths.iter().min(), Some(&4844));
+        assert_eq!(lengths.iter().max(), Some(&11800));
+        // Every row fits the reference's own read buffer, so nothing
+        // here is being silently truncated.
+        assert!(lengths.iter().all(|l| *l <= max_row_bytes(width)));
+        // Row 0 begins at the sensor data itself, and its header's
+        // low three bits are `init_bits`.
+        assert_eq!(extents[0].0, 0);
+        assert_eq!(&data[..4], &[0x01, 0x00, 0x03, 0x00]);
+
+        let mut row = vec![0u16; width];
+        decode_row_format6(&data[..extents[0].1], &mut row);
+        // Block 0: both ranges read the absolute form of 9, the
+        // escape, so all eight pixels are plain fourteen-bit values.
+        assert_eq!(
+            &row[..8],
+            &[1040, 1052, 1076, 1072, 33056, 33408, 33248, 33216]
+        );
+        // Block 1: both ranges 5, extra 2, so take 5, shift 3 and
+        // bias 127 for both parities.
+        let stored = |v: i32| (v << 2) as u16;
+        assert_eq!(
+            &row[8..16],
+            &[8281, 8273, 8306, 8378, 8219, 8275, 8300, 8212].map(stored)
+        );
+        // Block 2: the two parities' ranges differ (8 and 6), so they
+        // carry different shifts and biases over one shared `take`.
+        assert_eq!(
+            &row[16..24],
+            &[8333, 8149, 8174, 8358, 8687, 8127, 8144, 8224].map(stored)
+        );
+
+        // The *second* row in file order, at offset 4884. It is frame
+        // row 7775, not row 1: the second half of the sensor is
+        // written into the gaps between the first half's rows.
+        let (start, len) = extents[7775];
+        assert_eq!((start, len), (4884, 4852));
+        let mut row = vec![0u16; width];
+        decode_row_format6(&data[start..start + len], &mut row);
+        assert_eq!(
+            &row[..8],
+            &[268, 253, 275, 264, 8328, 8088, 8264, 8232].map(stored)
+        );
+        assert_eq!(
+            &row[8..16],
+            &[8265, 8297, 8218, 8202, 8243, 8155, 8124, 8180].map(stored)
+        );
+        assert_eq!(&row[16..18], &[8317, 8229].map(stored));
+        // And the tail: the last four columns of a 10380-wide row are
+        // outside the 1297 whole blocks and are plain 14-bit samples.
+        assert_eq!(((width - BLOCK6) >> 3) + 1, 1297);
+        assert!(row[width - 4..].iter().all(|s| s.is_multiple_of(4)));
+    }
+
+    /// The H 25: format 5, whose stream is format 3's exactly and
+    /// whose samples are eight-bit companded codes.
+    #[test]
+    fn the_h25_companded_row_matches_its_stored_codes() {
+        let Some(bytes) = sample("H_25-H25_Outdoor_.IIQ") else {
+            return;
+        };
+        let (data, offsets, width, height) = sensor(&bytes);
+        assert_eq!((width, height), (4134, 5488));
+        let extents = row_extents(offsets, data.len(), height).unwrap();
+        assert_eq!(extents[0].0, 0);
+        assert_eq!(extents[1].0, 2732);
+
+        // The same row read twice: once as format 3 would, giving the
+        // stored eight-bit codes, and once as format 5 does.
+        let mut stored = vec![0u16; width];
+        decode_row(&data[extents[0].0..], &mut stored, None);
+        assert_eq!(
+            stored[..16].iter().map(|s| s >> 2).collect::<Vec<_>>(),
+            vec![57, 57, 66, 57, 57, 57, 65, 64, 65, 65, 65, 64, 64, 64, 64, 64]
+        );
+        let table = companding_table();
+        let mut expanded = vec![0u16; width];
+        decode_row(&data[extents[0].0..], &mut expanded, Some(&table));
+        assert_eq!(
+            expanded[..16].iter().map(|s| s >> 2).collect::<Vec<_>>(),
+            vec![
+                819, 819, 1098, 819, 819, 819, 1064, 1032, 1064, 1064, 1064, 1032, 1032, 1032,
+                1032, 1032
+            ]
+        );
+        let mut second = vec![0u16; width];
+        decode_row(&data[extents[1].0..], &mut second, Some(&table));
+        assert_eq!(
+            second[..16].iter().map(|s| s >> 2).collect::<Vec<_>>(),
+            vec![819, 819, 877, 790, 819, 819, 848, 848, 848, 848, 848, 848, 848, 819, 819, 848]
+        );
+    }
+
+    /// The P25+ pair: the same back and the same geometry, one file
+    /// format 5 and one format 3, so the companding is the only
+    /// difference between them. The format-3 file's row 0 is well
+    /// above 256 and must come through untouched.
+    #[test]
+    fn the_p25_pair_differs_only_by_the_companding() {
+        let (Some(lossy), Some(lossless)) =
+            (sample("P25+-CF028662.IIQ"), sample("P25+-CF028663.IIQ"))
+        else {
+            return;
+        };
+        let table = companding_table();
+        let (data, offsets, width, height) = sensor(&lossy);
+        let extents = row_extents(offsets, data.len(), height).unwrap();
+        let mut stored = vec![0u16; width];
+        decode_row(&data[extents[0].0..], &mut stored, None);
+        assert_eq!(
+            stored[..16].iter().map(|s| s >> 2).collect::<Vec<_>>(),
+            vec![31, 31, 181, 181, 181, 181, 181, 181, 181, 181, 195, 197, 192, 196, 199, 196]
+        );
+        let mut row = vec![0u16; width];
+        decode_row(&data[extents[0].0..], &mut row, Some(&table));
+        assert_eq!(
+            row[..16].iter().map(|s| s >> 2).collect::<Vec<_>>(),
+            vec![
+                242, 242, 8254, 8254, 8254, 8254, 8254, 8254, 8254, 8254, 9580, 9778, 9288, 9679,
+                9978, 9679
+            ]
+        );
+
+        let (data, offsets, width, height) = sensor(&lossless);
+        let extents = row_extents(offsets, data.len(), height).unwrap();
+        let mut row = vec![0u16; width];
+        decode_row(&data[extents[0].0..], &mut row, None);
+        assert_eq!(
+            row[..16].iter().map(|s| s >> 2).collect::<Vec<_>>(),
+            vec![
+                256, 256, 8192, 8192, 8192, 8192, 8192, 8192, 8192, 8192, 10720, 10496, 10368,
+                10912, 10752, 10464
+            ]
+        );
     }
 
     #[test]

--- a/crates/codec-raw/src/formats/raf.rs
+++ b/crates/codec-raw/src/formats/raf.rs
@@ -305,10 +305,11 @@ fn parse_raw_tiff<'a>(header: &Header<'a>) -> Result<Option<Frame<'a>>> {
 
 /// How the samples of an uncompressed strip are stored.
 ///
-/// Fujifilm has used three layouts, and the strip's own byte count
-/// tells them apart without guessing: it is exactly the pixel count
-/// times two (16-bit words), or times the bit depth over eight
-/// (packed), or neither — and neither means compressed.
+/// Fujifilm has used three uncompressed layouts, and the strip's own
+/// byte count tells them apart without guessing: it is exactly the
+/// pixel count times two (16-bit words) or times the bit depth over
+/// eight (packed). A compressed strip is recognised before either, by
+/// its own header (see [`super::raf_compressed::is_compressed`]).
 ///
 /// The two packings differ, and not in a way any tag announces. The
 /// 12-bit EXR compacts pack least significant bit first across plain
@@ -324,10 +325,20 @@ enum Storage {
     PackedLsb(u32),
     /// Most significant bit first inside 32-bit little-endian words.
     PackedMsb32(u32),
+    /// Fujifilm's own entropy coding, which says so in its own header.
     Compressed,
+    /// A strip that is none of the above: a layout this decoder does
+    /// not know, rather than one it can guess at.
+    Unknown,
 }
 
-fn storage(pixels: usize, bits: u32, len: usize) -> Storage {
+fn storage(strip: &[u8], pixels: usize, bits: u32, len: usize) -> Storage {
+    // The compressed strips announce themselves, and asking them
+    // first is what keeps a frame whose compressed size happens to
+    // land on one of the packings from being unpacked as noise.
+    if super::raf_compressed::is_compressed(strip) {
+        return Storage::Compressed;
+    }
     if len == pixels * 2 {
         return Storage::Words16;
     }
@@ -341,7 +352,7 @@ fn storage(pixels: usize, bits: u32, len: usize) -> Storage {
             };
         }
     }
-    Storage::Compressed
+    Storage::Unknown
 }
 
 /// Little-endian 16-bit words, the simplest and oldest layout.
@@ -563,11 +574,17 @@ pub fn decode(bytes: &[u8]) -> Result<RawImage> {
         Some(frame) => frame.strip,
         None => header.cfa,
     };
-    let data = match storage(pixels, bits, strip.len()) {
+    let data = match storage(strip, pixels, bits, strip.len()) {
         Storage::Words16 => unpack_words16(strip, pixels),
         Storage::PackedLsb(bits) => unpack_packed(strip, width, height, bits, false),
         Storage::PackedMsb32(bits) => unpack_packed(strip, width, height, bits, true),
         Storage::Compressed => super::raf_compressed::decode(strip, width, height, &cfa)?,
+        Storage::Unknown => {
+            return Err(Error::Unsupported(format!(
+            "RAF: a {}-byte strip is no known layout of a {width}x{height} frame at {bits} bits",
+            strip.len()
+        )))
+        }
     };
 
     let mut raw = RawImage::new(Format::Raf, width, height, 1, RawData::U16(data), cfa);
@@ -775,10 +792,18 @@ mod tests {
 
     #[test]
     fn storage_follows_the_strip_length() {
-        assert_eq!(storage(1000, 14, 2000), Storage::Words16);
-        assert_eq!(storage(1000, 14, 1750), Storage::PackedMsb32(14));
-        assert_eq!(storage(1000, 12, 1500), Storage::PackedLsb(12));
-        assert_eq!(storage(1000, 14, 900), Storage::Compressed);
+        assert_eq!(storage(&[], 1000, 14, 2000), Storage::Words16);
+        assert_eq!(storage(&[], 1000, 14, 1750), Storage::PackedMsb32(14));
+        assert_eq!(storage(&[], 1000, 12, 1500), Storage::PackedLsb(12));
+        assert_eq!(storage(&[], 1000, 14, 900), Storage::Unknown);
+        // A compressed header wins over every byte-count rule, even
+        // when the count happens to match a packing exactly.
+        let mut strip = vec![
+            0x49, 0x53, 0x01, 0x10, 0x0e, 0x0f, 0xc6, 0x18, 0x00, 0x17, 0xa0, 0x03, 0x00, 0x08,
+            0x02, 0xa1,
+        ];
+        strip.resize(2000, 0);
+        assert_eq!(storage(&strip, 1000, 14, 2000), Storage::Compressed);
     }
 
     #[test]
@@ -891,13 +916,6 @@ mod corpus {
         // has nowhere to put that.
         ("FinePix_S9600", "SuperCCD"),
         ("DBP_for_GX680", "SuperCCD"),
-        // Fujifilm's compressed strips, lossless and lossy alike: the
-        // container, levels and geometry are read, the entropy-coded
-        // body is not. See `super::super::raf_compressed`.
-        ("GFX100S", "compression"),
-        ("X100F-DSCF5760", "compression"),
-        ("X-Pro3-_DSF2385", "compression"),
-        ("X-T5", "compression"),
     ];
 
     fn corpus_files() -> Vec<PathBuf> {
@@ -1128,9 +1146,17 @@ mod corpus {
             if !tiff.exists() {
                 continue;
             }
-            let want = image::open(&tiff)
-                .unwrap_or_else(|e| panic!("{}: {e}", tiff.display()))
-                .into_luma16();
+            // `image::open` caps its allocation, and a 100-megapixel
+            // oracle is past the cap; the file is ours, so lift it.
+            let want = {
+                let mut reader = image::ImageReader::open(&tiff)
+                    .unwrap_or_else(|e| panic!("{}: {e}", tiff.display()));
+                reader.limits(image::Limits::no_limits());
+                reader
+                    .decode()
+                    .unwrap_or_else(|e| panic!("{}: {e}", tiff.display()))
+                    .into_luma16()
+            };
             assert_eq!(
                 (want.width() as usize, want.height() as usize),
                 (raw.width, raw.height),

--- a/crates/codec-raw/src/formats/raf_compressed.rs
+++ b/crates/codec-raw/src/formats/raf_compressed.rs
@@ -1,103 +1,112 @@
 //! Fujifilm's compressed sensor strips, from the X-T2 (2016) onwards.
 //!
-//! This module reads the compressed stream's *header* — which is
-//! documented enough to check a file against its own container and to
-//! say precisely what a file is — and refuses the entropy-coded body.
-//! Nothing in the RAF container announces compression: the decision is
-//! made in [`super::raf`] from the strip's byte count, and a strip that
-//! is neither 16-bit words nor packed samples arrives here.
+//! One entropy coder covers all four combinations the cameras ship:
+//! lossless and lossy, X-Trans and Bayer. It is a predictive coder in
+//! the JPEG-LS family — predict from the neighbours, classify the
+//! local gradient into a context, Golomb-Rice the residual with a
+//! per-context adaptive shift — wrapped in a frame layout that is
+//! entirely Fujifilm's own.
 //!
-//! # What the header says
+//! # Layout
 //!
-//! Sixteen big-endian bytes, then one 32-bit length per vertical
-//! stripe, the table padded to a 16-byte boundary:
+//! Nothing in the RAF container says a strip is compressed, so the
+//! strip is probed: sixteen big-endian header bytes starting `0x4953`
+//! and agreeing with themselves ([`Header::parse`]).
 //!
 //! ```text
 //! 0   u16  0x4953, the signature
-//! 2   u8   version: 0 on the Bayer bodies, 1 on the X-Trans ones
-//! 3   u8   sensor: 0x10 X-Trans, 0x00 Bayer
-//! 4   u8   bits a sample (12 or 14)
-//! 5   u16  frame height
+//! 2   u8   1 = lossless compressed, 0 = lossy compressed
+//! 3   u8   filter array: 0x10 X-Trans, 0x00 Bayer
+//! 4   u8   bits a sample (12, 14 or 16)
+//! 5   u16  frame height, a multiple of six
 //! 7   u16  frame width rounded up to a whole number of stripes
 //! 9   u16  frame width
-//! 11  u16  stripe width in pixels (768 in every file seen)
+//! 11  u16  stripe width in pixels (0x300 in every file)
 //! 13  u8   stripes across the frame
 //! 14  u16  six-row blocks down the frame (height / 6)
 //! ```
 //!
-//! Every field is redundant with the container or with another field,
-//! which is what makes the header worth parsing even without a
-//! decoder: `rounded_width == stripes * stripe_width`,
-//! `blocks * 6 == height`, and the width, height and depth must equal
-//! the ones the RAF's own tags gave. A file that disagrees with itself
-//! is corrupt, and saying so is more use to a caller than a blanket
-//! "unsupported".
+//! Then one `u32` byte count per stripe, the *offset* past the table
+//! rounded up to sixteen bytes; then, in a lossy file only, one
+//! quantiser base per stripe per block, each stripe's run padded to
+//! sixteen; then the stripes' entropy data, back to back.
 //!
-//! # What is not implemented
+//! Byte 2 is the mode flag, not a version. It is the only reliable way
+//! to tell the modes apart: a decoder that guesses from the bit rate
+//! mis-reads any unusually flat or unusually noisy frame.
 //!
-//! The body. Each stripe is decoded independently, six sensor rows at
-//! a time, into twelve line buffers — three red, six green, three blue,
-//! each `stripe_width * 2 / 3` samples for X-Trans (`/ 2` for Bayer),
-//! with the previous block's last two lines of each colour kept as
-//! history. A sample is predicted from its neighbours in the line
-//! above (and, at odd positions, from the two already-decoded
-//! neighbours beside it), the prediction error is classified into one
-//! of 41 gradient contexts, and the error is Golomb-Rice coded with a
-//! per-context adaptive parameter.
+//! # The frame
 //!
-//! The entropy layer is fully pinned down against real files, and is
-//! recorded here so that whoever finishes this starts from the part
-//! that is already known to be right:
+//! A stripe is 768 columns wide, spans the frame's full height and is
+//! completely independent of its neighbours — its own bit reader, line
+//! buffers and contexts — so the stripes decode in parallel. The last
+//! stripe is *decoded* at full width like all the others and only
+//! *copied out* narrow; its trailing symbols are real and must be
+//! consumed.
 //!
-//! * A context is a pair `(sum, count)` starting at
-//!   `(max(2, ((1 << bits) + 32) >> 6), 1)` — `(256, 1)` at 14 bits —
-//!   and `k` is the smallest shift with `count << k >= sum`, capped at
-//!   12. Before each update, `sum` and `count` are halved if `count`
-//!   has reached 64; then `count` is incremented and `sum` grows by
-//!   the magnitude of the difference just decoded.
-//! * A symbol is a unary run of zero bits terminated by a one, then
-//!   `k` more bits: `sample = (zeros << k) + rest`. When the run
-//!   reaches `4 * bits - bits - 1` zeros (41 at 14 bits) the symbol
-//!   escapes: the terminating one is still consumed, then `bits`
-//!   literal bits follow and `sample = literal + 1`. Consuming that
-//!   one bit is the whole difference between decoding a file and
-//!   decoding noise.
-//! * `sample` folds to a signed difference: even gives `sample / 2`,
-//!   odd gives `-(sample + 1) / 2`.
-//! * The gradient quantiser has thresholds 0, 0x12, 0x43, 0x114 and
-//!   the saturation value, giving nine levels from two differences;
-//!   the context is `9 * a + b`, folded to 41 by taking the magnitude
-//!   and negating the difference when the index was negative.
+//! Each stripe is a stack of six-row blocks. A block is held in
+//! eighteen line buffers — three red, six green, three blue, plus two
+//! rows of history a colour — each `line_width + 2` samples, the extra
+//! two being guard slots either side that hold the neighbouring line's
+//! first and last samples so the edge taps need no special case.
+//! `line_width` is `2/3` of the stripe width for X-Trans (three sensor
+//! columns share two buffer slots) and half of it for Bayer.
 //!
-//! Two checks say this is right rather than merely plausible. Decoding
-//! a stripe's leading run of identical samples reproduces the observed
-//! code lengths exactly — one code of 9 bits, two of 8, four of 7,
-//! eight of 6, sixteen of 5, thirty-two of 4, then thirty-two each of
-//! 3, 2 and 1, for two contexts in step — and the first symbol after
-//! that run, an escape, yields a difference of 1067 against a
-//! prediction of zero, which is the value the oracle has for the first
-//! non-blank pixel of the frame (the X100F sample's row 5, column 0).
-//! Samples also arrive in groups of `stripe_width`, each group taking
-//! the next of three gradient sets, so the sets cycle 0, 1, 2, 0, 1, 2
-//! over a six-row block.
+//! A block is coded as six two-row passes, each pairing one green
+//! buffer with one red or blue buffer, and within a pass the even
+//! positions run five steps ahead of the odd ones — the odd
+//! prediction needs the sample to its right. On an X-Trans block some
+//! even slots of the red, blue and two of the green buffers cover no
+//! photosite; those consume no bits and are filled with the even
+//! prediction, but they are ordinary state afterwards and later
+//! samples read them as neighbours.
 //!
-//! What is *not* pinned down is the order the twelve line buffers'
-//! even and odd positions are visited in, and which of their slots
-//! hold sensor pixels rather than interpolated filler. The three
-//! two-row passes of an X-Trans block are not alike — the array puts
-//! two red pixels in the first pair of rows and three in each of the
-//! others — so there is no single loop over the passes to infer, and
-//! every uniform arrangement tried desynchronises the bit reader
-//! within the first row. Rather than return a frame that looks decoded
-//! and is not, this module refuses, and [`Header::parse`] still
-//! extracts everything the stream says about itself.
+//! # Lossy
+//!
+//! Lossy mode is a uniform quantiser on the residual: the value is
+//! `pred ± (2 * q_base + 1) * residual`, with `q_base` read per block
+//! from the header's array. There is no transform and no reconstruction
+//! offset. Three fixed "fine" tables with `q_base` 0, 1 and 2 take over
+//! in flat neighbourhoods, so smooth areas stay near-lossless; each has
+//! its own alphabet, escape width, gradient scale and contexts.
+//!
+//! Everything here was written from a functional description of the
+//! format and checked against real files and their unpacked oracles.
 
-use crate::{Cfa, Error, Result};
+use crate::bits::{BitPump, BitPumpMsb};
+use crate::{Cfa, CfaColor, Error, Result};
+use rayon::prelude::*;
+
+/// The signature every compressed strip starts with.
+pub const SIGNATURE: u16 = 0x4953;
+
+/// Rows of the sensor in one coded block, for both filter arrays.
+pub const BLOCK_ROWS: usize = 6;
+
+/// Line buffers a stripe keeps: three red, six green, three blue, each
+/// colour preceded by two rows of history from the previous block.
+const LINES: usize = 18;
+
+/// Gradient contexts the main table indexes: `|9 * l1 + l2|` with both
+/// levels in `-4..=4`.
+const CONTEXTS: usize = 41;
+
+/// `sum` and `count` halve once `count` reaches this, which is what
+/// makes the coder adapt to the recent past rather than the whole line.
+const HALVE_AT: u32 = 0x40;
+
+/// The only stripe width Fujifilm has shipped. The reference decoder
+/// rejects anything else outright and so does this one: the pass
+/// schedule's `% 4` phases are only correct for a stripe that is a
+/// whole number of filter-array periods wide.
+const STRIPE_WIDTH: usize = 0x300;
 
 /// A compressed strip's header.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Header {
-    pub version: u8,
+    /// Byte 2: the coding mode. Lossy files carry a quantiser-base
+    /// array the lossless ones do not.
+    pub lossless: bool,
     /// 0x10 on the X-Trans bodies, 0 on the Bayer ones.
     pub sensor: u8,
     pub bits: u32,
@@ -111,78 +120,137 @@ pub struct Header {
     pub blocks: usize,
 }
 
-/// The signature every compressed strip starts with.
-pub const SIGNATURE: u16 = 0x4953;
+fn corrupt<T>(why: impl Into<String>) -> Result<T> {
+    Err(Error::Corrupt(why.into()))
+}
 
-/// Rows of the sensor in one coded block, for both filter arrays.
-pub const BLOCK_ROWS: usize = 6;
+/// `n` rounded up to a multiple of sixteen.
+const fn roundup16(n: usize) -> usize {
+    (n + 15) & !15
+}
 
 impl Header {
     /// Read and check a header. `Err(Corrupt)` when the strip claims a
-    /// geometry that contradicts itself.
+    /// geometry that contradicts itself or the format.
+    ///
+    /// Every one of these constraints is a property of the format
+    /// rather than of the corpus, which is what makes the check double
+    /// as the compression probe: an uncompressed strip that happened to
+    /// start `0x4953` would have to satisfy all of them as well.
     pub fn parse(strip: &[u8]) -> Result<Header> {
-        let be16 = |at: usize| -> Result<usize> {
-            strip
-                .get(at..at + 2)
-                .and_then(|b| b.try_into().ok())
-                .map(|b| u16::from_be_bytes(b) as usize)
-                .ok_or_else(|| Error::Corrupt("truncated compressed strip header".into()))
+        let head: &[u8; 16] = match strip.get(..16).and_then(|b| b.try_into().ok()) {
+            Some(head) => head,
+            None => return corrupt("truncated compressed strip header"),
         };
-        let byte = |at: usize| -> Result<u8> {
-            strip
-                .get(at)
-                .copied()
-                .ok_or_else(|| Error::Corrupt("truncated compressed strip header".into()))
-        };
-        if be16(0)? != SIGNATURE as usize {
-            return Err(Error::Corrupt(
-                "compressed sensor strip without its 0x4953 signature".into(),
-            ));
+        let be16 = |at: usize| u16::from_be_bytes([head[at], head[at + 1]]) as usize;
+        if be16(0) != SIGNATURE as usize {
+            return corrupt("compressed sensor strip without its 0x4953 signature");
+        }
+        if head[2] > 1 {
+            return corrupt(format!("compressed strip mode byte {}", head[2]));
         }
         let header = Header {
-            version: byte(2)?,
-            sensor: byte(3)?,
-            bits: byte(4)? as u32,
-            height: be16(5)?,
-            rounded_width: be16(7)?,
-            width: be16(9)?,
-            stripe_width: be16(11)?,
-            stripes: byte(13)? as usize,
-            blocks: be16(14)?,
+            lossless: head[2] == 1,
+            sensor: head[3],
+            bits: head[4] as u32,
+            height: be16(5),
+            rounded_width: be16(7),
+            width: be16(9),
+            stripe_width: be16(11),
+            stripes: head[13] as usize,
+            blocks: be16(14),
         };
-        // Four cross-checks the format makes free: every one of them
-        // holds in every sample file, and a stream that fails one is
-        // not a stream this crate could decode even with a decoder.
-        if header.stripe_width == 0 || header.stripes == 0 {
-            return Err(Error::Corrupt("compressed strip with no stripes".into()));
+        if !matches!(header.sensor, 0x00 | 0x10) {
+            return corrupt(format!(
+                "compressed strip filter kind {:#04x}",
+                header.sensor
+            ));
         }
-        if header.stripes * header.stripe_width != header.rounded_width {
-            return Err(Error::Corrupt(format!(
-                "{} stripes of {} do not make the rounded width {}",
-                header.stripes, header.stripe_width, header.rounded_width
-            )));
+        if !matches!(header.bits, 12 | 14 | 16) {
+            return corrupt(format!("compressed strip at {} bits", header.bits));
         }
-        if header.rounded_width < header.width
+        if header.height < BLOCK_ROWS
+            || header.height > 0x4002
+            || !header.height.is_multiple_of(BLOCK_ROWS)
+        {
+            return corrupt(format!("compressed strip is {} rows", header.height));
+        }
+        if header.width < STRIPE_WIDTH || header.width > 0x4200 || !header.width.is_multiple_of(24)
+        {
+            return corrupt(format!("compressed strip is {} columns", header.width));
+        }
+        if header.stripe_width != STRIPE_WIDTH {
+            return corrupt(format!(
+                "compressed strip in stripes of {}",
+                header.stripe_width
+            ));
+        }
+        if header.rounded_width > 0x4200
+            || header.rounded_width < header.stripe_width
+            || !header.rounded_width.is_multiple_of(header.stripe_width)
+            || header.rounded_width < header.width
             || header.rounded_width - header.width >= header.stripe_width
         {
-            return Err(Error::Corrupt(format!(
-                "rounded width {} does not round {} up by less than a stripe",
-                header.rounded_width, header.width
-            )));
+            return corrupt(format!(
+                "rounded width {} does not round {} up by less than a stripe of {}",
+                header.rounded_width, header.width, header.stripe_width
+            ));
         }
-        if header.blocks * BLOCK_ROWS != header.height {
-            return Err(Error::Corrupt(format!(
+        if header.stripes == 0
+            || header.stripes > 0x10
+            || header.stripes * header.stripe_width != header.rounded_width
+        {
+            return corrupt(format!(
+                "{} stripes of {} do not make the rounded width {}",
+                header.stripes, header.stripe_width, header.rounded_width
+            ));
+        }
+        if header.blocks == 0
+            || header.blocks > 0xAAB
+            || header.blocks * BLOCK_ROWS != header.height
+        {
+            return corrupt(format!(
                 "{} six-row blocks do not make {} rows",
                 header.blocks, header.height
-            )));
+            ));
         }
         Ok(header)
     }
 
-    /// Where the entropy-coded data starts: the header, then a 32-bit
-    /// length for each stripe, padded to a 16-byte boundary.
+    /// Whether the header calls the frame X-Trans.
+    pub fn is_x_trans(&self) -> bool {
+        self.sensor == 0x10
+    }
+
+    /// The largest sample the depth can hold.
+    fn max_value(&self) -> i32 {
+        (1i32 << self.bits) - 1
+    }
+
+    /// Samples in one line buffer: three X-Trans sensor columns share
+    /// two slots, two Bayer columns share one.
+    fn line_width(&self) -> usize {
+        if self.is_x_trans() {
+            self.stripe_width * 2 / 3
+        } else {
+            self.stripe_width / 2
+        }
+    }
+
+    /// Bytes of quantiser bases between the size table and the first
+    /// stripe: none in a lossless file, one per block per stripe with
+    /// each stripe's run padded to sixteen bytes in a lossy one.
+    fn qbase_bytes(&self) -> usize {
+        if self.lossless {
+            0
+        } else {
+            self.stripes * roundup16(self.blocks)
+        }
+    }
+
+    /// Where the first stripe's entropy-coded data starts.
     pub fn data_offset(&self) -> usize {
-        16 + (self.stripes * 4).div_ceil(16) * 16
+        16 + roundup16(self.stripes * 4) + self.qbase_bytes()
     }
 
     /// Each stripe's compressed length, in order.
@@ -190,85 +258,738 @@ impl Header {
         let mut out = Vec::with_capacity(self.stripes);
         for i in 0..self.stripes {
             let at = 16 + i * 4;
-            let bytes: [u8; 4] = strip
-                .get(at..at + 4)
-                .and_then(|b| b.try_into().ok())
-                .ok_or_else(|| Error::Corrupt("truncated stripe length table".into()))?;
+            let bytes: [u8; 4] = match strip.get(at..at + 4).and_then(|b| b.try_into().ok()) {
+                Some(bytes) => bytes,
+                None => return corrupt("truncated stripe length table"),
+            };
             out.push(u32::from_be_bytes(bytes) as usize);
         }
         Ok(out)
     }
 
-    /// Whether the entropy-coded body is lossless.
-    ///
-    /// Nothing in the header says so directly, so this asks the only
-    /// question a header can answer: how much room the body takes.
-    /// Fujifilm's lossless mode spends between seven and nine bits a
-    /// pixel on every sample in the corpus (X100F 8.51, X-Pro3 8.15,
-    /// X-T5 7.64); the lossy mode quantises first and spends far less
-    /// — the GFX100S sample takes 4.71, which no lossless coder gets
-    /// from a 14-bit frame with ordinary photon noise. Six bits is
-    /// comfortably between the two.
-    pub fn looks_lossless(&self, body_bytes: usize) -> bool {
-        let pixels = self.width as u64 * self.height as u64;
-        pixels > 0 && (body_bytes as u64 * 8) / pixels >= 6
+    /// Stripe `s`'s quantiser bases, one a block, or `None` when the
+    /// file is lossless. A short array is a corrupt file: the bases
+    /// steer the quantiser and a missing one cannot be guessed.
+    pub fn qbases<'a>(&self, strip: &'a [u8], s: usize) -> Result<Option<&'a [u8]>> {
+        if self.lossless {
+            return Ok(None);
+        }
+        let start = 16 + roundup16(self.stripes * 4) + s * roundup16(self.blocks);
+        match strip.get(start..start + self.blocks) {
+            Some(run) => Ok(Some(run)),
+            None => corrupt("truncated quantiser-base array"),
+        }
     }
 }
 
-/// Decode a compressed sensor strip into `width * height` samples.
+/// Whether a sensor strip holds a compressed frame.
 ///
-/// Always `Err`: see the module documentation for what is known about
-/// the coding and what is not.
+/// The container gives no hint, so this is the probe: the signature
+/// plus every self-consistency rule the header can be held to.
+pub fn is_compressed(strip: &[u8]) -> bool {
+    Header::parse(strip).is_ok()
+}
+
+/// Bits needed to write `n - 1`, with the format's own two edge cases
+/// (`0` for an empty alphabet, `1` for a one-symbol one).
+fn ceil_log2(n: u32) -> u32 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => 32 - (n - 1).leading_zeros(),
+    }
+}
+
+/// One quantiser: thresholds, alphabet and step.
+///
+/// Lossless files use a single table with `q_base` 0. Lossy files
+/// rebuild a main table whenever the block's quantiser base changes,
+/// and keep three fixed fine tables for flat neighbourhoods.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Table {
+    q_base: i32,
+    /// The four gradient thresholds. A fifth (`max_value`) exists in
+    /// the format's own description but no rule reads it.
+    t: [i32; 4],
+    /// Symbols in the alphabet, and the modulus the coder works to.
+    total_values: i32,
+    /// Literal bits an escape reads — the *table's* width, not the
+    /// frame's depth, which is the whole difference in lossy mode.
+    raw_bits: u32,
+    /// Zero-run length at which a symbol escapes.
+    esc: u32,
+    /// 9 for the main table, 3 for the fine ones.
+    grad_mult: i32,
+    /// Largest neighbourhood roughness a fine table will accept.
+    max_flatness: i32,
+    /// `2 * q_base + 1`: what the decoded residual is multiplied by.
+    step: i32,
+    /// Every context of the table starts here.
+    init_sum: u32,
+}
+
+impl Table {
+    fn new(q_base: i32, max_value: i32, max_bits: u32, grad_mult: i32, max_flatness: i32) -> Table {
+        // The thresholds spread with the quantiser base, and collapse
+        // onto each other when the frame's depth cannot carry them —
+        // which only happens on hypothetical shallow frames, but the
+        // order of the clamps matters and is reproduced as given.
+        let mut t1 = 3 * q_base + 0x12;
+        let mut t2 = 5 * q_base + 0x43;
+        let mut t3 = 7 * q_base + 0x114;
+        if t1 > max_value || t1 < q_base + 1 {
+            t1 = q_base + 1;
+        }
+        if t2 < t1 || t2 > max_value {
+            t2 = t1;
+        }
+        if t3 < t2 || t3 > max_value {
+            t3 = t2;
+        }
+        let total_values = (max_value + 2 * q_base) / (2 * q_base + 1) + 1;
+        let raw_bits = ceil_log2(total_values as u32);
+        Table {
+            q_base,
+            t: [q_base, t1, t2, t3],
+            total_values,
+            raw_bits,
+            esc: max_bits.saturating_sub(raw_bits + 1),
+            grad_mult,
+            max_flatness,
+            step: 2 * q_base + 1,
+            init_sum: 2.max(((total_values as u32) + 0x20) >> 6),
+        }
+    }
+
+    /// A difference quantised to nine levels.
+    ///
+    /// The comparisons are deliberately lopsided — `<=` on the
+    /// negative side of the outer thresholds, `<` on the positive —
+    /// which only shows when a difference lands exactly on a
+    /// threshold, and then it shows as a wrong context and a wrong
+    /// pixel.
+    #[inline(always)]
+    fn level(&self, v: i32) -> i32 {
+        let [t0, t1, t2, t3] = self.t;
+        if v <= -t3 {
+            -4
+        } else if v <= -t2 {
+            -3
+        } else if v <= -t1 {
+            -2
+        } else if v < -t0 {
+            -1
+        } else if v <= t0 {
+            0
+        } else if v < t1 {
+            1
+        } else if v < t2 {
+            2
+        } else if v < t3 {
+            3
+        } else {
+            4
+        }
+    }
+}
+
+/// One adaptive Golomb-Rice context.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Ctx {
+    sum: u32,
+    count: u32,
+}
+
+/// Which even slots of a line buffer carry a photosite.
+///
+/// The red and blue buffers each serve two sensor rows whose colours
+/// sit at different phases of the 6x6 array, so their pattern repeats
+/// every four slots and differs from pass to pass. Bayer blocks code
+/// everything.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EvenRule {
+    Coded,
+    Filled,
+    /// Filled where `slot % 4` is this, coded elsewhere.
+    FilledWhen(usize),
+}
+
+impl EvenRule {
+    #[inline(always)]
+    fn coded(self, p: usize) -> bool {
+        match self {
+            EvenRule::Coded => true,
+            EvenRule::Filled => false,
+            EvenRule::FilledWhen(m) => p % 4 != m,
+        }
+    }
+}
+
+/// The six two-row passes: which two line buffers each codes, in
+/// order. Identical for both filter arrays. Note that the green buffer
+/// is not always the first of its pair.
+const PASSES: [(usize, usize); 6] = [(2, 7), (8, 15), (3, 9), (10, 16), (4, 11), (12, 17)];
+
+/// Even-position rules per pass, X-Trans. Straight out of the filter
+/// array: see [`sensor_map`] for the other half of the same fact.
+const XTRANS_RULES: [(EvenRule, EvenRule); 6] = [
+    (EvenRule::Filled, EvenRule::Coded),
+    (EvenRule::Coded, EvenRule::Filled),
+    (EvenRule::FilledWhen(0), EvenRule::Filled),
+    (EvenRule::Coded, EvenRule::FilledWhen(2)),
+    (EvenRule::FilledWhen(2), EvenRule::Coded),
+    (EvenRule::Filled, EvenRule::FilledWhen(0)),
+];
+
+const BAYER_RULES: [(EvenRule, EvenRule); 6] = [(EvenRule::Coded, EvenRule::Coded); 6];
+
+/// Line buffer indices, in the fixed order the vertical taps assume:
+/// every tap reads the buffer immediately before it, which is why the
+/// two history rows sit in front of each colour's current rows.
+const RED: [usize; 3] = [2, 3, 4];
+const GREEN: [usize; 6] = [7, 8, 9, 10, 11, 12];
+const BLUE: [usize; 3] = [15, 16, 17];
+
+/// A zero run, terminator consumed.
+///
+/// The reader feeds zeros for ever past the end of a stripe, so an
+/// unterminated run is how a truncated or forged stream shows itself;
+/// no table escapes past 47 zeros, so anything beyond 128 is refused
+/// rather than looped on.
+#[inline]
+fn zero_run(pump: &mut BitPumpMsb<'_>) -> Result<u32> {
+    let mut total = 0u32;
+    loop {
+        let word = pump.peek(32);
+        if word != 0 {
+            let n = word.leading_zeros();
+            pump.consume(n + 1);
+            return Ok(total + n);
+        }
+        pump.consume(32);
+        total += 32;
+        if total > 128 {
+            return corrupt("compressed strip holds an unterminated zero run");
+        }
+    }
+}
+
+/// One stripe's decoder: a bit reader, eighteen line buffers and the
+/// adaptive state, all of it private to the stripe.
+struct Stripe<'a> {
+    pump: BitPumpMsb<'a>,
+    /// The eighteen buffers, flat: buffer `x` slot `s` is
+    /// `buf[x * stride + s]`. Flattening is what makes the vertical
+    /// taps uniform — the buffer above is always `stride` earlier.
+    buf: Vec<i32>,
+    stride: usize,
+    line_width: usize,
+    max_value: i32,
+    max_bits: u32,
+    lossy: bool,
+    /// The main table, then the three fine ones.
+    tables: [Table; 4],
+    /// Per table: three even context sets then three odd ones. A pass
+    /// uses set `pass % 3`, and both its buffers share it.
+    ctx: [[[Ctx; CONTEXTS]; 6]; 4],
+    rules: [(EvenRule, EvenRule); 6],
+    /// Symbols consumed, and the per-pass split of the last block —
+    /// both only exist because they are the cheapest check there is on
+    /// the visit order.
+    symbols: u64,
+    pass_symbols: [u32; 6],
+}
+
+impl<'a> Stripe<'a> {
+    fn new(data: &'a [u8], header: &Header) -> Stripe<'a> {
+        let line_width = header.line_width();
+        let max_value = header.max_value();
+        let max_bits = 4 * ceil_log2(max_value as u32 + 1);
+        let main = Table::new(0, max_value, max_bits, 9, 0);
+        let tables = [
+            main,
+            Table::new(0, max_value, max_bits, 3, 5),
+            Table::new(1, max_value, max_bits, 3, 6),
+            Table::new(2, max_value, max_bits, 3, 7),
+        ];
+        let mut stripe = Stripe {
+            pump: BitPumpMsb::new(data),
+            buf: vec![0; LINES * (line_width + 2)],
+            stride: line_width + 2,
+            line_width,
+            max_value,
+            max_bits,
+            lossy: !header.lossless,
+            tables,
+            ctx: [[[Ctx { sum: 0, count: 0 }; CONTEXTS]; 6]; 4],
+            rules: if header.is_x_trans() {
+                XTRANS_RULES
+            } else {
+                BAYER_RULES
+            },
+            symbols: 0,
+            pass_symbols: [0; 6],
+        };
+        for t in 0..4 {
+            stripe.reset_contexts(t);
+        }
+        stripe
+    }
+
+    /// Put every context of one table back to its opening state.
+    fn reset_contexts(&mut self, t: usize) {
+        let start = Ctx {
+            sum: self.tables[t].init_sum,
+            count: 1,
+        };
+        for set in self.ctx[t].iter_mut() {
+            set.fill(start);
+        }
+    }
+
+    /// Point the main table at a new quantiser base, resetting its
+    /// contexts. The fine tables' contexts survive — they are tuned to
+    /// flat neighbourhoods, which do not change character when the
+    /// block's coarse step does.
+    fn set_q_base(&mut self, q_base: i32) {
+        self.tables[0] = Table::new(q_base, self.max_value, self.max_bits, 9, 0);
+        self.reset_contexts(0);
+    }
+
+    /// Which table codes a sample whose neighbourhood is this rough.
+    ///
+    /// A fine table is only eligible while the main quantiser is at
+    /// least as coarse as it is, so lossless frames (base 0) never
+    /// reach one.
+    #[inline(always)]
+    fn select(&self, flatness: i32) -> usize {
+        if !self.lossy {
+            return 0;
+        }
+        let q_base = self.tables[0].q_base;
+        for i in 1..=3 {
+            if q_base < i as i32 {
+                break;
+            }
+            if flatness <= self.tables[i].max_flatness {
+                return i;
+            }
+        }
+        0
+    }
+
+    /// Decode one symbol in context `ci` of set `set` of table `t`,
+    /// returning the signed residual and updating the context.
+    #[inline(always)]
+    fn residual(&mut self, t: usize, set: usize, ci: usize) -> Result<i32> {
+        let table = &self.tables[t];
+        let (esc, raw_bits, total_values) = (table.esc, table.raw_bits, table.total_values);
+        let Ctx { sum, count } = self.ctx[t][set][ci];
+        // The shift that makes the coder's guess at the residual's
+        // magnitude: `sum / count`, rounded to a power of two, and
+        // never past 15.
+        let k = if count >= sum {
+            0
+        } else {
+            let mut k = 1u32;
+            while k < 15 && (count << k) < sum {
+                k += 1;
+            }
+            k
+        };
+        let z = zero_run(&mut self.pump)?;
+        let v = if z < esc {
+            ((z << k) + self.pump.get(k)) as i32
+        } else {
+            // The escape spends the table's full width on a literal,
+            // biased by one so it can never re-code a zero residual.
+            self.pump.get(raw_bits) as i32 + 1
+        };
+        if v < 0 || v >= total_values {
+            return corrupt("compressed strip holds a symbol outside its alphabet");
+        }
+        // Fold: even to a positive residual, odd to a negative one.
+        let r = if v & 1 == 0 { v >> 1 } else { -1 - (v >> 1) };
+        let ctx = &mut self.ctx[t][set][ci];
+        ctx.sum = sum + r.unsigned_abs();
+        ctx.count = count;
+        if count == HALVE_AT {
+            ctx.sum >>= 1;
+            ctx.count >>= 1;
+        }
+        ctx.count += 1;
+        self.symbols += 1;
+        Ok(r)
+    }
+
+    /// `pred +/- step * r`, wrapped into the alphabet and clamped.
+    ///
+    /// The middle step is a modular wrap and not a clamp: the coder
+    /// works modulo `total_values * step`, so a residual that would
+    /// take a value off one end of the range brings it back at the
+    /// other. It fires only on clipped highlights, which is exactly
+    /// why getting it wrong survives casual testing.
+    #[inline(always)]
+    fn reconstruct(&self, t: usize, pred: i32, r: i32, grad: i32) -> i32 {
+        let table = &self.tables[t];
+        let mut x = if grad < 0 {
+            pred - r * table.step
+        } else {
+            pred + r * table.step
+        };
+        if x < -table.q_base {
+            x += table.total_values * table.step;
+        } else if x > table.q_base + self.max_value {
+            x -= table.total_values * table.step;
+        }
+        x.clamp(0, self.max_value)
+    }
+
+    /// An even position: coded, or filled from its own prediction.
+    #[inline(always)]
+    fn even(&mut self, x: usize, p: usize, set: usize, coded: bool) -> Result<()> {
+        let here = x * self.stride;
+        let up = here - self.stride;
+        let up2 = here - 2 * self.stride;
+        // Slot p is position p-1, slot p+1 is position p: the guards
+        // make the left and right edges ordinary.
+        let b = self.buf[up + p + 1];
+        let c = self.buf[up + p];
+        let d = self.buf[up + p + 2];
+        let f = self.buf[up2 + p + 1];
+        let dcb = (c - b).abs();
+        let dfb = (f - b).abs();
+        let ddb = (d - b).abs();
+        // A crude edge detector: drop whichever horizontal neighbour
+        // lies across the strongest gradient and lean on the sample
+        // two rows up instead.
+        let pred4 = if dcb > dfb && dcb > ddb {
+            f + d + 2 * b
+        } else if ddb > dcb && ddb > dfb {
+            f + c + 2 * b
+        } else {
+            d + c + 2 * b
+        };
+        let pred = pred4 >> 2;
+        if !coded {
+            self.buf[here + p + 1] = pred;
+            return Ok(());
+        }
+        let t = self.select(dfb + dcb);
+        let table = &self.tables[t];
+        let grad = table.grad_mult * table.level(b - f) + table.level(c - b);
+        let r = self.residual(t, set, grad.unsigned_abs() as usize)?;
+        self.buf[here + p + 1] = self.reconstruct(t, pred, r, grad);
+        Ok(())
+    }
+
+    /// An odd position. Always coded, and it reads the sample to its
+    /// right — which is why the even side runs ahead.
+    #[inline(always)]
+    fn odd(&mut self, x: usize, p: usize, set: usize) -> Result<()> {
+        let here = x * self.stride;
+        let up = here - self.stride;
+        let a = self.buf[here + p];
+        let g = self.buf[here + p + 2];
+        let b = self.buf[up + p + 1];
+        let c = self.buf[up + p];
+        let d = self.buf[up + p + 2];
+        let pred = if (b > c && b > d) || (b < c && b < d) {
+            // The row above turns here, so trust it as a level.
+            (g + a + 2 * b) >> 2
+        } else {
+            (a + g) >> 1
+        };
+        let t = self.select((b - c).abs() + (c - a).abs());
+        let table = &self.tables[t];
+        let grad = table.grad_mult * table.level(b - c) + table.level(c - a);
+        let r = self.residual(t, set, grad.unsigned_abs() as usize)?;
+        self.buf[here + p + 1] = self.reconstruct(t, pred, r, grad);
+        Ok(())
+    }
+
+    /// Refresh a colour's guard slots, cascading down its buffers: a
+    /// line's left guard is the first real sample of the line above it
+    /// and its right guard that line's last.
+    fn guards(&mut self, first: usize, last: usize) {
+        for x in first..=last {
+            let up = (x - 1) * self.stride;
+            let (left, right) = (self.buf[up + 1], self.buf[up + self.line_width]);
+            let here = x * self.stride;
+            self.buf[here] = left;
+            self.buf[here + self.line_width + 1] = right;
+        }
+    }
+
+    /// Copy buffer `from` over buffer `to`, guards included.
+    fn copy_line(&mut self, to: usize, from: usize) {
+        let (to, from) = (to * self.stride, from * self.stride);
+        self.buf.copy_within(from..from + self.stride, to);
+    }
+
+    /// One six-row block, six two-row passes.
+    fn block(&mut self) -> Result<()> {
+        for (pass, &(first, second)) in PASSES.iter().enumerate() {
+            let before = self.symbols;
+            let set = pass % 3;
+            let (rule1, rule2) = self.rules[pass];
+            let mut even_pos = 0usize;
+            let mut odd_pos = 1usize;
+            // The odd side starts once the even counter passes eight,
+            // tested after the increment, so it trails by five
+            // positions. Two would satisfy the right-hand tap; five is
+            // what the format does, and the interleave of symbols in
+            // the bitstream depends on it exactly.
+            loop {
+                if even_pos < self.line_width {
+                    self.even(first, even_pos, set, rule1.coded(even_pos))?;
+                    self.even(second, even_pos, set, rule2.coded(even_pos))?;
+                    even_pos += 2;
+                }
+                if (even_pos > 8 || even_pos >= self.line_width) && odd_pos < self.line_width {
+                    self.odd(first, odd_pos, 3 + set)?;
+                    self.odd(second, odd_pos, 3 + set)?;
+                    odd_pos += 2;
+                }
+                if even_pos >= self.line_width && odd_pos >= self.line_width {
+                    break;
+                }
+            }
+            // Green's guards are refreshed after every pass, red's
+            // after the odd-numbered ones and blue's after the even.
+            if pass % 2 == 0 {
+                self.guards(RED[0], RED[2]);
+                self.guards(GREEN[0], GREEN[5]);
+            } else {
+                self.guards(GREEN[0], GREEN[5]);
+                self.guards(BLUE[0], BLUE[2]);
+            }
+            self.pass_symbols[pass] = (self.symbols - before) as u32;
+        }
+        Ok(())
+    }
+
+    /// Retire the block: keep each colour's last two coded rows as the
+    /// next block's history, then clear the current rows, leaving only
+    /// the first buffer of each colour holding guards from history.
+    ///
+    /// Red and blue keep rows 1 and 2 and drop row 0 entirely — with
+    /// three rows a block, only two can be kept.
+    fn rotate(&mut self) {
+        self.copy_line(0, RED[1]);
+        self.copy_line(1, RED[2]);
+        self.copy_line(5, GREEN[4]);
+        self.copy_line(6, GREEN[5]);
+        self.copy_line(13, BLUE[1]);
+        self.copy_line(14, BLUE[2]);
+        for x in RED.iter().chain(GREEN.iter()).chain(BLUE.iter()) {
+            let at = x * self.stride;
+            self.buf[at..at + self.stride].fill(0);
+        }
+        for first in [RED[0], GREEN[0], BLUE[0]] {
+            let up = (first - 1) * self.stride;
+            let (left, right) = (self.buf[up + 1], self.buf[up + self.line_width]);
+            let here = first * self.stride;
+            self.buf[here] = left;
+            self.buf[here + self.line_width + 1] = right;
+        }
+    }
+
+    /// One sample out of the buffers.
+    #[inline(always)]
+    fn sample(&self, buffer: usize, slot: usize) -> u16 {
+        self.buf[buffer * self.stride + slot + 1] as u16
+    }
+}
+
+/// Where every sensor column of a block row lives: `(line buffer,
+/// slot)`.
+///
+/// For X-Trans each run of three sensor columns maps onto two slots:
+/// the run's first column takes the even slot and its other two take
+/// the odd one, in different buffers — a 6x6 array never puts two
+/// samples of the same colour in the same row of a run. That is where
+/// `line_width = 2 * stripe_width / 3` comes from, and the slots left
+/// over are exactly the ones the passes interpolate. For Bayer two
+/// columns share a slot and nothing is interpolated.
+fn sensor_map(cfa: &Cfa, x_trans: bool, stripe_width: usize) -> Result<Vec<Vec<(usize, usize)>>> {
+    let mut map = Vec::with_capacity(BLOCK_ROWS);
+    for r in 0..BLOCK_ROWS {
+        let mut row = Vec::with_capacity(stripe_width);
+        for c in 0..stripe_width {
+            // Stripes start on a multiple of 768 and blocks on a
+            // multiple of six, so a column's phase in the array is the
+            // same in every stripe and every block.
+            let color = match cfa.color_at(c, r) {
+                Some(color) => color,
+                None => return corrupt("compressed strip under a filter array with no colours"),
+            };
+            let slot = if x_trans {
+                2 * (c / 3) + usize::from(!c.is_multiple_of(3))
+            } else {
+                c / 2
+            };
+            let buffer = match color {
+                CfaColor::Green | CfaColor::Green2 => GREEN[r],
+                CfaColor::Red => RED[r / 2],
+                CfaColor::Blue => BLUE[r / 2],
+                other => {
+                    return Err(Error::Unsupported(format!(
+                        "RAF: compressed frame with a {other:?} filter"
+                    )))
+                }
+            };
+            row.push((buffer, slot));
+        }
+        map.push(row);
+    }
+    Ok(map)
+}
+
+/// The 6x6 phase the pass schedule is wired to. Every compressed
+/// X-Trans RAF carries exactly this array; a file that did not would
+/// need a different coded/filled pattern in every pass, so it is
+/// refused rather than decoded into a plausible-looking wrong frame.
+const XTRANS_PHASE: [[CfaColor; 6]; 6] = {
+    use CfaColor::{Blue as B, Green as G, Red as R};
+    [
+        [G, G, R, G, G, B],
+        [G, G, B, G, G, R],
+        [B, R, G, R, B, G],
+        [G, G, B, G, G, R],
+        [G, G, R, G, G, B],
+        [R, B, G, B, R, G],
+    ]
+};
+
+/// Decode one stripe into its columns of the frame.
+fn decode_stripe(
+    data: &[u8],
+    header: &Header,
+    qbases: Option<&[u8]>,
+    map: &[Vec<(usize, usize)>],
+    rows: &mut [&mut [u16]],
+) -> Result<()> {
+    let mut stripe = Stripe::new(data, header);
+    let mut q_base = None;
+    for b in 0..header.blocks {
+        if let Some(qbases) = qbases {
+            let next = qbases.get(b).copied().unwrap_or(0) as i32;
+            // The contexts only survive a block boundary when the
+            // quantiser does not move.
+            if q_base != Some(next) {
+                stripe.set_q_base(next);
+                q_base = Some(next);
+            }
+        }
+        stripe.block()?;
+        // The emit has to come before the retire: the retire clears
+        // the very buffers it reads.
+        for (r, columns) in map.iter().enumerate() {
+            let Some(row) = rows.get_mut(b * BLOCK_ROWS + r) else {
+                break;
+            };
+            for (out, &(buffer, slot)) in row.iter_mut().zip(columns.iter()) {
+                *out = stripe.sample(buffer, slot);
+            }
+        }
+        stripe.rotate();
+    }
+    Ok(())
+}
+
+/// Decode a compressed sensor strip into `width * height` samples.
 pub fn decode(strip: &[u8], width: usize, height: usize, cfa: &Cfa) -> Result<Vec<u16>> {
     let header = Header::parse(strip)?;
     if header.width != width || header.height != height {
-        return Err(Error::Corrupt(format!(
+        return corrupt(format!(
             "compressed strip is {}x{} inside a {width}x{height} frame",
             header.width, header.height
-        )));
+        ));
     }
-    // The header names the filter array too, and disagreeing with the
-    // container would mean one of the two was misread.
+    // Disagreeing with the container about the filter array would mean
+    // one of the two was misread, which is a corrupt file rather than
+    // an unsupported one.
     let x_trans = matches!(cfa, Cfa::XTrans(_));
-    if x_trans != (header.sensor == 0x10) {
-        return Err(Error::Corrupt(format!(
+    if x_trans != header.is_x_trans() {
+        return corrupt(format!(
             "compressed strip says sensor type {:#04x} for a {} frame",
             header.sensor,
             if x_trans { "X-Trans" } else { "Bayer" }
-        )));
+        ));
     }
-    let body = strip.len().saturating_sub(header.data_offset());
-    Err(Error::Unsupported(format!(
-        "RAF: Fujifilm {} compression ({} {}-bit, {} stripes of {})",
-        if header.looks_lossless(body) {
-            "lossless"
-        } else {
-            "lossy"
-        },
-        if x_trans { "X-Trans" } else { "Bayer" },
-        header.bits,
-        header.stripes,
-        header.stripe_width
-    )))
+    if let Cfa::XTrans(grid) = cfa {
+        if *grid != XTRANS_PHASE {
+            return Err(Error::Unsupported(
+                "RAF: compressed X-Trans frame on an unknown filter-array phase".into(),
+            ));
+        }
+    }
+    let samples = crate::frame_samples(width, height, 1)?;
+    let map = sensor_map(cfa, x_trans, header.stripe_width)?;
+    let sizes = header.stripe_lengths(strip)?;
+
+    // Each stripe owns a column range of every row, so handing out the
+    // rows split at the stripe boundaries lets the stripes decode
+    // straight into the frame in parallel with no sharing at all.
+    let mut frame = vec![0u16; samples];
+    let mut columns: Vec<Vec<&mut [u16]>> = (0..header.stripes)
+        .map(|_| Vec::with_capacity(height))
+        .collect();
+    for row in frame.chunks_mut(width) {
+        let mut rest = row;
+        for stripe in columns.iter_mut() {
+            let take = rest.len().min(header.stripe_width);
+            let (head, tail) = rest.split_at_mut(take);
+            stripe.push(head);
+            rest = tail;
+        }
+    }
+
+    let mut at = header.data_offset();
+    let mut starts = Vec::with_capacity(header.stripes);
+    for size in &sizes {
+        starts.push(at);
+        at = at.saturating_add(*size);
+    }
+
+    columns
+        .into_par_iter()
+        .enumerate()
+        .try_for_each(|(s, mut rows)| -> Result<()> {
+            // A stripe's declared length may run past the end of the
+            // file; the reader feeds zeros past whatever is there, and
+            // a stream that needs them fails on its own.
+            let start = starts[s].min(strip.len());
+            let end = start.saturating_add(sizes[s]).min(strip.len());
+            let qbases = header.qbases(strip, s)?;
+            decode_stripe(&strip[start..end], &header, qbases, &map, &mut rows)
+        })?;
+    Ok(frame)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// The X100F's real header, byte for byte.
+    /// The X100F's real strip header, byte for byte.
     const X100F: [u8; 16] = [
         0x49, 0x53, 0x01, 0x10, 0x0e, 0x0f, 0xc6, 0x18, 0x00, 0x17, 0xa0, 0x03, 0x00, 0x08, 0x02,
         0xa1,
     ];
+    /// The GFX100S's: lossy, Bayer, sixteen stripes.
+    const GFX100S: [u8; 16] = [
+        0x49, 0x53, 0x00, 0x00, 0x0e, 0x22, 0x32, 0x30, 0x00, 0x2e, 0x20, 0x03, 0x00, 0x10, 0x05,
+        0xb3,
+    ];
 
     #[test]
-    fn reads_a_real_header() {
+    fn reads_a_real_lossless_header() {
         let header = Header::parse(&X100F).unwrap();
         assert_eq!(
             header,
             Header {
-                version: 1,
+                lossless: true,
                 sensor: 0x10,
                 bits: 14,
                 height: 4038,
@@ -279,8 +1000,34 @@ mod tests {
                 blocks: 673,
             }
         );
-        // Eight lengths is 32 bytes, which is already a multiple of 16.
+        // Eight lengths is 32 bytes, already a multiple of 16, and a
+        // lossless file carries no quantiser bases.
         assert_eq!(header.data_offset(), 48);
+        assert_eq!(header.line_width(), 512);
+    }
+
+    #[test]
+    fn reads_a_real_lossy_header() {
+        let header = Header::parse(&GFX100S).unwrap();
+        assert_eq!(
+            header,
+            Header {
+                lossless: false,
+                sensor: 0x00,
+                bits: 14,
+                height: 8754,
+                rounded_width: 12288,
+                width: 11808,
+                stripe_width: 768,
+                stripes: 16,
+                blocks: 1459,
+            }
+        );
+        // 64 bytes of size table, then sixteen stripes of 1459
+        // quantiser bases each padded to 1472.
+        assert_eq!(header.data_offset(), 16 + 64 + 16 * 1472);
+        assert_eq!(header.data_offset(), 23632);
+        assert_eq!(header.line_width(), 384);
     }
 
     #[test]
@@ -288,58 +1035,797 @@ mod tests {
         // The X-Pro3's nine stripes: 36 bytes of table, padded to 48.
         let mut header = Header::parse(&X100F).unwrap();
         header.stripes = 9;
+        header.rounded_width = 9 * 768;
         assert_eq!(header.data_offset(), 64);
         header.stripes = 16;
+        header.rounded_width = 16 * 768;
         assert_eq!(header.data_offset(), 80);
     }
 
     #[test]
     fn rejects_a_header_that_contradicts_itself() {
         assert!(matches!(Header::parse(&X100F[..8]), Err(Error::Corrupt(_))));
-        let mut bad = X100F;
-        bad[0] = 0;
-        assert!(matches!(Header::parse(&bad), Err(Error::Corrupt(_))));
-        // Stripes that do not cover the rounded width.
-        let mut bad = X100F;
-        bad[13] = 7;
-        assert!(matches!(Header::parse(&bad), Err(Error::Corrupt(_))));
-        // A block count that does not make the height.
-        let mut bad = X100F;
-        bad[14..16].copy_from_slice(&100u16.to_be_bytes());
-        assert!(matches!(Header::parse(&bad), Err(Error::Corrupt(_))));
-        // A rounded width that rounds by more than a whole stripe.
-        let mut bad = X100F;
-        bad[9..11].copy_from_slice(&1000u16.to_be_bytes());
-        assert!(matches!(Header::parse(&bad), Err(Error::Corrupt(_))));
+        let bad = |at: usize, to: &[u8]| {
+            let mut bad = X100F;
+            bad[at..at + to.len()].copy_from_slice(to);
+            assert!(
+                matches!(Header::parse(&bad), Err(Error::Corrupt(_))),
+                "byte {at} = {to:?} was accepted"
+            );
+        };
+        bad(0, &[0, 0]); // no signature
+        bad(2, &[2]); // neither lossless nor lossy
+        bad(3, &[0x20]); // no such filter array
+        bad(4, &[13]); // no such depth
+        bad(5, &[0x0e, 0x0d]); // a height that is not six rows a block
+        bad(11, &[0x02, 0x00]); // a stripe width Fujifilm never shipped
+        bad(13, &[7]); // stripes that do not cover the rounded width
+        bad(14, &[0, 100]); // blocks that do not make the height
+        bad(9, &[0x03, 0xe8]); // a width rounded up by more than a stripe
+                               // A width that is not a whole number of filter-array periods.
+        bad(9, &[0x17, 0x9c]);
     }
 
     #[test]
-    fn the_body_size_tells_lossless_from_lossy() {
-        let header = Header::parse(&X100F).unwrap();
-        // The X100F's own body: 8.5 bits a pixel.
-        assert!(header.looks_lossless(25_977_312));
-        // The GFX100S's rate, scaled to this frame: 4.7 bits a pixel.
-        assert!(!header.looks_lossless(6048 * 4038 * 47 / 80));
-        assert!(!header.looks_lossless(0));
+    fn the_alphabet_width_is_the_bits_the_largest_symbol_needs() {
+        assert_eq!(ceil_log2(0), 0);
+        assert_eq!(ceil_log2(1), 1);
+        assert_eq!(ceil_log2(2), 1);
+        assert_eq!(ceil_log2(3), 2);
+        assert_eq!(ceil_log2(16384), 14);
+        assert_eq!(ceil_log2(5462), 13);
+        assert_eq!(ceil_log2(2342), 12);
+    }
+
+    /// The six quantiser bases the format's own worked table lists at
+    /// 14 bits, and what each makes of the main table.
+    #[test]
+    fn the_main_table_matches_the_formats_worked_values() {
+        let max_bits = 4 * ceil_log2(16384);
+        assert_eq!(max_bits, 56);
+        let want = [
+            // q_base, t0..t3, total_values, raw_bits, escape, step, sum
+            (0, [0, 18, 67, 276], 16384, 14, 41, 1, 256),
+            (1, [1, 21, 72, 283], 5462, 13, 42, 3, 85),
+            (2, [2, 24, 77, 290], 3278, 12, 43, 5, 51),
+            (3, [3, 27, 82, 297], 2342, 12, 43, 7, 37),
+            (4, [4, 30, 87, 304], 1822, 11, 44, 9, 28),
+            (5, [5, 33, 92, 311], 1491, 11, 44, 11, 23),
+        ];
+        for (q, t, total, raw_bits, esc, step, sum) in want {
+            let table = Table::new(q, 16383, max_bits, 9, 0);
+            assert_eq!(table.t, t, "thresholds at q_base {q}");
+            assert_eq!(table.total_values, total, "alphabet at q_base {q}");
+            assert_eq!(table.raw_bits, raw_bits, "escape width at q_base {q}");
+            assert_eq!(table.esc, esc, "escape threshold at q_base {q}");
+            assert_eq!(table.step, step, "step at q_base {q}");
+            assert_eq!(table.init_sum, sum, "context seed at q_base {q}");
+        }
+        // The three fine tables, built once a file and never rebuilt.
+        for (q, t, total, raw_bits, esc) in [
+            (0, [0, 0x12, 0x43, 0x114], 16384, 14, 41),
+            (1, [1, 0x15, 0x48, 0x11b], 5462, 13, 42),
+            (2, [2, 0x18, 0x4d, 0x122], 3278, 12, 43),
+        ] {
+            let table = Table::new(q, 16383, max_bits, 3, 5 + q);
+            assert_eq!(table.t, t);
+            assert_eq!(table.total_values, total);
+            assert_eq!(table.raw_bits, raw_bits);
+            assert_eq!(table.esc, esc);
+        }
+        // Shallower frames: the escape threshold moves with the depth.
+        let twelve = Table::new(0, 4095, 4 * ceil_log2(4096), 9, 0);
+        assert_eq!(
+            (
+                twelve.total_values,
+                twelve.raw_bits,
+                twelve.esc,
+                twelve.init_sum
+            ),
+            (4096, 12, 35, 64)
+        );
+        let sixteen = Table::new(0, 65535, 4 * ceil_log2(65536), 9, 0);
+        assert_eq!(
+            (
+                sixteen.total_values,
+                sixteen.raw_bits,
+                sixteen.esc,
+                sixteen.init_sum
+            ),
+            (65536, 16, 47, 1024)
+        );
+    }
+
+    /// The quantiser's comparisons are lopsided, and it only shows on
+    /// a difference that lands exactly on a threshold.
+    #[test]
+    fn the_gradient_quantiser_is_asymmetric_on_its_thresholds() {
+        let t = Table::new(0, 16383, 56, 9, 0);
+        assert_eq!(t.t, [0, 18, 67, 276]);
+        assert_eq!(t.level(0), 0);
+        assert_eq!(t.level(1), 1);
+        assert_eq!(t.level(-1), -1);
+        // On the positive side a threshold belongs to the level above,
+        // on the negative side to the level below.
+        assert_eq!(t.level(18), 2);
+        assert_eq!(t.level(17), 1);
+        assert_eq!(t.level(-18), -2);
+        assert_eq!(t.level(-17), -1);
+        assert_eq!(t.level(276), 4);
+        assert_eq!(t.level(-276), -4);
+        assert_eq!(t.level(275), 3);
+        assert_eq!(t.level(-275), -3);
+        assert_eq!(t.level(16383), 4);
+        assert_eq!(t.level(-16383), -4);
+    }
+
+    /// The shift a context asks for as it warms up. A stripe that
+    /// opens on a run of identical samples spends `1 + k` bits a
+    /// symbol, and this ladder — one 9-bit code, two 8-bit, four
+    /// 7-bit, eight 6-bit, sixteen 5-bit, thirty-two 4-bit — is the
+    /// first thing to check against a real file.
+    #[test]
+    fn the_shift_ladder_warms_up_by_halves() {
+        let shift = |count: u32, sum: u32| -> u32 {
+            if count >= sum {
+                0
+            } else {
+                let mut k = 1;
+                while k < 15 && (count << k) < sum {
+                    k += 1;
+                }
+                k
+            }
+        };
+        let sum = Table::new(0, 16383, 56, 9, 0).init_sum;
+        assert_eq!(sum, 256);
+        // Zero residuals leave `sum` alone, so only `count` walks.
+        let ladder: Vec<u32> = (1..=16).map(|count| shift(count, sum)).collect();
+        assert_eq!(ladder, [8, 7, 7, 6, 6, 6, 6, 5, 5, 5, 5, 5, 5, 5, 5, 4]);
+        assert_eq!(shift(256, 256), 0);
+        assert_eq!(shift(300, 256), 0);
+        // A context whose residuals are enormous still stops at 15.
+        assert_eq!(shift(1, 1 << 20), 15);
     }
 
     #[test]
-    fn decoding_says_what_the_file_is() {
-        let mut strip = X100F.to_vec();
-        strip.resize(16 + 32 + 25_977_264, 0);
-        let cfa = Cfa::XTrans([[crate::CfaColor::Green; 6]; 6]);
-        let why = decode(&strip, 6048, 4038, &cfa).unwrap_err().to_string();
-        assert!(why.contains("lossless"), "{why}");
-        assert!(why.contains("X-Trans"), "{why}");
-        // A Bayer container with an X-Trans header is a misread, not
-        // an unsupported file.
+    fn a_zero_run_consumes_its_terminator() {
+        // 0b0001_0110: three zeros, the one, then 0b0110 left over.
+        let mut pump = BitPumpMsb::new(&[0b0001_0110, 0xff]);
+        assert_eq!(zero_run(&mut pump).unwrap(), 3);
+        assert_eq!(pump.get(4), 0b0110);
+        // A run that spans bytes.
+        let mut pump = BitPumpMsb::new(&[0, 0, 0, 0, 0, 0x40]);
+        assert_eq!(zero_run(&mut pump).unwrap(), 41);
+        // Past the end the reader feeds zeros for ever; the run is
+        // refused rather than looped on.
+        let mut pump = BitPumpMsb::new(&[0; 4]);
+        assert!(zero_run(&mut pump).is_err());
+    }
+
+    #[test]
+    fn the_even_rules_place_exactly_one_symbol_a_photosite() {
+        // Every X-Trans block codes 4608 symbols: the odd half of all
+        // twelve buffers, plus whatever evens the rules keep.
+        let line_width = 512;
+        let mut total = 0;
+        for (first, second) in XTRANS_RULES {
+            for rule in [first, second] {
+                total += line_width / 2; // the odd positions
+                total += (0..line_width)
+                    .step_by(2)
+                    .filter(|p| rule.coded(*p))
+                    .count();
+            }
+        }
+        assert_eq!(total, 9 * line_width);
+        assert_eq!(total, 6 * STRIPE_WIDTH);
+        let bayer: usize = BAYER_RULES.len() * 2 * 384;
+        assert_eq!(bayer, 6 * STRIPE_WIDTH);
+    }
+
+    /// The smallest legal frame: one stripe, one block.
+    fn tiny(lossless: bool, x_trans: bool) -> Vec<u8> {
+        let mut head = vec![
+            0x49,
+            0x53,
+            u8::from(lossless),
+            if x_trans { 0x10 } else { 0 },
+            14,
+        ];
+        head.extend_from_slice(&6u16.to_be_bytes()); // height
+        head.extend_from_slice(&768u16.to_be_bytes()); // rounded width
+        head.extend_from_slice(&768u16.to_be_bytes()); // width
+        head.extend_from_slice(&768u16.to_be_bytes()); // stripe width
+        head.push(1); // stripes
+        head.extend_from_slice(&1u16.to_be_bytes()); // blocks
+        assert_eq!(head.len(), 16);
+        head
+    }
+
+    /// Nothing a forged or truncated strip can say may panic: the
+    /// reader feeds zeros past the end and every table index is
+    /// bounded by construction, so the only outcomes are a frame and
+    /// an error.
+    #[test]
+    fn hostile_strips_return_errors_rather_than_panicking() {
+        let xtrans = Cfa::XTrans(XTRANS_PHASE);
+        for (lossless, cfa) in [(true, &xtrans), (false, &Cfa::RGGB)] {
+            let x_trans = matches!(cfa, Cfa::XTrans(_));
+            let mut strip = tiny(lossless, x_trans);
+            // A size table, a quantiser base and a body of noise.
+            strip.extend_from_slice(&4096u32.to_be_bytes());
+            strip.resize(Header::parse(&strip).unwrap().data_offset(), 0xa5);
+            let mut seed = 0x1234_5678u32;
+            for _ in 0..4096 {
+                seed = seed.wrapping_mul(1_103_515_245).wrapping_add(12345);
+                strip.push((seed >> 16) as u8);
+            }
+            for cut in 0..=32 {
+                let at = strip.len() * cut / 32;
+                let _ = decode(&strip[..at], 768, 6, cfa);
+            }
+            // And a body of nothing but zero bits, which is an
+            // unterminated run rather than a frame of zeros.
+            let mut zeros = tiny(lossless, x_trans);
+            zeros.resize(20_000, 0);
+            assert!(decode(&zeros, 768, 6, cfa).is_err());
+        }
+        // A strip whose header does not match the container it sits in.
+        let strip = tiny(true, true);
         assert!(matches!(
-            decode(&strip, 6048, 4038, &Cfa::RGGB),
+            decode(&strip, 768, 6, &Cfa::RGGB),
             Err(Error::Corrupt(_))
         ));
         assert!(matches!(
-            decode(&strip, 10, 10, &cfa),
+            decode(&strip, 100, 6, &Cfa::XTrans(XTRANS_PHASE)),
             Err(Error::Corrupt(_))
         ));
+        // An X-Trans phase the pass schedule is not wired to.
+        let mut phase = XTRANS_PHASE;
+        phase[0][0] = CfaColor::Red;
+        assert!(matches!(
+            decode(&strip, 768, 6, &Cfa::XTrans(phase)),
+            Err(Error::Unsupported(_))
+        ));
+    }
+
+    /// The column-to-slot map is the other half of the same fact as
+    /// the pass rules: a slot the rules interpolate must be a slot the
+    /// map never reads.
+    #[test]
+    fn the_map_reads_only_the_slots_the_passes_code() {
+        let cfa = Cfa::XTrans(XTRANS_PHASE);
+        let map = sensor_map(&cfa, true, STRIPE_WIDTH).unwrap();
+        let line_width = STRIPE_WIDTH * 2 / 3;
+        // Which (buffer, slot) pairs the six rows read.
+        let mut read = std::collections::HashSet::new();
+        for row in &map {
+            for &pair in row {
+                assert!(read.insert(pair), "two sensor columns share {pair:?}");
+            }
+        }
+        assert_eq!(read.len(), BLOCK_ROWS * STRIPE_WIDTH);
+        // And which the passes code.
+        let mut coded = std::collections::HashSet::new();
+        for (pass, &(first, second)) in PASSES.iter().enumerate() {
+            for (buffer, rule) in [
+                (first, XTRANS_RULES[pass].0),
+                (second, XTRANS_RULES[pass].1),
+            ] {
+                for p in 0..line_width {
+                    if !p.is_multiple_of(2) || rule.coded(p) {
+                        coded.insert((buffer, p));
+                    }
+                }
+            }
+        }
+        assert_eq!(read, coded);
+    }
+}
+
+/// The format's own worked examples, walked one checkpoint at a time
+/// against the files they were taken from.
+///
+/// Every number here is the decoder's own state at a named point in a
+/// named file, so a failure says *which* rule is wrong rather than
+/// only that the picture is. Gated on `SCHIST_RAW_CORPUS`; silent when
+/// the corpus is not there.
+#[cfg(test)]
+mod checkpoints {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// A stripe decoded a few blocks deep, with its state kept at
+    /// every step it is worth comparing.
+    struct Trace {
+        stride: usize,
+        /// The eighteen buffers after each block's six passes, before
+        /// the history rotates.
+        after_block: Vec<Vec<i32>>,
+        /// ... and after the rotate and clear.
+        after_rotate: Vec<Vec<i32>>,
+        /// The sensor rows the blocks emitted.
+        rows: Vec<Vec<u16>>,
+        pass_symbols: Vec<[u32; 6]>,
+    }
+
+    impl Trace {
+        /// Slots `0 ..= last` of one line buffer.
+        fn line(&self, state: &[i32], buffer: usize, last: usize) -> Vec<i32> {
+            state[buffer * self.stride..buffer * self.stride + last + 1].to_vec()
+        }
+        fn block(&self, b: usize, buffer: usize, last: usize) -> Vec<i32> {
+            self.line(&self.after_block[b], buffer, last)
+        }
+        fn rotated(&self, b: usize, buffer: usize, last: usize) -> Vec<i32> {
+            self.line(&self.after_rotate[b], buffer, last)
+        }
+    }
+
+    /// Decode the first `blocks` blocks of stripe 0 of a corpus file,
+    /// keeping everything. `strip_at` is the strip's file offset, and
+    /// the header there is checked against `head` so a corpus that has
+    /// moved fails loudly instead of quietly decoding rubbish.
+    fn trace(name: &str, strip_at: usize, head: &[u8; 16], blocks: usize) -> Option<Trace> {
+        let root = std::env::var("SCHIST_RAW_CORPUS").ok()?;
+        let path = PathBuf::from(root).join("Fujifilm").join(name);
+        let bytes = std::fs::read(&path).ok()?;
+        let strip = bytes.get(strip_at..)?;
+        assert_eq!(&strip[..16], head, "{name}: the strip has moved");
+        let header = Header::parse(strip).unwrap();
+        let cfa = if header.is_x_trans() {
+            Cfa::XTrans(XTRANS_PHASE)
+        } else {
+            Cfa::RGGB
+        };
+        let map = sensor_map(&cfa, header.is_x_trans(), header.stripe_width).unwrap();
+        let sizes = header.stripe_lengths(strip).unwrap();
+        let start = header.data_offset();
+        let end = (start + sizes[0]).min(strip.len());
+        let qbases = header.qbases(strip, 0).unwrap();
+
+        let mut stripe = Stripe::new(&strip[start..end], &header);
+        let mut trace = Trace {
+            stride: stripe.stride,
+            after_block: Vec::new(),
+            after_rotate: Vec::new(),
+            rows: Vec::new(),
+            pass_symbols: Vec::new(),
+        };
+        let mut q_base = None;
+        for b in 0..blocks {
+            if let Some(qbases) = qbases {
+                let next = qbases[b] as i32;
+                if q_base != Some(next) {
+                    stripe.set_q_base(next);
+                    q_base = Some(next);
+                }
+            }
+            stripe.block().unwrap();
+            trace.pass_symbols.push(stripe.pass_symbols);
+            trace.after_block.push(stripe.buf.clone());
+            for columns in &map {
+                trace.rows.push(
+                    columns
+                        .iter()
+                        .map(|&(buffer, slot)| stripe.sample(buffer, slot))
+                        .collect(),
+                );
+            }
+            stripe.rotate();
+            trace.after_rotate.push(stripe.buf.clone());
+        }
+        Some(trace)
+    }
+
+    const X100F: &str = "X100F-DSCF5760_x100f_lossless_compressed_raw_Temple.RAF";
+    const X100F_AT: usize = 884224;
+    const X100F_HEAD: [u8; 16] = [
+        0x49, 0x53, 0x01, 0x10, 0x0e, 0x0f, 0xc6, 0x18, 0x00, 0x17, 0xa0, 0x03, 0x00, 0x08, 0x02,
+        0xa1,
+    ];
+    const XT5: &str = "X-T5-DSCF0021.RAF";
+    const XT5_AT: usize = 4041216;
+    const XT5_HEAD: [u8; 16] = [
+        0x49, 0x53, 0x01, 0x10, 0x0e, 0x14, 0x4c, 0x21, 0x00, 0x1e, 0xc0, 0x03, 0x00, 0x0b, 0x03,
+        0x62,
+    ];
+    const GFX: &str = "GFX100S-Fujifilm-GFX100S-14bits-compress-4_3.RAF";
+    const GFX_AT: usize = 3453440;
+    const GFX_HEAD: [u8; 16] = [
+        0x49, 0x53, 0x00, 0x00, 0x0e, 0x22, 0x32, 0x30, 0x00, 0x2e, 0x20, 0x03, 0x00, 0x10, 0x05,
+        0xb3,
+    ];
+
+    /// Checkpoint 3: the symbol count. A block codes one symbol a
+    /// photosite however the photosites are arranged, and the per-pass
+    /// split is the cheapest check there is on the visit order.
+    #[test]
+    fn a_block_codes_one_symbol_a_photosite() {
+        let Some(xtrans) = trace(X100F, X100F_AT, &X100F_HEAD, 2) else {
+            return;
+        };
+        assert_eq!(xtrans.pass_symbols[0], [768, 768, 640, 896, 896, 640]);
+        assert_eq!(xtrans.pass_symbols[0].iter().sum::<u32>(), 4608);
+        assert_eq!(xtrans.pass_symbols[1], [768, 768, 640, 896, 896, 640]);
+
+        let Some(bayer) = trace(GFX, GFX_AT, &GFX_HEAD, 2) else {
+            return;
+        };
+        // Bayer blocks code every slot of every buffer: 2 * 384 a pass.
+        assert_eq!(bayer.pass_symbols[0], [768; 6]);
+        assert_eq!(bayer.pass_symbols[0].iter().sum::<u32>(), 4608);
+    }
+
+    /// Checkpoint 5: the whole buffer state at the end of the first
+    /// block. The first four sensor rows of this frame are blank, so
+    /// only the row-5 buffers hold anything, and their zero pattern
+    /// *is* the coded-versus-filled table.
+    #[test]
+    fn the_cold_start_leaves_only_the_last_row_populated() {
+        let Some(trace) = trace(X100F, X100F_AT, &X100F_HEAD, 2) else {
+            return;
+        };
+        // R2: `slot % 4` in {0, 3} are row 5's reds; `% 4 == 1` is row
+        // 4's, which is blank, and `% 4 == 2` is interpolated filler.
+        assert_eq!(
+            trace.block(0, 4, 34),
+            [
+                0, 1067, 0, 0, 1058, 1070, 0, 0, 1062, 1064, 0, 0, 1058, 1064, 0, 0, 1051, 1047, 0,
+                0, 1051, 1051, 0, 0, 1065, 1077, 0, 0, 1071, 1058, 0, 0, 1083, 1076, 0
+            ]
+        );
+        // G5: only the odd positions carry photosites.
+        assert_eq!(
+            trace.block(0, 12, 34),
+            [
+                0, 0, 1110, 0, 1107, 0, 1120, 0, 1121, 0, 1113, 0, 1122, 0, 1083, 0, 1091, 0, 1096,
+                0, 1096, 0, 1102, 0, 1130, 0, 1154, 0, 1113, 0, 1109, 0, 1156, 0, 1116
+            ]
+        );
+        // B2: `slot % 4` in {1, 2}.
+        assert_eq!(
+            trace.block(0, 17, 34),
+            [
+                0, 0, 1061, 1069, 0, 0, 1063, 1060, 0, 0, 1046, 1056, 0, 0, 1051, 1040, 0, 0, 1050,
+                1049, 0, 0, 1055, 1080, 0, 0, 1066, 1074, 0, 0, 1064, 1068, 0, 0, 1067
+            ]
+        );
+        for buffer in 0..LINES {
+            if matches!(buffer, 4 | 12 | 17) {
+                continue;
+            }
+            assert!(
+                trace.block(0, buffer, 34).iter().all(|v| *v == 0),
+                "buffer {buffer} should still be blank"
+            );
+        }
+    }
+
+    /// Checkpoint 6: the column-to-slot map, read off the frame rather
+    /// than off the buffers.
+    #[test]
+    fn the_first_live_row_lands_where_the_filter_array_says() {
+        let Some(trace) = trace(X100F, X100F_AT, &X100F_HEAD, 2) else {
+            return;
+        };
+        for row in &trace.rows[..5] {
+            assert!(row.iter().all(|v| *v == 0));
+        }
+        assert_eq!(
+            trace.rows[5][..32],
+            [
+                1067, 1061, 1110, 1069, 1058, 1107, 1070, 1063, 1120, 1060, 1062, 1121, 1064, 1046,
+                1113, 1056, 1058, 1122, 1064, 1051, 1083, 1040, 1051, 1091, 1047, 1050, 1096, 1049,
+                1051, 1096, 1051, 1055
+            ]
+        );
+    }
+
+    /// Checkpoint 7: the rotate keeps each colour's last two coded
+    /// rows, the clear empties the rest, and only the first buffer of
+    /// each colour comes out of it holding guards.
+    #[test]
+    fn retiring_a_block_keeps_two_rows_and_three_pairs_of_guards() {
+        let Some(trace) = trace(X100F, X100F_AT, &X100F_HEAD, 2) else {
+            return;
+        };
+        // R-1 is the old R2, guards and all; R-2 is the old R1, blank.
+        assert_eq!(trace.rotated(0, 1, 34), trace.block(0, 4, 34));
+        assert!(trace.rotated(0, 0, 34).iter().all(|v| *v == 0));
+        assert_eq!(trace.rotated(0, 6, 34), trace.block(0, 12, 34));
+        assert_eq!(trace.rotated(0, 14, 34), trace.block(0, 17, 34));
+        // Only R0's left guard survives the clear, because only R-1's
+        // first sample is non-zero on this frame.
+        let mut r0 = vec![0; 35];
+        r0[0] = 1067;
+        assert_eq!(trace.rotated(0, 2, 34), r0);
+        for buffer in [3, 4, 7, 8, 9, 10, 11, 12, 15, 16, 17] {
+            assert!(
+                trace.rotated(0, buffer, 34).iter().all(|v| *v == 0),
+                "buffer {buffer} should have been cleared"
+            );
+        }
+    }
+
+    /// Checkpoint 8: the first block where the history, the guards and
+    /// the interpolated fillers are all live at once. If this matches,
+    /// the X-Trans lossless path is right.
+    #[test]
+    fn the_second_block_has_a_live_neighbourhood() {
+        let Some(trace) = trace(X100F, X100F_AT, &X100F_HEAD, 2) else {
+            return;
+        };
+        let want: [(usize, [i32; 35]); 15] = [
+            (
+                1,
+                [
+                    0, 1067, 0, 0, 1058, 1070, 0, 0, 1062, 1064, 0, 0, 1058, 1064, 0, 0, 1051,
+                    1047, 0, 0, 1051, 1051, 0, 0, 1065, 1077, 0, 0, 1071, 1058, 0, 0, 1083, 1076,
+                    0,
+                ],
+            ),
+            (
+                2,
+                [
+                    1067, 533, 1066, 0, 1174, 799, 1089, 0, 1077, 797, 1069, 0, 1057, 796, 1045, 0,
+                    1062, 786, 1059, 0, 1056, 788, 1070, 0, 1084, 804, 1072, 0, 1078, 796, 1066, 0,
+                    1071, 808, 1083,
+                ],
+            ),
+            (
+                3,
+                [
+                    533, 799, 1076, 1063, 1086, 939, 1150, 1139, 1132, 931, 1068, 1083, 1100, 923,
+                    1059, 1050, 1063, 919, 1071, 1059, 1074, 920, 1059, 1069, 1075, 939, 1098,
+                    1069, 1062, 929, 1075, 1056, 1056, 940, 1086,
+                ],
+            ),
+            (
+                4,
+                [
+                    799, 1067, 1104, 1072, 1077, 1076, 1134, 1140, 1220, 1222, 1107, 1083, 1122,
+                    1111, 1060, 1055, 1139, 1110, 1072, 1065, 1087, 1135, 1103, 1068, 1090, 1102,
+                    1080, 1074, 1075, 1050, 1055, 1060, 1054, 1047, 1049,
+                ],
+            ),
+            (
+                6,
+                [
+                    0, 0, 1110, 0, 1107, 0, 1120, 0, 1121, 0, 1113, 0, 1122, 0, 1083, 0, 1091, 0,
+                    1096, 0, 1096, 0, 1102, 0, 1130, 0, 1154, 0, 1113, 0, 1109, 0, 1156, 0, 1116,
+                ],
+            ),
+            (
+                7,
+                [
+                    0, 1116, 1113, 1147, 1176, 1171, 1165, 1141, 1137, 1131, 1112, 1119, 1104,
+                    1102, 1102, 1086, 1094, 1101, 1082, 1084, 1091, 1091, 1090, 1132, 1153, 1186,
+                    1140, 1176, 1165, 1118, 1104, 1127, 1132, 1203, 1182,
+                ],
+            ),
+            (
+                8,
+                [
+                    1116, 1155, 1105, 1116, 1187, 1258, 1267, 1265, 1204, 1121, 1107, 1111, 1103,
+                    1093, 1112, 1087, 1092, 1098, 1111, 1091, 1096, 1091, 1100, 1122, 1133, 1192,
+                    1169, 1122, 1150, 1141, 1107, 1122, 1156, 1165, 1197,
+                ],
+            ),
+            (
+                9,
+                [
+                    1155, 1135, 1122, 1121, 1256, 1242, 1325, 1250, 1196, 1120, 1134, 1108, 1150,
+                    1097, 1083, 1088, 1097, 1097, 1109, 1090, 1092, 1092, 1112, 1127, 1147, 1184,
+                    1139, 1140, 1163, 1137, 1102, 1119, 1155, 1170, 1124,
+                ],
+            ),
+            (
+                10,
+                [
+                    1135, 1200, 1217, 1155, 1102, 1265, 1348, 1223, 1254, 1230, 1179, 1231, 1211,
+                    1166, 1133, 1111, 1129, 1125, 1139, 1136, 1122, 1121, 1124, 1124, 1144, 1156,
+                    1150, 1148, 1138, 1145, 1159, 1113, 1088, 1121, 1092,
+                ],
+            ),
+            (
+                11,
+                [
+                    1200, 1142, 1200, 1187, 1144, 1132, 1192, 1274, 1330, 1377, 1296, 1246, 1260,
+                    1201, 1157, 1143, 1215, 1167, 1124, 1166, 1189, 1225, 1204, 1147, 1150, 1196,
+                    1169, 1136, 1141, 1117, 1104, 1103, 1105, 1096, 1100,
+                ],
+            ),
+            (
+                12,
+                [
+                    1142, 1171, 1146, 1182, 1154, 1150, 1260, 1275, 1389, 1345, 1366, 1245, 1263,
+                    1181, 1148, 1138, 1263, 1145, 1132, 1164, 1196, 1210, 1276, 1142, 1149, 1179,
+                    1160, 1140, 1105, 1119, 1088, 1103, 1083, 1099, 1097,
+                ],
+            ),
+            (
+                14,
+                [
+                    0, 0, 1061, 1069, 0, 0, 1063, 1060, 0, 0, 1046, 1056, 0, 0, 1051, 1040, 0, 0,
+                    1050, 1049, 0, 0, 1055, 1080, 0, 0, 1066, 1074, 0, 0, 1064, 1068, 0, 0, 1067,
+                ],
+            ),
+            (
+                15,
+                [
+                    0, 0, 1054, 799, 1088, 0, 1108, 795, 1060, 0, 1054, 789, 1048, 0, 1051, 782,
+                    1048, 0, 1054, 787, 1050, 0, 1058, 803, 1066, 0, 1062, 803, 1064, 0, 1067, 800,
+                    1078, 0, 1063,
+                ],
+            ),
+            (
+                16,
+                [
+                    0, 1074, 1078, 930, 1082, 1151, 1130, 927, 1099, 1064, 1080, 920, 1068, 1062,
+                    1069, 913, 1052, 1063, 1076, 918, 1063, 1056, 1063, 932, 1063, 1062, 1066, 933,
+                    1061, 1064, 1057, 933, 1062, 1051, 1049,
+                ],
+            ),
+            (
+                17,
+                [
+                    1074, 806, 1057, 1076, 1083, 1128, 1102, 1195, 1136, 1076, 1133, 1082, 1098,
+                    1065, 1080, 1092, 1087, 1063, 1060, 1071, 1110, 1059, 1137, 1086, 1062, 1063,
+                    1056, 1063, 1050, 1061, 1043, 1044, 1049, 1053, 1052,
+                ],
+            ),
+        ];
+        for (buffer, slots) in want {
+            assert_eq!(trace.block(1, buffer, 34), slots, "buffer {buffer}");
+        }
+        // The two history buffers red and green skipped stay blank.
+        for buffer in [0, 5, 13] {
+            assert!(trace.block(1, buffer, 34).iter().all(|v| *v == 0));
+        }
+        assert_eq!(
+            trace.rows[6][..32],
+            [
+                1116, 1113, 1066, 1147, 1176, 1088, 1171, 1165, 1089, 1141, 1137, 1060, 1131, 1112,
+                1069, 1119, 1104, 1048, 1102, 1102, 1045, 1086, 1094, 1048, 1101, 1082, 1059, 1084,
+                1091, 1050, 1091, 1090
+            ]
+        );
+    }
+
+    /// The same cold start on a second body, with different numbers
+    /// and a different geometry (eleven stripes, so a padded size
+    /// table).
+    #[test]
+    fn a_second_body_cold_starts_the_same_way() {
+        let Some(trace) = trace(XT5, XT5_AT, &XT5_HEAD, 1) else {
+            return;
+        };
+        assert_eq!(
+            trace.block(0, 4, 34),
+            [
+                0, 1979, 0, 0, 2004, 2016, 0, 0, 1926, 1975, 0, 0, 1967, 1958, 0, 0, 1917, 1963, 0,
+                0, 1991, 1946, 0, 0, 1971, 1954, 0, 0, 2028, 1971, 0, 0, 1995, 1995, 0
+            ]
+        );
+        assert_eq!(
+            trace.block(0, 12, 34),
+            [
+                0, 0, 3272, 0, 3292, 0, 3288, 0, 3348, 0, 3236, 0, 3344, 0, 3344, 0, 3308, 0, 3304,
+                0, 3316, 0, 3344, 0, 3332, 0, 3328, 0, 3312, 0, 3316, 0, 3340, 0, 3324
+            ]
+        );
+        assert_eq!(
+            trace.block(0, 17, 34),
+            [
+                0, 0, 2717, 2662, 0, 0, 2756, 2729, 0, 0, 2732, 2717, 0, 0, 2701, 2705, 0, 0, 2646,
+                2725, 0, 0, 2740, 2744, 0, 0, 2740, 2725, 0, 0, 2799, 2717, 0, 0, 2803
+            ]
+        );
+        assert_eq!(trace.rows[5][..6], [1979, 2717, 3272, 2662, 2004, 3292]);
+    }
+
+    /// Checkpoint 10: the lossy path. The quantiser bases, the fine
+    /// tables that take over in flat neighbourhoods, the per-block
+    /// rebuild and the step that multiplies every residual.
+    #[test]
+    fn the_lossy_path_quantises_per_block() {
+        let Some(root) = std::env::var("SCHIST_RAW_CORPUS").ok() else {
+            return;
+        };
+        let path = PathBuf::from(&root).join("Fujifilm").join(GFX);
+        let Ok(bytes) = std::fs::read(&path) else {
+            return;
+        };
+        let strip = &bytes[GFX_AT..];
+        let header = Header::parse(strip).unwrap();
+        assert!(!header.lossless);
+        // The first stripe's data only starts in the right place if
+        // the quantiser-base array is accounted for.
+        assert_eq!(GFX_AT + header.data_offset(), 3477072);
+        assert_eq!(
+            header.qbases(strip, 0).unwrap().unwrap()[..16],
+            [1, 3, 4, 4, 4, 4, 4, 4, 4, 5, 5, 4, 5, 5, 5, 4]
+        );
+
+        let Some(trace) = trace(GFX, GFX_AT, &GFX_HEAD, 2) else {
+            return;
+        };
+        // Row 0 of this frame is blank; row 1 is R0/G0's neighbours,
+        // G1 and B0 interleaved, and it is coded on fine table F1
+        // even though the block's own quantiser base is 1.
+        assert!(trace.rows[0].iter().all(|v| *v == 0));
+        assert_eq!(
+            trace.rows[1][..32],
+            [
+                5532, 3709, 5516, 3782, 5537, 3771, 5489, 3714, 5670, 3718, 5549, 3742, 5603, 3743,
+                5630, 3737, 5562, 3689, 5617, 3724, 5612, 3694, 5657, 3740, 5619, 3829, 5614, 3700,
+                5597, 3734, 5678, 3787
+            ]
+        );
+        assert_eq!(
+            trace.rows[2][..32],
+            [
+                2829, 5483, 2841, 5505, 2889, 5615, 2843, 5636, 2840, 5498, 2791, 5640, 2803, 5605,
+                2893, 5570, 2845, 5622, 2908, 5563, 2863, 5759, 2861, 5628, 2860, 5645, 2807, 5669,
+                2839, 5501, 2791, 5545
+            ]
+        );
+        // Block 1 raises the quantiser base from 1 to 3, which rebuilds
+        // the main table and resets its contexts but not the fine ones.
+        // Every slot is populated: a Bayer block fills nothing.
+        for (buffer, slots) in [
+            (
+                2,
+                [
+                    2835, 2793, 2874, 2830, 2786, 2827, 2870, 2774, 2879, 2847, 2966, 2847, 2851,
+                    2860, 2910, 2793, 2822, 2921, 2890, 2904, 2841, 2900, 2873, 2895, 2832, 2866,
+                    2824,
+                ],
+            ),
+            (
+                3,
+                [
+                    2793, 2793, 2872, 2809, 2833, 2869, 2825, 2862, 2921, 2842, 2786, 2989, 2873,
+                    2884, 2891, 2891, 2869, 2847, 2882, 2789, 2876, 2894, 2845, 2883, 2835, 2850,
+                    2832,
+                ],
+            ),
+            (
+                7,
+                [
+                    5521, 5623, 5577, 5481, 5605, 5674, 5525, 5586, 5668, 5540, 5639, 5657, 5554,
+                    5639, 5668, 5610, 5514, 5607, 5646, 5573, 5634, 5672, 5614, 5628, 5703, 5698,
+                    5711,
+                ],
+            ),
+            (
+                8,
+                [
+                    5623, 5551, 5668, 5645, 5665, 5574, 5558, 5552, 5685, 5574, 5597, 5691, 5623,
+                    5583, 5576, 5609, 5623, 5688, 5708, 5658, 5643, 5727, 5592, 5668, 5534, 5653,
+                    5633,
+                ],
+            ),
+            (
+                15,
+                [
+                    3637, 3721, 3784, 3736, 3784, 3760, 3713, 3694, 3662, 3716, 3752, 3762, 3752,
+                    3751, 3778, 3749, 3805, 3764, 3833, 3734, 3736, 3766, 3829, 3756, 3776, 3788,
+                    3770,
+                ],
+            ),
+            (
+                16,
+                [
+                    3721, 3687, 3694, 3718, 3756, 3740, 3739, 3683, 3726, 3732, 3748, 3750, 3685,
+                    3746, 3806, 3813, 3776, 3738, 3672, 3678, 3687, 3738, 3716, 3805, 3817, 3773,
+                    3766,
+                ],
+            ),
+        ] {
+            assert_eq!(trace.block(1, buffer, 26), slots, "buffer {buffer}");
+        }
     }
 }

--- a/crates/codec-raw/src/formats/rw2.rs
+++ b/crates/codec-raw/src/formats/rw2.rs
@@ -17,10 +17,11 @@
 //!   12-bit pixels to sixteen bytes, read through a stream that is
 //!   shuffled in 16 KB blocks. See [`decode_v4`];
 //! * 6 and 7 — the 14-bit scheme on the full-frame S bodies;
-//! * 8 — the newest (GH6, G9 II), 16-bit.
+//! * 8 — the newest (GH6, G9 II): genuinely 16-bit, and the only one
+//!   that is entropy coded. See [`decode_v8`].
 //!
-//! Only the first two are implemented; the others return
-//! [`Error::Unsupported`] naming their version.
+//! All of them are implemented; a RawFormat this module does not know
+//! returns [`Error::Unsupported`] naming its version.
 //!
 //! The other oddity is where the metadata lives. Shutter speed,
 //! aperture, focal length and the lens name are *not* in the RW2's own
@@ -70,6 +71,31 @@ mod tag {
     pub const CROP_RIGHT: u16 = 0x0032;
     /// Which codec the sensor data uses.
     pub const RAW_FORMAT: u16 = 0x002D;
+    /// RawFormat 8's output curve: six 32-bit segment mode words, and
+    /// six 32-bit segment descriptors (input threshold in the low
+    /// half, output base in the high half).
+    pub const CURVE_MODES: u16 = 0x0039;
+    pub const CURVE_SEGMENTS: u16 = 0x003A;
+    /// The ceiling every reconstructed RawFormat 8 sample is clipped
+    /// to.
+    pub const DATA_MAX: u16 = 0x003B;
+    /// The four initial predictors, one per position in the Bayer
+    /// quad, in the order top-left, top-right, bottom-left,
+    /// bottom-right.
+    pub const INITIAL_PREDICTORS: u16 = 0x003C;
+    /// Seventeen `(code length, code)` pairs, one per magnitude class.
+    pub const HUFFMAN_CODES: u16 = 0x0040;
+    /// Seventeen quantiser shifts, one per magnitude class.
+    pub const HUFFMAN_SHIFTS: u16 = 0x0041;
+    /// How many vertical stripes the frame is cut into, and then one
+    /// entry each of: absolute file offset, left column, compressed
+    /// size *in bits*, width, height.
+    pub const STRIPE_COUNT: u16 = 0x0042;
+    pub const STRIPE_OFFSETS: u16 = 0x0044;
+    pub const STRIPE_LEFTS: u16 = 0x0045;
+    pub const STRIPE_BITS: u16 = 0x0046;
+    pub const STRIPE_WIDTHS: u16 = 0x0047;
+    pub const STRIPE_HEIGHTS: u16 = 0x0048;
     /// The full-size JPEG, inline.
     pub const JPEG_FROM_RAW: u16 = 0x002E;
     /// Where the sensor data starts, on every body that has a codec.
@@ -89,6 +115,9 @@ enum Codec {
     /// RawFormat 6: eleven 14-bit pixels to sixteen bytes, two of them
     /// whole and the other nine predicted.
     Groups11,
+    /// RawFormat 8: Huffman-coded DPCM over 2x2 Bayer quads, 16-bit,
+    /// in independently coded vertical stripes.
+    Quads16,
     /// A version this module knows of but cannot decode.
     Unsupported(u32),
 }
@@ -114,6 +143,7 @@ pub fn decode(bytes: &[u8]) -> Result<RawImage> {
         Some(4) => Codec::Blocks14,
         Some(6) => Codec::Groups11,
         Some(7) => Codec::PackedBlocks,
+        Some(8) => Codec::Quads16,
         Some(other) => Codec::Unsupported(other),
         None if compression == 34826 => Codec::Uncompressed,
         None => Codec::Unsupported(0),
@@ -150,10 +180,14 @@ pub fn decode(bytes: &[u8]) -> Result<RawImage> {
         Codec::Groups11 => decode_v6(data, width, height),
         Codec::PackedBlocks => decode_packed_blocks(data, width, height, bits),
         Codec::Uncompressed => decode_words(data, width, height, bits),
+        // The only codec that does not read from `data`: its stripes
+        // carry their own absolute file offsets.
+        Codec::Quads16 => decode_v8(bytes, ifd, width, height)?,
         Codec::Unsupported(version) => {
             return Err(Error::Unsupported(format!(
                 "RW2 RawFormat {version}: the 12-bit block codec (4), the \
-                 14-bit ones (6, 7) and the uncompressed layout are implemented"
+                 14-bit ones (6, 7), the 16-bit one (8) and the uncompressed \
+                 layout are implemented"
             )))
         }
     };
@@ -605,9 +639,483 @@ fn decode_v4(data: &[u8], width: usize, height: usize) -> Vec<u16> {
     out
 }
 
+// -------------------------------------------------------- RawFormat 8
+
+/// Magnitude classes in RawFormat 8's Huffman code, `0..=16`.
+const V8_CLASSES: usize = 17;
+/// The most stripes the format allows.
+const V8_MAX_STRIPES: usize = 5;
+
+/// RawFormat 8's bit reader.
+///
+/// The rule is simply "the stripe's bytes in file order, least
+/// significant bit first within each byte". A window of the next 64
+/// bits is kept most-significant-bit aligned, so a code is matched
+/// against the top of it; nothing is ever realigned after the start of
+/// a stripe, and there are no restart markers.
+struct V8Bits<'a> {
+    bytes: &'a [u8],
+    /// Next byte to feed the window.
+    pos: usize,
+    /// Live bits, left-aligned: the next bit out is bit 63.
+    cache: u64,
+    nbits: u32,
+}
+
+impl<'a> V8Bits<'a> {
+    fn new(bytes: &'a [u8]) -> V8Bits<'a> {
+        V8Bits {
+            bytes,
+            pos: 0,
+            cache: 0,
+            nbits: 0,
+        }
+    }
+
+    /// Top the window up to at least 57 live bits, reversing each
+    /// byte as it goes in — that reversal *is* the LSB-first rule.
+    /// Past the end of the stripe it feeds zeros, so a truncated file
+    /// decodes to a short picture rather than failing.
+    #[inline]
+    fn fill(&mut self) {
+        while self.nbits <= 56 {
+            let byte = self.bytes.get(self.pos).copied().unwrap_or(0);
+            self.pos += 1;
+            self.cache |= (byte.reverse_bits() as u64) << (56 - self.nbits);
+            self.nbits += 8;
+        }
+    }
+
+    #[inline(always)]
+    fn peek(&mut self, n: u32) -> u32 {
+        debug_assert!((1..=32).contains(&n));
+        if self.nbits < n {
+            self.fill();
+        }
+        ((self.cache >> 32) as u32) >> (32 - n)
+    }
+
+    #[inline(always)]
+    fn consume(&mut self, n: u32) {
+        self.cache <<= n;
+        self.nbits -= n;
+    }
+
+    #[inline(always)]
+    fn get(&mut self, n: u32) -> u32 {
+        if n == 0 {
+            return 0;
+        }
+        let value = self.peek(n);
+        self.consume(n);
+        value
+    }
+}
+
+/// RawFormat 8's Huffman code.
+///
+/// Seventeen magnitude classes, each with an explicit `(length, code)`
+/// pair in tag `0x0040`. This is a plain prefix code written out in
+/// the file: there is no length-count array and no canonical
+/// reconstruction to do, and the codes arrive in symbol order rather
+/// than in code order.
+struct V8Huffman {
+    /// Bits of the widest code, and so of the lookup index.
+    bits: u32,
+    /// `(length << 8) | class` per index; 0 where no code matches.
+    lookup: Vec<u16>,
+}
+
+impl V8Huffman {
+    fn new(pairs: &[(u32, u32)]) -> Result<V8Huffman> {
+        let bits = pairs.iter().map(|(length, _)| *length).max().unwrap_or(0);
+        if !(1..=16).contains(&bits) {
+            return Err(Error::Corrupt(format!(
+                "RW2 RawFormat 8 Huffman code with a longest code of {bits} bits"
+            )));
+        }
+        let mut lookup = vec![0u16; 1usize << bits];
+        for (class, (length, code)) in pairs.iter().enumerate() {
+            if *length == 0 || *length > bits || *code >= (1u32 << length) {
+                return Err(Error::Corrupt(format!(
+                    "RW2 RawFormat 8 class {class} has a {length}-bit code of {code:#x}"
+                )));
+            }
+            let shift = bits - length;
+            let base = (*code as usize) << shift;
+            for slot in &mut lookup[base..base + (1usize << shift)] {
+                // Two classes claiming one bit pattern would make the
+                // stream ambiguous, so the code must be prefix-free.
+                if *slot != 0 {
+                    return Err(Error::Corrupt(
+                        "RW2 RawFormat 8 Huffman code is not prefix-free".into(),
+                    ));
+                }
+                *slot = ((*length as u16) << 8) | class as u16;
+            }
+        }
+        Ok(V8Huffman { bits, lookup })
+    }
+
+    /// The next magnitude class, or `None` when the window matches no
+    /// code (which only an incomplete table can produce).
+    #[inline(always)]
+    fn decode(&self, pump: &mut V8Bits<'_>) -> Option<u32> {
+        let entry = self.lookup[pump.peek(self.bits) as usize];
+        if entry == 0 {
+            return None;
+        }
+        pump.consume((entry >> 8) as u32);
+        Some((entry & 0xFF) as u32)
+    }
+}
+
+/// One signed difference: the mantissa of a magnitude class, in the
+/// lossless-JPEG sign convention with the format's quantiser folded in.
+///
+/// The difference has `class` bits of dynamic range; the low `shift`
+/// of them were thrown away by the encoder, so only `class - shift`
+/// are transmitted and the reconstruction puts them back at the top
+/// and adds half a step. With `shift` zero — which is what every file
+/// seen carries — this is exactly lossless JPEG: a value whose top bit
+/// is set is itself, one whose top bit is clear is `m - (2^class - 1)`.
+#[inline(always)]
+fn v8_difference(pump: &mut V8Bits<'_>, class: u32, shift: u32) -> i32 {
+    let take = class.saturating_sub(shift);
+    let transmitted = pump.get(take) as i32;
+    let magnitude = transmitted << shift;
+    // The sign is the top bit of the full magnitude, which is the
+    // first mantissa bit read.
+    let negative = take == 0 || (transmitted >> (take - 1)) & 1 == 0;
+    let mut delta = if class == 0 {
+        0
+    } else if !negative {
+        magnitude
+    } else if shift == 0 {
+        magnitude - (1 << class) + 1
+    } else {
+        magnitude - (1 << class)
+    };
+    if shift > 0 {
+        // The mid-point of the interval the quantiser threw away.
+        delta += 1 << (shift - 1);
+    }
+    delta
+}
+
+/// A codec tag's payload: a 16-bit count, then that many little-endian
+/// integers `width` bytes wide. `per` values are read for each counted
+/// entry (tag `0x0040` counts pairs).
+fn v8_counted(ifd: &Ifd, tag: u16, width: usize, per: usize) -> Result<Vec<u32>> {
+    let bytes = ifd
+        .get(tag)
+        .and_then(|entry| entry.bytes())
+        .ok_or_else(|| Error::Corrupt(format!("RW2 RawFormat 8 has no tag {tag:#06x}")))?;
+    let count = bytes
+        .get(..2)
+        .map(|b| u16::from_le_bytes([b[0], b[1]]) as usize)
+        .ok_or_else(|| Error::Corrupt(format!("RW2 tag {tag:#06x} is empty")))?;
+    let mut out = Vec::with_capacity(count * per);
+    for i in 0..count * per {
+        let at = 2 + i * width;
+        let slice = bytes.get(at..at + width).ok_or_else(|| {
+            Error::Corrupt(format!(
+                "RW2 tag {tag:#06x} promises {count} entries but holds {} bytes",
+                bytes.len()
+            ))
+        })?;
+        out.push(slice.iter().rev().fold(0u32, |v, b| (v << 8) | *b as u32));
+    }
+    Ok(out)
+}
+
+/// The output curve as a 65536-entry lookup, or `None` when it is the
+/// identity and can be skipped.
+///
+/// Six linear segments, each with an input threshold, an output base
+/// and a power-of-two slope — a right shift compresses, a left shift
+/// expands — plus two encodings for a flat segment. On both bodies in
+/// the corpus every descriptor is zero and every mode word is
+/// `0x00010000`, which comes out as the identity; the rest of this is
+/// therefore written from the format's description and unverified
+/// against a body that ships a real curve.
+fn v8_curve(modes: &[u32], segments: &[u32], datamax: u32) -> Option<Vec<u16>> {
+    let entry = |table: &[u32], i: usize| table.get(i).copied().unwrap_or(0);
+    let threshold = |i: usize| entry(segments, i) & 0xFFFF;
+    let base = |i: usize| (entry(segments, i) >> 16) & 0xFFFF;
+    let mut lookup = vec![0u16; 1 << 16];
+    let mut identity = true;
+    for (x, slot) in lookup.iter_mut().enumerate() {
+        let x = x as u32;
+        let mut k = 0usize;
+        for j in 1..6 {
+            if x >= threshold(j) {
+                k = j;
+            }
+        }
+        let mode = entry(modes, k);
+        let n = mode & 0x1F;
+        // `threshold(0)` need not be zero in a forged table; below it
+        // the distance is simply nothing.
+        let mut d = x.saturating_sub(threshold(k));
+        let value = if n == 31 {
+            // A flat segment reading the *next* segment's base.
+            if k == 5 {
+                0xFFFF
+            } else {
+                base(k + 1)
+            }
+        } else {
+            if mode & 0x10 == 0 {
+                if n == 15 {
+                    // The other flat encoding: this segment's base.
+                    d = 0;
+                } else if n > 0 {
+                    d = (d + (1 << (n - 1))) >> n;
+                }
+            } else {
+                d <<= mode & 0x0F;
+            }
+            d + base(k)
+        };
+        let value = value.min(datamax).min(0xFFFF) as u16;
+        identity &= value as u32 == x;
+        *slot = value;
+    }
+    (!identity).then_some(lookup)
+}
+
+/// One stripe: its own bit stream, its own predictors, no prediction
+/// across its edges.
+///
+/// A stripe is decoded as `height / 2` row-pairs of `width / 2` 2x2
+/// Bayer quads. The four samples of a quad arrive top-left,
+/// bottom-left, top-right, bottom-right, and each is predicted from
+/// the same position of the quad immediately to its left — a four-way
+/// interleaved DPCM. What starts a row-pair is the *first* quad of the
+/// row-pair above, not its last and not the sample directly overhead,
+/// which is the one thing in this codec easy to get wrong.
+#[allow(clippy::too_many_arguments)]
+fn decode_v8_stripe(
+    stream: &[u8],
+    huffman: &V8Huffman,
+    shifts: &[u32; V8_CLASSES],
+    initial: [i32; 4],
+    width: usize,
+    height: usize,
+    datamax: i32,
+    curve: Option<&[u16]>,
+) -> Result<Vec<u16>> {
+    let mut out = vec![0u16; width * height];
+    let mut pump = V8Bits::new(stream);
+    let mut predictor = initial;
+    for pair in 0..height / 2 {
+        let mut carry = predictor;
+        for quad in 0..width / 2 {
+            let mut values = [0i32; 4];
+            for (position, value) in values.iter_mut().enumerate() {
+                let class = huffman.decode(&mut pump).ok_or_else(|| {
+                    Error::Corrupt("RW2 RawFormat 8 stream holds no valid code".into())
+                })?;
+                let delta = v8_difference(&mut pump, class, shifts[class as usize]);
+                *value = (predictor[position] + delta).clamp(0, datamax);
+            }
+            predictor = values;
+            if quad == 0 {
+                carry = values;
+            }
+            let store = |value: i32| -> u16 {
+                let value = value as u16;
+                curve.map_or(value, |curve| curve[value as usize])
+            };
+            let top = 2 * pair * width + 2 * quad;
+            out[top] = store(values[0]);
+            out[top + 1] = store(values[2]);
+            out[top + width] = store(values[1]);
+            out[top + width + 1] = store(values[3]);
+        }
+        predictor = carry;
+    }
+    Ok(out)
+}
+
+/// One stripe's place in the frame and in the file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct V8Stripe {
+    offset: usize,
+    /// Bytes of coded data: the tag counts *bits*, and the reader
+    /// takes whole 64-bit words.
+    bytes: usize,
+    left: usize,
+    width: usize,
+    height: usize,
+}
+
+/// The stripe table, checked against the frame and the file.
+///
+/// The five parallel tags are read together because only together do
+/// they say anything: the widths must tile the frame exactly, every
+/// stripe must be the frame's full height, and every byte range must
+/// be inside the file. A stripe table that fails any of those would
+/// otherwise decode into a frame with a seam or a hole in it.
+fn v8_stripes(ifd: &Ifd, file_len: usize, width: usize, height: usize) -> Result<Vec<V8Stripe>> {
+    let count = ifd
+        .get(tag::STRIPE_COUNT)
+        .and_then(|e| e.u32(0))
+        .unwrap_or(0) as usize;
+    if count == 0 || count > V8_MAX_STRIPES {
+        return Err(Error::Corrupt(format!(
+            "RW2 RawFormat 8 in {count} stripes"
+        )));
+    }
+    let offsets = v8_counted(ifd, tag::STRIPE_OFFSETS, 4, 1)?;
+    let lefts = v8_counted(ifd, tag::STRIPE_LEFTS, 4, 1)?;
+    let sizes = v8_counted(ifd, tag::STRIPE_BITS, 4, 1)?;
+    let widths = v8_counted(ifd, tag::STRIPE_WIDTHS, 2, 1)?;
+    let heights = v8_counted(ifd, tag::STRIPE_HEIGHTS, 2, 1)?;
+    if [&offsets, &lefts, &sizes, &widths, &heights]
+        .iter()
+        .any(|table| table.len() < count)
+    {
+        return Err(Error::Corrupt(
+            "RW2 RawFormat 8 stripe tables are shorter than the stripe count".into(),
+        ));
+    }
+
+    let mut stripes = Vec::with_capacity(count);
+    let mut covered = 0usize;
+    for i in 0..count {
+        let stripe = V8Stripe {
+            offset: offsets[i] as usize,
+            // The tag counts bits; the reader takes whole 64-bit
+            // words, so round up twice.
+            bytes: (sizes[i] as usize).div_ceil(8).next_multiple_of(8),
+            left: lefts[i] as usize,
+            width: widths[i] as usize,
+            height: heights[i] as usize,
+        };
+        if stripe.height != height
+            || stripe.width == 0
+            || stripe.left + stripe.width > width
+            || stripe
+                .offset
+                .checked_add(stripe.bytes)
+                .is_none_or(|end| end > file_len)
+        {
+            return Err(Error::Corrupt(format!(
+                "RW2 RawFormat 8 stripe {i} is {}x{} at column {} offset {}, outside a \
+                 {width}x{height} frame or the file",
+                stripe.width, stripe.height, stripe.left, stripe.offset
+            )));
+        }
+        covered += stripe.width;
+        stripes.push(stripe);
+    }
+    if covered != width {
+        return Err(Error::Corrupt(format!(
+            "RW2 RawFormat 8 stripes cover {covered} of {width} columns"
+        )));
+    }
+    Ok(stripes)
+}
+
+/// RawFormat 8: Huffman-coded DPCM over Bayer quads, in independently
+/// coded vertical stripes.
+fn decode_v8(bytes: &[u8], ifd: &Ifd, width: usize, height: usize) -> Result<Vec<u16>> {
+    let short = |tag: u16| ifd.get(tag).and_then(|e| e.u32(0));
+    let datamax = short(tag::DATA_MAX).unwrap_or(u16::MAX as u32).min(0xFFFF);
+
+    let codes = v8_counted(ifd, tag::HUFFMAN_CODES, 2, 2)?;
+    if codes.len() != V8_CLASSES * 2 {
+        return Err(Error::Corrupt(format!(
+            "RW2 RawFormat 8 Huffman table holds {} values, not {}",
+            codes.len(),
+            V8_CLASSES * 2
+        )));
+    }
+    let pairs: Vec<(u32, u32)> = codes
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|p| (p[0], p[1]))
+        .collect();
+    let huffman = V8Huffman::new(&pairs)?;
+
+    let raw_shifts = v8_counted(ifd, tag::HUFFMAN_SHIFTS, 2, 1)?;
+    if raw_shifts.len() != V8_CLASSES {
+        return Err(Error::Corrupt(format!(
+            "RW2 RawFormat 8 shift table holds {} values, not {V8_CLASSES}",
+            raw_shifts.len()
+        )));
+    }
+    let shifts: [u32; V8_CLASSES] = std::array::from_fn(|i| raw_shifts[i] & 0x1F);
+    // A class whose quantiser is as wide as the class itself would
+    // transmit no mantissa at all and leave the sign bit undefined.
+    // No file seen has a non-zero shift; refusing is better than
+    // guessing what one would mean.
+    if shifts
+        .iter()
+        .enumerate()
+        .any(|(class, shift)| *shift >= (class as u32).max(1))
+    {
+        return Err(Error::Unsupported(
+            "RW2 RawFormat 8 with a quantiser shift at or above its magnitude class".into(),
+        ));
+    }
+
+    // Tag order is top-left, top-right, bottom-left, bottom-right; the
+    // stream's order is top-left, bottom-left, top-right,
+    // bottom-right. Both bodies ship zeros, so the mapping is an
+    // assumption — but it is the one the tags' own numbering makes.
+    let initial = [
+        short(tag::INITIAL_PREDICTORS).unwrap_or(0) as i32,
+        short(tag::INITIAL_PREDICTORS + 2).unwrap_or(0) as i32,
+        short(tag::INITIAL_PREDICTORS + 1).unwrap_or(0) as i32,
+        short(tag::INITIAL_PREDICTORS + 3).unwrap_or(0) as i32,
+    ];
+
+    let curve = v8_curve(
+        &v8_counted(ifd, tag::CURVE_MODES, 4, 1)?,
+        &v8_counted(ifd, tag::CURVE_SEGMENTS, 4, 1)?,
+        datamax,
+    );
+
+    let stripes = v8_stripes(ifd, bytes.len(), width, height)?;
+
+    // Stripes share nothing — separate streams, separate predictors —
+    // so they decode in parallel into their own buffers and are
+    // stitched afterwards.
+    let planes: Result<Vec<Vec<u16>>> = stripes
+        .par_iter()
+        .map(|stripe| {
+            decode_v8_stripe(
+                &bytes[stripe.offset..stripe.offset + stripe.bytes],
+                &huffman,
+                &shifts,
+                initial,
+                stripe.width,
+                stripe.height,
+                datamax as i32,
+                curve.as_deref(),
+            )
+        })
+        .collect();
+    let planes = planes?;
+
+    let mut out = vec![0u16; crate::frame_samples(width, height, 1)?];
+    for (stripe, plane) in stripes.iter().zip(&planes) {
+        for (row, line) in plane.chunks_exact(stripe.width).enumerate() {
+            let at = row * width + stripe.left;
+            out[at..at + stripe.width].copy_from_slice(line);
+        }
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tiff::Entry;
 
     /// A minimal RW2: the `IIU\0` signature and an IFD0 of Panasonic
     /// tags, with `data` at the end as the sensor stream.
@@ -741,6 +1249,212 @@ mod tests {
         assert_eq!(&out[5..8], &[100 * 16 - 15; 3]);
     }
 
+    // ---------------------------------------------------- RawFormat 8
+
+    /// The seventeen `(code length, code)` pairs both bodies ship, in
+    /// symbol order 0..=16.
+    pub(super) const V8_TABLE: [(u32, u32); 17] = [
+        (10, 0x3FE),
+        (11, 0x7FE),
+        (8, 0x0FE),
+        (9, 0x1FE),
+        (7, 0x07E),
+        (4, 0x00E),
+        (4, 0x00C),
+        (3, 0x004),
+        (3, 0x002),
+        (2, 0x000),
+        (3, 0x003),
+        (3, 0x005),
+        (4, 0x00D),
+        (5, 0x01E),
+        (6, 0x03E),
+        (12, 0xFFE),
+        (12, 0xFFF),
+    ];
+
+    /// A RawFormat 8 bit stream: the fields most-significant bit
+    /// first, packed into bytes least-significant bit first.
+    fn v8_stream(fields: &[(u32, u32)]) -> Vec<u8> {
+        let mut bits = Vec::new();
+        for (value, length) in fields {
+            for i in (0..*length).rev() {
+                bits.push(((value >> i) & 1) as u8);
+            }
+        }
+        // Eight bytes of slack so the reader's window can always fill.
+        let mut out = vec![0u8; bits.len().div_ceil(8) + 8];
+        for (i, bit) in bits.iter().enumerate() {
+            out[i / 8] |= bit << (i % 8);
+        }
+        out
+    }
+
+    /// Bytes in file order, least significant bit first within each.
+    /// Reading the bytes the other way up fails here rather than three
+    /// megapixels later.
+    #[test]
+    fn the_v8_reader_takes_the_low_bit_of_each_byte_first() {
+        // 0b1011_0001 low bit first is 1, 0, 0, 0, 1, 1, 0, 1.
+        let mut pump = V8Bits::new(&[0b1011_0001, 0, 0, 0, 0, 0, 0, 0, 0]);
+        assert_eq!(pump.get(4), 0b1000);
+        assert_eq!(pump.get(4), 0b1101);
+        // A field may straddle a byte boundary without realignment.
+        let stream = v8_stream(&[(0x2A5, 12), (7, 3)]);
+        let mut pump = V8Bits::new(&stream);
+        assert_eq!(pump.get(12), 0x2A5);
+        assert_eq!(pump.get(3), 7);
+        // Past the end the window feeds zeros rather than failing.
+        let mut pump = V8Bits::new(&[]);
+        assert_eq!(pump.get(16), 0);
+    }
+
+    /// The Huffman table is a plain prefix code written out in the
+    /// file, in symbol order rather than code order.
+    #[test]
+    fn the_v8_huffman_table_is_a_complete_prefix_code() {
+        let huffman = V8Huffman::new(&V8_TABLE).expect("builds");
+        assert_eq!(huffman.bits, 12);
+        // Complete: the seventeen codes tile the twelve-bit window
+        // exactly, so no window is left undecodable.
+        let total: u32 = V8_TABLE
+            .iter()
+            .map(|(length, _)| 1u32 << (12 - length))
+            .sum();
+        assert_eq!(total, 1 << 12);
+        assert!(huffman.lookup.iter().all(|entry| *entry != 0));
+        // Every code decodes back to its own class.
+        for (class, (length, code)) in V8_TABLE.iter().enumerate() {
+            let stream = v8_stream(&[(*code, *length), (0, 16)]);
+            let mut pump = V8Bits::new(&stream);
+            assert_eq!(huffman.decode(&mut pump), Some(class as u32));
+        }
+        // A table two classes share a code with is refused.
+        let mut clash = V8_TABLE;
+        clash[0] = (2, 0);
+        assert!(V8Huffman::new(&clash).is_err());
+    }
+
+    /// The lossless-JPEG sign rule the differences use, and the lossy
+    /// reconstruction the format defines but no file in the corpus
+    /// exercises.
+    #[test]
+    fn v8_differences_follow_the_lossless_jpeg_sign_rule() {
+        let difference = |class: u32, mantissa: u32, shift: u32| {
+            let stream = v8_stream(&[(mantissa, class - shift), (0, 16)]);
+            let mut pump = V8Bits::new(&stream);
+            v8_difference(&mut pump, class, shift)
+        };
+        // Class 12, a top bit set: the value is itself. This is the
+        // GH6's very first sample.
+        assert_eq!(difference(12, 2229, 0), 2229);
+        // Class 9 with the top bit clear: 223 - 511, the G9M2's
+        // quad 1 bottom-left.
+        assert_eq!(difference(9, 223, 0), -288);
+        // Class 6 either way.
+        assert_eq!(difference(6, 0b100011, 0), 35);
+        assert_eq!(difference(6, 0b001110, 0), -49);
+        // Class 0 is a difference of zero and reads no mantissa.
+        let mut pump = V8Bits::new(&[0xFF; 16]);
+        assert_eq!(v8_difference(&mut pump, 0, 0), 0);
+        // With a quantiser the thrown-away low bits come back as a
+        // half-step: two transmitted bits stand for four, and the
+        // rounding term is 2^(shift-1).
+        assert_eq!(difference(4, 0b11, 2), (0b11 << 2) + 2);
+        assert_eq!(difference(4, 0b01, 2), (0b01 << 2) - 16 + 2);
+    }
+
+    /// The output curve. Both bodies ship the identity, which is
+    /// detected and skipped; the rest is the format's description,
+    /// exercised here on a curve built by hand.
+    #[test]
+    fn the_v8_output_curve_is_six_shifted_segments() {
+        // What the corpus carries: every descriptor zero, every mode
+        // word 0x00010000.
+        assert!(v8_curve(&[0x0001_0000; 6], &[0; 6], 65535).is_none());
+        // A forged table whose first threshold is above zero: every
+        // input below it is simply at distance zero, never an
+        // underflow.
+        let _ = v8_curve(&[0x0001_0000; 6], &[1; 6], 65535);
+
+        // Six segments 256 apart, each with its own base.
+        let segments: [u32; 6] = std::array::from_fn(|k| {
+            let edge = (k as u32) * 256;
+            (edge << 16) | edge
+        });
+        let modes: [u32; 6] = [
+            0x0001_0000, // slope 1
+            0x0001_0001, // right shift 1, rounded
+            0x0001_0012, // bit 4 set: left shift 2
+            0x0001_001F, // flat, taking the next segment's base
+            0x0001_000F, // flat, taking this segment's base
+            0x0001_0000,
+        ];
+        let curve = v8_curve(&modes, &segments, 65535).expect("not the identity");
+        assert_eq!(curve[100], 100);
+        // Segment 1: ((300 - 256) + 1) >> 1, then base 256.
+        assert_eq!(curve[300], 278);
+        // Segment 2: (600 - 512) << 2, then base 512.
+        assert_eq!(curve[600], 864);
+        // Segment 3 is flat at segment 4's base.
+        assert_eq!(curve[800], 1024);
+        // Segment 4 is flat at its own base.
+        assert_eq!(curve[1100], 1024);
+        // Segment 5 has slope 1 again.
+        assert_eq!(curve[2000], 2000);
+        // Nothing leaves `datamax`.
+        let clipped = v8_curve(&modes, &segments, 1000).expect("not the identity");
+        assert!(clipped.iter().all(|v| *v <= 1000));
+    }
+
+    /// A stripe table that does not tile the frame, or that points
+    /// outside the file, is refused rather than decoded into a frame
+    /// with a hole in it.
+    #[test]
+    fn v8_stripe_tables_must_tile_the_frame() {
+        fn counted(tag: u16, width: usize, values: &[u32]) -> Entry {
+            let mut bytes = (values.len() as u16).to_le_bytes().to_vec();
+            for value in values {
+                bytes.extend_from_slice(&value.to_le_bytes()[..width]);
+            }
+            Entry {
+                tag,
+                kind: crate::tiff::Kind::Undefined,
+                count: bytes.len(),
+                offset: 0,
+                value: crate::tiff::Value::Undefined(bytes),
+            }
+        }
+        let ifd = |widths: &[u32], lefts: &[u32]| Ifd {
+            offset: 0,
+            entries: vec![
+                Entry {
+                    tag: tag::STRIPE_COUNT,
+                    kind: crate::tiff::Kind::Short,
+                    count: 1,
+                    offset: 0,
+                    value: crate::tiff::Value::Short(vec![widths.len() as u16]),
+                },
+                counted(tag::STRIPE_OFFSETS, 4, &vec![0; widths.len()]),
+                counted(tag::STRIPE_LEFTS, 4, lefts),
+                counted(tag::STRIPE_BITS, 4, &vec![64; widths.len()]),
+                counted(tag::STRIPE_WIDTHS, 2, widths),
+                counted(tag::STRIPE_HEIGHTS, 2, &vec![4; widths.len()]),
+            ],
+            ..Ifd::default()
+        };
+        let stripes = v8_stripes(&ifd(&[8, 8], &[0, 8]), 1024, 16, 4).expect("tiles");
+        assert_eq!(stripes.len(), 2);
+        assert_eq!(stripes[1].left, 8);
+        // 64 bits of stream is eight bytes, and the reader wants whole
+        // 64-bit words, so that is what a stripe reserves.
+        assert_eq!(stripes[0].bytes, 8);
+        // Widths that do not sum to the frame's.
+        assert!(v8_stripes(&ifd(&[8, 4], &[0, 8]), 1024, 16, 4).is_err());
+        // A stripe running past the end of the file.
+        assert!(v8_stripes(&ifd(&[8, 8], &[0, 8]), 4, 16, 4).is_err());
+    }
+
     #[test]
     fn hostile_input_never_panics() {
         assert!(decode(&[]).is_err());
@@ -760,16 +1474,16 @@ mod tests {
 #[cfg(test)]
 mod corpus {
     use super::super::orf::oracle;
+    use super::tests::V8_TABLE;
     use super::*;
+    use crate::RawImage;
 
     /// Files this crate knowingly cannot decode yet, with the reason.
     /// A file on this list still has to probe as an RW2 and fail with
     /// `Unsupported` rather than a panic or a wrong picture.
-    const UNSUPPORTED: &[&str] = &[
-        // RawFormat 6 and 7: the 14-bit codec on the full-frame S
-        // bodies. RawFormat 8: the 16-bit one on the GH6 and G9 II.
-        "RawFormat",
-    ];
+    /// Empty: every RawFormat in the corpus decodes. The list stays
+    /// for the codec a future body brings.
+    const UNSUPPORTED: &[&str] = &[];
 
     /// `.RAW` is on the list for the Digilux 2 and the LC1, whose
     /// files predate the RW2 extension; other makers use it too, so
@@ -786,8 +1500,177 @@ mod corpus {
             .collect()
     }
 
+    /// A corpus file by name.
+    fn sample(name: &str) -> Option<Vec<u8>> {
+        let path = files()
+            .into_iter()
+            .find(|p| p.file_name().is_some_and(|f| f == name))?;
+        std::fs::read(path).ok()
+    }
+
+    fn frame(raw: &RawImage) -> &[u16] {
+        let RawData::U16(data) = &raw.data else {
+            panic!("RW2 frames are integers")
+        };
+        data
+    }
+
+    /// The GH6's stripe tables, exactly as tag `0x0044`..`0x0048`
+    /// carry them, including that `0x0046` counts bits and not bytes.
+    #[test]
+    fn the_v8_stripe_tables_parse_as_the_bodies_write_them() {
+        for (name, width, height, first_class, want) in [
+            (
+                "DC-GH6-3-2.RW2",
+                5792usize,
+                4352usize,
+                12u32,
+                [
+                    (6_926_848usize, 149_867_038usize, 0usize, 2848usize),
+                    (25_660_256, 154_571_946, 2848, 2944),
+                ],
+            ),
+            (
+                "DC-G9M2-P1000019.RW2",
+                5784,
+                4344,
+                14,
+                [
+                    (6_683_648, 137_423_474, 0, 2880),
+                    (23_861_600, 139_106_557, 2880, 2904),
+                ],
+            ),
+        ] {
+            let Some(bytes) = sample(name) else { return };
+            let tiff = crate::tiff::Tiff::parse(&bytes).expect("RW2 parses");
+            let ifd = tiff.root();
+            assert_eq!(ifd.get(tag::RAW_FORMAT).and_then(|e| e.u32(0)), Some(8));
+            // The Huffman table both bodies ship is the same one.
+            let codes = v8_counted(ifd, tag::HUFFMAN_CODES, 2, 2).expect("code table");
+            let pairs: Vec<(u32, u32)> = codes
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|p| (p[0], p[1]))
+                .collect();
+            assert_eq!(pairs, V8_TABLE.to_vec(), "{name} Huffman table");
+            // Every quantiser shift is zero: these files are lossless.
+            assert_eq!(
+                v8_counted(ifd, tag::HUFFMAN_SHIFTS, 2, 1).expect("shift table"),
+                vec![0u32; 17],
+                "{name} shifts"
+            );
+            // And the curve is the identity, so it is never applied.
+            assert!(v8_curve(
+                &v8_counted(ifd, tag::CURVE_MODES, 4, 1).unwrap(),
+                &v8_counted(ifd, tag::CURVE_SEGMENTS, 4, 1).unwrap(),
+                65535,
+            )
+            .is_none());
+
+            let stripes = v8_stripes(ifd, bytes.len(), width, height).expect("stripe table");
+            assert_eq!(stripes.len(), 2, "{name} stripe count");
+            for (stripe, (offset, bits, left, stripe_width)) in stripes.iter().zip(want) {
+                assert_eq!(stripe.offset, offset, "{name} stripe offset");
+                assert_eq!(stripe.left, left, "{name} stripe left");
+                assert_eq!(stripe.width, stripe_width, "{name} stripe width");
+                assert_eq!(stripe.height, height, "{name} stripe height");
+                // The tag is a bit count; the reader wants whole
+                // 64-bit words.
+                assert_eq!(
+                    stripe.bytes,
+                    bits.div_ceil(8).next_multiple_of(8),
+                    "{name} stripe bytes"
+                );
+            }
+            assert_eq!(
+                stripes.iter().map(|s| s.width).sum::<usize>(),
+                width,
+                "{name} stripes tile the frame"
+            );
+
+            // The very first code of stripe 0: the four-bit one for
+            // magnitude class 12 on the GH6, the six-bit one for
+            // class 14 on the G9M2. Reading the bytes the wrong way
+            // up fails right here rather than a megapixel later.
+            let huffman = V8Huffman::new(&pairs).expect("builds");
+            let stripe = stripes[0];
+            let mut pump = V8Bits::new(&bytes[stripe.offset..stripe.offset + stripe.bytes]);
+            assert_eq!(
+                huffman.decode(&mut pump),
+                Some(first_class),
+                "{name} first symbol"
+            );
+        }
+    }
+
+    /// The GH6's first two row-pairs, quad by quad. The second pair is
+    /// the decisive test of the vertical carry: it predicts from the
+    /// *first* quad of the pair above, not the last one and not the
+    /// sample directly overhead.
+    #[test]
+    fn the_gh6_decodes_its_first_row_pairs_sample_for_sample() {
+        let Some(bytes) = sample("DC-GH6-3-2.RW2") else {
+            return;
+        };
+        let raw = crate::decode(&bytes).expect("decodes");
+        assert_eq!((raw.width, raw.height), (5792, 4352));
+        assert_eq!(raw.cfa, Cfa::RGGB);
+        assert_eq!(raw.white_level, 65535.0);
+        assert_eq!(raw.black_levels, [2048.0; 4]);
+        let frame = frame(&raw);
+        let width = raw.width;
+        let row = |r: usize| &frame[r * width..(r + 1) * width];
+        // Row-pair 0, quads 0..=3 and the two that follow.
+        assert_eq!(
+            &row(0)[..12],
+            &[2229, 2452, 2264, 2532, 2094, 2493, 2099, 2495, 2189, 2390, 2136, 2428]
+        );
+        assert_eq!(
+            &row(1)[..12],
+            &[2663, 2224, 2614, 2151, 2523, 2156, 2388, 2225, 2551, 2188, 2416, 2117]
+        );
+        // Row-pair 1: its predictors are row-pair 0's *first* quad —
+        // 2229, 2452, 2663, 2224 — so quad 0 lands on these values.
+        assert_eq!(
+            &row(2)[..12],
+            &[2426, 3009, 2405, 2930, 2274, 2729, 2391, 2590, 2206, 2483, 2188, 2502]
+        );
+        assert_eq!(
+            &row(3)[..12],
+            &[4245, 2540, 3573, 2458, 3100, 2340, 2914, 2261, 2690, 2195, 2535, 2186]
+        );
+        // Stripe 1 restarts from the initial predictors at column
+        // 2848, with no prediction across the seam.
+        assert_eq!(&row(0)[2848..2852], &[2405, 3292, 2488, 3462]);
+        assert_eq!(&row(1)[2848..2852], &[3355, 2334, 3473, 2307]);
+    }
+
+    /// The G9M2 is the better fixture for the sign rule: its first
+    /// quad spends the two twelve-bit codes and its second exercises
+    /// the negative branch at magnitude class 9.
+    #[test]
+    fn the_g9m2_decodes_its_first_row_pair_sample_for_sample() {
+        let Some(bytes) = sample("DC-G9M2-P1000019.RW2") else {
+            return;
+        };
+        let raw = crate::decode(&bytes).expect("decodes");
+        assert_eq!((raw.width, raw.height), (5784, 4344));
+        let frame = frame(&raw);
+        let width = raw.width;
+        assert_eq!(
+            &frame[..12],
+            &[10899, 26184, 11028, 26263, 10600, 26069, 10617, 26639, 10501, 26508, 10791, 25734]
+        );
+        assert_eq!(
+            &frame[width..width + 12],
+            &[26010, 19649, 25722, 19679, 26256, 19991, 26058, 20038, 26055, 19969, 25871, 20057]
+        );
+    }
+
     #[test]
     fn every_file_matches_the_oracle() {
+        let mut checked = 0;
         for path in &files() {
             let bytes = std::fs::read(path).expect("corpus file readable");
             assert_eq!(
@@ -808,7 +1691,9 @@ mod corpus {
             oracle::compare_samples(path, &raw);
             oracle::compare_metadata(path, &raw);
             oracle::check_preview(path, &raw);
+            checked += 1;
         }
+        eprintln!("rw2: {checked} corpus files matched the oracle");
     }
 
     #[test]

--- a/crates/codec-raw/src/formats/srw.rs
+++ b/crates/codec-raw/src/formats/srw.rs
@@ -17,8 +17,9 @@
 //!   NX300 generation). See [`decompress_v1`].
 //! * `32772` — a Huffman-coded difference per pixel against a table
 //!   built into the firmware (NX mini, NX3000). See [`decompress_v2`].
-//! * `32773` — the last codec, on the NX1 and NX500. Not implemented;
-//!   [`decode`] returns [`crate::Error::Unsupported`] for it.
+//! * `32773` — the last codec, on the NX1 and NX500: sixteen-column
+//!   blocks predicted from the two rows above with a one-dimensional
+//!   motion vector, over an optional quantiser. See [`decompress_v3`].
 //!
 //! Written from observation of the files and their LibRaw-unpacked
 //! frames, plus the TIFF 6.0 and Exif specifications and ExifTool's
@@ -121,11 +122,7 @@ pub fn decode(bytes: &[u8]) -> Result<RawImage> {
                 decompress_v1(strip, &pointers, width, height)
             }
             COMPRESSION_V2 => decompress_v2(strip, width, height),
-            COMPRESSION_V3 => {
-                return Err(Error::Unsupported(
-                    "SRW compression 32773, the NX1 and NX500 codec".into(),
-                ))
-            }
+            COMPRESSION_V3 => decompress_v3(strip, width, height)?,
             other => {
                 return Err(Error::Unsupported(format!(
                     "SRW compression {other} with a strip too small to be plain samples"
@@ -611,6 +608,304 @@ fn decompress_v2(strip: &[u8], width: usize, height: usize) -> Vec<u16> {
     out
 }
 
+// ------------------------------------------------------------ codec v3
+
+/// Columns to a block of the NX1/NX500 codec.
+const V3_BLOCK: usize = 16;
+/// The stream header's size, and the boundary every row starts on.
+const V3_ALIGN: usize = 16;
+/// The narrowest and shortest frame the codec is defined for. Below
+/// this a block's prediction would reach outside the frame.
+const V3_MIN_WIDTH: usize = 646;
+const V3_MIN_HEIGHT: usize = 436;
+
+/// Bits of the header's option nibble. Each one *removes* a per-block
+/// field from the stream, so a decoder that ignored them would read
+/// the fields that are not there and lose the stream immediately.
+mod v3 {
+    /// The difference lengths are in every block; the one-bit "lengths
+    /// unchanged" flag is not written.
+    pub const LENGTHS_ALWAYS: u32 = 1;
+    /// The prediction mode is one bit: 0 means mode 7, 1 means mode 3.
+    pub const SHORT_MODE: u32 = 2;
+    /// No quantiser-scale field: the file is lossless.
+    pub const LOSSLESS: u32 = 4;
+}
+
+/// How far left or right of the target column a prediction mode looks,
+/// and whether it averages two references to land on a half-way
+/// offset. Modes 0..=6; mode 7 predicts along the row instead.
+const V3_MOTION_OFFSET: [i32; 7] = [-4, -2, -2, 0, 0, 2, 4];
+const V3_MOTION_AVERAGE: [bool; 7] = [false, false, true, false, true, false, false];
+
+/// The sixteen-byte stream header. Only three of its fields have a
+/// known meaning; the rest is identical between the two bodies in the
+/// corpus and is skipped by width.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct V3Header {
+    /// Sample depth, stored one less than it is.
+    depth: u32,
+    /// See the [`v3`] option bits.
+    options: u32,
+    /// The predictor for the first sixteen columns of every row.
+    initial: u16,
+}
+
+/// Read the header out of the first sixteen bytes of the stream.
+///
+/// The whole header is bit-packed and read with the codec's own
+/// reader — most significant bit first inside 32-bit little-endian
+/// words — so getting the word order wrong is caught here rather than
+/// three megapixels later.
+fn v3_header(strip: &[u8]) -> V3Header {
+    let mut pump = BitPumpMsb32::new(strip);
+    pump.consume(20);
+    let depth = pump.get(4) + 1;
+    // Bits 24..=83: unknown, and the same on both bodies.
+    pump.consume(8);
+    pump.consume(32);
+    pump.consume(16);
+    pump.consume(4);
+    let options = pump.get(4);
+    // Bits 88..=113: unknown.
+    pump.consume(26);
+    V3Header {
+        depth,
+        options,
+        initial: pump.get(14) as u16,
+    }
+}
+
+/// Decode Samsung's last codec (Compression 32773).
+///
+/// The frame is one stream. Rows are independent: each starts on a
+/// sixteen-byte boundary measured from the start of the stream, with
+/// the bit reader reset, so a row's length is only known once it has
+/// been decoded. Within a row, columns are taken sixteen at a time.
+///
+/// Every block first *fills* its sixteen columns with a prediction and
+/// then adds a difference to each in place. The prediction is either
+/// along the row — every column takes the value two columns back,
+/// which for the first block of a row is the header's initial value —
+/// or from the two rows above: on this GRBG sensor the greens of a row
+/// sit diagonally next to the greens of the row above and the reds and
+/// blues sit two rows straight up, so a mode picks that reference and
+/// then slides it left or right by up to four columns. It is a
+/// one-dimensional motion vector, and the two averaging modes give it
+/// the half-way offsets.
+///
+/// The differences are coded in an interleaved order — all eight
+/// even-parity columns of the block, then all eight odd ones — in four
+/// groups of four, each group with its own bit width carried from the
+/// previous block. A quantiser scale, refreshed every fourth block,
+/// multiplies them; at scale 0, which is what a lossless file uses
+/// throughout, it is the identity.
+fn decompress_v3(strip: &[u8], width: usize, height: usize) -> Result<Vec<u16>> {
+    if width < V3_MIN_WIDTH || height < V3_MIN_HEIGHT {
+        return Err(Error::Corrupt(format!(
+            "SRW compression 32773 needs at least {V3_MIN_WIDTH}x{V3_MIN_HEIGHT}, not {width}x{height}"
+        )));
+    }
+    if strip.len() < V3_ALIGN {
+        return Err(Error::Corrupt(
+            "SRW compression 32773 with no room for its header".into(),
+        ));
+    }
+    let header = v3_header(strip);
+    if !(8..=16).contains(&header.depth) {
+        return Err(Error::Corrupt(format!(
+            "SRW compression 32773 claims {} bits a sample",
+            header.depth
+        )));
+    }
+    let datamax = ((1u32 << header.depth) - 1) as i32;
+    let mut out = vec![0u16; width * height];
+    // Row 0 opens immediately after the header.
+    let mut at = V3_ALIGN;
+    for row in 0..height {
+        let mut pump = BitPumpMsb32::new(strip.get(at..).unwrap_or(&[]));
+        decode_v3_row(&mut pump, &mut out, row, width, &header, datamax);
+        // The next row starts at the next sixteen-byte boundary. The
+        // reader fetches whole 32-bit words, so rounding the bits it
+        // consumed up to a byte and then to sixteen lands exactly
+        // where its own fetch pointer would.
+        at += pump.position().div_ceil(8).next_multiple_of(V3_ALIGN);
+    }
+    Ok(out)
+}
+
+/// One row: blocks of sixteen columns until fewer than sixteen are
+/// left. A width that is not a whole number of blocks leaves its last
+/// few columns black; no body in the corpus has one.
+fn decode_v3_row(
+    pump: &mut impl BitPump,
+    out: &mut [u16],
+    row: usize,
+    width: usize,
+    header: &V3Header,
+    datamax: i32,
+) {
+    let mut scale = 0i32;
+    let mut motion = 7u32;
+    // The first two rows have no rows above to lean on, so they open
+    // expecting the wide differences of an absolute-ish first block.
+    let mut lengths = [if row < 2 { 7i32 } else { 4 }; 4];
+    let mut col = 0;
+    while col + V3_BLOCK <= width {
+        // Once every four blocks, and only on a lossy file.
+        if header.options & v3::LOSSLESS == 0 && col.is_multiple_of(4 * V3_BLOCK) {
+            match pump.get(2) {
+                1 => scale -= 2,
+                2 => scale += 2,
+                3 => scale = pump.get(12) as i32,
+                _ => {}
+            }
+        }
+        if header.options & v3::SHORT_MODE != 0 {
+            motion = if pump.get(1) == 0 { 7 } else { 3 };
+        } else if pump.get(1) == 0 {
+            motion = pump.get(3);
+        }
+        // Rows 0 and 1 have no rows above them: only mode 7 is legal
+        // there, and a file that says otherwise is broken rather than
+        // a reason to read outside the frame.
+        let mode = if row < 2 { 7 } else { motion };
+        v3_predict(out, row, col, width, mode, header.initial);
+
+        // With option bit 0 set the lengths are always written; with
+        // it clear a leading 1 bit means "the previous block's".
+        if header.options & v3::LENGTHS_ALWAYS != 0 || pump.get(1) == 0 {
+            v3_lengths(pump, &mut lengths);
+        }
+        if lengths
+            .iter()
+            .any(|l| !(0..=header.depth as i32 + 1).contains(l))
+        {
+            // A length the format cannot mean: the stream has come
+            // apart, and reading on would only spend bits wildly.
+            return;
+        }
+
+        for i in 0..V3_BLOCK {
+            let target = v3_target(row, col, i);
+            let length = lengths[i / 4];
+            // A length of zero reads no bits and codes a quantised
+            // difference of zero — but *not* a difference of zero: the
+            // dequantiser's mid-point offset still applies, so a lossy
+            // file shifts such a group up by its scale.
+            let quantised = if length == 0 {
+                0
+            } else {
+                let value = pump.get(length as u32) as i32;
+                // Two's complement in `length` bits.
+                if value & (1 << (length - 1)) != 0 {
+                    value - (1 << length)
+                } else {
+                    value
+                }
+            };
+            // The lossy step, and its mid-point reconstruction
+            // offset. At scale 0 this is the identity.
+            let difference = quantised * (2 * scale + 1) + scale;
+            let at = row * width + target;
+            if let Some(sample) = out.get_mut(at) {
+                // The clamp is not cosmetic: without it one clipped
+                // highlight propagates into every row below through
+                // the prediction above.
+                *sample = (*sample as i32 + difference).clamp(0, datamax) as u16;
+            }
+        }
+        col += V3_BLOCK;
+    }
+}
+
+/// The four difference lengths of a block, one for each group of four
+/// entries of the interleaved order.
+///
+/// All four two-bit selectors are read before any of them is resolved,
+/// and a selector's "predicted value" is the length the same group had
+/// in the previous block of this row.
+fn v3_lengths(pump: &mut impl BitPump, lengths: &mut [i32; 4]) {
+    let flags = [pump.get(2), pump.get(2), pump.get(2), pump.get(2)];
+    for (length, flag) in lengths.iter_mut().zip(flags) {
+        *length = match flag {
+            1 => *length + 1,
+            2 => *length - 1,
+            3 => pump.get(4) as i32,
+            _ => *length,
+        };
+    }
+}
+
+/// Which column entry `i` of a block's sixteen differences belongs to.
+///
+/// Differences are coded interleaved by column parity: on an even row
+/// the eight even columns come first and the eight odd ones after, and
+/// on an odd row the other way round. The predictions of the same
+/// block were written in plain column order, so the two meet in the
+/// frame.
+fn v3_target(row: usize, col: usize, i: usize) -> usize {
+    if row.is_multiple_of(2) {
+        col + 2 * (i % 8) + i / 8
+    } else {
+        col + 2 * (i % 8) + 1 - i / 8
+    }
+}
+
+/// Fill a block's sixteen columns with their predictions, before any
+/// difference is read.
+fn v3_predict(out: &mut [u16], row: usize, col: usize, width: usize, mode: u32, initial: u16) {
+    let base = row * width;
+    if mode >= 7 || row < 2 {
+        // Along the row, and sequentially: because the source is two
+        // columns back, every even offset in the block ends up with
+        // the last even column of the previous block and every odd
+        // offset with the last odd one.
+        for i in 0..V3_BLOCK {
+            let at = base + col + i;
+            if at >= out.len() {
+                return;
+            }
+            out[at] = if col == 0 { initial } else { out[at - 2] };
+        }
+        return;
+    }
+    let offset = V3_MOTION_OFFSET[mode as usize] as isize;
+    let average = V3_MOTION_AVERAGE[mode as usize];
+    for i in 0..V3_BLOCK {
+        // Green samples sit diagonally above, one row up and one
+        // column across; red and blue sit two rows straight up.
+        let far = !(row + i).is_multiple_of(2);
+        let reference_row = if far { row - 2 } else { row - 1 };
+        let across = if far {
+            0
+        } else if i.is_multiple_of(2) {
+            1
+        } else {
+            -1
+        };
+        let from = (reference_row * width) as isize + (col + i) as isize + offset + across;
+        // The frame is one flat buffer, so a reference that runs off
+        // the side of a row is simply a neighbouring row's sample; one
+        // that runs off the buffer reads as black.
+        let sample = |index: isize| -> u32 {
+            usize::try_from(index)
+                .ok()
+                .and_then(|i| out.get(i))
+                .map_or(0, |s| *s as u32)
+        };
+        let value = if average {
+            (sample(from) + sample(from + 2) + 1) >> 1
+        } else {
+            sample(from)
+        };
+        let at = base + col + i;
+        if at < out.len() {
+            out[at] = value as u16;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -676,6 +971,183 @@ mod tests {
         }
         let out = decompress_v2(&bits.finish(), 6, 2);
         assert_eq!(out, vec![4, 5, 4, 5, 4, 5, 6, 7, 6, 7, 6, 7]);
+    }
+
+    // ------------------------------------------------------- codec v3
+
+    /// Writes bits MSB-first into 32-bit little-endian words, the
+    /// order [`BitPumpMsb32`] reads them back in.
+    #[derive(Default)]
+    struct Words {
+        out: Vec<u8>,
+        cache: u64,
+        bits: u32,
+    }
+
+    impl Words {
+        fn put(&mut self, value: u32, bits: u32) {
+            self.cache = (self.cache << bits) | (value & ((1u64 << bits) - 1) as u32) as u64;
+            self.bits += bits;
+            while self.bits >= 32 {
+                self.bits -= 32;
+                let word = (self.cache >> self.bits) as u32;
+                self.out.extend_from_slice(&word.to_le_bytes());
+            }
+        }
+        fn finish(mut self) -> Vec<u8> {
+            if self.bits > 0 {
+                let pad = 32 - self.bits;
+                self.put(0, pad);
+            }
+            self.out
+        }
+    }
+
+    /// The sixteen header bytes of the two bodies in the corpus. Ten
+    /// of the sixteen have no known meaning, but the three that do are
+    /// enough to catch a reader that takes the words the wrong way up.
+    #[test]
+    fn the_v3_header_is_read_out_of_little_endian_words() {
+        let nx1 = v3_header(&[
+            0x4B, 0x6D, 0x33, 0x56, 0xF0, 0x10, 0x60, 0x19, 0x00, 0x05, 0x00, 0x00, 0x80, 0x00,
+            0x02, 0x01,
+        ]);
+        assert_eq!(
+            nx1,
+            V3Header {
+                depth: 14,
+                // Lengths always present, and lossless.
+                options: v3::LENGTHS_ALWAYS | v3::LOSSLESS,
+                initial: 128,
+            }
+        );
+        let nx500 = v3_header(&[
+            0x45, 0x6D, 0x33, 0x56, 0xF0, 0x10, 0x60, 0x19, 0x00, 0x00, 0x00, 0x00, 0x80, 0x00,
+            0x02, 0x01,
+        ]);
+        assert_eq!(
+            nx500,
+            V3Header {
+                depth: 14,
+                options: 0,
+                initial: 128,
+            }
+        );
+    }
+
+    /// The four length selectors, resolved against the previous
+    /// block's lengths. This is the NX1's row 0, block at column 32:
+    /// flags 0, 3, 0, 1 over the lengths 10, 9, 9, 8 that its block at
+    /// column 16 left behind.
+    #[test]
+    fn v3_lengths_carry_from_the_previous_block() {
+        let mut bits = Words::default();
+        bits.put(0, 2);
+        bits.put(3, 2);
+        bits.put(0, 2);
+        bits.put(1, 2);
+        // The one literal, for the group whose flag was 3. All four
+        // selectors are read before any literal.
+        bits.put(11, 4);
+        let stream = bits.finish();
+        let mut pump = BitPumpMsb32::new(&stream);
+        let mut lengths = [10, 9, 9, 8];
+        v3_lengths(&mut pump, &mut lengths);
+        assert_eq!(lengths, [10, 11, 9, 9]);
+        assert_eq!(pump.position(), 12);
+    }
+
+    /// The interleaved order the sixteen differences arrive in.
+    #[test]
+    fn v3_differences_are_interleaved_by_column_parity() {
+        let even: Vec<usize> = (0..16).map(|i| v3_target(0, 16, i)).collect();
+        assert_eq!(
+            even,
+            vec![16, 18, 20, 22, 24, 26, 28, 30, 17, 19, 21, 23, 25, 27, 29, 31]
+        );
+        let odd: Vec<usize> = (0..16).map(|i| v3_target(1, 16, i)).collect();
+        assert_eq!(
+            odd,
+            vec![17, 19, 21, 23, 25, 27, 29, 31, 16, 18, 20, 22, 24, 26, 28, 30]
+        );
+    }
+
+    /// Mode 7 predicts two columns back, sequentially, so a whole
+    /// block takes the previous block's last even and last odd column.
+    /// The first block of a row takes the header's initial value.
+    #[test]
+    fn v3_mode_seven_predicts_along_the_row() {
+        let width = 32;
+        let mut frame = vec![0u16; width * 3];
+        v3_predict(&mut frame, 0, 0, width, 7, 128);
+        assert!(frame[..16].iter().all(|s| *s == 128));
+        // Give the first block the NX1's real row 0 and predict the
+        // second: every even offset becomes 4333, every odd 2362.
+        frame[14] = 4333;
+        frame[15] = 2362;
+        v3_predict(&mut frame, 0, 16, width, 7, 128);
+        for (i, sample) in frame[16..32].iter().enumerate() {
+            assert_eq!(*sample, if i.is_multiple_of(2) { 4333 } else { 2362 });
+        }
+    }
+
+    /// Modes 0..=6 take their reference from the row above for the
+    /// diagonal (green) neighbours and from two rows above for the
+    /// ones straight up, then slide it sideways. Mode 3 is the
+    /// no-slide, no-average case; mode 4 averages two references two
+    /// columns apart.
+    #[test]
+    fn v3_motion_prediction_reads_the_two_rows_above() {
+        let width = 32;
+        let mut frame = vec![0u16; width * 3];
+        for c in 0..width {
+            frame[c] = 100 + c as u16;
+            frame[width + c] = 200 + c as u16;
+        }
+        v3_predict(&mut frame, 2, 0, width, 3, 0);
+        // Row 2, column 0 comes from row 1 column 1; column 1 from row
+        // 0 column 1; column 2 from row 1 column 3; and so on.
+        assert_eq!(
+            &frame[2 * width..2 * width + 6],
+            &[201, 101, 203, 103, 205, 105]
+        );
+        v3_predict(&mut frame, 2, 0, width, 4, 0);
+        // Averaging takes the reference and the one two columns on.
+        // (201 + 203 + 1) >> 1 and so on: the reference and the one
+        // two columns further along.
+        assert_eq!(&frame[2 * width..2 * width + 4], &[202, 102, 204, 104]);
+    }
+
+    /// The dequantiser, and its mid-point offset. A group whose length
+    /// resolves to zero reads no bits, but still picks up the offset:
+    /// the difference is `scale`, not zero.
+    #[test]
+    fn v3_dequantises_around_the_interval_midpoint() {
+        let dequantise = |q: i32, scale: i32| q * (2 * scale + 1) + scale;
+        // The NX500's first difference: 3364 = 3 * 1121 + 1.
+        assert_eq!(dequantise(1121, 1), 3364);
+        // Lossless files leave it the identity.
+        assert_eq!(dequantise(-97, 0), -97);
+        assert_eq!(dequantise(0, 3), 3);
+    }
+
+    /// A width narrower than a block, and a stream with no room for a
+    /// header, are refused rather than decoded into nonsense.
+    #[test]
+    fn v3_refuses_frames_it_cannot_describe() {
+        assert!(decompress_v3(&[0; 4096], 640, 480).is_err());
+        assert!(decompress_v3(&[0; 8], 6496, 4336).is_err());
+        // An all-zero header claims one bit a sample.
+        assert!(decompress_v3(&vec![0u8; 1 << 16], V3_MIN_WIDTH, V3_MIN_HEIGHT).is_err());
+        // A real header over a stream of zeros: every field reads
+        // zero, which is a legal stream, and nothing panics.
+        let mut stream = vec![
+            0x4B, 0x6D, 0x33, 0x56, 0xF0, 0x10, 0x60, 0x19, 0x00, 0x05, 0x00, 0x00, 0x80, 0x00,
+            0x02, 0x01,
+        ];
+        stream.resize(1 << 16, 0);
+        let frame = decompress_v3(&stream, V3_MIN_WIDTH, V3_MIN_HEIGHT).unwrap();
+        assert_eq!(frame.len(), V3_MIN_WIDTH * V3_MIN_HEIGHT);
     }
 
     #[test]
@@ -745,11 +1217,9 @@ mod tests {
 
     /// Files this decoder knowingly cannot read, with the reason. A
     /// corpus file that is `Unsupported` for any other reason fails.
-    const UNSUPPORTED: &[&str] = &[
-        // Compression 32773, the NX1/NX500 codec: a sixteen-by-sixteen
-        // block predictor this crate has not reverse-engineered.
-        "SRW compression 32773",
-    ];
+    /// Empty: every Samsung compression in the corpus decodes. The
+    /// list stays for the compressions a future body might bring.
+    const UNSUPPORTED: &[&str] = &[];
 
     fn corpus() -> Vec<PathBuf> {
         let Ok(root) = std::env::var("SCHIST_RAW_CORPUS") else {
@@ -825,6 +1295,104 @@ mod tests {
             })
             .collect();
         Some(Cfa::Bayer(colors.try_into().ok()?))
+    }
+
+    /// A corpus file by name, with its decoded frame.
+    fn decoded(name: &str) -> Option<RawImage> {
+        let path = corpus()
+            .into_iter()
+            .find(|p| p.file_name().is_some_and(|f| f == name))?;
+        let bytes = std::fs::read(path).expect("corpus file reads");
+        Some(crate::decode(&bytes).expect("decodes"))
+    }
+
+    fn samples(raw: &RawImage) -> &[u16] {
+        let RawData::U16(data) = &raw.data else {
+            panic!("SRW frames are integers")
+        };
+        data
+    }
+
+    /// The NX1: option flags 5, so the lengths are in every block and
+    /// the file is lossless. Its first row exercises mode 7 from the
+    /// header's initial value, four 4-bit length literals and the
+    /// interleaved difference order in one block.
+    #[test]
+    fn the_nx1_decodes_its_first_rows_sample_for_sample() {
+        let Some(raw) = decoded("NX1-sam_9364.srw") else {
+            return;
+        };
+        assert_eq!((raw.width, raw.height), (6496, 4336));
+        assert_eq!(raw.cfa, Cfa::GRBG);
+        assert_eq!(raw.white_level, 16383.0);
+        let frame = samples(&raw);
+        let width = raw.width;
+        assert_eq!(
+            &frame[..16],
+            &[
+                4524, 2306, 4662, 2339, 4504, 2464, 4839, 2432, 4384, 2344, 4423, 2373, 4353, 2218,
+                4333, 2362
+            ]
+        );
+        // The second block's predictions are the first's last even and
+        // last odd column, 4333 and 2362.
+        assert_eq!(
+            &[frame[16], frame[18], frame[20], frame[22]],
+            &[4230, 4309, 4604, 4501]
+        );
+
+        // Row 2 is the first that can use the motion modes; its first
+        // block chooses mode 3 — no slide, no averaging — so column 0
+        // predicts from row 1 column 1 and column 1 from row 0
+        // column 1.
+        assert_eq!(&[frame[width + 1], frame[width + 3]], &[4495, 4458]);
+        assert_eq!(&[frame[1], frame[3]], &[2306, 2339]);
+        let row2 = &frame[2 * width..];
+        assert_eq!(
+            &[row2[0], row2[2], row2[4], row2[6]],
+            &[4904, 4453, 4666, 4558]
+        );
+    }
+
+    /// The NX500: option flags 0, so every field is present and the
+    /// file is lossy. Its row 0 opens with a scale selector reading 3
+    /// and a twelve-bit literal of 1, so every difference on that row
+    /// is `3q + 1`.
+    #[test]
+    fn the_nx500_decodes_its_lossy_first_rows_sample_for_sample() {
+        let Some(raw) = decoded("NX500-SAM_2922.SRW") else {
+            return;
+        };
+        assert_eq!((raw.width, raw.height), (6496, 4336));
+        let frame = samples(&raw);
+        let width = raw.width;
+        assert_eq!(
+            &frame[..16],
+            &[
+                3492, 1695, 3510, 1668, 3531, 1620, 3495, 1680, 3531, 1728, 3504, 1728, 3537, 1641,
+                3477, 1725
+            ]
+        );
+        // Row 2's first block uses mode 4: offset zero and an average
+        // of two references two columns apart. Its predictions are
+        // therefore these averages of rows 0 and 1.
+        let average = |a: u16, b: u16| (a as u32 + b as u32 + 1) >> 1;
+        assert_eq!(average(frame[width + 1], frame[width + 3]), 3482);
+        assert_eq!(average(frame[1], frame[3]), 1682);
+        assert_eq!(average(frame[width + 3], frame[width + 5]), 3440);
+        assert_eq!(average(frame[3], frame[5]), 1644);
+        assert_eq!(average(frame[width + 5], frame[width + 7]), 3446);
+        assert_eq!(average(frame[5], frame[7]), 1650);
+        assert_eq!(average(frame[width + 7], frame[width + 9]), 3506);
+        assert_eq!(average(frame[7], frame[9]), 1704);
+        let row2 = &frame[2 * width..];
+        assert_eq!(
+            &[row2[0], row2[2], row2[4], row2[6]],
+            &[3546, 3489, 3450, 3450]
+        );
+        // The clamp: no sample may leave the fourteen-bit range, and
+        // this frame does reach the top of it.
+        assert_eq!(frame.iter().copied().max(), Some(16383));
     }
 
     #[test]

--- a/docs/web.md
+++ b/docs/web.md
@@ -115,8 +115,8 @@ rather than left to fail.
 ## Known gaps
 
 Camera raws open through the pure-Rust `schist-codec-raw` decoder, the
-same one the desktop uses first. The few codecs it declines — Canon CR3
-pixels, Fuji's compressed RAF, a handful of odd ones — go to a runtime
+same one the desktop uses first. The few codecs it declines — Sigma's
+Foveon data, GoPro's VC-5, a handful of old odd ones — go to a runtime
 LibRaw on the desktop; a browser has no library to load, so those files
 are refused with a message saying so (their embedded previews still
 show).


### PR DESCRIPTION
## Summary

The six codecs `schist-codec-raw` declined after #94 now decode natively, so LibRaw is only reached for Foveon, GoPro VC-5 and a few old odd formats. Based on main with #97 merged.

**Method.** Classic two-team clean room: three separate agents read the LGPL reference (fetched under `/tmp`, never into the repo), instrumented it, and wrote functional specifications in prose and tables with worked intermediate values (`/tmp/raw-specs/*.md`). Three implementers then worked from those specifications, the sample files and LibRaw's oracle output only, and never opened the reference. The specification writers reported only summaries to the coordinator, so no source entered the coordinating context either.

| codec | exact vs LibRaw's unpacked frame |
|---|---|
| Canon CR3 — CRX lossless and lossy (cRAW), 0–3 wavelet levels, multi-tile | 10/10 (EOS R, 90D, R5, R8 incl. dual-pixel); EOS R in 120 ms |
| Fujifilm compressed RAF — lossless and lossy, X-Trans and Bayer | 4/4 (X100F, X-Pro3, X-T5, GFX100S) |
| Canon CRW compressed | 3/3 (D60, 10D, PowerShot G2) |
| Samsung SRW compression 32773 | 2/2 (NX1, NX500) |
| Phase One IIQ S, formats 5 and 6 | 6/6 → all 11 Phase One files exact |
| Panasonic RW2 RawFormat 8 | 2/2 (GH6, G9 II) |

Every allow-list in those modules is now empty. Against LibRaw's own development the new paths sit at 36–45 dB in the plugin's comparison harness (110 files compared, none below 20 dB).

**Oracle note.** LibRaw 0.21.2 (the box's package) does not implement RawFormat 8 and lacks the Samsung output clamp; the four affected oracle dumps were regenerated from LibRaw 0.22.2 (recorded in `/tmp/raw-specs/oracle-notes.md`).

**Spec corrections found by the implementers** (all in module docs): the Samsung length-0 dequantiser offset (would have corrupted 15% of an NX500 frame followed literally), Phase One row interleave and companding notes, a CRW record-field offset, a Fuji prose off-by-one, and CRX's predictor being numerically the LOCO-I median.

**Review.** 80,863 mutated inputs across all six codecs with overflow checks on: no blind panics. Five hand-targeted crashes were found and are fixed here: CRX allocating from an unbounded header (now through the crate's frame ceiling), a zero bit depth, a quantiser-step overflow, the Panasonic curve underflowing on a forged threshold, the CRW predictor overflowing on a crafted stream; plus a quadratic CRX frame assembly (24 MB → 9 s) rewritten to one pass. Latent items noted, not fixed: a compressed RAF whose strip header disagrees with the container is refused rather than trusting the header; a corrupt Samsung v3 row desyncs the rest of the frame into noise rather than black; Phase One's per-row/column black tables are not applied (LibRaw's dump doesn't either).

## For a human to judge

- The reviewer flagged three comment phrasings that mention "the reference decoder" or "every other decoder"; the content is spec-supported and no code was transcribed, but the wording invites the question. Left as is for you to see.

## Test plan

- [x] Crate: 360 tests incl. every spec's worked values as assertions and per-format corpus comparison (`SCHIST_RAW_CORPUS=/tmp/rawsamples`)
- [x] Plugin sweep over the full corpus; native-vs-LibRaw PSNR table
- [x] The reviewer's five crash inputs run clean in a debug build with a 4 GB address-space limit
- [x] `cargo fmt --check`, clippy `-D warnings` on the crate

🤖 Generated with [Claude Code](https://claude.com/claude-code)
