### PR TITLE
feat(raw): decode Foveon, GoPro VC-5, Canon sRAW and Kodak RADC natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ rest, developed with the camera's white balance to 16-bit sRGB. Raws
 decode through Schist's own clean-room `schist-codec-raw` crate (pure
 Rust, written from the public specifications and verified sample for
 sample against LibRaw across some 250 camera files), which covers most
-bodies, Canon's CR3 and Fuji's compressed RAF included; what it
-declines — Sigma's Foveon sensor data, GoPro's VC-5, a few old odd
-codecs, and cameras with no colour matrix in its table yet —
+bodies, Canon's CR3 and Fuji's compressed RAF, Sigma's Foveon and
+GoPro's VC-5 included; what it still declines — a couple of ancient
+Sigma and Fuji sensors, Nikon's licensed High Efficiency NEF, and
+cameras with no colour matrix in its table yet —
 falls back to the system's LibRaw, loaded at runtime (`brew install
 libraw`, or the distro's package); the browser build, which cannot load
 one, refuses those few files and opens everything else. HEIC decodes through libheif the

--- a/crates/codec-raw/README.md
+++ b/crates/codec-raw/README.md
@@ -9,7 +9,9 @@ public description (Canon's CRX and compressed CRW, Fuji's compressed
 RAF, Samsung's NX1 scheme, Phase One's IIQ S, Panasonic's RawFormat 8),
 it was implemented from a written functional specification produced by
 a separate party who read the reference — the standard clean-room
-arrangement — and verified against the reference's output only.
+arrangement — and verified against the reference's output only. The
+same went for Sigma's Foveon, GoPro's VC-5, Canon's sRAW and Kodak's
+RADC.
 
 `decode` reads a file into a `RawImage` (the sensor frame, its filter
 array, levels, white balance, colour matrix, crop, orientation and the
@@ -24,22 +26,22 @@ frame on the files listed, drawn from the raw.pixls.us sample set.
 
 | container | status |
 | --- | --- |
-| DNG (incl. ProRAW, Pixel, Leica, Pentax, Ricoh, Sigma, DJI, Hasselblad) | exact on 26; uncompressed, lossless JPEG, deflate, lossy JPEG, float; GoPro VC-5 and JPEG XL unsupported |
+| DNG (incl. ProRAW, Pixel, Leica, Pentax, Ricoh, Sigma, DJI, Hasselblad, GoPro GPR) | exact on 30; uncompressed, lossless JPEG, deflate, lossy JPEG, float, VC-5; JPEG XL unsupported |
 | Sony ARW / SR2 / SRF | exact on 24, every generation incl. ARW 1.0 and ARW 4 lossless |
 | Nikon NEF / NRW | exact on 36 (20 bodies); Z 8/9 High Efficiency unsupported |
-| Canon CR2 | exact on 14; sRAW/mRAW unsupported |
+| Canon CR2 | exact on 18, sRAW and mRAW included on the 50D and 7D; sRAW on other bodies is declined by model until verified |
 | Canon CRW | exact on 4 (compressed and uncompressed) |
 | Canon CR3 | exact on 10: CRX lossless and lossy (cRAW), EOS R through R8, dual-pixel included |
-| Fujifilm RAF | exact on 13: uncompressed, lossless and lossy compressed, X-Trans and Bayer; SuperCCD unsupported |
+| Fujifilm RAF | exact on 13: uncompressed, lossless and lossy compressed, X-Trans and Bayer; SuperCCD's 45° grid is decodable but not representable yet |
 | Olympus / OM ORF | exact on 12, four sensor layouts |
 | Panasonic RW2 / Leica RWL | exact on 31, RawFormat 4 through 8 |
 | Pentax PEF | exact on 10 |
 | Samsung SRW | exact on 17, every compression |
-| Minolta MRW, Kodak DCR/KDC, Epson ERF, Mamiya MEF | exact on 15 bodies; Kodak DC50 unsupported; Epson's as-shot balance is not found in the file |
+| Minolta MRW, Kodak DCR/KDC, Epson ERF, Mamiya MEF | exact on 16 bodies, Kodak's DC50 included; Epson's as-shot balance is not found in the file |
 | Hasselblad 3FR / FFF | exact on 7 |
 | Phase One IIQ | exact on 11, raw, "IIQ L" and both "IIQ S" formats |
 | Leaf MOS | exact on 3 |
-| Sigma X3F | metadata and preview only |
+| Sigma X3F | exact on 6: Merrill and Quattro sensor planes (colour from the camera table); SD9/SD10/SD14 unsupported for want of a sample |
 
 Colour needs a matrix. DNG carries its own; the other formats look one
 up in `cameras.rs` (189 bodies, each entry naming its source). A camera

--- a/crates/codec-raw/src/formats/cr2.rs
+++ b/crates/codec-raw/src/formats/cr2.rs
@@ -40,6 +40,9 @@ const CR2_CFA_PATTERN: u16 = 0xC5E0;
 
 /// Canon makernote tags this module reads.
 mod canon {
+    /// CanonModelID: the body as a LONG, `0x8000_0000` plus a small
+    /// number for the EOS bodies.
+    pub const MODEL_ID: u16 = 0x0010;
     /// SensorInfo: the full sensor size, the borders of the area the
     /// camera itself would show, and the optically black mask.
     pub const SENSOR_INFO: u16 = 0x00E0;
@@ -53,14 +56,24 @@ pub fn decode(bytes: &[u8]) -> Result<RawImage> {
         raw_ifd(&tiff).ok_or_else(|| Error::Corrupt("cr2: no IFD holds sensor data".into()))?;
     let stream = raw_stream(&tiff, raw_ifd)?;
 
-    // sRAW and mRAW keep a subsampled YCbCr picture rather than a CFA,
-    // in a three-component frame; every Bayer CR2 ever written has two
-    // or four. Say so before the lossless decoder refuses the sampling
-    // factors, which would be a much less helpful message.
+    // sRAW and mRAW keep a subsampled YCbCr picture rather than a CFA.
+    // The luma component's sampling factors are the only mark of it,
+    // and `ljpeg::header` refuses such a frame outright, so the branch
+    // has to be taken before the frame header is read.
+    if ljpeg::sampling(stream)? != 0x11 {
+        return sraw(&tiff, raw_ifd, stream);
+    }
     let shape = ljpeg::header(stream)?;
+    // A three-component frame at 1:1 is not a Bayer CR2 either: Canon
+    // groups a sensor row into two or four components, and three only
+    // ever means Y, Cb, Cr. Without sampling factors there is no
+    // telling how its blocks are shaped, so it is refused rather than
+    // un-sliced into a single-channel frame of nonsense.
     if shape.components == 3 {
         return Err(Error::Unsupported(
-            "cr2: sRAW/mRAW (subsampled YCbCr, not a colour filter array)".into(),
+            "cr2: a three-component lossless JPEG without sampling factors (an sRAW/mRAW shape \
+             no Canon body writes)"
+                .into(),
         ));
     }
     let frame = ljpeg::decode(stream)?;
@@ -79,11 +92,7 @@ pub fn decode(bytes: &[u8]) -> Result<RawImage> {
         RawData::U16(data),
         cfa(&tiff, raw_ifd),
     );
-    let (make, model) = tiff.make_model();
-    raw.set_camera(&make, &model);
-    raw.orientation = common::orientation(&tiff);
-    raw.metadata = common::metadata(&tiff);
-    raw.preview = common::largest_jpeg(&tiff);
+    common_fields(&mut raw, &tiff);
 
     // The lossless JPEG's precision is the sensor's: 12-bit on the
     // compacts and the pre-2007 bodies, 14 since. Canon's real
@@ -289,6 +298,339 @@ fn cfa(tiff: &Tiff<'_>, raw_ifd: &Ifd) -> Cfa {
     }
 }
 
+/// The camera, orientation, metadata and preview: the same for a Bayer
+/// frame and a subsampled one.
+fn common_fields(raw: &mut RawImage, tiff: &Tiff<'_>) {
+    let (make, model) = tiff.make_model();
+    raw.set_camera(&make, &model);
+    raw.orientation = common::orientation(tiff);
+    raw.metadata = common::metadata(tiff);
+    raw.preview = common::largest_jpeg(tiff);
+}
+
+// ----------------------------------------------------------- sRAW/mRAW
+
+/// The chroma level a neutral pixel decodes to, `1 << 14`. Subtracting
+/// it centres the two chroma planes on zero.
+const SRAW_NEUTRAL: i32 = 1 << 14;
+
+/// The bodies whose sRAW reconstruction has been checked sample for
+/// sample against a reference frame, by CanonModelID.
+///
+/// The hue offset and the matrix in [`sraw_to_rgb`] are per generation,
+/// and the trim in [`sraw_width`] is fitted, so a body that has not
+/// been measured is refused outright: a frame that decodes to plausible
+/// but wrong colour is the worst outcome, because nothing downstream
+/// can tell. Of the bodies with samples to hand, the 5D Mark III wants
+/// a matrix this module does not have. The 5D Mark II is closer: with
+/// the other hue rule (`P << 1`) and the matrix below, both of its
+/// samples reconstruct sample for sample *given* the right width — but
+/// it trims to 3866 columns from a 3872-column frame whose last border
+/// column is 3860, and to the full 2808 with borders 12..=2795, and no
+/// rule over the numbers in the file produces either. Until the width
+/// can be read rather than fitted, it stays refused.
+const SRAW_VERIFIED_BODIES: &[(u32, &str)] = &[
+    // Both modes, against the planar and full reference dumps.
+    (0x8000_0261, "EOS 50D"),
+    // Both modes, against the full reference dump.
+    (0x8000_0250, "EOS 7D"),
+];
+
+/// Makernote 0x0010, the body as a number.
+fn model_id(mn: &Ifd) -> Option<u32> {
+    mn.get(canon::MODEL_ID)?.u32(0)
+}
+
+/// `Ok` for a body on [`SRAW_VERIFIED_BODIES`], the refusal otherwise.
+fn sraw_verified_body(model_id: Option<u32>, model: &str) -> Result<()> {
+    if model_id.is_some_and(|id| SRAW_VERIFIED_BODIES.iter().any(|(known, _)| *known == id)) {
+        return Ok(());
+    }
+    let body = match (model.is_empty(), model_id) {
+        (false, _) => model.to_string(),
+        (true, Some(id)) => format!("model id {id:#x}"),
+        (true, None) => "an unnamed body".to_string(),
+    };
+    Err(Error::Unsupported(format!(
+        "Canon sRAW on {body}: colour reconstruction not verified for this body"
+    )))
+}
+
+/// Canon's sRAW and mRAW: a half- or quarter-resolution YCbCr picture
+/// in place of a colour filter array.
+///
+/// The lossless JPEG carries, per minimum coded unit, the luma of a
+/// two-pixel-wide block and the one chroma pair they share. The block
+/// is two rows tall for mRAW, whose luma is sampled 2x2, and one row
+/// for sRAW, sampled 2x1 — Canon's names run the other way from the
+/// pixel counts: mRAW is the larger picture and subsamples its chroma
+/// the more. This puts those blocks back where they belong, fills the
+/// chroma the encoder did not send, and turns the result into the
+/// camera's own RGB.
+///
+/// What comes out is *camera* RGB, not a white-balanced picture: the
+/// per-channel gains in ColorData only put the three reconstructed
+/// planes onto the sensor's scale (they leave green well above unity),
+/// so the as-shot white balance still belongs in `wb_coeffs` where the
+/// developer applies it, exactly as for a Bayer frame.
+fn sraw(tiff: &Tiff<'_>, raw_ifd: &Ifd, stream: &[u8]) -> Result<RawImage> {
+    let makernote = makernote(tiff);
+    let (sensor, colour, model_id) = match &makernote {
+        Some(mn) => {
+            let (root, le) = (mn.root(), mn.little_endian());
+            (sensor_info(root, le), color_data(root, le), model_id(root))
+        }
+        None => (None, None, None),
+    };
+    let (_, model) = tiff.make_model();
+    // Before the entropy decode: refusing after it would only waste
+    // the work.
+    sraw_verified_body(model_id, &model)?;
+
+    let sub = ljpeg::decode_subsampled(stream)?;
+    let width = sraw_width(sensor.as_ref(), sub.width);
+    let height = sub.height;
+    let mut planes = sraw_planes(&sub, width, slices(raw_ifd, sub.row))?;
+    sraw_upsample(&mut planes, width, height, sub.p);
+    // Without the multipliers the three planes still reconstruct, just
+    // on the matrix's own scale; unity is the honest fallback for a
+    // ColorData layout this module has not measured, but it is a
+    // visibly green picture, so it is not a silent one.
+    let multipliers = match colour.as_ref().and_then(ColorData::sraw_multipliers) {
+        Some(multipliers) => multipliers,
+        None => {
+            log::warn!(
+                "cr2: {model}: ColorData version {} ({} words) holds no usable sRAW multipliers; \
+                 reconstructing at unity gain",
+                colour.as_ref().map_or(0, |c| c.version),
+                colour.as_ref().map_or(0, ColorData::count)
+            );
+            [1024; 3]
+        }
+    };
+    let data = sraw_to_rgb(&planes, sub.p, multipliers);
+
+    let mut raw = RawImage::new(Format::Cr2, width, height, 3, RawData::U16(data), Cfa::None);
+    common_fields(&mut raw, tiff);
+    if let Some(colour) = &colour {
+        if let Some(wb) = colour.as_shot_wb() {
+            raw.wb_coeffs = wb;
+        }
+    }
+    if let Some(sensor) = &sensor {
+        if let Some(crop) = sensor.crop(width, height) {
+            raw.crop = crop;
+        }
+    }
+    raw.apply_camera_table();
+    // After the camera table, because a Bayer body's tabulated levels
+    // say nothing about a reconstructed frame: the YCbCr maths has
+    // already centred the data, so there is no pedestal to subtract.
+    raw.black_levels = [0.0; 4];
+    raw.white_level = 16383.0;
+    Ok(raw)
+}
+
+/// The width a subsampled frame is trimmed to.
+///
+/// The lossless JPEG codes the picture padded out to whole slices — the
+/// 50D's mRAW writes 3344 luma columns for a 3272-column picture — and
+/// no tag in the file states the real width outright. SensorInfo names
+/// the picture's last column (3266 on that file), and rounding the
+/// count of columns up to and including it to the next eight-column
+/// boundary gives the width the picture is trimmed to. The frame keeps
+/// its origin, so the left border plays no part: the trim is at the
+/// right edge only.
+///
+/// This is the one quantity here fitted to the reference frames rather
+/// than read from the file. It reproduces the 50D and 7D samples (3272,
+/// 2376, 3888, 2592) and is known not to hold everywhere: the 5D Mark
+/// II reconstructs to 3866 and 2808 columns, and no multiple-of-eight
+/// rule over its borders (last column 3860; 12..=2795) gives either.
+/// That body is refused by [`sraw_verified_body`] for this among other
+/// reasons.
+fn sraw_width(sensor: Option<&SensorInfo>, jpeg_width: usize) -> usize {
+    let full = jpeg_width & !1;
+    let Some(sensor) = sensor else { return full };
+    match sensor
+        .right
+        .checked_add(1)
+        .and_then(|a| a.checked_next_multiple_of(8))
+    {
+        Some(active) => (active.min(full)) & !1,
+        None => full,
+    }
+}
+
+/// Place the decoded MCUs, un-slicing as the Bayer path does.
+///
+/// Returns the three planes interleaved Y, Cb, Cr with the chroma
+/// centred on zero and still present only at each block's anchor pixel
+/// — the stage the `.sraw-planar` oracle captures, before any
+/// interpolation or colour.
+///
+/// Canon cuts the frame into vertical strips exactly as it does a Bayer
+/// one, and the same three-integer tag describes the cut; the only
+/// difference is the unit. A slice is `first` samples of an entropy
+/// row, and an MCU spends `components` samples on two columns, so a
+/// slice spans `first * 2 / components` columns. Each strip is written
+/// full height before the next begins, and the last is cut short where
+/// the picture ends — the samples the encoder wrote past that are
+/// padding and are stepped over, which is why the read position
+/// advances by the slice's full width whatever the strip's width on
+/// screen.
+fn sraw_planes(sub: &ljpeg::SubsampledImage, width: usize, slices: [usize; 3]) -> Result<Vec<i32>> {
+    let (height, components) = (sub.height, sub.components);
+    let [count, first, last] = slices;
+    // The identity the Bayer path holds the tag to: the slices together
+    // are exactly one entropy row. It is checked before anything is
+    // allocated because it ties the container's numbers to the frame
+    // header's — a tag that lies about the cut, or a header forged to
+    // claim a huge frame, fails here rather than getting its planes —
+    // and because a count that does not add up is a count this loop
+    // must not run to.
+    let row = count
+        .checked_mul(first)
+        .and_then(|w| w.checked_add(last))
+        .ok_or_else(|| Error::Corrupt("cr2: sRAW slice widths overflow".into()))?;
+    if row != sub.row {
+        return Err(Error::Corrupt(format!(
+            "cr2: slices {count}x{first}+{last} make {row} samples a row, the sRAW frame has {}",
+            sub.row
+        )));
+    }
+    // A slice is whole MCUs, or its columns cannot be counted.
+    if !first.is_multiple_of(components) || !last.is_multiple_of(components) {
+        return Err(Error::Corrupt(format!(
+            "cr2: sRAW slices of {first} and {last} samples are not whole {components}-sample MCUs"
+        )));
+    }
+    // A zero first width is the single-slice spelling whatever the
+    // count says (the identity above then makes `last` the whole row),
+    // and must not be walked `count` times.
+    let count = if first == 0 { 0 } else { count };
+
+    let stride = width
+        .checked_mul(3)
+        .ok_or_else(|| Error::Corrupt("cr2: sRAW frame too wide".into()))?;
+    let mut out = vec![0i32; crate::frame_samples(width, height, 3)?];
+    let last_column = width & !1;
+
+    let mut read = 0usize;
+    let mut ecol = 0usize;
+    for slice in 0..=count {
+        let scol = ecol;
+        let slice_row = if slice < count { first } else { last };
+        // The last slice always reaches the coded width, which is at
+        // least the picture's; the clamp is where the trim happens.
+        ecol = scol
+            .saturating_add(slice_row * 2 / components)
+            .min(last_column);
+        if ecol == scol {
+            // Nothing left to place: every column is in, and whatever
+            // the stream still holds is padding.
+            break;
+        }
+        for row in (0..height).step_by(sub.block_rows.max(1)) {
+            let mut at = read;
+            read = read.saturating_add(slice_row);
+            let mut col = scol;
+            while col < ecol {
+                let mcu = sub.data.get(at..at + components).ok_or_else(|| {
+                    Error::Corrupt("cr2: sRAW slice runs past the decoded frame".into())
+                })?;
+                at += components;
+                // The luma of one MCU are the block in raster order:
+                // two across, then two more on the row below when the
+                // block is 2x2.
+                for (k, luma) in mcu[..components - 2].iter().enumerate() {
+                    let (y, x) = (row + (k >> 1), col + (k & 1));
+                    if y < height && x < width {
+                        out[y * stride + x * 3] = *luma as i32;
+                    }
+                }
+                let anchor = row * stride + col * 3;
+                out[anchor + 1] = mcu[components - 2] as i32 - SRAW_NEUTRAL;
+                out[anchor + 2] = mcu[components - 1] as i32 - SRAW_NEUTRAL;
+                col += 2;
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Fill in the chroma the encoder did not send, bilinearly.
+///
+/// A 2x2 block leaves every odd row without chroma, so those are
+/// averaged from the rows above and below first; then every odd column
+/// of every row is averaged from the even columns either side. Edges
+/// copy their one neighbour.
+fn sraw_upsample(planes: &mut [i32], width: usize, height: usize, p: usize) {
+    let stride = width * 3;
+    if p >> 1 != 0 {
+        for row in (1..height).step_by(2) {
+            let above = (row - 1) * stride;
+            let below = if row + 1 < height {
+                above + 2 * stride
+            } else {
+                above
+            };
+            let here = row * stride;
+            for col in (0..width).step_by(2) {
+                let x = col * 3;
+                for c in 1..3 {
+                    planes[here + x + c] = (planes[above + x + c] + planes[below + x + c] + 1) >> 1;
+                }
+            }
+        }
+    }
+    for row in 0..height {
+        let base = row * stride;
+        for col in (1..width).step_by(2) {
+            let left = base + (col - 1) * 3;
+            let right = if col + 1 < width { left + 6 } else { left };
+            let here = base + col * 3;
+            for c in 1..3 {
+                planes[here + c] = (planes[left + c] + planes[right + c] + 1) >> 1;
+            }
+        }
+    }
+}
+
+/// Y, Cb, Cr to the camera's RGB.
+///
+/// Canon shifts the chroma left two bits and adds a per-generation
+/// *hue* offset before a fixed-point matrix over 2^14. The 50D and 7D
+/// use `(P + 1) << 2` and the matrix below, and both are verified
+/// against reference frames. Other bodies differ: the 5D Mark II wants
+/// `P << 1` with this matrix, and the 5D Mark III a matrix this module
+/// does not have — which is why [`sraw_verified_body`] admits only the
+/// two. Each channel is then put on the sensor's scale by ColorData's
+/// multipliers and clipped.
+fn sraw_to_rgb(planes: &[i32], p: usize, multipliers: [i32; 3]) -> Vec<u16> {
+    let hue = ((p as i64) + 1) << 2;
+    let mut out = vec![0u16; planes.len()];
+    let (pixels, _) = planes.as_chunks::<3>();
+    let (out_pixels, _) = out.as_chunks_mut::<3>();
+    for (pixel, rgb) in pixels.iter().zip(out_pixels.iter_mut()) {
+        let y = pixel[0] as i64;
+        let cb = ((pixel[1] as i64) << 2) + hue;
+        let cr = ((pixel[2] as i64) << 2) + hue;
+        // 64-bit throughout: the shifted chroma times the largest
+        // coefficient is within a hair of overflowing 32 bits, and a
+        // forged ColorData could make the final gain much larger.
+        let camera = [
+            y + ((50 * cb + 22929 * cr) >> 14),
+            y + ((-5640 * cb - 11751 * cr) >> 14),
+            y + ((29040 * cb - 101 * cr) >> 14),
+        ];
+        for c in 0..3 {
+            rgb[c] = ((camera[c] * multipliers[c] as i64) >> 10).clamp(0, 32767) as u16;
+        }
+    }
+    out
+}
+
 // ------------------------------------------------------------ makernote
 
 /// The Canon makernote as a directory of its own.
@@ -463,6 +805,63 @@ impl ColorData {
         }
         let g = g1 as f32;
         Some([r as f32 / g, 1.0, b as f32 / g, g2 as f32 / g])
+    }
+
+    /// Where the sRAW channel multipliers start, by version.
+    ///
+    /// Like the black level, they move with the version stamp rather
+    /// than the block length. Versions 6 (50D, 1250 words) and 7 (7D,
+    /// 1337 words) are verified against reference frames; version 10
+    /// (5D Mark III, 1312 words) has the quad's shape confirmed on a
+    /// sample but no reconstruction to check it in; version 14 is
+    /// documented, not measured. [`Self::sraw_multipliers`] checks the
+    /// quad's shape, so a wrong line here reconstructs at unity with a
+    /// warning rather than scaling by noise.
+    fn sraw_mul_offset(&self) -> Option<usize> {
+        let offset = match self.version {
+            6 | 7 => 0x4E,
+            10 => 0x7B,
+            14 => 0x80,
+            _ => return None,
+        };
+        (offset + 4 <= self.count()).then_some(offset)
+    }
+
+    /// The per-channel gains the sRAW reconstruction finishes with.
+    ///
+    /// Four words in sensor order R, Gr, Gb, B. The two greens are one
+    /// number, so words 0, 1 and 3 are R, G and B, and every one is
+    /// then multiplied by the largest of the four over 1024 and
+    /// truncated.
+    ///
+    /// Despite sitting where a white balance would, these are not one:
+    /// on the 50D they come out near 687, 1336, 855, leaving green a
+    /// third above unity. They put the three reconstructed planes onto
+    /// the sensor's own scale, which is why the frame still wants the
+    /// as-shot multipliers applied on top of them.
+    fn sraw_multipliers(&self) -> Option<[i32; 3]> {
+        let at = self.sraw_mul_offset()?;
+        let levels: Vec<u16> = (0..4).map_while(|i| self.short(at + i)).collect();
+        let levels = <[u16; 4]>::try_from(levels).ok()?;
+        // The quad's shape is the check that the offset is right for
+        // this version: the two greens are equal — 1170 on every body
+        // measured, 50D, 7D, 5D Mark II and 5D Mark III alike — and the
+        // red and blue are positive numbers either side of them. The
+        // as-shot white balance, which sits nearby in every layout,
+        // has 1024 greens and fails this.
+        let [r, g1, g2, b] = levels;
+        if g1 != g2 || g1.abs_diff(1170) > 128 || r == 0 || b == 0 {
+            return None;
+        }
+        let largest = *levels.iter().max()?;
+        if largest == 0 {
+            return None;
+        }
+        let scale = largest as f64 / 1024.0;
+        // Clamped so that a forged block cannot make the final
+        // multiply in `sraw_to_rgb` unbounded.
+        let gain = |i: usize| ((levels[i] as f64 * scale) as i64).clamp(0, 1 << 20) as i32;
+        Some([gain(0), gain(1), gain(3)])
     }
 
     /// `PerChannelBlackLevel`, in the same RGGB order.
@@ -710,6 +1109,241 @@ mod tests {
     }
 
     #[test]
+    fn sraw_width_rounds_the_sensor_borders_up() {
+        let sensor = |left, right| SensorInfo {
+            left,
+            top: 0,
+            right,
+            bottom: 0,
+            mask: None,
+        };
+        // The 50D's mRAW: 3267 columns of picture inside a frame the
+        // encoder padded to 3344, trimmed to the next multiple of 8.
+        assert_eq!(sraw_width(Some(&sensor(0, 3266)), 3344), 3272);
+        // Its sRAW needs no trim: the borders already fill the frame.
+        assert_eq!(sraw_width(Some(&sensor(0, 2375)), 2376), 2376);
+        // The 7D's pair, likewise untrimmed.
+        assert_eq!(sraw_width(Some(&sensor(0, 3887)), 3888), 3888);
+        assert_eq!(sraw_width(Some(&sensor(0, 2591)), 2592), 2592);
+        // The trim is at the right edge: a left border does not
+        // narrow the frame, whose origin is still column 0.
+        assert_eq!(sraw_width(Some(&sensor(12, 3266)), 3344), 3272);
+        // The rounding never runs past what the JPEG actually codes.
+        assert_eq!(sraw_width(Some(&sensor(0, 3340)), 3344), 3344);
+        // No makernote at all: the whole coded frame, made even.
+        assert_eq!(sraw_width(None, 3344), 3344);
+        assert_eq!(sraw_width(None, 3345), 3344);
+        // A border that overflows falls back rather than panicking.
+        assert_eq!(sraw_width(Some(&sensor(0, usize::MAX)), 3344), 3344);
+    }
+
+    /// A subsampled frame built by hand, for `sraw_planes`.
+    fn subsampled(p: usize, width: usize, height: usize, data: Vec<u16>) -> ljpeg::SubsampledImage {
+        let components = 3 + p;
+        let block_rows = p.div_ceil(2);
+        let row = (width / 2) * components;
+        let rows = height / block_rows;
+        assert_eq!(data.len(), row * rows);
+        ljpeg::SubsampledImage {
+            width,
+            height,
+            p,
+            components,
+            block_rows,
+            row,
+            rows,
+            precision: 15,
+            data,
+        }
+    }
+
+    #[test]
+    fn sraw_planes_unslices_the_blocks() {
+        // A 2x1 frame, four columns by two rows, so two MCUs a row;
+        // cut into two slices of one MCU each, so the stream holds
+        // column pair 0 for both rows, then column pair 1 for both.
+        let n = |y: u16, x: u16| 100 * y + x;
+        let mcu = |y, x| [n(y, x), n(y, x + 1), 16384 + n(y, x), 16384 - n(y, x)];
+        let stream: Vec<u16> = [mcu(0, 0), mcu(1, 0), mcu(0, 2), mcu(1, 2)].concat();
+        let sub = subsampled(1, 4, 2, stream);
+        let planes = sraw_planes(&sub, 4, [1, 4, 4]).unwrap();
+        let px = |x: usize, y: usize| {
+            let at = (y * 4 + x) * 3;
+            (planes[at], planes[at + 1], planes[at + 2])
+        };
+        for y in 0..2u16 {
+            for x in 0..4u16 {
+                let (luma, cb, cr) = px(x as usize, y as usize);
+                assert_eq!(luma, n(y, x) as i32, "luma at {x},{y}");
+                // Chroma sits on the anchor (even) column only, centred
+                // on zero; the odd column is left for the upsample.
+                let anchor = x & !1;
+                let want = if x % 2 == 0 { n(y, anchor) as i32 } else { 0 };
+                assert_eq!((cb, cr), (want, -want), "chroma at {x},{y}");
+            }
+        }
+        // The single-slice spellings place the same frame from a
+        // stream in reading order.
+        let reading: Vec<u16> = [mcu(0, 0), mcu(0, 2), mcu(1, 0), mcu(1, 2)].concat();
+        let sub = subsampled(1, 4, 2, reading);
+        let single = sraw_planes(&sub, 4, [0, 0, 8]).unwrap();
+        assert_eq!(single, planes);
+        assert_eq!(sraw_planes(&sub, 4, [usize::MAX, 0, 8]).unwrap(), planes);
+        // Trimmed to two columns: the second MCU of each row is padding.
+        let trimmed = sraw_planes(&sub, 2, [0, 0, 8]).unwrap();
+        assert_eq!(trimmed.len(), 2 * 2 * 3);
+        assert_eq!(trimmed[3], n(0, 1) as i32);
+        assert_eq!(trimmed[6], n(1, 0) as i32);
+    }
+
+    #[test]
+    fn sraw_planes_rejects_a_cut_that_does_not_add_up() {
+        let sub = subsampled(1, 4, 2, vec![0; 16]);
+        // Slices that do not make one entropy row, including the count
+        // that used to spin for hours.
+        for slices in [
+            [2, 4, 4],
+            [1, 4, 0],
+            [usize::MAX, 4, 4],
+            [usize::MAX, usize::MAX, 8],
+        ] {
+            assert!(
+                matches!(sraw_planes(&sub, 4, slices), Err(Error::Corrupt(_))),
+                "{slices:?}"
+            );
+        }
+        // Slices that are not whole MCUs.
+        assert!(matches!(
+            sraw_planes(&sub, 4, [1, 3, 5]),
+            Err(Error::Corrupt(_))
+        ));
+        // A frame short of samples is an error, not a read past the end.
+        let short = subsampled(1, 4, 2, vec![0; 16]);
+        let short = ljpeg::SubsampledImage {
+            data: short.data[..8].to_vec(),
+            ..short
+        };
+        assert!(matches!(
+            sraw_planes(&short, 4, [0, 0, 8]),
+            Err(Error::Corrupt(_))
+        ));
+    }
+
+    #[test]
+    fn sraw_multipliers_come_from_the_version_offset() {
+        let block = |version: i32, len: usize, at: usize, quad: [u16; 4]| {
+            let mut values = vec![0u16; len];
+            values[0] = version as u16;
+            values[at..at + 4].copy_from_slice(&quad);
+            ColorData { values, version }
+        };
+        // The 7D's block: version 7, gains at 0x4E, scaled by 1170/1024.
+        let seven_d = block(7, 1337, 0x4E, [848, 1170, 1170, 490]);
+        assert_eq!(seven_d.sraw_multipliers(), Some([968, 1336, 559]));
+        // Version 10 moves them to 0x7B.
+        let five_d3 = block(10, 1312, 0x7B, [836, 1170, 1170, 437]);
+        assert_eq!(five_d3.sraw_multipliers(), Some([955, 1336, 499]));
+        // A quad of the wrong shape — here the as-shot white balance,
+        // whose greens are 1024 — means the offset is wrong for this
+        // block, and unity is the answer.
+        let wrong = block(7, 1337, 0x4E, [2166, 1024, 1024, 1524]);
+        assert_eq!(wrong.sraw_multipliers(), None);
+        let unequal = block(6, 1250, 0x4E, [602, 1170, 1171, 749]);
+        assert_eq!(unequal.sraw_multipliers(), None);
+        // A version this module has no offset for.
+        let unknown = block(9, 1312, 0x7B, [836, 1170, 1170, 437]);
+        assert_eq!(unknown.sraw_multipliers(), None);
+    }
+
+    #[test]
+    fn sraw_bodies_are_gated_by_model_id() {
+        assert!(sraw_verified_body(Some(0x8000_0261), "Canon EOS 50D").is_ok());
+        assert!(sraw_verified_body(Some(0x8000_0250), "Canon EOS 7D").is_ok());
+        for (id, model) in [
+            (Some(0x8000_0218), "Canon EOS 5D Mark II"),
+            (Some(0x8000_0285), "Canon EOS 5D Mark III"),
+            (Some(0x8000_0285), ""),
+            (None, "Canon EOS 60D"),
+            (None, ""),
+        ] {
+            match sraw_verified_body(id, model) {
+                Err(Error::Unsupported(why)) => {
+                    assert!(
+                        why.contains("sRAW") && why.contains("not verified"),
+                        "{why}"
+                    );
+                    if !model.is_empty() {
+                        assert!(why.contains(model), "{why}");
+                    }
+                }
+                other => panic!("{model}: {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn sraw_upsample_fills_the_gaps_bilinearly() {
+        // Two 2x2 blocks side by side: chroma only at (0,0) and (0,2),
+        // so the odd column is their mean and the odd row copies down.
+        let (width, height) = (4, 2);
+        let mut planes = vec![0i32; width * height * 3];
+        let set = |p: &mut Vec<i32>, x: usize, y: usize, cb, cr| {
+            p[(y * width + x) * 3 + 1] = cb;
+            p[(y * width + x) * 3 + 2] = cr;
+        };
+        set(&mut planes, 0, 0, 100, -40);
+        set(&mut planes, 2, 0, 200, -50);
+        sraw_upsample(&mut planes, width, height, 3);
+        let cb = |x: usize, y: usize| planes[(y * width + x) * 3 + 1];
+        let cr = |x: usize, y: usize| planes[(y * width + x) * 3 + 2];
+        // Odd column: the mean of its neighbours, rounded half up.
+        assert_eq!(cb(1, 0), 150);
+        assert_eq!(cr(1, 0), -45);
+        // Last column has only a left neighbour to copy.
+        assert_eq!(cb(3, 0), 200);
+        // Row 1 has no chroma of its own and no row below, so it takes
+        // row 0 unchanged.
+        assert_eq!((cb(0, 1), cb(1, 1), cb(2, 1)), (100, 150, 200));
+        assert_eq!(cr(0, 1), -40);
+
+        // A 2x1 frame carries chroma on every row, so only the odd
+        // columns are filled and the rows are left alone.
+        let mut planes = vec![0i32; width * height * 3];
+        set(&mut planes, 0, 1, 60, 20);
+        set(&mut planes, 2, 1, 80, 30);
+        sraw_upsample(&mut planes, width, height, 1);
+        assert_eq!(planes[(width + 1) * 3 + 1], 70);
+        // Row 0 was never given chroma and must stay neutral.
+        assert_eq!(planes[1], 0);
+    }
+
+    #[test]
+    fn sraw_to_rgb_matches_the_worked_first_pixel() {
+        // The 50D mRAW sample's (IMG_9517: Canon's sRAW1, luma sampled
+        // 2x2, factor byte 0x22, P = 3) first pixel: Y 572 with the
+        // chroma the stream carries (16386, 16376) centred on zero, the
+        // hue offset (P + 1) << 2 = 16, and ColorData's gains
+        // 687/1336/855.
+        let planes = vec![572, 16386 - SRAW_NEUTRAL, 16376 - SRAW_NEUTRAL];
+        assert_eq!(
+            sraw_to_rgb(&planes, 3, [687, 1336, 855]),
+            vec![368, 750, 512]
+        );
+        // Unity gains leave the matrix's own scale, and a neutral
+        // pixel stays very nearly grey.
+        let grey = vec![8000, 0, 0];
+        let rgb = sraw_to_rgb(&grey, 3, [1024; 3]);
+        assert!(
+            rgb.iter().all(|v| v.abs_diff(8000) < 40),
+            "a neutral pixel should stay grey, got {rgb:?}"
+        );
+        // Hostile values must clip, not wrap or panic.
+        let extreme = vec![32767, 32767, -32768];
+        let rgb = sraw_to_rgb(&extreme, 3, [1 << 20, 1 << 20, 1 << 20]);
+        assert!(rgb.iter().all(|v| *v <= 32767));
+    }
+
+    #[test]
     fn hostile_input_is_an_error_not_a_panic() {
         for bytes in [
             &b""[..],
@@ -726,12 +1360,27 @@ mod tests {
 
     // ---------------------------------------------------------- corpus
 
-    /// Files LibRaw's oracle covers but this decoder knowingly does
-    /// not, with the reason. Both are Canon's subsampled raws: the
-    /// frame is a YCbCr picture at half or quarter resolution, not a
-    /// colour filter array, and `crate::ljpeg` refuses the sampling
-    /// factors.
-    const UNSUPPORTED: &[&str] = &["EOS_50D-IMG_9517.CR2", "EOS_50D-IMG_9518.CR2"];
+    /// Whether a sample's lossless JPEG is subsampled — an sRAW or mRAW
+    /// — read from its frame header rather than from a list of names.
+    ///
+    /// These are the only CR2s this decoder may refuse: a subsampled
+    /// frame from a body whose colour reconstruction is not verified
+    /// comes back `Unsupported` (see `SRAW_VERIFIED_BODIES`), and
+    /// `corpus_sraw_matches_the_full_oracle_or_is_refused` checks that
+    /// every subsampled sample is either exact or refused. The one
+    /// other subsampled variant, sRAW inside a CR3 container, lives in
+    /// `formats::cr3`, not here.
+    fn is_subsampled(bytes: &[u8]) -> bool {
+        let Ok(tiff) = Tiff::parse(bytes) else {
+            return false;
+        };
+        let Some(ifd) = raw_ifd(&tiff) else {
+            return false;
+        };
+        raw_stream(&tiff, ifd)
+            .and_then(ljpeg::sampling)
+            .is_ok_and(|factor| factor != 0x11)
+    }
 
     fn corpus() -> Option<PathBuf> {
         std::env::var_os("SCHIST_RAW_CORPUS").map(PathBuf::from)
@@ -760,6 +1409,9 @@ mod tests {
     #[derive(Debug, Default)]
     struct Identify {
         full: Option<(usize, usize)>,
+        /// LibRaw's "Image size": what a subsampled frame reconstructs
+        /// to, which is narrower than its padded "Full size".
+        image: Option<(usize, usize)>,
         inset: Option<(usize, usize, usize, usize)>,
         flip: Option<u32>,
         pattern: Option<String>,
@@ -780,6 +1432,7 @@ mod tests {
             let level = |i: usize| word(i).and_then(|w| w.parse::<f64>().ok());
             match words.as_slice() {
                 ["Full", "size:", ..] => out.full = Some((size(2)?, size(4)?)),
+                ["Image", "size:", ..] => out.image = Some((size(2)?, size(4)?)),
                 // "Raw inset, width x height: W x H left: L top: T"
                 ["Raw", "inset,", ..] => {
                     out.inset = Some((size(5)?, size(7)?, size(9)?, size(11)?))
@@ -826,7 +1479,7 @@ mod tests {
             );
             let raw = match crate::decode(&bytes) {
                 Ok(raw) => raw,
-                Err(Error::Unsupported(why)) if UNSUPPORTED.contains(&name.as_str()) => {
+                Err(Error::Unsupported(why)) if is_subsampled(&bytes) => {
                     assert!(why.contains("sRAW"), "{name}: {why}");
                     // The picture is still there even when the sensor
                     // data cannot be read.
@@ -870,10 +1523,25 @@ mod tests {
             }
 
             if let Some(identify) = identify(path) {
-                if let Some(full) = identify.full {
-                    assert_eq!((raw.width, raw.height), full, "{name} full size");
+                // A subsampled frame's "Full size" is the padded luma
+                // width the lossless JPEG codes (3344 on the 50D's
+                // mRAW); the picture the reference hands on, and that
+                // its sidecar holds, is the narrower "Image size".
+                let want = if raw.cpp == 3 {
+                    identify.image
+                } else {
+                    identify.full
+                };
+                if let Some(want) = want {
+                    assert_eq!((raw.width, raw.height), want, "{name} frame size");
                 }
-                if let Some((width, height, left, top)) = identify.inset {
+                // For a subsampled frame LibRaw reports the makernote's
+                // CroppedImageWidth/Height instead of SensorInfo's
+                // borders (2352x1568 against 2376x1584 on the 50D's
+                // sRAW), and those numbers are the same on both sample
+                // files whatever the mode, so they cannot be the
+                // frame's own crop. SensorInfo's borders are kept.
+                if let Some((width, height, left, top)) = identify.inset.filter(|_| raw.cpp == 1) {
                     // LibRaw rounds an odd top border up so that its
                     // single Bayer phase still describes the crop, and
                     // loses the last row doing it; this decoder keeps
@@ -943,7 +1611,9 @@ mod tests {
                 high < raw.white_level / 4.0 && high - low <= 4.0,
                 "{name} black {black:?}"
             );
-            assert!(high > 0.0, "{name} found no black level");
+            // A reconstructed sRAW frame has no pedestal: the YCbCr
+            // maths centred it, and its black level really is zero.
+            assert!(high > 0.0 || raw.cpp == 3, "{name} found no black level");
 
             let preview = raw
                 .preview
@@ -957,6 +1627,395 @@ mod tests {
             );
         }
         assert!(checked > 0, "no oracle TIFF beside any sample");
+    }
+
+    // ------------------------------------------------ sRAW / mRAW
+
+    /// The bodies whose subsampled frames must match their reference
+    /// dumps sample for sample, by the TIFF model string. Every other
+    /// body's subsampled file must be refused. This list is the test's
+    /// own, so that the decoder's gate is checked against it rather
+    /// than against itself.
+    const SRAW_EXACT_MODELS: &[&str] = &["Canon EOS 50D", "Canon EOS 7D"];
+
+    /// The shapes and worked values the specification records for the
+    /// 50D pair, applied when a discovered file is one of them.
+    ///
+    /// Note which is which: 9517 is the *larger* picture — Canon's mRAW,
+    /// or sRAW1 — and its luma is sampled 2x2 (factor byte 0x22, so
+    /// P = 3); 9518 is the smaller sRAW (sRAW2), sampled 2x1 (0x21,
+    /// P = 1). The written spec labels these the other way round in its
+    /// prose; the factor byte in the file is what the arithmetic keys
+    /// off, and the per-file worked values agree with the byte.
+    struct Worked {
+        name: &'static str,
+        p: usize,
+        width: usize,
+        height: usize,
+        /// Planar stage, in the sidecar's units: pixel 0's Y, Cb, Cr
+        /// and the first four row-0 luma anchors.
+        planar: (i32, i32, i32, [i32; 4]),
+        /// Full stage: pixels 0, 1, 2 and the first of row 1.
+        full: [(i32, i32, i32); 4],
+    }
+
+    const WORKED: &[Worked] = &[
+        Worked {
+            name: "EOS_50D-IMG_9517.CR2",
+            p: 3,
+            width: 3272,
+            height: 2178,
+            planar: (572, 8194, 8184, [572, 579, 565, 541]),
+            full: [
+                (368, 750, 512),
+                (369, 752, 514),
+                (373, 760, 512),
+                (366, 725, 501),
+            ],
+        },
+        Worked {
+            name: "EOS_50D-IMG_9518.CR2",
+            p: 1,
+            width: 2376,
+            height: 1584,
+            planar: (584, 8192, 8188, [584, 571, 549, 522]),
+            // The spec records only the first two pixels of this one.
+            full: [(383, 764, 502), (374, 746, 497), (-1, -1, -1), (-1, -1, -1)],
+        },
+    ];
+
+    fn worked(name: &str) -> Option<&'static Worked> {
+        WORKED.iter().find(|w| w.name == name)
+    }
+
+    /// Every subsampled CR2 under the corpus, with its bytes and model.
+    fn subsampled_files(dir: &std::path::Path) -> Vec<(PathBuf, String, Vec<u8>)> {
+        let mut files = Vec::new();
+        cr2_files(dir, &mut files);
+        files.sort();
+        files
+            .into_iter()
+            .filter_map(|path| {
+                let bytes = std::fs::read(&path).ok()?;
+                if !is_subsampled(&bytes) {
+                    return None;
+                }
+                let model = Tiff::parse(&bytes).ok()?.make_model().1;
+                Some((path, model, bytes))
+            })
+            .collect()
+    }
+
+    fn file_name(path: &std::path::Path) -> String {
+        path.file_name()
+            .unwrap_or_default()
+            .to_string_lossy()
+            .to_string()
+    }
+
+    /// A raw little-endian `u16` sidecar beside a sample.
+    fn sidecar(path: &std::path::Path, which: &str) -> Option<Vec<u16>> {
+        let name = format!("{}.{}", path.file_name()?.to_string_lossy(), which);
+        let bytes = std::fs::read(path.with_file_name(name)).ok()?;
+        Some(
+            bytes
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .map(|b| u16::from_le_bytes(*b))
+                .collect(),
+        )
+    }
+
+    /// Decode a sample as far as the planar stage: the placed blocks,
+    /// before any chroma interpolation or colour.
+    fn planar_stage(bytes: &[u8]) -> Result<(ljpeg::SubsampledImage, usize, Vec<i32>)> {
+        let tiff = Tiff::parse(bytes)?;
+        let raw_ifd = raw_ifd(&tiff).ok_or_else(|| Error::Corrupt("no raw IFD".into()))?;
+        let stream = raw_stream(&tiff, raw_ifd)?;
+        let sub = ljpeg::decode_subsampled(stream)?;
+        let sensor = makernote(&tiff).and_then(|mn| {
+            let (root, le) = (mn.root(), mn.little_endian());
+            sensor_info(root, le)
+        });
+        let width = sraw_width(sensor.as_ref(), sub.width);
+        let planes = sraw_planes(&sub, width, slices(raw_ifd, sub.row))?;
+        Ok((sub, width, planes))
+    }
+
+    /// Compare `got` with `want` sample for sample and fail with the
+    /// first few disagreements.
+    fn same_samples(name: &str, stage: &str, got: &[i32], want: &[i32]) {
+        assert_eq!(got.len(), want.len(), "{name} {stage}: sample count");
+        let wrong: Vec<usize> = got
+            .iter()
+            .zip(want)
+            .enumerate()
+            .filter(|(_, (a, b))| a != b)
+            .map(|(i, _)| i)
+            .take(6)
+            .collect();
+        let total = got.iter().zip(want).filter(|(a, b)| a != b).count();
+        assert!(
+            wrong.is_empty(),
+            "{name} {stage}: {total} of {} samples differ, first at {wrong:?} \
+             (got {:?}, want {:?})",
+            got.len(),
+            wrong.iter().map(|i| got[*i]).collect::<Vec<_>>(),
+            wrong.iter().map(|i| want[*i]).collect::<Vec<_>>(),
+        );
+    }
+
+    /// Stage one: entropy decode and MCU placement, against
+    /// `<file>.sraw-planar.rgb16`, for every subsampled sample that has
+    /// one (the 50D pair). This stage has no body-specific constants in
+    /// it, so it runs whether or not the body's colour is verified.
+    ///
+    /// The sidecar holds the luma straight and the two chroma with a
+    /// bias of 8192 — a neutral block reads 8192, and a pixel the
+    /// encoder sent no chroma for reads 8192 too. This module centres
+    /// the chroma on zero instead, so the bias goes back on here.
+    #[test]
+    fn corpus_sraw_matches_the_planar_oracle() {
+        let Some(dir) = corpus() else { return };
+        let files = subsampled_files(&dir);
+        assert!(
+            !files.is_empty(),
+            "no subsampled CR2 under {}",
+            dir.display()
+        );
+        let mut checked = 0;
+        for (path, _, bytes) in &files {
+            let name = file_name(path);
+            let Some(oracle) = sidecar(path, "sraw-planar.rgb16") else {
+                continue;
+            };
+            let start = std::time::Instant::now();
+            let (sub, width, planes) =
+                planar_stage(bytes).unwrap_or_else(|e| panic!("{name}: planar stage: {e}"));
+            let elapsed = start.elapsed();
+            let height = sub.height;
+            assert_eq!(sub.components, 3 + sub.p, "{name} MCU components");
+            assert_eq!(
+                oracle.len(),
+                width * height * 3,
+                "{name}: the planar sidecar is not {width}x{height}x3"
+            );
+
+            if let Some(worked) = worked(&name) {
+                assert_eq!(sub.p, worked.p, "{name} sraw parameter");
+                assert_eq!(
+                    (width, height),
+                    (worked.width, worked.height),
+                    "{name} shape"
+                );
+                // The worked first pixels the specification records,
+                // in the sidecar's own units.
+                let at = |i: usize| planes[i];
+                let (y0, cb0, cr0, anchors) = worked.planar;
+                assert_eq!(
+                    (at(0), at(1) + 8192, at(2) + 8192),
+                    (y0, cb0, cr0),
+                    "{name} first pixel of the planar stage"
+                );
+                let got: Vec<i32> = (0..4).map(|i| at(i * 2 * 3)).collect();
+                assert_eq!(got, anchors, "{name} row-0 luma anchors");
+            }
+
+            let biased: Vec<i32> = planes
+                .as_chunks::<3>()
+                .0
+                .iter()
+                .flat_map(|px| [px[0], px[1] + 8192, px[2] + 8192])
+                .collect();
+            let want: Vec<i32> = oracle.iter().map(|v| *v as i32).collect();
+            same_samples(&name, "planar", &biased, &want);
+            println!(
+                "{name}: planar {width}x{height} P={} matches the oracle, entropy+placement {:.3}s",
+                sub.p,
+                elapsed.as_secs_f64()
+            );
+            checked += 1;
+        }
+        assert!(
+            checked > 0,
+            "no subsampled sample with a planar sidecar under {}",
+            dir.display()
+        );
+        println!("checked {checked} subsampled samples against the planar oracle");
+    }
+
+    /// Stage two: the whole decode, against `<file>.sraw-full.rgb16`,
+    /// for every subsampled sample in the corpus. A body on
+    /// `SRAW_EXACT_MODELS` must match its sidecar sample for sample;
+    /// any other body must be refused as unverified — a frame that
+    /// decodes to plausible but wrong colour is the failure this
+    /// guards against, so a decode on a gated body fails the test.
+    #[test]
+    fn corpus_sraw_matches_the_full_oracle_or_is_refused() {
+        let Some(dir) = corpus() else { return };
+        let files = subsampled_files(&dir);
+        assert!(
+            !files.is_empty(),
+            "no subsampled CR2 under {}",
+            dir.display()
+        );
+        let (mut exact, mut refused) = (0, 0);
+        for (path, model, bytes) in &files {
+            let name = file_name(path);
+            let oracle = sidecar(path, "sraw-full.rgb16")
+                .unwrap_or_else(|| panic!("{name}: no .sraw-full.rgb16 sidecar"));
+            let start = std::time::Instant::now();
+            let result = decode(bytes);
+            let elapsed = start.elapsed();
+
+            if !SRAW_EXACT_MODELS.contains(&model.as_str()) {
+                match result {
+                    Err(Error::Unsupported(why)) => {
+                        assert!(
+                            why.contains("sRAW") && why.contains("not verified"),
+                            "{name} ({model}): refused for the wrong reason: {why}"
+                        );
+                        assert!(why.contains(model), "{name}: {why} does not name {model}");
+                        // The picture is still there.
+                        let jpeg = super::preview(bytes).unwrap().expect("preview");
+                        image::load_from_memory(&jpeg)
+                            .unwrap_or_else(|e| panic!("{name} preview: {e}"));
+                        println!("{name} ({model}): refused as unverified: {why}");
+                        refused += 1;
+                    }
+                    Ok(raw) => panic!(
+                        "{name} ({model}): decoded {}x{} on a body whose colour reconstruction \
+                         is not verified; it must be refused",
+                        raw.width, raw.height
+                    ),
+                    Err(e) => panic!("{name} ({model}): {e}"),
+                }
+                continue;
+            }
+
+            let raw = result.unwrap_or_else(|e| panic!("{name} ({model}): {e}"));
+            raw.validate().unwrap_or_else(|e| panic!("{name}: {e}"));
+            let (width, height) = (raw.width, raw.height);
+            assert_eq!(raw.cpp, 3, "{name} samples a pixel");
+            assert_eq!(raw.cfa, Cfa::None, "{name} has no filter array");
+            assert_eq!(raw.white_level, 16383.0, "{name} white level");
+            assert_eq!(raw.black_levels, [0.0; 4], "{name} black level");
+            // The reconstruction is camera RGB, not a white-balanced
+            // picture, so the as-shot multipliers must still be here
+            // for the developer to apply.
+            assert!(
+                raw.wb_coeffs[0] > 1.5 && raw.wb_coeffs[1] == 1.0,
+                "{name} kept no as-shot white balance: {:?}",
+                raw.wb_coeffs
+            );
+            let RawData::U16(got) = &raw.data else {
+                panic!("{name} is not 16-bit")
+            };
+            assert_eq!(
+                oracle.len(),
+                width * height * 3,
+                "{name}: the full sidecar is not {width}x{height}x3"
+            );
+
+            if let Some(worked) = worked(&name) {
+                assert_eq!(
+                    (width, height),
+                    (worked.width, worked.height),
+                    "{name} shape"
+                );
+                // The worked first pixels the specification records.
+                let px = |i: usize| {
+                    (
+                        got[i * 3] as i32,
+                        got[i * 3 + 1] as i32,
+                        got[i * 3 + 2] as i32,
+                    )
+                };
+                for (i, want) in [0, 1, 2, width].into_iter().zip(worked.full) {
+                    if want.0 >= 0 {
+                        assert_eq!(px(i), want, "{name} pixel at index {i}");
+                    }
+                }
+            }
+
+            let mine: Vec<i32> = got.iter().map(|v| *v as i32).collect();
+            let want: Vec<i32> = oracle.iter().map(|v| *v as i32).collect();
+            same_samples(&name, "full", &mine, &want);
+            let mp = (width * height) as f64 / 1e6;
+            println!(
+                "{name} ({model}): full {width}x{height} RGB matches the oracle, {:.3}s ({:.1} MP/s)",
+                elapsed.as_secs_f64(),
+                mp / elapsed.as_secs_f64()
+            );
+            exact += 1;
+        }
+        assert!(
+            exact > 0,
+            "no subsampled sample of a verified body under {}",
+            dir.display()
+        );
+        println!("{exact} subsampled samples exact, {refused} refused as unverified bodies");
+    }
+
+    /// The white-balance decision, checked against the Bayer frame of
+    /// the same scene.
+    ///
+    /// 9516, 9517 and 9518 are one subject photographed three times in
+    /// a row: full Bayer, then the two subsampled modes. ColorData's
+    /// sRAW multipliers sit where a white balance would and the written
+    /// specification calls them one, but they are not: on this body
+    /// they come out near 687, 1336, 855, so a neutral subject
+    /// reconstructs strongly green — camera RGB, exactly like a Bayer
+    /// frame before balancing. So this module bakes them in (they are
+    /// part of the reconstruction, and the oracle contains them) and
+    /// leaves the *as-shot* multipliers in `wb_coeffs` for `develop`,
+    /// which is what makes the developed colour right.
+    ///
+    /// Had the choice gone the other way — `wb_coeffs` left at unity —
+    /// the developed sRAW would come out roughly a stop green against
+    /// the Bayer shot, which is what this measures.
+    #[test]
+    fn corpus_sraw_develops_like_the_bayer_shot_of_the_same_scene() {
+        let Some(dir) = corpus() else { return };
+        // Mean R/G and B/G of a developed frame.
+        let balance = |name: &str| -> Option<(f64, f64)> {
+            let bytes = std::fs::read(dir.join("Canon").join(name)).ok()?;
+            let raw = decode(&bytes).unwrap_or_else(|e| panic!("{name}: {e}"));
+            let out = crate::develop(&raw, &crate::DevelopOptions::default())
+                .unwrap_or_else(|e| panic!("{name} develop: {e}"));
+            let mut sums = [0f64; 3];
+            for pixel in out.rgb.as_chunks::<3>().0 {
+                for (s, v) in sums.iter_mut().zip(pixel) {
+                    *s += *v as f64;
+                }
+            }
+            (sums[1] > 0.0).then(|| (sums[0] / sums[1], sums[2] / sums[1]))
+        };
+        let Some(bayer) = balance("EOS_50D-IMG_9516.CR2") else {
+            return;
+        };
+        for name in ["EOS_50D-IMG_9517.CR2", "EOS_50D-IMG_9518.CR2"] {
+            let Some(sraw) = balance(name) else { continue };
+            println!(
+                "{name}: developed R/G {:.3} B/G {:.3} against the Bayer shot's {:.3} / {:.3}",
+                sraw.0, sraw.1, bayer.0, bayer.1
+            );
+            // Chroma subsampling, a different demosaic and a slightly
+            // different crop move the scene mean by a few per cent, so
+            // the bar is loose. It is still nowhere near the failure
+            // being guarded against: leaving `wb_coeffs` at unity puts
+            // R/G out by the as-shot multiplier itself, about 2x.
+            assert!(
+                (sraw.0 / bayer.0 - 1.0).abs() < 0.15 && (sraw.1 / bayer.1 - 1.0).abs() < 0.15,
+                "{name} develops to R/G {:.3} B/G {:.3}, the Bayer shot of the same scene to \
+                 {:.3} / {:.3}: the white balance is being applied wrongly",
+                sraw.0,
+                sraw.1,
+                bayer.0,
+                bayer.1
+            );
+        }
     }
 
     #[test]

--- a/crates/codec-raw/src/formats/dng.rs
+++ b/crates/codec-raw/src/formats/dng.rs
@@ -21,6 +21,7 @@ use rayon::prelude::*;
 
 use crate::bits::{BitPump, BitPumpMsb};
 use crate::formats::common;
+use crate::formats::vc5;
 use crate::ljpeg;
 use crate::tiff::{tags, Ifd, ImageLayout, Tiff};
 use crate::{Cfa, CfaColor, Error, Format, RawData, RawImage, Rect, Result};
@@ -471,9 +472,35 @@ fn decode_samples(
             return Err(Error::Unsupported("DNG 1.7 JPEG XL compression".into()))
         }
         compression::VC5 => {
-            return Err(Error::Unsupported(
-                "GoPro GPR: a DNG whose raw IFD is a VC-5 wavelet stream".into(),
-            ))
+            // A GoPro GPR: the tile is a VC-5 wavelet stream rather
+            // than anything in the DNG specification. The codec works
+            // in 12-bit log space and its decoder log curve lands on
+            // 16 bits, so the samples come down to the depth WhiteLevel
+            // advertises -- 14 bits, a shift of 2, in every GPR seen.
+            if spp != 1 {
+                return Err(Error::Unsupported(format!(
+                    "VC-5 tile with {spp} samples a pixel"
+                )));
+            }
+            // A VC-5 sample carries the whole frame's dimensions in its
+            // own header, so one tile always spans the frame. Nothing
+            // GoPro ships is tiled, and a grid would need the layer and
+            // image-section loops this decoder does not implement.
+            if grid.across != 1 || grid.down != 1 {
+                return Err(Error::Unsupported(format!(
+                    "VC-5 split across a {}x{} tile grid",
+                    grid.across, grid.down
+                )));
+            }
+            let white = ifd
+                .get(tag::WHITE_LEVEL)
+                .and_then(|e| e.u32(0))
+                .unwrap_or(16383)
+                .clamp(1, 65535);
+            let shift = 16 - (32 - white.leading_zeros());
+            assemble(bytes, layout, &grid, spp, |chunk, cols, rows| {
+                Tile::new(vc5::decode(chunk, cols, rows, shift)?, cols, rows)
+            })?
         }
         other => return Err(Error::Unsupported(format!("DNG compression {other}"))),
     };
@@ -2320,13 +2347,24 @@ mod tests {
     #[test]
     fn compressions_this_module_has_no_decoder_for_are_unsupported() {
         let pixels = pack_msb(&vec![vec![0u16; 4]; 2], 12);
-        for (code, what) in [(52546u16, "JPEG XL"), (9, "VC-5"), (5, "LZW")] {
+        for (code, what) in [(52546u16, "JPEG XL"), (5, "LZW")] {
             let build = Build::new(4, 2)
                 .raw(tags::COMPRESSION, V::Short(vec![code]))
                 .strip(pixels.clone());
             let error = decode(&build.bytes()).expect_err(what);
             assert!(matches!(error, Error::Unsupported(_)), "{what}: {error}");
         }
+    }
+
+    /// Compression 9 now reaches the VC-5 decoder, so a tile that is
+    /// not a VC-5 sample is corrupt rather than unsupported.
+    #[test]
+    fn a_vc5_tile_that_is_not_a_vc5_sample_is_corrupt() {
+        let build = Build::new(4, 2)
+            .raw(tags::COMPRESSION, V::Short(vec![compression::VC5 as u16]))
+            .strip(pack_msb(&vec![vec![0u16; 4]; 2], 12));
+        let error = decode(&build.bytes()).expect_err("not a VC-5 sample");
+        assert!(matches!(error, Error::Corrupt(_)), "{error}");
     }
 
     #[test]
@@ -2418,11 +2456,11 @@ mod tests {
 
     /// Files this module knowingly refuses, and why. A corpus file
     /// that fails for any other reason fails the test.
-    fn unsupported_reason(path: &Path) -> Option<&'static str> {
-        let name = path.file_name()?.to_str()?;
-        name.to_ascii_lowercase()
-            .ends_with(".gpr")
-            .then_some("GoPro VC-5, not a DNG compression")
+    fn unsupported_reason(_path: &Path) -> Option<&'static str> {
+        // Nothing in the corpus is refused any more: GoPro's GPR, the
+        // one dialect that used to be listed here, decodes through the
+        // VC-5 module.
+        None
     }
 
     /// LibRaw's own view of a file, as far as this test compares it.
@@ -2676,6 +2714,9 @@ mod tests {
             }
             if let Some(flip) = identify.flip {
                 let want = match flip {
+                    // LibRaw's flip 1 is a horizontal mirror, which is
+                    // what every GoPro GPR carries (EXIF orientation 2).
+                    1 => crate::Orientation::MirrorHorizontal,
                     3 => crate::Orientation::Rotate180,
                     5 => crate::Orientation::Rotate270CW,
                     6 => crate::Orientation::Rotate90CW,

--- a/crates/codec-raw/src/formats/kodak.rs
+++ b/crates/codec-raw/src/formats/kodak.rs
@@ -33,8 +33,17 @@
 //!   want them.
 //! * 65000 — Kodak's own scheme, on the DCR bodies. See
 //!   [`decode_65000_segment`].
-//! * 32867 — the DC40/DC50's much older scheme. `Unsupported`.
+//! * 32867 — the DC40/DC50's much older "RADC" scheme. A
+//!   green/colour-difference pyramid coder behind an 8-bit table-driven
+//!   Huffman front end; see [`decode_radc`].
 //! * 1 — uncompressed, packed at the stated depth.
+//!
+//! Two Kodak variants are deliberately out of scope. RADC's finer
+//! escape quantiser (`CompressedBitsPerPixel` 243, [`radc_shift`]) is
+//! implemented but unexercised — no sample selects it, so it has never
+//! been checked against an oracle. The DC120 is a *different* scheme
+//! again, a bilinear-interpolated loader rather than this one, and is
+//! not folded in here.
 //!
 //! Whichever codec wrote it, a DCS frame decodes to *indices* into a
 //! linearisation curve rather than to samples — KodakIFD 0x090D where
@@ -82,6 +91,10 @@ const GRAY_RESPONSE_CURVE: u16 = 0x0123;
 // Tags of a 65000-compressed image IFD.
 const K65000_SEGMENT: u16 = 0xFDE8;
 const K65000_OFFSETS: u16 = 0xFDE9;
+
+/// EXIF CompressedBitsPerPixel, tag 0x9102. The RADC codec keys its
+/// escape-table quantiser off it: a value of 243 means a finer step.
+const COMPRESSED_BITS_PER_PIXEL: u16 = 0x9102;
 
 /// A private directory Kodak points at with a plain LONG offset: not a
 /// SubIFD, so the shared parser never followed it, but an ordinary IFD
@@ -292,6 +305,405 @@ fn decode_65000(strip: &[u8], ifd: &Ifd, width: usize, height: usize) -> Result<
     Ok(out)
 }
 
+// ------------------------------------------------------------- RADC
+
+// The DC40/DC50 "RADC" scheme. Every frame is a fixed 768x512, decoded
+// in stripes of four rows. Three colour channels are reconstructed at
+// half horizontal resolution into small line buffers, then scattered
+// into the Bayer output; a diagonal fix-up and a tone curve finish it.
+//
+// The whole thing is a green/colour-difference pyramid coder behind an
+// 8-bit table-driven Huffman front end: peek eight bits, index a
+// 256-entry table, consume the length the table records and take its
+// symbol byte as a signed char. Tables 0..9 are "tree" tables whose
+// symbol is the next tree to read; tables 10..17 carry step and
+// difference values; table 18 is a procedural escape quantiser.
+
+/// RADC frames are always this size; the reference rejects anything
+/// larger, and the tag-declared 756x504 is only the active window.
+const RADC_WIDTH: usize = 768;
+const RADC_HEIGHT: usize = 512;
+/// Working columns: everything happens at half horizontal resolution.
+const RADC_HALF: usize = RADC_WIDTH / 2;
+/// Line-buffer width: the 384 working columns plus two guard columns.
+/// The walk seeds column `RADC_HALF` and every predictor reads its
+/// right neighbour `x + 1`, so index 384 must exist; the green
+/// channel's slide is offset by one short and writes index 385.
+const RADC_LINE: usize = RADC_HALF + 2;
+/// Saturation after the tone curve maps the ~12-bit working range up.
+const RADC_MAX: u16 = 0x3FFF;
+
+/// The 19 direct-lookup Huffman tables. Each entry packs
+/// `(codeLength << 8) | symbolByte`; a peek of eight bits indexes it.
+struct RadcTables {
+    tables: [[u16; 256]; 19],
+}
+
+impl RadcTables {
+    /// Build the tables. Tables 0..17 come from a fixed `(length,
+    /// symbol)` list, replicated across `256 >> length` lookup slots and
+    /// laid end to end so each 256-slot span is one table. Table 18 is
+    /// the escape quantiser, whose step is `1 << shift`.
+    fn build(shift: u32) -> RadcTables {
+        // The (length, symbol) list, read left to right. Tables 0..9 are
+        // the tree tables selected by the walk; 10..17 the value/step
+        // tables. Symbols are signed. Each table's lengths sum to
+        // exactly 256 lookup slots, so the boundaries fall out of a
+        // straight sequential fill.
+        #[rustfmt::skip]
+        const SPEC: &[(u8, i8)] = &[
+            (1,1),(2,3),(3,4),(4,2),(5,7),(6,5),(7,6),(7,8),
+            (1,0),(2,1),(3,3),(4,4),(5,2),(6,7),(7,6),(8,5),(8,8),
+            (2,1),(2,3),(3,0),(3,2),(3,4),(4,6),(5,5),(6,7),(6,8),
+            (2,0),(2,1),(2,3),(3,2),(4,4),(5,6),(6,7),(7,5),(7,8),
+            (2,1),(2,4),(3,0),(3,2),(3,3),(4,7),(5,5),(6,6),(6,8),
+            (2,3),(3,1),(3,2),(3,4),(3,5),(3,6),(4,7),(5,0),(5,8),
+            (2,3),(2,6),(3,0),(3,1),(4,4),(4,5),(4,7),(5,2),(5,8),
+            (2,4),(2,7),(3,3),(3,6),(4,1),(4,2),(4,5),(5,0),(5,8),
+            (2,6),(3,1),(3,3),(3,5),(3,7),(3,8),(4,0),(5,2),(5,4),
+            (2,0),(2,1),(3,2),(3,3),(4,4),(4,5),(5,6),(5,7),(4,8),
+            (1,0),(2,2),(2,-2),(1,-3),(1,3),
+            (2,-17),(2,-5),(2,5),(2,17),(2,-7),(2,2),(2,9),(2,18),
+            (2,-18),(2,-9),(2,-2),(2,7),(2,-28),(2,28),
+            (3,-49),(3,-9),(3,9),(4,49),(5,-79),(5,79),
+            (2,-1),(2,13),(2,26),(3,39),(4,-16),(5,55),(6,-37),(6,76),
+            (2,-26),(2,-13),(2,1),(3,-39),(4,16),(5,-55),(6,-76),(6,37),
+        ];
+        let mut tables = [[0u16; 256]; 19];
+        let mut table = 0usize;
+        let mut slot = 0usize;
+        for &(length, symbol) in SPEC {
+            let packed = ((length as u16) << 8) | (symbol as u8 as u16);
+            // A code of length L fills 2^(8-L) consecutive slots.
+            for _ in 0..(256usize >> length) {
+                tables[table][slot] = packed;
+                slot += 1;
+                if slot == 256 {
+                    slot = 0;
+                    table += 1;
+                }
+            }
+        }
+        debug_assert_eq!((table, slot), (18, 0), "RADC list did not fill 18 tables");
+
+        // Table 18: coarse, evenly spaced luma levels. Code length is
+        // 8-shift; the symbol is the index rounded down to a multiple of
+        // 2^shift with the mid-step bit set.
+        for (c, entry) in tables[18].iter_mut().enumerate() {
+            let symbol = ((c >> shift) << shift) | (1 << (shift - 1));
+            *entry = (((8 - shift) as u16) << 8) | symbol as u16;
+        }
+        RadcTables { tables }
+    }
+}
+
+/// The RADC bit reader and table set. MSB-first over the payload; past
+/// the end it yields zero bits so truncated input never panics.
+struct Radc<'a> {
+    data: &'a [u8],
+    pos: usize,
+    accumulator: u64,
+    buffered_bits: u32,
+    tables: RadcTables,
+}
+
+impl<'a> Radc<'a> {
+    fn new(data: &'a [u8], shift: u32) -> Radc<'a> {
+        Radc {
+            data,
+            pos: 0,
+            accumulator: 0,
+            buffered_bits: 0,
+            tables: RadcTables::build(shift),
+        }
+    }
+
+    /// Pull bytes until at least `need` bits are buffered, zero-filling
+    /// past the end of the payload.
+    fn refill(&mut self, need: u32) {
+        while self.buffered_bits < need {
+            let byte = self.data.get(self.pos).copied().unwrap_or(0);
+            self.pos += 1;
+            self.accumulator = (self.accumulator << 8) | byte as u64;
+            self.buffered_bits += 8;
+        }
+    }
+
+    /// The next `n` bits (n <= 8 here), MSB first.
+    fn getbits(&mut self, n: u32) -> u32 {
+        if n == 0 {
+            return 0;
+        }
+        self.refill(n);
+        let shift = self.buffered_bits - n;
+        let value = ((self.accumulator >> shift) & ((1u64 << n) - 1)) as u32;
+        self.buffered_bits = shift;
+        self.accumulator &= (1u64 << shift) - 1;
+        value
+    }
+
+    /// Decode one Huffman symbol from `table`: peek eight bits, look up,
+    /// consume the recorded length, return the symbol as a signed char.
+    fn radc_token(&mut self, table: usize) -> i32 {
+        self.refill(8);
+        let index = ((self.accumulator >> (self.buffered_bits - 8)) & 0xff) as usize;
+        let entry = self.tables.tables[table][index];
+        let length = (entry >> 8) as u32;
+        // Every filled slot has a non-zero length; guard anyway so a
+        // hostile build can never spin here.
+        debug_assert!(length > 0);
+        self.buffered_bits -= length.min(self.buffered_bits);
+        self.accumulator &= (1u64 << self.buffered_bits) - 1;
+        (entry as u8 as i8) as i32
+    }
+}
+
+/// The spatial predictor. Green (channel 0) averages three neighbours
+/// with the one above weighted double; the colour-difference channels
+/// average the two orthogonal neighbours.
+fn radc_predictor(buf: &[[[i16; RADC_LINE]; 3]; 3], c: usize, y: usize, x: usize) -> i32 {
+    let at = |yy: usize, xx: usize| buf[c][yy][xx] as i32;
+    if c == 0 {
+        (at(y - 1, x + 1) + 2 * at(y - 1, x) + at(y, x + 1)) / 4
+    } else {
+        (at(y - 1, x) + at(y, x + 1)) / 2
+    }
+}
+
+/// The global tone curve: piecewise-linear across a fixed knot table,
+/// carrying the ~12-bit working range up to a 14-bit output and
+/// clipping everything above 4095 to the maximum.
+fn radc_curve() -> Vec<u16> {
+    // Interleaved (x, y) control points.
+    const PT: [(i64, i64); 6] = [
+        (0, 0),
+        (1280, 1344),
+        (2320, 3616),
+        (3328, 8000),
+        (4095, 16383),
+        (65535, 16383),
+    ];
+    let mut curve = vec![0u16; 65536];
+    for pair in PT.windows(2) {
+        let (x0, y0) = pair[0];
+        let (x1, y1) = pair[1];
+        for c in x0..=x1 {
+            // Linear interpolation rounded to nearest, halves up: the
+            // oracle differs from plain truncation by one count over
+            // much of the range. Done in integers as
+            // floor(v + 1/2) = (2*num + den) / (2*den).
+            let (num, den) = ((c - x0) * (y1 - y0), x1 - x0);
+            let value = (2 * num + den) / (2 * den) + y0;
+            curve[c as usize] = value as u16;
+        }
+    }
+    curve
+}
+
+/// The escape table's quantiser step, from the file's
+/// CompressedBitsPerPixel. A value of 243 asks for the finer grid
+/// (six-bit codes); everything else, the DC40/DC50 sample included
+/// (which reads 1.52), gets the coarse one.
+///
+/// The 243 branch is untested: no corpus file selects it. See the
+/// module notes.
+fn radc_shift(compressed_bpp: Option<f64>) -> u32 {
+    if compressed_bpp.is_some_and(|v| (v - 243.0).abs() < 0.5) {
+        2
+    } else {
+        3
+    }
+}
+
+/// Decode a whole RADC strip into the 768x512 single-channel Bayer
+/// frame, black not subtracted, tone curve applied.
+fn decode_radc(strip: &[u8], compressed_bpp: Option<f64>) -> Result<Vec<u16>> {
+    let total = crate::frame_samples(RADC_WIDTH, RADC_HEIGHT, 1)?;
+    let mut r = Radc::new(strip, radc_shift(compressed_bpp));
+    let mut raw = vec![0u16; total];
+
+    // Working buffers: three channels, three lines each, persisting
+    // across stripes and channels. Initialised to 2048 (the green bias
+    // the diagonal fix-up later removes).
+    let mut buf = [[[2048i16; RADC_LINE]; 3]; 3];
+    // Per-channel gain memory carried into the next stripe's rescale.
+    let mut last = [16i64; 3];
+
+    for row in (0..RADC_HEIGHT).step_by(4) {
+        let mul = [
+            r.getbits(6) as i64,
+            r.getbits(6) as i64,
+            r.getbits(6) as i64,
+        ];
+        if mul.contains(&0) {
+            return Err(Error::Corrupt(
+                "Kodak RADC stripe with a zero channel gain".into(),
+            ));
+        }
+
+        for c in 0..3 {
+            // 4.2 Rescale the carried buffer from the previous stripe's
+            // gain to this one's. The val>65564 threshold and the
+            // 0x7ff/round constants are empirical fixed constants from
+            // the reference, reproduced verbatim.
+            // The working buffer is read as signed here; the spec's
+            // pseudo-code masks it to sixteen bits (unsigned). On the
+            // one sample with an oracle no value is ever negative at
+            // this point, so the two readings agree and the choice is
+            // an interpretation awaiting a second body.
+            let mut val = ((0x100_0000i64 / last[c] + 0x7ff) >> 12) * mul[c];
+            let sh: u32 = if val > 65564 { 10 } else { 12 };
+            let round = (1i64 << (sh - 1)) - 1;
+            val <<= 12 - sh;
+            for line in buf[c].iter_mut() {
+                for sample in line.iter_mut() {
+                    let scaled = ((*sample as i64) * val + round).min(0x7FFF_FFFF);
+                    *sample = ((scaled >> sh) & 0xFFFF) as u16 as i16;
+                }
+            }
+            last[c] = mul[c];
+
+            // 4.3 Decode the field: green as two sub-rows, colour
+            // channels as one.
+            let sub_rows = if c == 0 { 2 } else { 1 };
+            for sub in 0..sub_rows {
+                // Seed the middle of the two working lines.
+                buf[c][1][RADC_HALF] = (mul[c] << 7) as i16;
+                buf[c][2][RADC_HALF] = (mul[c] << 7) as i16;
+
+                let mut col = RADC_HALF as i32;
+                let mut tree = 1usize;
+                while col > 0 {
+                    // The token both drives this cell and becomes the
+                    // next tree to read: a non-zero token descends to
+                    // tree 1..8, a zero (run) token drops back to tree 0.
+                    let token = r.radc_token(tree);
+                    tree = token as usize;
+                    if token != 0 {
+                        col -= 2;
+                        if col >= 0 {
+                            let x0 = col as usize;
+                            // Both branches read a *fresh* token at each
+                            // of the four cell positions — the spec's
+                            // "apply the assignment to the four buffer
+                            // positions" means the token read inside it
+                            // too, as the oracle proves: one token per
+                            // cell desynchronises the bitstream.
+                            if token == 8 {
+                                // Coarse absolute levels from the escape
+                                // table, scaled by gain. The symbol is
+                                // taken unsigned here.
+                                for y in [1usize, 2] {
+                                    for x in [x0 + 1, x0] {
+                                        let level = (r.radc_token(18) & 0xff) as i64;
+                                        buf[c][y][x] = (level * mul[c]) as i16;
+                                    }
+                                }
+                            } else {
+                                // Signed differences (value table
+                                // tree+10) times 16, over the predictor.
+                                for y in [1usize, 2] {
+                                    for x in [x0 + 1, x0] {
+                                        let diff = r.radc_token(tree + 10);
+                                        let pred = radc_predictor(&buf, c, y, x);
+                                        buf[c][y][x] = (diff * 16 + pred) as i16;
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        // A run token: a run of copy/step cells.
+                        loop {
+                            let nreps = if col > 2 { r.radc_token(9) + 1 } else { 1 };
+                            let mut rep = 0;
+                            while rep < 8 && rep < nreps && col > 0 {
+                                col -= 2;
+                                if col >= 0 {
+                                    let x0 = col as usize;
+                                    for y in [1usize, 2] {
+                                        for x in [x0 + 1, x0] {
+                                            buf[c][y][x] = radc_predictor(&buf, c, y, x) as i16;
+                                        }
+                                    }
+                                    // Every odd repeat adds a step.
+                                    if rep & 1 == 1 {
+                                        let step = r.radc_token(10) << 4;
+                                        for y in [1usize, 2] {
+                                            buf[c][y][x0 + 1] =
+                                                (buf[c][y][x0 + 1] as i32 + step) as i16;
+                                            buf[c][y][x0] = (buf[c][y][x0] as i32 + step) as i16;
+                                        }
+                                    }
+                                }
+                                rep += 1;
+                            }
+                            // A run of exactly nine continues.
+                            if nreps != 9 {
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                // 4.4 Emit the field to the Bayer output, undoing the
+                // <<7 gain domain.
+                // Each (x, y) lands on its own Bayer site, so the two
+                // loops may run in either order.
+                for y in [0usize, 1] {
+                    for (x, sample) in buf[c][y + 1][..RADC_HALF].iter().enumerate() {
+                        let mut value = ((*sample as i32) << 4) / (mul[c] as i32);
+                        if value < 0 {
+                            value = 0;
+                        }
+                        // Green fills both sites of its 2x2 across the
+                        // two sub-rows; red and blue their one diagonal.
+                        let (out_row, out_col) = if c != 0 {
+                            (row + y * 2 + c - 1, x * 2 + 2 - c)
+                        } else {
+                            (row + sub * 2 + y, x * 2 + y)
+                        };
+                        raw[out_row * RADC_WIDTH + out_col] = value as u16;
+                    }
+                }
+
+                // 4.5 Slide working line 2 down to line 0 as the top
+                // predictor context for the next sub-row/stripe; green
+                // is offset by one short.
+                let off = if c == 0 { 1 } else { 0 };
+                for i in 0..(RADC_LINE - off) {
+                    buf[c][0][off + i] = buf[c][2][i];
+                }
+            }
+        }
+
+        // 5. Diagonal fix-up over the four stripe rows: the differential
+        // green samples at the "odd" sites become absolute values from
+        // their horizontal neighbours and the 2048 bias.
+        for y in row..row + 4 {
+            for x in 0..RADC_WIDTH {
+                if (x + y) & 1 == 1 {
+                    let left = if x > 0 { x - 1 } else { x + 1 };
+                    let right = if x + 1 < RADC_WIDTH { x + 1 } else { x - 1 };
+                    let mut value = (raw[y * RADC_WIDTH + x] as i32 - 2048) * 2
+                        + (raw[y * RADC_WIDTH + left] as i32 + raw[y * RADC_WIDTH + right] as i32)
+                            / 2;
+                    if value < 0 {
+                        value = 0;
+                    }
+                    raw[y * RADC_WIDTH + x] = value as u16;
+                }
+            }
+        }
+    }
+
+    // 6. Global tone curve, once, over the whole frame.
+    let curve = radc_curve();
+    for sample in raw.iter_mut() {
+        *sample = curve[*sample as usize];
+    }
+    Ok(raw)
+}
+
 // ---------------------------------------------------------- packing
 
 /// Unpack samples stored without compression at `bits` a piece, most
@@ -441,9 +853,25 @@ fn decode_tiff_raw(
         }
         65000 => decode_65000(strip, ifd, layout.width, layout.height)?,
         32867 => {
-            return Err(Error::Unsupported(
-                "Kodak Compression 32867, the DC40/DC50 scheme".into(),
-            ))
+            // RADC always reconstructs the full 768x512 sensor frame,
+            // wider than the 756x504 the SubIFD tags advertise, and it
+            // owns its own colour layout and white level. The oracle
+            // dumps the full frame, so build the result here and return
+            // rather than fall through the tag-driven path below.
+            let compressed_bpp = ifd.get(COMPRESSED_BITS_PER_PIXEL).and_then(|e| e.f64(0));
+            let samples = decode_radc(strip, compressed_bpp)?;
+            let mut raw = RawImage::new(
+                Format::Kodak,
+                RADC_WIDTH,
+                RADC_HEIGHT,
+                1,
+                RawData::U16(samples),
+                // Filter code 0xE1E1E1E1 (cdesc RGBG) is GRBG, which the
+                // §4.4 site formulae place at the frame origin.
+                Cfa::GRBG,
+            );
+            raw.white_level = RADC_MAX as f32;
+            return Ok(raw);
         }
         other => return Err(Error::Unsupported(format!("Kodak Compression {other}"))),
     };
@@ -958,6 +1386,129 @@ mod tests {
     }
 
     #[test]
+    fn radc_tables_fill_sequentially() {
+        let t = RadcTables::build(3);
+        // Tree table 0 opens with a length-1 code for symbol 1, filling
+        // the low half of its 256 slots, then a length-2 code for 3.
+        assert_eq!(t.tables[0][0], (1 << 8) | 1);
+        assert_eq!(t.tables[0][127], (1 << 8) | 1);
+        assert_eq!(t.tables[0][128], (2 << 8) | 3);
+        // Table 1 opens with length-1 symbol 0.
+        // Length 1, symbol 0.
+        assert_eq!(t.tables[1][0], 1 << 8);
+        // Table 10's first three entries (1,0)(2,2)(2,-2) exactly fill
+        // its 256 slots: 128 + 64 + 64.
+        assert_eq!(t.tables[10][0], 1 << 8);
+        assert_eq!(t.tables[10][128], (2 << 8) | 2);
+        assert_eq!(t.tables[10][192], (2 << 8) | (0xFEu16)); // -2 as a byte
+                                                             // A negative symbol round-trips through the signed-char decode.
+        let entry = t.tables[10][192];
+        assert_eq!((entry as u8 as i8) as i32, -2);
+    }
+
+    #[test]
+    fn radc_tables_are_complete_and_prefix_free() {
+        // Every slot of all 19 tables must carry a usable code length:
+        // a zero would stall the reader, and a table that did not add up
+        // to 256 slots would silently shift every later table along. Per
+        // table the lengths must satisfy Kraft equality, sum(2^(8-L)) ==
+        // 256, which is exactly what "fills its 256 slots" means.
+        let t = RadcTables::build(3);
+        for (index, table) in t.tables.iter().enumerate() {
+            let mut slots = 0usize;
+            let mut i = 0usize;
+            while i < 256 {
+                let length = (table[i] >> 8) as u32;
+                assert!(
+                    (1..=8).contains(&length),
+                    "table {index} slot {i} has code length {length}"
+                );
+                let run = 256usize >> length;
+                // Every slot a code covers must repeat that code.
+                for j in i..i + run {
+                    assert_eq!(table[j], table[i], "table {index} slot {j} breaks its run");
+                }
+                slots += run;
+                i += run;
+            }
+            assert_eq!(slots, 256, "table {index} does not fill 256 slots");
+        }
+    }
+
+    #[test]
+    fn radc_shift_follows_compressed_bits_per_pixel() {
+        // The DC50 sample records 152/100; only a 243 selects the finer
+        // quantiser, and a file with no tag at all gets the coarse one.
+        assert_eq!(radc_shift(Some(1.52)), 3);
+        assert_eq!(radc_shift(None), 3);
+        assert_eq!(radc_shift(Some(243.0)), 2);
+    }
+
+    #[test]
+    fn radc_escape_table_is_a_coarse_quantiser() {
+        // shift 3: five-bit codes over levels that are the index rounded
+        // down to a multiple of 8 with bit 2 set.
+        let t = RadcTables::build(3);
+        assert_eq!(t.tables[18][0], (5 << 8) | 4);
+        assert_eq!(t.tables[18][7], (5 << 8) | 4);
+        assert_eq!(t.tables[18][8], (5 << 8) | 12);
+        assert_eq!(t.tables[18][255], (5 << 8) | 252);
+        // shift 2: six-bit codes over a finer grid.
+        let fine = RadcTables::build(2);
+        assert_eq!(fine.tables[18][0], (6 << 8) | 2);
+        assert_eq!(fine.tables[18][255], (6 << 8) | 254);
+    }
+
+    #[test]
+    fn radc_bit_reader_is_msb_first_and_zero_fills() {
+        // 0b1011_0010, 0b1100_0000 then nothing.
+        let mut r = Radc::new(&[0xB2, 0xC0], 3);
+        assert_eq!(r.getbits(3), 0b101);
+        assert_eq!(r.getbits(5), 0b10010);
+        assert_eq!(r.getbits(2), 0b11);
+        // Past the payload the reader yields zeros rather than failing.
+        assert_eq!(r.getbits(8), 0);
+        assert_eq!(r.getbits(8), 0);
+    }
+
+    #[test]
+    fn radc_curve_passes_through_its_knots() {
+        let curve = radc_curve();
+        assert_eq!(curve[0], 0);
+        assert_eq!(curve[1280], 1344);
+        assert_eq!(curve[2320], 3616);
+        assert_eq!(curve[3328], 8000);
+        assert_eq!(curve[4095], 16383);
+        // Everything above the last real knot clips to the maximum.
+        assert_eq!(curve[4096], 16383);
+        assert_eq!(curve[65535], 16383);
+        // Monotone non-decreasing across a segment.
+        assert!(curve[100] <= curve[200] && curve[200] <= curve[1280]);
+    }
+
+    #[test]
+    fn radc_rejects_a_zero_channel_gain() {
+        // Three six-bit gains of zero: the first stripe is corrupt.
+        let strip = [0u8; 64];
+        assert!(matches!(decode_radc(&strip, None), Err(Error::Corrupt(_))));
+    }
+
+    #[test]
+    fn radc_decodes_hostile_input_without_panicking() {
+        // Garbage must always terminate and either decode to a full
+        // frame or be rejected as corrupt, never loop or panic. A run of
+        // cut points exercises the zero-fill and the walk's bounds.
+        for len in [0usize, 1, 7, 64, 500, 4096] {
+            let strip = vec![0xA5u8; len];
+            match decode_radc(&strip, None) {
+                Ok(frame) => assert_eq!(frame.len(), RADC_WIDTH * RADC_HEIGHT),
+                Err(Error::Corrupt(_)) => {}
+                Err(other) => panic!("unexpected error on garbage: {other}"),
+            }
+        }
+    }
+
+    #[test]
     fn garbage_is_rejected() {
         assert!(decode(b"MM\0*nonsense").is_err());
         assert!(decode(&[]).is_err());
@@ -976,10 +1527,13 @@ mod tests {
                 Ok(raw) => raw,
                 Err(Error::Unsupported(why)) => {
                     let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-                    let allowed: &[(&str, &str)] = &[(
-                        "DC50",
-                        "Compression 32867, the DC40/DC50 scheme, is not implemented",
-                    )];
+                    // The DC50 (RADC, Compression 32867) now decodes. The
+                    // only Kodak variants still out of scope are the s=2
+                    // RADC quantiser (CompressedBitsPerPixel 243, no
+                    // corpus sample) and the DC120's separate bilinear
+                    // scheme; neither appears in the corpus, so the
+                    // allow-list is empty and any Unsupported is a bug.
+                    let allowed: &[(&str, &str)] = &[];
                     let reason = allowed
                         .iter()
                         .find(|(file, _)| name.contains(file))

--- a/crates/codec-raw/src/formats/mod.rs
+++ b/crates/codec-raw/src/formats/mod.rs
@@ -30,6 +30,7 @@ pub mod raf;
 pub mod raf_compressed;
 pub mod rw2;
 pub mod srw;
+pub mod vc5;
 pub mod x3f;
 
 /// Shared helpers for the TIFF-shaped formats.

--- a/crates/codec-raw/src/formats/vc5.rs
+++ b/crates/codec-raw/src/formats/vc5.rs
@@ -1,0 +1,1544 @@
+//! GoPro VC-5: the wavelet codec inside GPR files.
+//!
+//! A GPR is an ordinary DNG whose sensor IFD carries `Compression = 9`
+//! and whose single tile is a VC-5 elementary bitstream (SMPTE ST 2073,
+//! GoPro's "GPR" profile of it). Everything else about the file — black
+//! and white levels, the CFA layout, colour matrices, the active area —
+//! is plain DNG and is read by [`super::dng`]; this module only turns
+//! one tile of VC-5 into the `TileWidth x TileLength` block of RGGB
+//! samples that the DNG path then treats like any uncompressed tile.
+//!
+//! The shape of the codec, from the outside in:
+//!
+//! * The 2x2 Bayer mosaic is de-interleaved *before* compression into
+//!   four half-resolution planes, and those planes are a reversible
+//!   colour-difference transform of the quad rather than the four raw
+//!   CFA colours: green sum, red-minus-green, blue-minus-green and the
+//!   difference of the two greens (§7).
+//! * Each plane is compressed independently by a three-level 2-D
+//!   wavelet, so ten subbands per channel: one coarsest lowpass and
+//!   three highpass bands per level.
+//! * The lowpass band is stored as plain fixed-width integers; every
+//!   highpass band is run/value entropy coded against one fixed
+//!   codebook, then companded and quantised.
+//! * Reconstruction runs the inverse 2/6 wavelet back up the levels and
+//!   finally undoes the colour-difference transform and the camera's
+//!   log curve, which is where the 12-bit working precision becomes the
+//!   14-bit sensor codes the DNG advertises.
+//!
+//! Written from a functional specification of the bitstream plus
+//! observation of the corpus files; no reference decoder source was
+//! consulted.
+
+use rayon::prelude::*;
+
+use crate::bits::{BitPump, BitPumpMsb};
+use crate::{frame_samples, Error, Result};
+
+/// The tag dictionary. VC-5 structures its header as a stream of
+/// 4-byte tag-value tuples; these are the mandatory (positive) tags a
+/// GoPro Bayer stream uses. Tags this decoder does not know are
+/// harmless state updates and are ignored.
+mod tag {
+    pub const CHANNEL_COUNT: u16 = 12;
+    pub const SUBBAND_COUNT: u16 = 14;
+    pub const IMAGE_WIDTH: u16 = 20;
+    pub const IMAGE_HEIGHT: u16 = 21;
+    pub const LOWPASS_PRECISION: u16 = 35;
+    pub const SUBBAND_NUMBER: u16 = 48;
+    pub const QUANTIZATION: u16 = 53;
+    pub const CHANNEL_NUMBER: u16 = 62;
+    pub const IMAGE_FORMAT: u16 = 84;
+    pub const MAX_BITS_PER_COMPONENT: u16 = 102;
+    pub const PATTERN_WIDTH: u16 = 106;
+    pub const PATTERN_HEIGHT: u16 = 107;
+    pub const COMPONENTS_PER_SAMPLE: u16 = 108;
+    pub const PRESCALE_SHIFT: u16 = 109;
+    /// Multi-layer samples (GoPro has never shipped one) carry these.
+    pub const LAYER_COUNT: u16 = 120;
+}
+
+/// Chunk tags that would change the pixels but are not implemented,
+/// because nothing in the GoPro corpus carries them: an explicit
+/// inverse component permutation and an explicit inverse component
+/// transform, which if present override the fixed Bayer scheme of §7.
+mod chunk {
+    pub const INVERSE_PERMUTATION: u16 = 0xC001;
+    pub const INVERSE_TRANSFORM: u16 = 0xC002;
+}
+
+/// `ImageFormat` 4 is the Bayer arrangement; nothing else has ever been
+/// seen in a GPR and the component transform below assumes it.
+const IMAGE_FORMAT_BAYER: u16 = 4;
+
+/// Four colour-difference planes per frame, ten subbands per plane.
+const CHANNELS: usize = 4;
+const SUBBANDS: usize = 10;
+/// Three wavelet levels, each contributing three highpass subbands
+/// above the single coarsest lowpass.
+const LEVELS: usize = 3;
+
+/// The working precision of a component plane after the inverse
+/// transform, before the log curve: `MaxBitsPerComponent = 12`.
+const COMPONENT_MAX: i32 = 4095;
+/// The bias the three difference channels are stored with, so they can
+/// be carried as unsigned values.
+const MIDPOINT: i32 = 2048;
+/// Reconstructed wavelet samples are clamped to the unsigned working
+/// range of the transform.
+const TRANSFORM_MAX: i32 = 16383;
+
+/// (bit-length, codeword bits MSB-first, run, magnitude, kind:0=mag 1=zero-run 2=band-end)
+const CODEBOOK: [(u8, u32, u16, u16, u8); 264] = [
+    (1, 0x0000000, 1, 0, 0),
+    (2, 0x0000002, 1, 1, 0),
+    (3, 0x0000007, 1, 2, 0),
+    (5, 0x0000019, 1, 3, 0),
+    (6, 0x0000030, 1, 4, 0),
+    (6, 0x0000036, 1, 5, 0),
+    (7, 0x000006f, 1, 8, 0),
+    (7, 0x0000063, 1, 6, 0),
+    (7, 0x0000069, 12, 0, 1),
+    (7, 0x000006b, 1, 7, 0),
+    (8, 0x00000d1, 20, 0, 1),
+    (8, 0x00000d4, 1, 9, 0),
+    (8, 0x00000dc, 1, 10, 0),
+    (9, 0x0000189, 1, 11, 0),
+    (9, 0x000018a, 32, 0, 1),
+    (9, 0x00001a0, 1, 12, 0),
+    (9, 0x00001ab, 1, 13, 0),
+    (10, 0x0000377, 1, 18, 0),
+    (10, 0x0000310, 1, 14, 0),
+    (10, 0x0000316, 1, 15, 0),
+    (10, 0x0000343, 60, 0, 1),
+    (10, 0x0000354, 1, 16, 0),
+    (10, 0x0000375, 1, 17, 0),
+    (11, 0x0000623, 1, 19, 0),
+    (11, 0x0000684, 1, 20, 0),
+    (11, 0x0000685, 100, 0, 1),
+    (11, 0x00006ab, 1, 21, 0),
+    (11, 0x00006ec, 1, 22, 0),
+    (12, 0x0000ddb, 1, 29, 0),
+    (12, 0x0000c5c, 1, 24, 0),
+    (12, 0x0000c5e, 1, 25, 0),
+    (12, 0x0000c44, 1, 23, 0),
+    (12, 0x0000d55, 1, 26, 0),
+    (12, 0x0000dd1, 1, 27, 0),
+    (12, 0x0000dd3, 1, 28, 0),
+    (13, 0x0001bb5, 1, 35, 0),
+    (13, 0x000188b, 1, 30, 0),
+    (13, 0x00018bb, 1, 31, 0),
+    (13, 0x00018bf, 180, 0, 1),
+    (13, 0x0001aa8, 1, 32, 0),
+    (13, 0x0001ba0, 1, 33, 0),
+    (13, 0x0001ba5, 320, 0, 1),
+    (13, 0x0001ba4, 1, 34, 0),
+    (14, 0x0003115, 1, 36, 0),
+    (14, 0x0003175, 1, 37, 0),
+    (14, 0x000317d, 1, 38, 0),
+    (14, 0x0003553, 1, 39, 0),
+    (14, 0x0003768, 1, 40, 0),
+    (15, 0x0006e87, 1, 46, 0),
+    (15, 0x0006ed3, 1, 47, 0),
+    (15, 0x00062e8, 1, 42, 0),
+    (15, 0x00062f8, 1, 43, 0),
+    (15, 0x0006228, 1, 41, 0),
+    (15, 0x0006aa4, 1, 44, 0),
+    (15, 0x0006e85, 1, 45, 0),
+    (16, 0x000c453, 1, 48, 0),
+    (16, 0x000c5d3, 1, 49, 0),
+    (16, 0x000c5f3, 1, 50, 0),
+    (16, 0x000dda4, 1, 53, 0),
+    (16, 0x000dd08, 1, 51, 0),
+    (16, 0x000dd0c, 1, 52, 0),
+    (17, 0x001bb4b, 1, 61, 0),
+    (17, 0x001bb4a, 1, 60, 0),
+    (17, 0x0018ba5, 1, 55, 0),
+    (17, 0x0018be5, 1, 56, 0),
+    (17, 0x001aa95, 1, 57, 0),
+    (17, 0x001aa97, 1, 58, 0),
+    (17, 0x00188a4, 1, 54, 0),
+    (17, 0x001ba13, 1, 59, 0),
+    (18, 0x0031748, 1, 62, 0),
+    (18, 0x00317c8, 1, 63, 0),
+    (18, 0x0035528, 1, 64, 0),
+    (18, 0x003552c, 1, 65, 0),
+    (18, 0x0037424, 1, 66, 0),
+    (18, 0x0037434, 1, 67, 0),
+    (18, 0x0037436, 1, 68, 0),
+    (19, 0x0062294, 1, 69, 0),
+    (19, 0x0062e92, 1, 70, 0),
+    (19, 0x0062f92, 1, 71, 0),
+    (19, 0x006aa52, 1, 72, 0),
+    (19, 0x006aa5a, 1, 73, 0),
+    (19, 0x006e86a, 1, 75, 0),
+    (19, 0x006e86e, 1, 76, 0),
+    (19, 0x006e84a, 1, 74, 0),
+    (20, 0x00c452a, 1, 77, 0),
+    (20, 0x00c5d27, 1, 78, 0),
+    (20, 0x00c5f26, 1, 79, 0),
+    (20, 0x00d54a6, 1, 80, 0),
+    (20, 0x00d54b6, 1, 81, 0),
+    (20, 0x00dd096, 1, 82, 0),
+    (20, 0x00dd0d6, 1, 83, 0),
+    (20, 0x00dd0de, 1, 84, 0),
+    (21, 0x0188a56, 1, 85, 0),
+    (21, 0x018ba4d, 1, 86, 0),
+    (21, 0x018be4e, 1, 87, 0),
+    (21, 0x018be4f, 1, 88, 0),
+    (21, 0x01aa96e, 1, 89, 0),
+    (21, 0x01ba12e, 1, 90, 0),
+    (21, 0x01ba12f, 1, 91, 0),
+    (21, 0x01ba1af, 1, 92, 0),
+    (21, 0x01ba1bf, 1, 93, 0),
+    (22, 0x037435d, 1, 99, 0),
+    (22, 0x037437d, 1, 100, 0),
+    (22, 0x0317498, 1, 94, 0),
+    (22, 0x035529c, 1, 95, 0),
+    (22, 0x035529d, 1, 96, 0),
+    (22, 0x03552de, 1, 97, 0),
+    (22, 0x03552df, 1, 98, 0),
+    (23, 0x062e933, 1, 102, 0),
+    (23, 0x062295d, 1, 101, 0),
+    (23, 0x06aa53d, 1, 103, 0),
+    (23, 0x06aa53f, 1, 105, 0),
+    (23, 0x06aa53e, 1, 104, 0),
+    (23, 0x06e86b9, 1, 106, 0),
+    (23, 0x06e86f8, 1, 107, 0),
+    (24, 0x0d54a79, 1, 111, 0),
+    (24, 0x0c5d265, 1, 109, 0),
+    (24, 0x0c452b8, 1, 108, 0),
+    (24, 0x0dd0d71, 1, 113, 0),
+    (24, 0x0d54a78, 1, 110, 0),
+    (24, 0x0dd0d70, 1, 112, 0),
+    (24, 0x0dd0df2, 1, 114, 0),
+    (24, 0x0dd0df3, 1, 115, 0),
+    (25, 0x188a5f6, 1, 225, 0),
+    (25, 0x188a5f5, 1, 189, 0),
+    (25, 0x188a5f4, 1, 188, 0),
+    (25, 0x188a5f3, 1, 203, 0),
+    (25, 0x188a5f2, 1, 202, 0),
+    (25, 0x188a5f1, 1, 197, 0),
+    (25, 0x188a5f0, 1, 207, 0),
+    (25, 0x188a5ef, 1, 169, 0),
+    (25, 0x188a5ee, 1, 223, 0),
+    (25, 0x188a5ed, 1, 159, 0),
+    (25, 0x188a5aa, 1, 235, 0),
+    (25, 0x188a5e3, 1, 152, 0),
+    (25, 0x188a5df, 1, 192, 0),
+    (25, 0x188a589, 1, 179, 0),
+    (25, 0x188a5dd, 1, 201, 0),
+    (25, 0x188a578, 1, 172, 0),
+    (25, 0x188a5e0, 1, 149, 0),
+    (25, 0x188a588, 1, 178, 0),
+    (25, 0x188a5d6, 1, 120, 0),
+    (25, 0x188a5db, 1, 219, 0),
+    (25, 0x188a5e1, 1, 150, 0),
+    (25, 0x188a587, 1, 127, 0),
+    (25, 0x188a59a, 1, 211, 0),
+    (25, 0x188a5c4, 1, 125, 0),
+    (25, 0x188a5ec, 1, 158, 0),
+    (25, 0x188a586, 1, 247, 0),
+    (25, 0x188a573, 1, 238, 0),
+    (25, 0x188a59c, 1, 163, 0),
+    (25, 0x188a5c8, 1, 228, 0),
+    (25, 0x188a5fb, 1, 183, 0),
+    (25, 0x188a5a1, 1, 217, 0),
+    (25, 0x188a5eb, 1, 168, 0),
+    (25, 0x188a5a8, 1, 122, 0),
+    (25, 0x188a584, 1, 128, 0),
+    (25, 0x188a5d2, 1, 249, 0),
+    (25, 0x188a599, 1, 187, 0),
+    (25, 0x188a598, 1, 186, 0),
+    (25, 0x188a583, 1, 136, 0),
+    (25, 0x18ba4c9, 1, 181, 0),
+    (25, 0x188a5d0, 1, 255, 0),
+    (25, 0x188a594, 1, 230, 0),
+    (25, 0x188a582, 1, 135, 0),
+    (25, 0x188a5cb, 1, 233, 0),
+    (25, 0x188a5d8, 1, 222, 0),
+    (25, 0x188a5e7, 1, 145, 0),
+    (25, 0x188a581, 1, 134, 0),
+    (25, 0x188a5ea, 1, 167, 0),
+    (25, 0x188a5a9, 1, 248, 0),
+    (25, 0x188a5a6, 1, 209, 0),
+    (25, 0x188a580, 1, 243, 0),
+    (25, 0x188a5a0, 1, 216, 0),
+    (25, 0x188a59d, 1, 164, 0),
+    (25, 0x188a5c3, 1, 140, 0),
+    (25, 0x188a57f, 1, 157, 0),
+    (25, 0x188a5c0, 1, 239, 0),
+    (25, 0x188a5de, 1, 191, 0),
+    (25, 0x188a5d4, 1, 251, 0),
+    (25, 0x188a57e, 1, 156, 0),
+    (25, 0x188a5c2, 1, 139, 0),
+    (25, 0x188a592, 1, 242, 0),
+    (25, 0x188a5cd, 1, 133, 0),
+    (25, 0x188a57d, 1, 162, 0),
+    (25, 0x188a5a3, 1, 213, 0),
+    (25, 0x188a5e8, 1, 165, 0),
+    (25, 0x188a5a2, 1, 212, 0),
+    (25, 0x188a57c, 1, 227, 0),
+    (25, 0x188a58e, 1, 198, 0),
+    (25, 0x188a5b3, 1, 236, 0),
+    (25, 0x188a5b2, 1, 234, 0),
+    (25, 0x188a5b1, 1, 117, 0),
+    (25, 0x188a5b0, 1, 215, 0),
+    (25, 0x188a5af, 1, 124, 0),
+    (25, 0x188a5ae, 1, 123, 0),
+    (25, 0x188a5ad, 1, 254, 0),
+    (25, 0x188a5ac, 1, 253, 0),
+    (25, 0x188a5ab, 1, 148, 0),
+    (25, 0x188a5da, 1, 218, 0),
+    (25, 0x188a5e4, 1, 146, 0),
+    (25, 0x188a5e5, 1, 147, 0),
+    (25, 0x188a5d9, 1, 224, 0),
+    (25, 0x188a5b5, 1, 143, 0),
+    (25, 0x188a5bc, 1, 184, 0),
+    (25, 0x188a5bd, 1, 185, 0),
+    (25, 0x188a5e9, 1, 166, 0),
+    (25, 0x188a5cc, 1, 132, 0),
+    (25, 0x188a585, 1, 129, 0),
+    (25, 0x188a5d3, 1, 250, 0),
+    (25, 0x188a5e2, 1, 151, 0),
+    (25, 0x188a595, 1, 119, 0),
+    (25, 0x188a596, 1, 193, 0),
+    (25, 0x188a5b8, 1, 176, 0),
+    (25, 0x188a590, 1, 245, 0),
+    (25, 0x188a5c9, 1, 229, 0),
+    (25, 0x188a5a4, 1, 206, 0),
+    (25, 0x188a5e6, 1, 144, 0),
+    (25, 0x188a5a5, 1, 208, 0),
+    (25, 0x188a5ce, 1, 137, 0),
+    (25, 0x188a5bf, 1, 241, 0),
+    (25, 0x188a572, 1, 237, 0),
+    (25, 0x188a59b, 1, 190, 0),
+    (25, 0x188a5be, 1, 240, 0),
+    (25, 0x188a5c7, 1, 131, 0),
+    (25, 0x188a5ca, 1, 232, 0),
+    (25, 0x188a5d5, 1, 252, 0),
+    (25, 0x188a57b, 1, 171, 0),
+    (25, 0x188a58d, 1, 205, 0),
+    (25, 0x188a58c, 1, 204, 0),
+    (25, 0x188a58b, 1, 118, 0),
+    (25, 0x188a58a, 1, 214, 0),
+    (25, 0x18ba4c8, 1, 180, 0),
+    (25, 0x188a5c5, 1, 126, 0),
+    (25, 0x188a5fa, 1, 182, 0),
+    (25, 0x188a5bb, 1, 175, 0),
+    (25, 0x188a5c1, 1, 141, 0),
+    (25, 0x188a5cf, 1, 138, 0),
+    (25, 0x188a5b9, 1, 177, 0),
+    (25, 0x188a5b6, 1, 153, 0),
+    (25, 0x188a597, 1, 194, 0),
+    (25, 0x188a5fe, 1, 160, 0),
+    (25, 0x188a5d7, 1, 121, 0),
+    (25, 0x188a5ba, 1, 174, 0),
+    (25, 0x188a591, 1, 246, 0),
+    (25, 0x188a5c6, 1, 130, 0),
+    (25, 0x188a5dc, 1, 200, 0),
+    (25, 0x188a57a, 1, 170, 0),
+    (25, 0x188a59f, 1, 221, 0),
+    (25, 0x188a5f9, 1, 196, 0),
+    (25, 0x188a5b4, 1, 142, 0),
+    (25, 0x188a5a7, 1, 210, 0),
+    (25, 0x188a58f, 1, 199, 0),
+    (25, 0x188a5fd, 1, 155, 0),
+    (25, 0x188a5b7, 1, 154, 0),
+    (25, 0x188a593, 1, 244, 0),
+    (25, 0x188a59e, 1, 220, 0),
+    (25, 0x188a5f8, 1, 195, 0),
+    (25, 0x188a5ff, 1, 161, 0),
+    (25, 0x188a5fc, 1, 231, 0),
+    (25, 0x188a579, 1, 173, 0),
+    (25, 0x188a5f7, 1, 226, 0),
+    (26, 0x3114ba2, 1, 116, 0),
+    (26, 0x3114ba3, 0, 1, 2),
+];
+
+const KIND_MAGNITUDE: u8 = 0;
+const KIND_ZERO_RUN: u8 = 1;
+const KIND_BAND_END: u8 = 2;
+
+// -------------------------------------------------------------------
+// The tag-value / chunk layer
+// -------------------------------------------------------------------
+
+/// Everything the header tuples tell the decoder about the frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Header {
+    width: usize,
+    height: usize,
+    /// Per-level left shift undoing the encoder's prescale (§6.4),
+    /// indexed 0 = finest level.
+    descale: [u32; LEVELS],
+}
+
+/// One entropy- or raw-coded band, located in the stream.
+#[derive(Debug, Clone)]
+struct Codeblock<'a> {
+    channel: u16,
+    subband: u16,
+    /// The quantiser in force for this subband; the lowpass band is
+    /// unquantised and carries 0 here.
+    quant: i32,
+    /// Bits per coefficient of the lowpass band (`LowpassPrecision`).
+    precision: u32,
+    data: &'a [u8],
+}
+
+/// Split the elementary bitstream into its header state and the forty
+/// codeblocks (four channels of ten subbands).
+///
+/// The stream is a flat sequence of big-endian 4-byte tuples: a signed
+/// 16-bit tag and an unsigned 16-bit value. A non-negative tag is a
+/// mandatory state update (image size, current channel, current
+/// subband, current quantiser). A negative tag introduces a *chunk*,
+/// and this is the one place the format needs care.
+///
+/// Chunks nest: a section chunk wraps the tuples and the codeblock of
+/// one subband, and the codeblock chunk immediately precedes that
+/// subband's coefficient bytes. Both carry the same end offset, so the
+/// section is pure scaffolding — tracking `ChannelNumber` and
+/// `SubbandNumber` through a flat scan is enough, and every negative
+/// tag that is not a codeblock can be stepped over as a bare tuple.
+///
+/// A codeblock chunk is identified by its tag falling in
+/// `0x9000 ..= 0xA000`, and its payload length in 32-bit segments is
+///
+/// ```text
+/// size = ((0xA000 - tag) << 16) | value
+/// ```
+///
+/// so the tag's distance below `0xA000` supplies the high bits of a
+/// size too large for the 16-bit value alone. Bands under 64 K
+/// segments therefore all read `0xA000`, and only the big finest-level
+/// bands of a detailed frame drop to `0x9FFF` and below. Reading the
+/// value alone decodes most files and then silently desynchronises on
+/// the first large band, which is why the high bits matter.
+fn parse<'a>(stream: &'a [u8]) -> Result<(Header, Vec<Codeblock<'a>>)> {
+    if stream.len() < 4 || &stream[..4] != b"VC-5" {
+        return Err(Error::Corrupt(
+            "VC-5 sample does not start with the 'VC-5' marker".into(),
+        ));
+    }
+
+    let mut width = 0usize;
+    let mut height = 0usize;
+    let mut prescale = 0u16;
+    let mut channel_count = CHANNELS as u16;
+    let mut subband_count = SUBBANDS as u16;
+    let mut format = IMAGE_FORMAT_BAYER;
+    let mut pattern = (2u16, 2u16);
+    let mut per_sample = 1u16;
+    let mut max_bits = 12u16;
+
+    let mut channel = 0u16;
+    let mut subband = 0u16;
+    let mut quant = 0i32;
+    let mut precision = 16u32;
+
+    let mut layers = 1u16;
+    let mut blocks: Vec<Codeblock<'a>> = Vec::new();
+    let mut at = 0usize;
+    while at + 4 <= stream.len() {
+        let tag = u16::from_be_bytes([stream[at], stream[at + 1]]);
+        let value = u16::from_be_bytes([stream[at + 2], stream[at + 3]]);
+        at += 4;
+
+        if (0x9000..=0xA000).contains(&tag) {
+            // A codeblock: the payload is raw band data, measured in
+            // 32-bit segments, and the next tuple follows it.
+            let segments = (((0xA000 - tag) as usize) << 16) | value as usize;
+            let len = segments
+                .checked_mul(4)
+                .ok_or_else(|| Error::Corrupt("VC-5 codeblock larger than memory".into()))?;
+            let data = stream
+                .get(at..at + len)
+                .ok_or_else(|| Error::Corrupt("VC-5 codeblock runs past the sample".into()))?;
+            at += len;
+            if blocks.len() >= CHANNELS * SUBBANDS {
+                return Err(Error::Corrupt(
+                    "VC-5 sample carries more codeblocks than channels times subbands".into(),
+                ));
+            }
+            blocks.push(Codeblock {
+                channel,
+                subband,
+                quant,
+                precision,
+                data,
+            });
+        } else if tag == chunk::INVERSE_PERMUTATION || tag == chunk::INVERSE_TRANSFORM {
+            // These override the fixed component permutation and
+            // transform. Skipping them would silently produce the
+            // wrong colours, so say so instead.
+            return Err(Error::Unsupported(
+                "VC-5 with an explicit inverse component permutation or transform".into(),
+            ));
+        } else if tag & 0x8000 != 0 {
+            // Any other negative tag is a section marker, padding or a
+            // Part 7 metadata chunk: scaffolding with no pixel data,
+            // which this decoder steps over. Sections wrap the very
+            // codeblocks they precede, so ignoring them loses nothing.
+        } else {
+            match tag {
+                tag::IMAGE_WIDTH => width = value as usize,
+                tag::IMAGE_HEIGHT => height = value as usize,
+                tag::CHANNEL_COUNT => channel_count = value,
+                tag::SUBBAND_COUNT => subband_count = value,
+                tag::IMAGE_FORMAT => format = value,
+                tag::MAX_BITS_PER_COMPONENT => max_bits = value,
+                tag::PATTERN_WIDTH => pattern.0 = value,
+                tag::PATTERN_HEIGHT => pattern.1 = value,
+                tag::COMPONENTS_PER_SAMPLE => per_sample = value,
+                tag::PRESCALE_SHIFT => prescale = value,
+                tag::CHANNEL_NUMBER => channel = value,
+                tag::SUBBAND_NUMBER => subband = value,
+                tag::QUANTIZATION => quant = value as i32,
+                tag::LOWPASS_PRECISION => precision = value as u32,
+                tag::LAYER_COUNT => layers = value,
+                _ => {}
+            }
+        }
+    }
+
+    // Reject the profiles the GoPro corpus never uses rather than
+    // decoding them into nonsense.
+    if format != IMAGE_FORMAT_BAYER {
+        return Err(Error::Unsupported(format!(
+            "VC-5 ImageFormat {format} (only 4, Bayer, is implemented)"
+        )));
+    }
+    if pattern != (2, 2) || per_sample != 1 {
+        return Err(Error::Unsupported(format!(
+            "VC-5 with a {}x{} pattern of {per_sample} components a sample",
+            pattern.0, pattern.1
+        )));
+    }
+    if channel_count as usize != CHANNELS || subband_count as usize != SUBBANDS {
+        return Err(Error::Unsupported(format!(
+            "VC-5 with {channel_count} channels of {subband_count} subbands"
+        )));
+    }
+    // The component transform works in twelve bits (its clamp,
+    // midpoint and log curve are sized for it); a stream declaring
+    // another precision would decode to the wrong values silently.
+    if max_bits as i32 != 12 {
+        return Err(Error::Unsupported(format!(
+            "VC-5 with {max_bits}-bit components"
+        )));
+    }
+    if width == 0 || height == 0 || !width.is_multiple_of(2) || !height.is_multiple_of(2) {
+        return Err(Error::Corrupt(format!(
+            "VC-5 frame of {width}x{height} is not a whole number of 2x2 quads"
+        )));
+    }
+    if layers > 1 {
+        return Err(Error::Unsupported(format!(
+            "VC-5 sample of {layers} layers (multi-layer GPR)"
+        )));
+    }
+    if blocks.len() != CHANNELS * SUBBANDS {
+        return Err(Error::Corrupt(format!(
+            "VC-5 sample holds {} codeblocks, expected {}",
+            blocks.len(),
+            CHANNELS * SUBBANDS
+        )));
+    }
+    // Every channel must contribute each of its subbands exactly once.
+    // A chunk walk that lost synchronisation still tends to land the
+    // right number of codeblocks, so this is what actually catches it.
+    for (index, block) in blocks.iter().enumerate() {
+        let want = (index / SUBBANDS, index % SUBBANDS);
+        if (block.channel as usize, block.subband as usize) != want {
+            return Err(Error::Corrupt(format!(
+                "VC-5 codeblock {index} is channel {} subband {}, expected channel {} subband {}",
+                block.channel, block.subband, want.0, want.1
+            )));
+        }
+    }
+
+    Ok((
+        Header {
+            width,
+            height,
+            descale: descale_of(prescale),
+        },
+        blocks,
+    ))
+}
+
+/// Unpack `PrescaleShift`, which holds a 2-bit prescale per wavelet
+/// level starting at bit 14 and working down.
+///
+/// The prescale is the number of bits the encoder shifted a level's
+/// input down by to keep its coefficients in range, and reconstruction
+/// shifts the same number back up. Every GoPro sample reads 0x2800, so
+/// the two coarse reconstructions each shift by two bits and the finest
+/// does not shift at all.
+///
+/// The shift is used verbatim, not halved: reconstructing the corpus
+/// with a one-bit shift for a prescale of 2 lands a factor of four low.
+/// It is also applied inside the horizontal filter, before that
+/// filter's halving rather than after it (see [`lift`]) — undoing the
+/// prescale afterwards would discard the low bits the shift is there to
+/// recover and leaves the frame off by one or two codes.
+fn descale_of(prescale: u16) -> [u32; LEVELS] {
+    let mut descale = [0u32; LEVELS];
+    for (level, slot) in descale.iter_mut().enumerate() {
+        *slot = u32::from((prescale >> (14 - 2 * level)) & 3);
+    }
+    descale
+}
+
+// -------------------------------------------------------------------
+// Band geometry
+// -------------------------------------------------------------------
+
+/// The size of each wavelet level's bands for a component plane.
+///
+/// Every halving rounds **up**, so an odd dimension keeps a column or
+/// row that the inverse transform later discards: the Fusion frames
+/// halve 1500 to 750 to 375 to 188, and reconstructing 188 rows back
+/// into 375 drops the trailing odd output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Geometry {
+    /// `dims[0]` is the full component plane, `dims[k]` the lowpass of
+    /// level `k`, so `dims[3]` sizes the coarsest lowpass band.
+    dims: [(usize, usize); LEVELS + 1],
+}
+
+impl Geometry {
+    fn of(component_width: usize, component_height: usize) -> Geometry {
+        let mut dims = [(0usize, 0usize); LEVELS + 1];
+        dims[0] = (component_width, component_height);
+        for level in 1..=LEVELS {
+            let (w, h) = dims[level - 1];
+            dims[level] = (w.div_ceil(2), h.div_ceil(2));
+        }
+        Geometry { dims }
+    }
+
+    /// The band dimensions a subband index is stored at: subbands 1..3
+    /// live at the coarsest level, 4..6 one finer, 7..9 finest.
+    fn band(&self, subband: usize) -> (usize, usize) {
+        let level = match subband {
+            0..=3 => 3,
+            4..=6 => 2,
+            _ => 1,
+        };
+        self.dims[level]
+    }
+}
+
+// -------------------------------------------------------------------
+// Entropy coding
+// -------------------------------------------------------------------
+
+/// The codebook as a binary trie, so a codeword is matched by walking
+/// one bit at a time. The code is prefix-free and at most 26 bits, so a
+/// walk always terminates; a bit pattern the codebook does not contain
+/// ends at a missing child and is reported rather than guessed at.
+struct Trie {
+    /// Each node's two children. A non-negative entry is another node,
+    /// `-1` is missing, and anything at or below `-2` encodes the
+    /// codebook index of a leaf as `-(index + 2)`.
+    children: Vec<[i32; 2]>,
+}
+
+impl Trie {
+    fn build() -> Trie {
+        let mut children: Vec<[i32; 2]> = vec![[-1, -1]];
+        for (index, &(length, code, _, _, _)) in CODEBOOK.iter().enumerate() {
+            let mut node = 0usize;
+            for step in (0..length).rev() {
+                let bit = ((code >> step) & 1) as usize;
+                if step == 0 {
+                    children[node][bit] = -((index as i32) + 2);
+                } else {
+                    let next = children[node][bit];
+                    node = if next < 0 {
+                        children.push([-1, -1]);
+                        let fresh = children.len() - 1;
+                        children[node][bit] = fresh as i32;
+                        fresh
+                    } else {
+                        next as usize
+                    };
+                }
+            }
+        }
+        Trie { children }
+    }
+
+    /// Match one codeword, returning its index in [`CODEBOOK`].
+    #[inline]
+    fn decode(&self, pump: &mut BitPumpMsb<'_>) -> Result<usize> {
+        let mut node = 0usize;
+        loop {
+            let bit = pump.get(1) as usize;
+            let next = self.children[node][bit];
+            if next >= 0 {
+                node = next as usize;
+            } else if next == -1 {
+                return Err(Error::Corrupt(
+                    "VC-5 highpass band holds a codeword outside the codebook".into(),
+                ));
+            } else {
+                return Ok((-(next + 2)) as usize);
+            }
+        }
+    }
+}
+
+fn trie() -> &'static Trie {
+    static TRIE: std::sync::OnceLock<Trie> = std::sync::OnceLock::new();
+    TRIE.get_or_init(Trie::build)
+}
+
+/// The inverse companding curve, mapping a codebook magnitude 0..255
+/// back onto the encoder's 0..1023 range.
+///
+/// The encoder companded large coefficients down so that every
+/// magnitude fits the 256-entry codebook; GoPro uses the cubic curve
+///
+/// ```text
+/// expanded(m) = m + trunc(768 * m^3 / 255^3)
+/// ```
+///
+/// so 0 stays 0 and 255 becomes 1023. The lowpass band is never
+/// companded.
+fn expand_curve() -> &'static [i32; 256] {
+    static CURVE: std::sync::OnceLock<[i32; 256]> = std::sync::OnceLock::new();
+    CURVE.get_or_init(|| {
+        let mut curve = [0i32; 256];
+        for (m, slot) in curve.iter_mut().enumerate() {
+            let m = m as i64;
+            *slot = (m + (768 * m * m * m) / (255 * 255 * 255)) as i32;
+        }
+        curve
+    })
+}
+
+/// The camera's decoder log curve: 12-bit log-domain component values
+/// back to 16-bit linear.
+///
+/// The encoder's forward curve is a base-113 logarithm over the 16-bit
+/// sensor range, so the decoder's is the matching power curve. Values
+/// are then shifted down to the sensor's real bit depth.
+fn log_curve() -> &'static [u16; 4096] {
+    static CURVE: std::sync::OnceLock<[u16; 4096]> = std::sync::OnceLock::new();
+    CURVE.get_or_init(|| {
+        let mut curve = [0u16; 4096];
+        for (i, slot) in curve.iter_mut().enumerate() {
+            let t = (i as f64) / 4095.0;
+            let linear = 65535.0 * (113f64.powf(t) - 1.0) / 112.0;
+            *slot = linear.floor().clamp(0.0, 65535.0) as u16;
+        }
+        curve
+    })
+}
+
+/// Decode one highpass subband into dequantised coefficients.
+///
+/// The band is filled in raster order by run/value codewords: a
+/// magnitude codeword contributes one coefficient and is followed by a
+/// sign bit, a zero-run codeword contributes that many zeros and has no
+/// sign bit. Runs are not restarted per row, so one may span the end of
+/// a row into the next. After the last coefficient the stream carries a
+/// band-end marker, which is read but not required — a band that filled
+/// exactly is already complete.
+fn decode_highpass(block: &Codeblock<'_>, width: usize, height: usize) -> Result<Vec<i32>> {
+    let count = frame_samples(width, height, 1)?;
+    let mut band = vec![0i32; count];
+
+    // Companding and dequantisation both depend only on the codebook
+    // magnitude, so fold them into one 256-entry table per band:
+    // expand the magnitude, scale by the subband's quantiser, and clamp
+    // to the signed 16-bit range the transform works in.
+    let expand = expand_curve();
+    let mut level = [0i32; 256];
+    for (m, slot) in level.iter_mut().enumerate() {
+        *slot = (expand[m] * block.quant).clamp(i16::MIN as i32, i16::MAX as i32);
+    }
+
+    let trie = trie();
+    let mut pump = BitPumpMsb::new(block.data);
+    let mut at = 0usize;
+    while at < count {
+        let (_, _, run, value, kind) = CODEBOOK[trie.decode(&mut pump)?];
+        match kind {
+            KIND_BAND_END => {
+                return Err(Error::Corrupt(format!(
+                    "VC-5 highpass band ended after {at} of {count} coefficients"
+                )))
+            }
+            KIND_ZERO_RUN => {
+                // Zeros need no writing, the band starts zeroed; a run
+                // overrunning the band is clamped rather than trusted.
+                at = at.saturating_add(run as usize).min(count);
+            }
+            KIND_MAGNITUDE => {
+                // A sign bit follows only a non-zero magnitude. The
+                // one-bit codeword for a single zero coefficient has
+                // none, and reading one anyway desynchronises the rest
+                // of the band.
+                if value != 0 {
+                    let magnitude = level[value as usize];
+                    band[at] = if pump.get(1) == 1 {
+                        -magnitude
+                    } else {
+                        magnitude
+                    };
+                }
+                at += 1;
+            }
+            other => {
+                return Err(Error::Corrupt(format!(
+                    "VC-5 codebook entry of unknown kind {other}"
+                )))
+            }
+        }
+        // A truncated or garbage band would otherwise spin here: the
+        // pump feeds zeros past its input, and the one-bit codeword for
+        // magnitude zero makes progress, so `at` always advances.
+    }
+    Ok(band)
+}
+
+/// Decode the single coarsest lowpass band, which is stored plainly as
+/// fixed-width unsigned integers in raster order — no sign, no
+/// prediction, no run coding, no companding.
+fn decode_lowpass(block: &Codeblock<'_>, width: usize, height: usize) -> Result<Vec<i32>> {
+    let count = frame_samples(width, height, 1)?;
+    if block.precision == 0 || block.precision > 16 {
+        return Err(Error::Corrupt(format!(
+            "VC-5 LowpassPrecision {} is not 1..=16",
+            block.precision
+        )));
+    }
+    let mut band = vec![0i32; count];
+    let mut pump = BitPumpMsb::new(block.data);
+    for slot in band.iter_mut() {
+        *slot = pump.get(block.precision) as i32;
+    }
+    Ok(band)
+}
+
+// -------------------------------------------------------------------
+// The inverse 2/6 wavelet
+// -------------------------------------------------------------------
+
+/// One pass of the inverse 2/6 filter along a line.
+///
+/// The wavelet is the reversible 2/6 (two-tap lowpass, six-tap
+/// highpass) spatial wavelet. Each input position yields two output
+/// samples, doubling the resolution along the axis: an "even" sample
+/// built by adding the highpass detail and an "odd" one by subtracting
+/// it. Interior positions use their two neighbours; the first and last
+/// positions have no neighbour on one side and use the one-sided
+/// `11,-4,1` and `5,4,-1` taps instead.
+///
+/// `out` may be one shorter than `2 * low.len()`, which is how an odd
+/// parent dimension drops the trailing odd sample.
+///
+/// `descale` undoes the encoder's prescale for this level. It is folded
+/// in before the filter's final halving, so the bits it restores
+/// survive; the vertical pass always passes 0 and only the horizontal
+/// pass carries a shift.
+fn lift(low: &[i32], high: &[i32], out: &mut [i32], descale: u32) {
+    let n = low.len();
+    debug_assert_eq!(n, high.len());
+    debug_assert!(n >= 3);
+    for c in 0..n {
+        // The `+ 4` is the filter's rounding term and is added before
+        // the divide-by-8; the final divide-by-2 is a bare shift.
+        let (even, odd) = if c == 0 {
+            (
+                (11 * low[0] - 4 * low[1] + low[2] + 4) >> 3,
+                (5 * low[0] + 4 * low[1] - low[2] + 4) >> 3,
+            )
+        } else if c == n - 1 {
+            (
+                (5 * low[n - 1] + 4 * low[n - 2] - low[n - 3] + 4) >> 3,
+                (11 * low[n - 1] - 4 * low[n - 2] + low[n - 3] + 4) >> 3,
+            )
+        } else {
+            (
+                low[c] + ((low[c - 1] - low[c + 1] + 4) >> 3),
+                low[c] + ((low[c + 1] - low[c - 1] + 4) >> 3),
+            )
+        };
+        if let Some(slot) = out.get_mut(2 * c) {
+            *slot = ((even + high[c]) << descale) >> 1;
+        }
+        if let Some(slot) = out.get_mut(2 * c + 1) {
+            *slot = ((odd - high[c]) << descale) >> 1;
+        }
+    }
+}
+
+/// Invert one wavelet level: four bands in, the next finer level's
+/// lowpass out.
+///
+/// The transform is separable and is undone in two passes. Vertically,
+/// the bands pair up as (lowpass, vertical detail) and (horizontal
+/// detail, diagonal detail); each pair is filtered down the columns,
+/// producing a full-height lowpass and a full-height highpass
+/// intermediate. Those two are then filtered across the rows to double
+/// the width.
+///
+/// `descale` undoes the encoder's prescale for this level. It rides
+/// into the horizontal filter rather than being applied to its output,
+/// which keeps the low bits, and the result is then clamped to the
+/// transform's unsigned working range.
+#[allow(clippy::too_many_arguments)]
+fn inverse_level(
+    lowpass: &[i32],
+    horizontal: &[i32],
+    vertical: &[i32],
+    diagonal: &[i32],
+    band: (usize, usize),
+    out: (usize, usize),
+    descale: u32,
+) -> Result<Vec<i32>> {
+    let (band_w, band_h) = band;
+    let (out_w, out_h) = out;
+    if band_w < 3 || band_h < 3 {
+        return Err(Error::Unsupported(format!(
+            "VC-5 wavelet band of {band_w}x{band_h} is too small for the 2/6 filter"
+        )));
+    }
+
+    // The two vertical intermediates are full height but still band
+    // width; the horizontal pass then widens them into the output.
+    let rows = frame_samples(band_w, out_h, 1)?;
+    let mut low_rows = vec![0i32; rows];
+    let mut high_rows = vec![0i32; rows];
+
+    let mut column_low = vec![0i32; band_h];
+    let mut column_high = vec![0i32; band_h];
+    let mut column_out = vec![0i32; out_h];
+    for x in 0..band_w {
+        for (pair, (l, h)) in [
+            (&mut low_rows, (lowpass, vertical)),
+            (&mut high_rows, (horizontal, diagonal)),
+        ] {
+            for y in 0..band_h {
+                column_low[y] = l[y * band_w + x];
+                column_high[y] = h[y * band_w + x];
+            }
+            lift(&column_low, &column_high, &mut column_out, 0);
+            for (y, value) in column_out.iter().enumerate() {
+                pair[y * band_w + x] = *value;
+            }
+        }
+    }
+
+    let mut frame = vec![0i32; frame_samples(out_w, out_h, 1)?];
+    for y in 0..out_h {
+        let source = y * band_w;
+        let row = &mut frame[y * out_w..(y + 1) * out_w];
+        lift(
+            &low_rows[source..source + band_w],
+            &high_rows[source..source + band_w],
+            row,
+            descale,
+        );
+        for value in row.iter_mut() {
+            *value = (*value).clamp(0, TRANSFORM_MAX);
+        }
+    }
+    Ok(frame)
+}
+
+/// Reconstruct one component plane from its ten subbands.
+fn reconstruct(
+    bands: &[Vec<i32>; SUBBANDS],
+    geometry: &Geometry,
+    descale: [u32; LEVELS],
+) -> Result<Vec<i32>> {
+    let mut lowpass = bands[0].clone();
+    // Levels run coarsest first: inverting level 3 makes the lowpass of
+    // level 2, and inverting level 1 makes the component plane.
+    for level in (1..=LEVELS).rev() {
+        let first = 3 * (LEVELS - level) + 1;
+        lowpass = inverse_level(
+            &lowpass,
+            &bands[first],
+            &bands[first + 1],
+            &bands[first + 2],
+            geometry.dims[level],
+            geometry.dims[level - 1],
+            descale[level - 1],
+        )?;
+    }
+    Ok(lowpass)
+}
+
+// -------------------------------------------------------------------
+// The inverse component transform
+// -------------------------------------------------------------------
+
+/// Decode one VC-5 tile into `width * height` RGGB sensor samples.
+///
+/// `shift` is how far the 16-bit output of the log curve is moved down
+/// to reach the sensor's real bit depth: a 14-bit GPR passes 2.
+pub fn decode(stream: &[u8], width: usize, height: usize, shift: u32) -> Result<Vec<u16>> {
+    let (header, blocks) = parse(stream)?;
+    if header.width != width || header.height != height {
+        return Err(Error::Corrupt(format!(
+            "VC-5 sample is {}x{}, the DNG tile is {width}x{height}",
+            header.width, header.height
+        )));
+    }
+    if shift > 16 {
+        return Err(Error::Corrupt(format!("VC-5 output shift {shift}")));
+    }
+
+    // Each channel is a half-resolution plane: the 2x2 quad is
+    // de-interleaved before compression.
+    let component = (width / 2, height / 2);
+    let geometry = Geometry::of(component.0, component.1);
+    let samples = frame_samples(width, height, 1)?;
+
+    // The four channels are independent, so decode and reconstruct them
+    // in parallel; each is well over a megapixel of wavelet work.
+    let mut planes: Vec<Result<Vec<i32>>> = Vec::with_capacity(CHANNELS);
+    (0..CHANNELS)
+        .into_par_iter()
+        .map(|channel| {
+            let mut bands: [Vec<i32>; SUBBANDS] = Default::default();
+            for (subband, band) in bands.iter_mut().enumerate() {
+                let block = blocks
+                    .iter()
+                    .find(|b| b.channel as usize == channel && b.subband as usize == subband)
+                    .ok_or_else(|| {
+                        Error::Corrupt(format!(
+                            "VC-5 sample is missing channel {channel} subband {subband}"
+                        ))
+                    })?;
+                let (w, h) = geometry.band(subband);
+                *band = if subband == 0 {
+                    decode_lowpass(block, w, h)?
+                } else {
+                    decode_highpass(block, w, h)?
+                };
+            }
+            reconstruct(&bands, &geometry, header.descale)
+        })
+        .collect_into_vec(&mut planes);
+    let planes = planes.into_iter().collect::<Result<Vec<_>>>()?;
+
+    // Undo the colour-difference transform and the log curve. The
+    // channels are green sum, red-minus-green, blue-minus-green and the
+    // difference of the two greens, the last three biased by a midpoint
+    // so they could be carried unsigned.
+    let curve = log_curve();
+    let mut frame = vec![0u16; samples];
+    let (green_sum, red, blue, green_diff) = (&planes[0], &planes[1], &planes[2], &planes[3]);
+    frame
+        .par_chunks_mut(2 * width)
+        .enumerate()
+        .for_each(|(y, quad_rows)| {
+            let (top, bottom) = quad_rows.split_at_mut(width);
+            for x in 0..component.0 {
+                let at = y * component.0 + x;
+                let gs = green_sum[at];
+                let rg = red[at] - MIDPOINT;
+                let bg = blue[at] - MIDPOINT;
+                let gd = green_diff[at] - MIDPOINT;
+                let look = |v: i32| curve[v.clamp(0, COMPONENT_MAX) as usize] >> shift;
+                top[2 * x] = look(2 * rg + gs);
+                top[2 * x + 1] = look(gs + gd);
+                bottom[2 * x] = look(gs - gd);
+                bottom[2 * x + 1] = look(2 * bg + gs);
+            }
+        });
+    Ok(frame)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// The codebook has to be prefix-free or the trie would have a leaf
+    /// on the path to another leaf and decoding would silently diverge.
+    #[test]
+    fn codebook_is_prefix_free_and_complete() {
+        for (i, &(a_len, a_code, _, _, _)) in CODEBOOK.iter().enumerate() {
+            assert!((1..=26).contains(&a_len), "entry {i} has length {a_len}");
+            for &(b_len, b_code, _, _, _) in CODEBOOK.iter().skip(i + 1) {
+                let (short, long, shift) = if a_len <= b_len {
+                    (a_code, b_code, b_len - a_len)
+                } else {
+                    (b_code, a_code, a_len - b_len)
+                };
+                assert_ne!(short, long >> shift, "entry {i} is a prefix of another");
+            }
+        }
+        let magnitudes: std::collections::BTreeSet<u16> = CODEBOOK
+            .iter()
+            .filter(|e| e.4 == KIND_MAGNITUDE)
+            .map(|e| e.3)
+            .collect();
+        assert_eq!(magnitudes.len(), 256, "the 256 magnitudes must all appear");
+        assert_eq!(*magnitudes.iter().next_back().unwrap(), 255);
+        assert_eq!(
+            CODEBOOK.iter().filter(|e| e.4 == KIND_BAND_END).count(),
+            1,
+            "exactly one band-end marker"
+        );
+        // The zero-runs the format defines.
+        let runs: Vec<u16> = CODEBOOK
+            .iter()
+            .filter(|e| e.4 == KIND_ZERO_RUN)
+            .map(|e| e.2)
+            .collect();
+        assert_eq!(runs, vec![12, 20, 32, 60, 100, 180, 320]);
+    }
+
+    /// The trie must decode every codeword back to the entry it came
+    /// from, reading exactly its own bits and no more.
+    #[test]
+    fn trie_round_trips_every_codeword() {
+        let trie = trie();
+        for (i, &(len, code, _, _, _)) in CODEBOOK.iter().enumerate() {
+            // Pack the codeword MSB-first into a buffer, padded with
+            // ones so a walk that reads too far lands somewhere else.
+            let mut bytes = vec![0xFFu8; 8];
+            for bit in 0..len {
+                let set = (code >> (len - 1 - bit)) & 1 == 1;
+                let (byte, offset) = (bit as usize / 8, 7 - (bit as usize % 8));
+                if set {
+                    bytes[byte] |= 1 << offset;
+                } else {
+                    bytes[byte] &= !(1 << offset);
+                }
+            }
+            let mut pump = BitPumpMsb::new(&bytes);
+            assert_eq!(trie.decode(&mut pump).unwrap(), i, "entry {i}");
+            assert_eq!(
+                pump.position(),
+                len as usize,
+                "entry {i} read the wrong bits"
+            );
+        }
+    }
+
+    /// The cubic companding curve: 0..255 expands onto 0..1023.
+    #[test]
+    fn companding_curve_matches_the_cubic() {
+        let curve = expand_curve();
+        assert_eq!(curve[0], 0);
+        assert_eq!(curve[255], 1023, "255 must reach 255 + 768");
+        for (m, value) in curve.iter().enumerate() {
+            let want = m as i64 + (768 * (m as i64).pow(3)) / (255i64.pow(3));
+            assert_eq!(*value as i64, want, "magnitude {m}");
+        }
+        // Monotonic, or dequantisation would fold distinct levels.
+        assert!(curve.windows(2).all(|w| w[0] < w[1]));
+    }
+
+    /// The decoder log curve, checked against the values the
+    /// specification's worked example quotes.
+    #[test]
+    fn log_curve_matches_the_worked_example() {
+        let curve = log_curve();
+        assert_eq!(curve[1217], 1799);
+        assert_eq!(curve[1843], 4326);
+        assert_eq!(curve[1963], 5056);
+        assert_eq!(curve[1781], 3987);
+        assert_eq!(curve[0], 0);
+        assert_eq!(curve[4095], 65535, "the curve must reach full scale");
+        assert!(curve.windows(2).all(|w| w[0] <= w[1]));
+    }
+
+    /// The §8 worked example, from component values to sensor codes:
+    /// the HERO8 frame's top-left quad.
+    #[test]
+    fn worked_example_component_transform() {
+        let curve = log_curve();
+        let quad = |gs: i32, rg: i32, bg: i32, gd: i32| {
+            let (rg, bg, gd) = (rg - MIDPOINT, bg - MIDPOINT, gd - MIDPOINT);
+            let look = |v: i32| curve[v.clamp(0, COMPONENT_MAX) as usize] >> 2;
+            (
+                look(2 * rg + gs),
+                look(gs + gd),
+                look(gs - gd),
+                look(2 * bg + gs),
+            )
+        };
+        // Component pixel (0, 0): GS 1903, RG 1705, BG 1987, GD 1988.
+        assert_eq!(quad(1903, 1705, 1987, 1988), (449, 1081, 1264, 996));
+        // Component pixel (1, 0), columns 2-3 of the same row pair.
+        assert_eq!(quad(1879, 1820, 1933, 2093), (609, 1202, 1069, 835));
+    }
+
+    /// `PrescaleShift` packs a 2-bit prescale per wavelet level; the
+    /// corpus value 0x2800 means the two coarse reconstructions each
+    /// shift a bit back up and the finest does not.
+    #[test]
+    fn prescale_unpacks_per_level() {
+        // The corpus value: the finest level does not shift, the two
+        // coarser reconstructions each shift two bits back up.
+        assert_eq!(descale_of(0x2800), [0, 2, 2]);
+        assert_eq!(descale_of(0x0000), [0, 0, 0]);
+        // Bits 14-15 are level 0, 12-13 level 1, 10-11 level 2.
+        assert_eq!(descale_of(0x8000), [2, 0, 0]);
+        assert_eq!(descale_of(0x2000), [0, 2, 0]);
+        assert_eq!(descale_of(0x0800), [0, 0, 2]);
+        // The shift is the prescale itself, so the field's other two
+        // values are one- and three-bit shifts. Nothing in the corpus
+        // uses them.
+        assert_eq!(descale_of(0x4000), [1, 0, 0]);
+        assert_eq!(descale_of(0xC000), [3, 0, 0]);
+    }
+
+    /// Band dimensions halve with a ceiling, which is what keeps the
+    /// Fusion frames' 1500 rows landing on 188 at the coarsest level.
+    #[test]
+    fn band_geometry_rounds_up() {
+        let hero = Geometry::of(2000, 1500);
+        assert_eq!(
+            hero.dims,
+            [(2000, 1500), (1000, 750), (500, 375), (250, 188)]
+        );
+        assert_eq!(hero.band(0), (250, 188));
+        assert_eq!(hero.band(3), (250, 188));
+        assert_eq!(hero.band(4), (500, 375));
+        assert_eq!(hero.band(6), (500, 375));
+        assert_eq!(hero.band(7), (1000, 750));
+        assert_eq!(hero.band(9), (1000, 750));
+        let fusion = Geometry::of(1552, 1500);
+        assert_eq!(
+            fusion.dims,
+            [(1552, 1500), (776, 750), (388, 375), (194, 188)]
+        );
+    }
+
+    /// A minimal header: the marker plus the tuples `parse` insists on,
+    /// with no codeblocks. Used to exercise the tag layer on its own.
+    fn header_stream(prescale: u16) -> Vec<u8> {
+        let mut out = b"VC-5".to_vec();
+        let mut tuple = |tag: u16, value: u16| {
+            out.extend_from_slice(&tag.to_be_bytes());
+            out.extend_from_slice(&value.to_be_bytes());
+        };
+        tuple(tag::CHANNEL_COUNT, 4);
+        tuple(tag::SUBBAND_COUNT, 10);
+        tuple(tag::IMAGE_WIDTH, 64);
+        tuple(tag::IMAGE_HEIGHT, 48);
+        tuple(tag::IMAGE_FORMAT, IMAGE_FORMAT_BAYER);
+        tuple(tag::PATTERN_WIDTH, 2);
+        tuple(tag::PATTERN_HEIGHT, 2);
+        tuple(tag::COMPONENTS_PER_SAMPLE, 1);
+        tuple(tag::MAX_BITS_PER_COMPONENT, 12);
+        tuple(tag::PRESCALE_SHIFT, prescale);
+        out
+    }
+
+    #[test]
+    fn rejects_a_sample_without_the_marker() {
+        let mut stream = header_stream(0x2800);
+        stream[0] = b'X';
+        assert!(matches!(parse(&stream), Err(Error::Corrupt(_))));
+    }
+
+    /// A header without its forty codeblocks is corrupt, not a frame of
+    /// zeros.
+    #[test]
+    fn rejects_a_sample_with_no_codeblocks() {
+        let error = parse(&header_stream(0x2800)).expect_err("no codeblocks");
+        assert!(matches!(error, Error::Corrupt(_)), "{error}");
+    }
+
+    /// The profiles the corpus never uses are refused by name rather
+    /// than decoded into nonsense.
+    #[test]
+    fn rejects_the_unused_profiles() {
+        let swap = |tag: u16, value: u16| {
+            let mut stream = header_stream(0x2800);
+            let mut at = 4;
+            while at + 4 <= stream.len() {
+                if u16::from_be_bytes([stream[at], stream[at + 1]]) == tag {
+                    stream[at + 2..at + 4].copy_from_slice(&value.to_be_bytes());
+                }
+                at += 4;
+            }
+            parse(&stream).expect_err("should be refused")
+        };
+        // Anything but Bayer, and any pattern that is not a 2x2 of one
+        // component, is a VC-5 profile this decoder does not implement.
+        assert!(matches!(swap(tag::IMAGE_FORMAT, 2), Error::Unsupported(_)));
+        assert!(matches!(swap(tag::PATTERN_WIDTH, 4), Error::Unsupported(_)));
+        assert!(matches!(
+            swap(tag::COMPONENTS_PER_SAMPLE, 3),
+            Error::Unsupported(_)
+        ));
+        assert!(matches!(swap(tag::CHANNEL_COUNT, 3), Error::Unsupported(_)));
+        assert!(matches!(swap(tag::SUBBAND_COUNT, 7), Error::Unsupported(_)));
+        // An odd frame cannot be a whole number of 2x2 quads.
+        assert!(matches!(swap(tag::IMAGE_WIDTH, 63), Error::Corrupt(_)));
+    }
+
+    /// The variants the corpus never uses are named rather than
+    /// decoded into the wrong colours.
+    #[test]
+    fn rejects_the_variants_this_decoder_does_not_implement() {
+        // A multi-layer sample (GoPro has never shipped one).
+        let mut stream = header_stream(0x2800);
+        stream.extend_from_slice(&tag::LAYER_COUNT.to_be_bytes());
+        stream.extend_from_slice(&2u16.to_be_bytes());
+        let error = parse(&stream).expect_err("multi-layer");
+        assert!(matches!(error, Error::Unsupported(_)), "{error}");
+
+        // An explicit inverse permutation or component transform would
+        // override the fixed Bayer scheme, so it cannot be skipped.
+        for chunk in [chunk::INVERSE_PERMUTATION, chunk::INVERSE_TRANSFORM] {
+            let mut stream = header_stream(0x2800);
+            stream.extend_from_slice(&chunk.to_be_bytes());
+            stream.extend_from_slice(&1u16.to_be_bytes());
+            let error = parse(&stream).expect_err("explicit transform");
+            assert!(matches!(error, Error::Unsupported(_)), "{error}");
+        }
+    }
+
+    /// A chunk walk that desynchronises still tends to find forty
+    /// codeblocks, so the ordering check is what catches it.
+    #[test]
+    fn rejects_codeblocks_that_are_out_of_order() {
+        let mut stream = header_stream(0x2800);
+        // Forty empty codeblocks, but every one claiming channel 0
+        // subband 0.
+        for _ in 0..CHANNELS * SUBBANDS {
+            stream.extend_from_slice(&0xA000u16.to_be_bytes());
+            stream.extend_from_slice(&0u16.to_be_bytes());
+        }
+        let error = parse(&stream).expect_err("all one subband");
+        assert!(matches!(error, Error::Corrupt(_)), "{error}");
+    }
+
+    /// The 2/6 filter's two boundary cases and its interior, checked by
+    /// hand against the lifting weights.
+    #[test]
+    fn lift_matches_the_2_6_weights() {
+        let low = [100, 200, 300, 400];
+        let high = [0, 0, 0, 0];
+        let mut out = [0i32; 8];
+        lift(&low, &high, &mut out, 0);
+        // Left border uses the one-sided 11,-4,1 and 5,4,-1 taps.
+        assert_eq!(out[0], ((11 * 100 - 4 * 200 + 300 + 4) >> 3) >> 1);
+        assert_eq!(out[1], ((5 * 100 + 4 * 200 - 300 + 4) >> 3) >> 1);
+        // Interior uses the neighbours either side.
+        assert_eq!(out[2], (200 + ((100 - 300 + 4) >> 3)) >> 1);
+        assert_eq!(out[3], (200 + ((300 - 100 + 4) >> 3)) >> 1);
+        // Right border mirrors the left.
+        assert_eq!(out[6], ((5 * 400 + 4 * 300 - 200 + 4) >> 3) >> 1);
+        assert_eq!(out[7], ((11 * 400 - 4 * 300 + 200 + 4) >> 3) >> 1);
+
+        // The highpass detail adds to the even output and subtracts
+        // from the odd, so a flat lowpass with one detail sample
+        // separates the pair symmetrically.
+        let mut detail = [0i32; 8];
+        lift(&[500, 500, 500, 500], &[0, 40, 0, 0], &mut detail, 0);
+        assert_eq!(detail[2], (500 + 40) >> 1);
+        assert_eq!(detail[3], (500 - 40) >> 1);
+
+        // An odd parent dimension simply drops the trailing sample.
+        let mut odd = [0i32; 7];
+        lift(&low, &high, &mut odd, 0);
+        assert_eq!(odd[..7], out[..7]);
+    }
+
+    /// A band smaller than the six-tap filter is refused rather than
+    /// indexed out of bounds.
+    #[test]
+    fn rejects_a_band_too_small_to_filter() {
+        let tiny = vec![0i32; 4];
+        let error = inverse_level(&tiny, &tiny, &tiny, &tiny, (2, 2), (4, 4), 0)
+            .expect_err("2x2 bands cannot feed a six-tap filter");
+        assert!(matches!(error, Error::Unsupported(_)), "{error}");
+    }
+
+    // ---------------------------------------------------------------
+    // Corpus. The GoPro samples under `$SCHIST_RAW_CORPUS` with their
+    // `.tiff` oracles beside them; the whole-file comparison lives in
+    // the DNG module's corpus test, so these check the VC-5 layer.
+    // ---------------------------------------------------------------
+
+    fn corpus_files() -> Vec<PathBuf> {
+        let Some(dir) = std::env::var_os("SCHIST_RAW_CORPUS").map(PathBuf::from) else {
+            return Vec::new();
+        };
+        let mut found = Vec::new();
+        let mut stack = vec![dir];
+        while let Some(at) = stack.pop() {
+            let Ok(entries) = std::fs::read_dir(&at) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    stack.push(path);
+                } else if path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .is_some_and(|e| e.eq_ignore_ascii_case("gpr"))
+                {
+                    found.push(path);
+                }
+            }
+        }
+        found.sort();
+        found
+    }
+
+    /// Every GPR's bitstream must resolve into exactly four channels of
+    /// ten subbands with the geometry the container advertises. This is
+    /// the checkpoint that catches a desynchronised chunk walk, which
+    /// is the failure mode the large-codeblock size encoding causes.
+    #[test]
+    fn corpus_bitstreams_parse() {
+        for path in corpus_files() {
+            let bytes = std::fs::read(&path).expect("read the sample");
+            let at =
+                find_sample(&bytes).unwrap_or_else(|| panic!("{}: no VC-5 marker", path.display()));
+            let (header, blocks) =
+                parse(&bytes[at..]).unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+            assert_eq!(blocks.len(), CHANNELS * SUBBANDS, "{}", path.display());
+            for (i, block) in blocks.iter().enumerate() {
+                assert_eq!(
+                    (block.channel as usize, block.subband as usize),
+                    (i / SUBBANDS, i % SUBBANDS),
+                    "{}: codeblocks out of order",
+                    path.display()
+                );
+            }
+            assert_eq!(header.descale, [0, 2, 2], "{}", path.display());
+            assert_eq!(header.width % 2, 0);
+            println!(
+                "{}: {}x{}, {} codeblocks",
+                path.display(),
+                header.width,
+                header.height,
+                blocks.len()
+            );
+        }
+    }
+
+    /// The specification's staged checkpoints on the HERO8 frame: the
+    /// coarsest lowpass band is a slowly varying DC image, the four
+    /// component planes hold the quoted values at (0, 0), and the
+    /// finished quad is 449 / 1081 / 1264 / 996.
+    #[test]
+    fn hero8_worked_example_end_to_end() {
+        let Some(path) = corpus_files()
+            .into_iter()
+            .find(|p| p.to_string_lossy().contains("GOPR0009"))
+        else {
+            return;
+        };
+        let bytes = std::fs::read(&path).expect("read the sample");
+        let at = find_sample(&bytes).expect("marker");
+        let (header, blocks) = parse(&bytes[at..]).expect("parse");
+        assert_eq!((header.width, header.height), (4000, 3000));
+
+        let geometry = Geometry::of(header.width / 2, header.height / 2);
+        assert_eq!(geometry.band(0), (250, 188));
+
+        // Checkpoint 3: channel 0's lowpass band, 250x188 of 16-bit
+        // values in the 7000-8500 range.
+        let lowpass = decode_lowpass(&blocks[0], 250, 188).expect("lowpass");
+        assert_eq!(lowpass.len(), 250 * 188);
+        // A DC image: every coefficient fits the 16-bit precision the
+        // header declares and the average sits in the range the
+        // specification quotes for this frame.
+        assert!(lowpass.iter().all(|v| (0..=65535).contains(v)));
+        let mean = lowpass.iter().map(|v| *v as i64).sum::<i64>() / lowpass.len() as i64;
+        assert!((6000..9000).contains(&mean), "lowpass mean {mean}");
+
+        // Checkpoints 4 and 5: the component planes and the quad.
+        let planes: Vec<Vec<i32>> = (0..CHANNELS)
+            .map(|channel| {
+                let mut bands: [Vec<i32>; SUBBANDS] = Default::default();
+                for subband in 0..SUBBANDS {
+                    let block = &blocks[channel * SUBBANDS + subband];
+                    let (w, h) = geometry.band(subband);
+                    bands[subband] = if subband == 0 {
+                        decode_lowpass(block, w, h).expect("lowpass")
+                    } else {
+                        decode_highpass(block, w, h).expect("highpass")
+                    };
+                }
+                reconstruct(&bands, &geometry, header.descale).expect("reconstruct")
+            })
+            .collect();
+        assert_eq!(
+            (planes[0][0], planes[1][0], planes[2][0], planes[3][0]),
+            (1903, 1705, 1987, 1988),
+            "component planes at (0, 0)"
+        );
+
+        let frame = decode(&bytes[at..], 4000, 3000, 2).expect("decode");
+        assert_eq!(frame.len(), 4000 * 3000);
+        // The specification quotes the reference frame's top-left 4x4.
+        let at4 = |x: usize, y: usize| frame[y * 4000 + x];
+        let corner: Vec<u16> = (0..4)
+            .flat_map(|y| (0..4).map(move |x| (x, y)))
+            .map(|(x, y)| at4(x, y))
+            .collect();
+        assert_eq!(
+            corner,
+            vec![
+                449, 1081, 609, 1202, 1264, 996, 1069, 835, 403, 1108, 463, 1087, 1171, 812, 1119,
+                890
+            ]
+        );
+    }
+
+    /// The tile of a GPR, located the same way the DNG module does but
+    /// without pulling the TIFF parser into this module's tests.
+    fn find_sample(bytes: &[u8]) -> Option<usize> {
+        bytes.windows(4).position(|w| w == b"VC-5")
+    }
+
+    /// Truncated and corrupted samples must return an error, never
+    /// panic and never allocate on a forged size.
+    #[test]
+    fn truncation_and_corruption_never_panic() {
+        for path in corpus_files() {
+            let bytes = std::fs::read(&path).expect("read the sample");
+            let Some(at) = find_sample(&bytes) else {
+                continue;
+            };
+            let stream = &bytes[at..];
+            // Each file's own frame: the Fusion is 3104 wide, and a
+            // wrong size is refused before any decoding happens.
+            let (w, h) = if path.to_string_lossy().contains("FUSION") {
+                (3104, 3000)
+            } else {
+                (4000, 3000)
+            };
+            for cut in 1..=16 {
+                let end = stream.len() * cut / 17;
+                let _ = decode(&stream[..end], w, h, 2);
+            }
+            // Flip bytes through the header and the first codeblock,
+            // where a forged chunk size would do the most damage.
+            for spot in [4, 8, 12, 36, 40, 100, 136, 140, 144, 1000, 50_000] {
+                if spot >= stream.len() {
+                    continue;
+                }
+                let mut broken = stream.to_vec();
+                broken[spot] ^= 0xFF;
+                let _ = decode(&broken, w, h, 2);
+                let mut broken = stream.to_vec();
+                broken[spot] = 0xA0;
+                let _ = decode(&broken, w, h, 2);
+            }
+        }
+    }
+}

--- a/crates/codec-raw/src/formats/x3f.rs
+++ b/crates/codec-raw/src/formats/x3f.rs
@@ -25,20 +25,34 @@
 //!    obfuscated, and decoding it is out of this module's scope:
 //!    `color_matrix` is left to the camera table.
 //!
-//! What this module does **not** do is the sensor data of any modern
-//! body. The Merrill's format 30 and the Quattro's format 35 are
-//! Foveon's "TRUE" codes, and the Quattro's top layer carries four
-//! times the resolution of the two below it — a frame that does not
-//! fit [`RawImage`]'s one-size-per-plane shape without a resampling
-//! policy this crate has not chosen. Both return
-//! [`Error::Unsupported`]; the preview and the metadata still come
-//! out, which is what a gallery needs from a file it cannot develop.
+//! The compressed sensor data is Foveon's "TRUE" entropy code. Two
+//! generations decode here:
 //!
-//! LibRaw 0.21 cannot read X3F at all, so there is no oracle frame
-//! for any of these files and nothing here is checked against one.
+//!  * **Merrill / TRUE-II** (format 30): three independent
+//!    full-resolution planes, each a category-Huffman + signed
+//!    difference bitstream over a two-parity horizontal predictor.
+//!  * **Quattro** (format 35, and the sd-Quattro 37/39/41 variants):
+//!    the same entropy engine, but the top layer is full resolution
+//!    while the two below it are quarter resolution. The top layer is
+//!    stored with a few overscan columns that are discarded; the two
+//!    quarter-resolution layers land on the even-row/even-column
+//!    lattice of the full frame, zero elsewhere — the exact shape of
+//!    the LibRaw oracle (colour/AF interpolation disabled).
+//!
+//! Both emit three samples a pixel, plane order {0 bottom, 1 middle,
+//! 2 top}, black/white left as metadata. Colour reconstruction (the
+//! CAMF matrices, the Quattro's R/G + AF interpolation) is out of
+//! scope: the camera table supplies the matrix.
+//!
+//! The pre-Merrill SD9/SD10/SD14 Huffman code (format 6/11) has no
+//! oracle sample here and stays [`Error::Unsupported`].
 
+use crate::bits::{BitPump, BitPumpMsb};
 use crate::tiff::Tiff;
-use crate::{Cfa, Error, Format, Metadata, Orientation, RawData, RawImage, Result};
+use crate::{
+    frame_samples, Cfa, Error, Format, Metadata, Orientation, RawData, RawImage, Rect, Result,
+};
+use rayon::prelude::*;
 
 /// Every X3F begins here.
 const MAGIC: &[u8; 4] = b"FOVb";
@@ -68,18 +82,24 @@ struct Image {
 mod formats {
     /// Three 16-bit samples a pixel, uncompressed.
     pub const PLAIN: u32 = 3;
-    /// The Huffman code of the SD9/SD10/SD14 era.
+    /// The Huffman code of the SD9/SD10/SD14 era (also seen as 6).
     pub const HUFFMAN: u32 = 11;
+    pub const HUFFMAN_OLD: u32 = 6;
     // 18 and 25 are the baseline JPEGs a camera writes for its
     // previews; they are recognised by their SOI rather than by
     // number, because the code varies with the body and any of them
     // may be the largest one.
-    /// Foveon's "TRUE" entropy code, on the DP/SD Merrill bodies.
+    /// Foveon's "TRUE" / "TRUE-II" entropy code, on the DP/SD Merrill
+    /// bodies (and the original SD1, which differs only in the section
+    /// `type` word — the engine is identical).
     pub const TRUE: u32 = 30;
-    pub const MERRILL: u32 = 32;
-    /// The Quattro's code, whose top layer is twice as wide and twice
-    /// as tall as the two below it.
+    /// The Quattro's code, whose top layer is full resolution over two
+    /// quarter-resolution layers. 37/39/41 are the sd-Quattro variants
+    /// of the same geometry.
     pub const QUATTRO: u32 = 35;
+    pub const SDQ_37: u32 = 37;
+    pub const SDQ_39: u32 = 39;
+    pub const SDQ_41: u32 = 41;
 }
 
 fn u32_at(bytes: &[u8], at: usize) -> Option<u32> {
@@ -293,6 +313,390 @@ impl Properties {
     }
 }
 
+// --- The TRUE / TRUE-II / Quattro entropy engine ------------------
+//
+// Both generations share one engine and differ only in plane
+// geometry. A layer is a category-Huffman stream: each Huffman symbol
+// `k` is a magnitude-bit count, and `k` bits then give a signed
+// difference (JPEG's DC rule: a leading 1 is the positive half, a
+// leading 0 the negative). Differences run through a two-parity
+// horizontal predictor, so each pixel predicts from the pixel two
+// columns to its left; the two leftmost columns of a row predict from
+// the two leftmost columns of the row two above (same parities).
+
+/// A little-endian reader that never runs past the buffer.
+fn take_u16(bytes: &[u8], off: &mut usize) -> Result<u16> {
+    let b = bytes
+        .get(*off..*off + 2)
+        .ok_or_else(|| Error::Corrupt("X3F TRUE header truncated".into()))?;
+    *off += 2;
+    Ok(u16::from_le_bytes([b[0], b[1]]))
+}
+
+fn take_u32(bytes: &[u8], off: &mut usize) -> Result<u32> {
+    let b = bytes
+        .get(*off..*off + 4)
+        .ok_or_else(|| Error::Corrupt("X3F TRUE header truncated".into()))?;
+    *off += 4;
+    Ok(u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+}
+
+/// A canonical "category" Huffman table, built from the file's byte
+/// pairs. The symbol value (a magnitude-bit count) is the pair's index
+/// in the table; the code is the top `L` bits of the code byte, MSB
+/// first. Decoding is a single flat lookup on the longest code length.
+struct Huff {
+    max_len: u32,
+    /// `1 << max_len` entries of `(symbol, code_length)`; a length of
+    /// zero marks an index no code reaches (an invalid bit pattern).
+    table: Vec<(u8, u8)>,
+}
+
+impl Huff {
+    /// `pairs[k] = (code length L, code byte C)`; `L == 0` never
+    /// appears here (the terminator is dropped by the caller).
+    fn build(pairs: &[(u8, u8)]) -> Result<Huff> {
+        let max_len = pairs.iter().map(|&(l, _)| l as u32).max().unwrap_or(0);
+        // A code is stored left-justified in one byte, so no length
+        // above eight can exist in this table whatever the coding
+        // could express in principle; a symbol is a magnitude bit
+        // count, so no sensor needs more than seventeen of them
+        // (0..=16). Both bounds keep the shifts below from underflowing
+        // and the bit reader's 32-bit reads in range.
+        if max_len == 0 || max_len > 8 || pairs.iter().any(|&(l, _)| l == 0) {
+            return Err(Error::Corrupt(format!(
+                "X3F Huffman code length {max_len} out of range"
+            )));
+        }
+        if pairs.len() > 17 {
+            return Err(Error::Corrupt(format!(
+                "X3F Huffman table of {} symbols; a difference has at most 16 bits",
+                pairs.len()
+            )));
+        }
+        let mut table = vec![(0u8, 0u8); 1usize << max_len];
+        for (symbol, &(l, c)) in pairs.iter().enumerate() {
+            let l = l as u32;
+            // The L-bit code, right-justified: the code byte holds it
+            // left-justified in eight bits.
+            let code = (c >> (8 - l)) as usize;
+            let shift = max_len - l;
+            let base = code << shift;
+            for slot in table.iter_mut().skip(base).take(1usize << shift) {
+                if slot.1 != 0 {
+                    return Err(Error::Corrupt(
+                        "X3F Huffman codes are not prefix-free".into(),
+                    ));
+                }
+                *slot = (symbol as u8, l as u8);
+            }
+        }
+        Ok(Huff { max_len, table })
+    }
+
+    /// The next symbol, or `None` on a bit pattern no code reaches.
+    #[inline]
+    fn decode(&self, pump: &mut BitPumpMsb) -> Option<u32> {
+        let (symbol, len) = self.table[pump.peek(self.max_len) as usize];
+        if len == 0 {
+            return None;
+        }
+        pump.consume(len as u32);
+        Some(symbol as u32)
+    }
+}
+
+/// One signed difference: a symbol `k`, then `k` magnitude bits under
+/// the leading-bit sign rule.
+#[inline]
+fn difference(pump: &mut BitPumpMsb, k: u32) -> i32 {
+    // The table builder bounds symbols at 16; the clamp makes that
+    // structural rather than a distant invariant.
+    let k = k.min(16);
+    if k == 0 {
+        return 0;
+    }
+    let v = pump.get(k) as i32;
+    if (v >> (k - 1)) & 1 == 1 {
+        v
+    } else {
+        v - ((1i32 << k) - 1)
+    }
+}
+
+/// Decode one layer's bitstream into its own `cols x ROWS` grid.
+///
+/// `slice` is the layer's bytes from its 16-byte-aligned start; the bit
+/// reader zero-fills past the end, so a stream that is exactly long
+/// enough decodes cleanly and a truncated one simply fails to find a
+/// code (returning `Err`) rather than reading out of bounds.
+fn decode_layer(
+    slice: &[u8],
+    huff: &Huff,
+    seed: i32,
+    cols: usize,
+    rows: usize,
+) -> Result<Vec<u16>> {
+    let n = frame_samples(cols, rows, 1)?;
+    let mut out = vec![0u16; n];
+    let mut pump = BitPumpMsb::new(slice);
+    // The 2x2 of left-edge seeds, one per (row parity, column parity),
+    // carries the two leftmost pixels down to the row two below.
+    let mut left = [[seed; 2]; 2];
+    for r in 0..rows {
+        // Two running predictors, one for even columns and one for odd.
+        let mut acc = [0i32; 2];
+        let row = &mut out[r * cols..(r + 1) * cols];
+        for (c, cell) in row.iter_mut().enumerate() {
+            let k = huff
+                .decode(&mut pump)
+                .ok_or_else(|| Error::Corrupt("X3F TRUE bitstream: no code matched".into()))?;
+            let diff = difference(&mut pump, k);
+            let predictor = if c < 2 {
+                left[r & 1][c & 1]
+            } else {
+                acc[c & 1]
+            };
+            let value = predictor.wrapping_add(diff);
+            acc[c & 1] = value;
+            if c < 2 {
+                left[r & 1][c & 1] = value;
+            }
+            // Values stay in the 14-bit sensor range by construction;
+            // `as u16` merely truncates a hostile stream's overflow
+            // rather than panicking.
+            *cell = value as u16;
+        }
+    }
+    Ok(out)
+}
+
+/// The parsed TRUE section header and the layer bitstream slices.
+struct TrueSection<'a> {
+    seeds: [i32; 3],
+    huff: Huff,
+    /// Each layer's own decode grid (columns, rows).
+    grids: [(usize, usize); 3],
+    /// The three layer bitstreams, each from its 16-byte-aligned start.
+    streams: [&'a [u8]; 3],
+    /// The declared compressed byte size of each layer (kept for tests
+    /// and diagnostics; the streams above are clamped to the section).
+    #[cfg_attr(not(test), allow(dead_code))]
+    sizes: [usize; 3],
+    /// True for the genuine Quattro geometry (layers 0/1 quarter-res);
+    /// false for Merrill and for a flat-layout Quattro (all full-res).
+    quattro: bool,
+}
+
+/// Parse everything between the 28-byte image header and the layer
+/// bitstreams: the optional Quattro plane table, the seeds, the
+/// per-file Huffman table, the plane byte sizes, and the 16-byte-padded
+/// layer addresses.
+fn parse_true<'a>(bytes: &'a [u8], raw: &Image, quattro_format: bool) -> Result<TrueSection<'a>> {
+    let cols = raw.columns;
+    let rows = raw.rows;
+    // Bound the header parse to the section's own bytes.
+    let section_end = raw
+        .data
+        .checked_add(raw.length)
+        .filter(|&e| e <= bytes.len())
+        .unwrap_or(bytes.len());
+    let mut off = raw.data;
+
+    // 2a: the Quattro plane table (skipped on Merrill).
+    let mut grids = [(cols, rows); 3];
+    let quattro = if quattro_format {
+        for grid in &mut grids {
+            let c = take_u16(bytes, &mut off)? as usize;
+            let r = take_u16(bytes, &mut off)? as usize;
+            *grid = (c, r);
+        }
+        // Layer 0 half-height is the true Quattro layout; full-height
+        // is a flat file whose engine is exactly Merrill's. Either
+        // way the table must describe *this* frame: the two lower
+        // layers alike, the top layer the frame's height and its
+        // width plus at most a small overscan. A table that says
+        // otherwise is a forgery sizing an allocation, not a camera.
+        let (c0, r0) = grids[0];
+        let quattro = if r0 == rows / 2 && c0 == cols / 2 {
+            true
+        } else if (c0, r0) == (cols, rows) {
+            false
+        } else {
+            return Err(Error::Corrupt(format!(
+                "X3F Quattro plane table: layer 0 is {c0}x{r0} for a {cols}x{rows} frame"
+            )));
+        };
+        // The top layer's overscan is a few hundred columns on the
+        // Quattro bodies (6272 for a 5888-wide frame); a quarter of
+        // the width bounds it without excluding a real back.
+        if grids[1] != grids[0]
+            || grids[2].1 != rows
+            || grids[2].0 < cols
+            || grids[2].0 > cols + cols / 4
+        {
+            return Err(Error::Corrupt(format!(
+                "X3F Quattro plane table {grids:?} does not describe a {cols}x{rows} frame"
+            )));
+        }
+        quattro
+    } else {
+        false
+    };
+
+    // 2b: seeds (three used, one reserved word).
+    let seeds = [
+        take_u16(bytes, &mut off)? as i32,
+        take_u16(bytes, &mut off)? as i32,
+        take_u16(bytes, &mut off)? as i32,
+    ];
+    let _reserved = take_u16(bytes, &mut off)?;
+
+    // 2c: the byte-pair Huffman table, read to the zero-length pair.
+    let mut pairs: Vec<(u8, u8)> = Vec::new();
+    loop {
+        let l = *bytes
+            .get(off)
+            .ok_or_else(|| Error::Corrupt("X3F Huffman table truncated".into()))?;
+        let c = *bytes
+            .get(off + 1)
+            .ok_or_else(|| Error::Corrupt("X3F Huffman table truncated".into()))?;
+        off += 2;
+        if l == 0 {
+            break;
+        }
+        pairs.push((l, c));
+        // A Foveon table is a dozen-odd codes; a runaway means a lost
+        // terminator in a corrupt file.
+        if pairs.len() > 256 {
+            return Err(Error::Corrupt("X3F Huffman table has no terminator".into()));
+        }
+    }
+    let huff = Huff::build(&pairs)?;
+
+    // 2d: a reserved word for Quattro/SDQ only.
+    if quattro_format {
+        let _unknown = take_u32(bytes, &mut off)?;
+    }
+
+    // 2e: the three compressed layer byte sizes.
+    let sizes = [
+        take_u32(bytes, &mut off)? as usize,
+        take_u32(bytes, &mut off)? as usize,
+        take_u32(bytes, &mut off)? as usize,
+    ];
+
+    // 2f: layer starts, each rounded up to a 16-byte boundary. The
+    // slices are clamped to the section so a lying size cannot reach
+    // past the file; the bit reader zero-fills any shortfall. Sizes
+    // that add up to more than the section is a lie outright.
+    let round16 = |n: usize| n.div_ceil(16) * 16;
+    // The last layer need not be padded, so the bound is the plain
+    // sum, not the rounded one.
+    let declared = sizes
+        .iter()
+        .try_fold(0usize, |acc, n| acc.checked_add(*n))
+        .ok_or_else(|| Error::Corrupt("X3F layer sizes overflow".into()))?;
+    if declared > section_end.saturating_sub(off) {
+        return Err(Error::Corrupt(format!(
+            "X3F layers declare {declared} bytes in a {}-byte section",
+            section_end.saturating_sub(off)
+        )));
+    }
+    let mut start = off;
+    let mut streams: [&[u8]; 3] = [&[]; 3];
+    for i in 0..3 {
+        let end = start.saturating_add(sizes[i]).min(section_end);
+        streams[i] = bytes.get(start..end).unwrap_or(&[]);
+        start = start.saturating_add(round16(sizes[i]));
+    }
+
+    Ok(TrueSection {
+        seeds,
+        huff,
+        grids,
+        streams,
+        sizes,
+        quattro,
+    })
+}
+
+/// Decode a TRUE section to the interleaved three-plane frame the rest
+/// of the crate expects: `(y * cols + x) * 3 + channel`, channel =
+/// layer = {0 bottom, 1 middle, 2 top}.
+fn decode_true(bytes: &[u8], raw: &Image, quattro_format: bool) -> Result<Vec<u16>> {
+    let (cols, rows) = (raw.columns, raw.rows);
+    let section = parse_true(bytes, raw, quattro_format)?;
+
+    let n = frame_samples(cols, rows, 3)?;
+    let mut data = vec![0u16; n];
+
+    // Decode the three layers independently, each on its own grid.
+    // They share nothing but the (read-only) Huffman table, so the
+    // three bitstreams decode in parallel.
+    let huff = &section.huff;
+    let planes: Vec<Vec<u16>> = (0..3)
+        .into_par_iter()
+        .map(|i| {
+            let (gc, gr) = section.grids[i];
+            decode_layer(section.streams[i], huff, section.seeds[i], gc, gr)
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    if section.quattro {
+        // Top layer: full resolution, its overscan columns (beyond
+        // `cols`) discarded. A well-formed file has `top_cols >= cols`
+        // and `top_rows == rows`; the `min`s keep a malformed one from
+        // reading past the decoded grid.
+        let (top_cols, top_rows) = section.grids[2];
+        let top = &planes[2];
+        for r in 0..rows.min(top_rows) {
+            let src = &top[r * top_cols..(r + 1) * top_cols];
+            for c in 0..cols.min(top_cols) {
+                data[(r * cols + c) * 3 + 2] = src[c];
+            }
+        }
+        // Bottom and middle layers: quarter resolution, placed on the
+        // even/even lattice with zeros left elsewhere (the oracle's
+        // shape; the odd positions are LibRaw's interpolation domain,
+        // which is out of scope).
+        for (channel, plane) in [(0usize, &planes[0]), (1usize, &planes[1])] {
+            let (gc, gr) = section.grids[channel];
+            for pr in 0..gr {
+                let fr = 2 * pr;
+                if fr >= rows {
+                    break;
+                }
+                for pc in 0..gc {
+                    let fc = 2 * pc;
+                    if fc >= cols {
+                        break;
+                    }
+                    data[(fr * cols + fc) * 3 + channel] = plane[pr * gc + pc];
+                }
+            }
+        }
+    } else {
+        // Merrill (and flat-layout Quattro): three full-resolution
+        // planes, one per channel, mapped one to one.
+        for (channel, plane) in planes.iter().enumerate() {
+            let (gc, gr) = section.grids[channel];
+            if gc != cols || gr != rows {
+                return Err(Error::Corrupt(format!(
+                    "X3F layer {channel} is {gc}x{gr} for a {cols}x{rows} frame"
+                )));
+            }
+            for r in 0..rows {
+                for c in 0..cols {
+                    data[(r * cols + c) * 3 + channel] = plane[r * cols + c];
+                }
+            }
+        }
+    }
+
+    Ok(data)
+}
+
 pub fn decode(bytes: &[u8]) -> Result<RawImage> {
     let sections = directory(bytes)?;
     let raw = sections
@@ -324,20 +728,20 @@ pub fn decode(bytes: &[u8]) -> Result<RawImage> {
                 .map(|b| u16::from_le_bytes(*b))
                 .collect()
         }
-        formats::HUFFMAN | formats::TRUE | formats::MERRILL => {
-            return Err(Error::Unsupported(format!(
-                "Foveon entropy-coded sensor data (X3F image format {}); the preview and \
-                 the metadata are still readable",
-                raw.format
-            )))
+        formats::TRUE => decode_true(bytes, &raw, false)?,
+        formats::QUATTRO | formats::SDQ_37 | formats::SDQ_39 | formats::SDQ_41 => {
+            decode_true(bytes, &raw, true)?
         }
-        formats::QUATTRO => {
-            return Err(Error::Unsupported(
-                "Foveon Quattro sensor data (X3F image format 35): the top layer has four \
-                 times the pixels of the two below it, which needs a resampling policy this \
-                 crate has not chosen"
-                    .into(),
-            ))
+        formats::HUFFMAN | formats::HUFFMAN_OLD => {
+            // The pre-Merrill SD9/SD10/SD14 code: a fixed coding table,
+            // an explicit per-row offset table, and the three colours
+            // interleaved in each row rather than split into planes.
+            // No oracle sample exists here, so it is not attempted.
+            return Err(Error::Unsupported(format!(
+                "Foveon SD9/SD10/SD14 Huffman sensor data (X3F image format {}); the preview \
+                 and the metadata are still readable",
+                raw.format
+            )));
         }
         other => return Err(Error::Unsupported(format!("X3F image format {other}"))),
     };
@@ -353,6 +757,40 @@ pub fn decode(bytes: &[u8]) -> Result<RawImage> {
         Cfa::None,
     );
     describe(bytes, &sections, &mut image);
+    // Levels and the active area the two generations use (spec §7);
+    // the file states neither in a place this module reads, and the
+    // camera table carries no Foveon entries, so the frame would
+    // otherwise develop against a 65535 white. The crop is applied
+    // only where it fits the frame.
+    let (black, white, crop) = match raw.format {
+        formats::TRUE => (
+            31.0,
+            3900.0,
+            Rect {
+                x: 12,
+                y: 0,
+                width: 4807,
+                height: 3205,
+            },
+        ),
+        _ => (
+            2047.0,
+            16383.0,
+            Rect {
+                x: 204,
+                y: 24,
+                width: 5446,
+                height: 3624,
+            },
+        ),
+    };
+    if image.white_level == 65535.0 {
+        image.black_levels = [black; 4];
+        image.white_level = white;
+    }
+    if crop.x + crop.width <= image.width && crop.y + crop.height <= image.height {
+        image.crop = crop;
+    }
     image.apply_camera_table();
     Ok(image)
 }
@@ -531,19 +969,201 @@ mod tests {
     }
 
     #[test]
-    fn the_true_codes_are_unsupported_by_name() {
-        for format in [
-            formats::HUFFMAN,
-            formats::TRUE,
-            formats::MERRILL,
-            formats::QUATTRO,
-        ] {
+    fn the_old_sd_huffman_is_unsupported_by_name() {
+        // SD9/SD10/SD14 (format 6/11) has no oracle sample and stays
+        // on the fallback; the modern TRUE/Quattro codes now decode.
+        for format in [formats::HUFFMAN, formats::HUFFMAN_OLD] {
             let file = build(1, format, 8, 8, &[0; 64]);
             match decode(&file) {
                 Err(Error::Unsupported(message)) => {
-                    assert!(message.contains("Foveon"), "{message}")
+                    assert!(message.contains("SD9"), "{message}")
                 }
                 other => panic!("format {format}: {other:?}"),
+            }
+        }
+    }
+
+    /// The Merrill worked Huffman table of the spec's Section 2c, as
+    /// `(code length, code byte)` pairs indexed by symbol.
+    const MERRILL_PAIRS: &[(u8, u8)] = &[
+        (3, 0x80),
+        (3, 0x40),
+        (3, 0x20),
+        (4, 0xC0),
+        (4, 0x60),
+        (4, 0xE0),
+        (4, 0x70),
+        (4, 0xF0),
+        (4, 0x10),
+        (4, 0xA0),
+        (5, 0xD0),
+        (6, 0xD8),
+        (6, 0xDC),
+    ];
+
+    #[test]
+    fn huffman_is_a_canonical_category_table() {
+        let huff = Huff::build(MERRILL_PAIRS).unwrap();
+        assert_eq!(huff.max_len, 6);
+        // Feed each code, MSB first, and read back its symbol (= the
+        // magnitude-bit count).
+        for (symbol, &(len, code)) in MERRILL_PAIRS.iter().enumerate() {
+            // A byte whose top `len` bits are the code, low bits set so
+            // the peek beyond the code cannot accidentally shorten it.
+            let bytes = [code | (0xFF >> len)];
+            let mut pump = BitPumpMsb::new(&bytes);
+            assert_eq!(
+                huff.decode(&mut pump).unwrap(),
+                symbol as u32,
+                "symbol {symbol}"
+            );
+            assert_eq!(pump.position(), len as usize);
+        }
+        // A prefix-free violation is rejected, not silently overwritten.
+        assert!(Huff::build(&[(1, 0x80), (2, 0x80)]).is_err());
+    }
+
+    #[test]
+    fn the_sign_rule_is_leading_bit() {
+        // k=9, V=26 (000011010): leading 0 → negative half.
+        let mut pump = BitPumpMsb::new(&[0b0000_1101, 0b0000_0000]);
+        assert_eq!(difference(&mut pump, 9), 26 - 511);
+        // k=4, V=11 (1011): leading 1 → positive half.
+        let mut pump = BitPumpMsb::new(&[0b1011_0000]);
+        assert_eq!(difference(&mut pump, 4), 11);
+        // k=0 consumes nothing and is zero.
+        let mut pump = BitPumpMsb::new(&[0xFF]);
+        assert_eq!(difference(&mut pump, 0), 0);
+        assert_eq!(pump.position(), 0);
+    }
+
+    /// Encode symbols and magnitudes MSB-first, the way a layer stream
+    /// is laid out, so a decode can be checked without a real file.
+    struct BitWriter {
+        bytes: Vec<u8>,
+        acc: u32,
+        nbits: u32,
+    }
+    impl BitWriter {
+        fn new() -> Self {
+            BitWriter {
+                bytes: Vec::new(),
+                acc: 0,
+                nbits: 0,
+            }
+        }
+        fn put(&mut self, value: u32, n: u32) {
+            for i in (0..n).rev() {
+                self.acc = (self.acc << 1) | ((value >> i) & 1);
+                self.nbits += 1;
+                if self.nbits == 8 {
+                    self.bytes.push(self.acc as u8);
+                    self.acc = 0;
+                    self.nbits = 0;
+                }
+            }
+        }
+        fn finish(mut self) -> Vec<u8> {
+            if self.nbits > 0 {
+                self.bytes.push((self.acc << (8 - self.nbits)) as u8);
+            }
+            self.bytes
+        }
+    }
+
+    /// Split a signed difference into the symbol (magnitude-bit count)
+    /// and the value bits the spec's Section 4 rule expects.
+    fn encode_diff(d: i32) -> (u32, u32) {
+        if d == 0 {
+            return (0, 0);
+        }
+        let k = 32 - (d.unsigned_abs()).leading_zeros();
+        let v = if d > 0 { d } else { d + ((1 << k) - 1) } as u32;
+        (k, v)
+    }
+
+    #[test]
+    fn the_predictor_reproduces_the_worked_first_row() {
+        // Spec Section 4/9, Merrill DP2M1726 layer 0 row 0.
+        let huff = Huff::build(MERRILL_PAIRS).unwrap();
+        let diffs = [-485, -485, 0, 0, 0, 0, 0, 0, 0, 11, 0, -4];
+        let want: [u16; 12] = [27, 27, 27, 27, 27, 27, 27, 27, 27, 38, 27, 34];
+
+        let mut writer = BitWriter::new();
+        for &d in &diffs {
+            let (k, v) = encode_diff(d);
+            let (len, code) = MERRILL_PAIRS[k as usize];
+            // The code, right-justified to its own length.
+            writer.put((code >> (8 - len)) as u32, len as u32);
+            writer.put(v, k);
+        }
+        let stream = writer.finish();
+        let plane = decode_layer(&stream, &huff, 512, diffs.len(), 1).unwrap();
+        assert_eq!(plane, want);
+    }
+
+    #[test]
+    fn quattro_maps_layers_onto_the_even_lattice() {
+        // A tiny synthetic Quattro: 4x2 frame, quarter-res 2x1 layers,
+        // full-res top 5 wide (one overscan column past the frame's 4).
+        // The one-symbol Huffman table maps every code to symbol 0
+        // (zero-magnitude), so every difference is 0 and every decoded
+        // pixel is the seed 512 — leaving only the placement rule for
+        // the assertions to read.
+        let (cols, rows) = (4usize, 2usize);
+        // Header: plane table (2x1, 2x1, 3x2), seeds, huff, quattro
+        // word, three sizes, then three 16-aligned all-"1"-bit streams.
+        let ones = |n: usize| vec![0xFFu8; n];
+        let mut payload = Vec::new();
+        for (c, r) in [(2u16, 1u16), (2, 1), (5, 2)] {
+            payload.extend_from_slice(&c.to_le_bytes());
+            payload.extend_from_slice(&r.to_le_bytes());
+        }
+        payload.extend_from_slice(&512u16.to_le_bytes()); // seeds (unused: seed passed below)
+        payload.extend_from_slice(&512u16.to_le_bytes());
+        payload.extend_from_slice(&512u16.to_le_bytes());
+        payload.extend_from_slice(&0u16.to_le_bytes());
+        payload.extend_from_slice(&[1, 0x80, 0, 0]); // huff: (1,0x80) then terminator
+        payload.extend_from_slice(&0u32.to_le_bytes()); // quattro reserved word
+                                                        // sizes: layer0/1 are 2 pixels (2 bits → 1 byte); layer2 is 10
+                                                        // pixels (10 bits → 2 bytes).
+        let sizes = [1u32, 1, 2];
+        for sz in sizes {
+            payload.extend_from_slice(&sz.to_le_bytes());
+        }
+        let start = payload.len();
+        // Each layer's "all-ones" stream from its 16-byte-aligned start.
+        payload.extend(ones(1));
+        payload.resize(start + 16, 0);
+        payload.extend(ones(1));
+        payload.resize(start + 32, 0);
+        payload.extend(ones(2));
+
+        let raw = Image {
+            kind: 1,
+            format: formats::QUATTRO,
+            columns: cols,
+            rows,
+            data: 0,
+            length: payload.len(),
+        };
+        let section = parse_true(&payload, &raw, true).unwrap();
+        assert!(section.quattro);
+        assert_eq!(section.sizes, [1, 1, 2]);
+        assert_eq!(section.grids, [(2, 1), (2, 1), (5, 2)]);
+        let data = decode_true(&payload, &raw, true).unwrap();
+        // Plane 2 (top) is full resolution: every pixel = 512.
+        for r in 0..rows {
+            for c in 0..cols {
+                assert_eq!(data[(r * cols + c) * 3 + 2], 512, "top ({r},{c})");
+            }
+        }
+        // Planes 0/1 populate only the even/even lattice.
+        for r in 0..rows {
+            for c in 0..cols {
+                let want = if r % 2 == 0 && c % 2 == 0 { 512 } else { 0 };
+                assert_eq!(data[(r * cols + c) * 3], want, "bottom ({r},{c})");
+                assert_eq!(data[(r * cols + c) * 3 + 1], want, "middle ({r},{c})");
             }
         }
     }
@@ -587,9 +1207,121 @@ mod tests {
         }
     }
 
+    /// The Foveon oracle TIFF: 16-bit RGB, three samples a pixel,
+    /// interleaved in the same `(y*w+x)*3+channel` order this module
+    /// emits. Read with the crate's own TIFF parser (the `image`
+    /// crate's default allocation limit refuses the ~130 MB frames).
+    fn oracle3(path: &std::path::Path) -> Option<(usize, usize, Vec<u16>)> {
+        let mut name = path.as_os_str().to_os_string();
+        name.push(".tiff");
+        let bytes = std::fs::read(&name).ok()?;
+        let tiff = crate::tiff::Tiff::parse(&bytes).ok()?;
+        let layout = crate::tiff::ImageLayout::of(&tiff, tiff.root()).ok()?;
+        if layout.bits_per_sample != 16 || layout.samples_per_pixel != 3 {
+            panic!(
+                "{}: oracle is {} bits x {} samples, expected 16x3",
+                path.display(),
+                layout.bits_per_sample,
+                layout.samples_per_pixel
+            );
+        }
+        let le = tiff.little_endian();
+        let mut out = Vec::with_capacity(layout.width * layout.height * 3);
+        for (start, len) in &layout.chunks {
+            out.extend(
+                bytes[*start..*start + *len]
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .map(|b| {
+                        if le {
+                            u16::from_le_bytes(*b)
+                        } else {
+                            u16::from_be_bytes(*b)
+                        }
+                    }),
+            );
+        }
+        out.truncate(layout.width * layout.height * 3);
+        Some((layout.width, layout.height, out))
+    }
+
+    /// Assert the spec's worked intermediate values for the two primary
+    /// files — plane byte sizes, first-row layer values, and (Quattro)
+    /// the active-crop corner — before the full oracle comparison.
+    fn worked_checks(name: &str, bytes: &[u8]) {
+        let sections = directory(bytes).unwrap();
+        let raw = sections
+            .iter()
+            .filter(|s| s.kind == *b"IMA2")
+            .filter_map(|s| image(bytes, s))
+            .find(|i| i.kind == 1)
+            .unwrap();
+        match name {
+            "SIGMA_DP2_Merrill-DP2M1726.X3F" => {
+                let section = parse_true(bytes, &raw, false).unwrap();
+                assert_eq!(
+                    section.sizes,
+                    [14938353, 16704166, 17228647],
+                    "{name} sizes"
+                );
+                assert!(!section.quattro);
+                let l0 = decode_layer(section.streams[0], &section.huff, section.seeds[0], 4928, 1)
+                    .unwrap();
+                assert_eq!(&l0[..12], &[27, 27, 27, 27, 27, 27, 27, 27, 27, 38, 27, 34]);
+                let l1 = decode_layer(section.streams[1], &section.huff, section.seeds[1], 4928, 1)
+                    .unwrap();
+                assert_eq!((l1[0], l1[1], l1[9], l1[10]), (27, 27, 29, 39));
+                let l2 = decode_layer(section.streams[2], &section.huff, section.seeds[2], 4928, 1)
+                    .unwrap();
+                assert_eq!((l2[0], l2[1], l2[9], l2[11]), (31, 31, 30, 32));
+            }
+            "DP0_Quattro-_SDI0263.X3F" => {
+                let section = parse_true(bytes, &raw, true).unwrap();
+                assert_eq!(section.sizes, [6831306, 6927865, 29012749], "{name} sizes");
+                assert!(section.quattro);
+                assert_eq!(section.grids, [(2944, 1836), (2944, 1836), (6272, 3672)]);
+                let l0 = decode_layer(section.streams[0], &section.huff, section.seeds[0], 2944, 1)
+                    .unwrap();
+                assert_eq!(&l0[..6], &[2198, 2026, 2044, 2047, 2049, 2061]);
+                let l1 = decode_layer(section.streams[1], &section.huff, section.seeds[1], 2944, 1)
+                    .unwrap();
+                assert_eq!(&l1[..3], &[2125, 2040, 2036]);
+                let l2 = decode_layer(section.streams[2], &section.huff, section.seeds[2], 6272, 1)
+                    .unwrap();
+                assert_eq!(&l2[..3], &[2087, 2039, 2044]);
+
+                // The mapped full frame: plane 0 on the even lattice,
+                // plane 2 full-res, and the active-crop corner values.
+                let (cols, rows) = (5888usize, 3672usize);
+                let data = decode_true(bytes, &raw, true).unwrap();
+                let p0 = |r: usize, c: usize| data[(r * cols + c) * 3];
+                let p2 = |r: usize, c: usize| data[(r * cols + c) * 3 + 2];
+                assert_eq!(
+                    [p0(0, 0), p0(0, 1), p0(0, 2), p0(0, 3), p0(0, 4)],
+                    [2198, 0, 2026, 0, 2044]
+                );
+                assert!(
+                    (0..cols).all(|c| p0(1, c) == 0),
+                    "plane 0 row 1 is all zero"
+                );
+                assert_eq!([p2(0, 0), p2(0, 1), p2(0, 2)], [2087, 2039, 2044]);
+                let _ = rows;
+                // Active crop origin (top 24, left 204).
+                assert_eq!([p0(24, 204), p0(24, 206)], [2641, 2654]);
+                assert_eq!([p2(24, 204), p2(24, 205), p2(24, 206)], [2981, 2968, 2998]);
+            }
+            _ => {}
+        }
+    }
+
     #[test]
-    fn corpus_previews_and_metadata() {
+    fn corpus_decodes_against_the_oracle() {
         let files = corpus::files(&["x3f"]);
+        // Every corpus file has an oracle and must decode exactly; no
+        // file is legitimately unsupported here (the SD9/10/14 code has
+        // no sample). Any format that ends up unsupported is listed.
+        let allow_unsupported: &[&str] = &[];
         for path in &files {
             let bytes = std::fs::read(path).unwrap();
             let name = corpus::name(path);
@@ -598,10 +1330,8 @@ mod tests {
                 Some(Format::X3f),
                 "{name} did not probe as X3F"
             );
-            // No LibRaw build reads X3F, so there is no oracle frame
-            // for any of these: the checks are the ones that can be
-            // made without one.
-            let (make, model, metadata, jpeg) = super::metadata(&bytes).unwrap();
+
+            let (make, model, _meta, jpeg) = super::metadata(&bytes).unwrap();
             assert_eq!(make, "SIGMA", "{name}: make");
             assert!(model.starts_with("SIGMA"), "{name}: model {model:?}");
             let jpeg = jpeg.unwrap_or_else(|| panic!("{name}: no preview"));
@@ -609,19 +1339,73 @@ mod tests {
                 .unwrap_or_else(|e| panic!("{name}: preview will not decode: {e}"));
             assert!(
                 decoded.width() >= 640,
-                "{name}: preview is only {}px wide",
+                "{name}: preview {}px",
                 decoded.width()
             );
             assert_eq!(preview(&bytes).unwrap(), Some(jpeg), "{name}");
-            match decode(&bytes) {
-                Ok(raw) => raw.validate().unwrap_or_else(|e| panic!("{name}: {e}")),
-                Err(Error::Unsupported(message)) => {
-                    eprintln!("{name}: {model}, {metadata:?} — unsupported: {message}")
+
+            worked_checks(&name, &bytes);
+
+            let raw = match decode(&bytes) {
+                Ok(raw) => raw,
+                Err(Error::Unsupported(msg)) if allow_unsupported.contains(&name.as_str()) => {
+                    eprintln!("{name}: unsupported (allowed): {msg}");
+                    continue;
                 }
                 Err(e) => panic!("{name}: {e}"),
+            };
+            raw.validate().unwrap_or_else(|e| panic!("{name}: {e}"));
+            assert_eq!(raw.cpp, 3, "{name}: cpp");
+            assert_eq!(raw.cfa, Cfa::None, "{name}");
+
+            if let Some((w, h, oracle)) = oracle3(path) {
+                assert_eq!((raw.width, raw.height), (w, h), "{name}: dimensions");
+                let RawData::U16(data) = &raw.data else {
+                    panic!("{name}: not U16")
+                };
+                assert_eq!(data.len(), oracle.len(), "{name}: sample count");
+                let mut mismatches = 0usize;
+                let mut first = Vec::new();
+                for (i, (&got, &want)) in data.iter().zip(&oracle).enumerate() {
+                    if got != want {
+                        mismatches += 1;
+                        if first.len() < 8 {
+                            let px = i / 3;
+                            first.push(format!(
+                                "({},{}) ch{}: {got} != {want}",
+                                px % w,
+                                px / w,
+                                i % 3
+                            ));
+                        }
+                    }
+                }
+                assert_eq!(
+                    mismatches,
+                    0,
+                    "{name}: {mismatches}/{} samples differ, first: {first:?}",
+                    data.len()
+                );
+                eprintln!("x3f: {name} matches oracle ({w}x{h}x3)");
+            } else {
+                panic!("{name}: no oracle TIFF present");
             }
         }
         eprintln!("x3f: {} corpus files checked", files.len());
+    }
+
+    /// The file cut at `cut` with its directory carried over and the
+    /// pointer fixed, so the cut lands inside the image section rather
+    /// than in the directory, which a plain truncation always destroys
+    /// first (the pointer is the file's last four bytes).
+    fn cut_keeping_directory(bytes: &[u8], cut: usize) -> Vec<u8> {
+        let dir = u32::from_le_bytes(bytes[bytes.len() - 4..].try_into().unwrap()) as usize;
+        let directory = &bytes[dir..bytes.len() - 4];
+        let mut out = bytes[..cut.min(dir)].to_vec();
+        let new_dir = out.len() as u32;
+        out.extend_from_slice(directory);
+        out.extend_from_slice(&new_dir.to_le_bytes());
+        out
     }
 
     #[test]
@@ -633,6 +1417,28 @@ mod tests {
             };
             for cut in [0, 1, 4, 64, 1024, bytes.len() / 2, bytes.len() - 1] {
                 let _ = preview(&bytes[..cut.min(bytes.len())]);
+            }
+            // Cuts inside the sensor section: the entropy decoder must
+            // see short layers and a short header, not just a missing
+            // directory.
+            for fraction in [2, 3, 5, 10, 50, 200, 1000] {
+                let cut = bytes.len() - bytes.len() / fraction;
+                let short = cut_keeping_directory(&bytes, cut);
+                match decode(&short) {
+                    Ok(_) | Err(Error::Corrupt(_)) | Err(Error::Unsupported(_)) => {}
+                    Err(other) => panic!("{}: {other:?}", path.display()),
+                }
+            }
+            // And a forged Huffman table: a code length past eight and
+            // a table of too many symbols must be refused, not indexed.
+            for (len, syms) in [(9u8, 12usize), (3, 40), (24, 12), (0, 12)] {
+                let pairs: Vec<(u8, u8)> = (0..syms)
+                    .map(|i| (len, (i as u8).wrapping_mul(17)))
+                    .collect();
+                assert!(
+                    Huff::build(&pairs).is_err(),
+                    "length {len} x {syms} symbols"
+                );
             }
         }
     }

--- a/crates/codec-raw/src/ljpeg.rs
+++ b/crates/codec-raw/src/ljpeg.rs
@@ -56,14 +56,41 @@ struct Header {
     tables: [Option<HuffTable>; 4],
     /// Which table each scan component reads its differences with.
     component_tables: [usize; 4],
+    /// Each frame component's sampling-factor byte: high nibble the
+    /// horizontal factor, low nibble the vertical. `0x11` on every
+    /// component is an ordinary frame, which is all that
+    /// [`decode`] and [`header`] accept; Canon's mRAW puts `0x22` and
+    /// its sRAW `0x21` on the luma component, and both are decoded by
+    /// [`decode_subsampled`].
+    sampling: [u8; 4],
     /// Offset of the first entropy-coded byte.
     scan_start: usize,
+}
+
+impl Header {
+    /// The first component whose sampling factors are not 1:1, if any.
+    fn subsampled(&self) -> Option<(usize, u8)> {
+        (0..self.components)
+            .map(|c| (c, self.sampling[c]))
+            .find(|(_, factor)| *factor != 0x11)
+    }
+
+    /// The error the 1:1 entry points answer a subsampled frame with.
+    fn refuse_subsampling(&self) -> Result<()> {
+        match self.subsampled() {
+            Some((c, factor)) => Err(Error::Unsupported(format!(
+                "lossless JPEG component {c} with sampling factors {factor:#04x} (Canon sRAW/mRAW)"
+            ))),
+            None => Ok(()),
+        }
+    }
 }
 
 /// Decode a complete lossless JPEG stream (SOI through EOI; trailing
 /// bytes ignored).
 pub fn decode(bytes: &[u8]) -> Result<LjpegImage> {
     let header = parse(bytes, false)?;
+    header.refuse_subsampling()?;
     let samples = header
         .width
         .checked_mul(header.height)
@@ -130,6 +157,7 @@ pub fn decode(bytes: &[u8]) -> Result<LjpegImage> {
 /// callers that size their output before decoding. `data` is empty.
 pub fn header(bytes: &[u8]) -> Result<LjpegImage> {
     let header = parse(bytes, true)?;
+    header.refuse_subsampling()?;
     Ok(LjpegImage {
         width: header.width,
         height: header.height,
@@ -173,6 +201,7 @@ fn parse(bytes: &[u8], header_only: bool) -> Result<Header> {
     let mut height = 0usize;
     let mut components = 0usize;
     let mut ids = [0u8; 4];
+    let mut sampling = [0x11u8; 4];
     let mut restart_interval = 0usize;
     let mut tables: [Option<HuffTable>; 4] = [None, None, None, None];
 
@@ -260,19 +289,12 @@ fn parse(bytes: &[u8], header_only: bool) -> Result<Header> {
                     let spec = &payload[6 + c * 3..9 + c * 3];
                     ids[c] = spec[0];
                     // Subsampling has no meaning for a lossless frame
-                    // and nothing writes it, but a file that claims it
-                    // would decode to nonsense if it were ignored.
-                    if spec[1] != 0x11 {
-                        // Canon's sRAW and mRAW are the only raw
-                        // streams that do this: a subsampled YCbCr
-                        // lossless frame. Decoding it needs the MCU
-                        // interleave rules and a chroma upsampler,
-                        // neither of which belongs here yet.
-                        return Err(Error::Unsupported(format!(
-                            "lossless JPEG component {c} with sampling factors {:#04x} (Canon sRAW/mRAW)",
-                            spec[1]
-                        )));
-                    }
+                    // and only Canon's sRAW and mRAW write it. The
+                    // factors are recorded rather than refused here so
+                    // that [`decode_subsampled`] can read them; the
+                    // 1:1 entry points refuse them on the way out, so
+                    // nothing that used to decode changes.
+                    sampling[c] = spec[1];
                 }
             }
             // Any other SOFn is a different JPEG process entirely.
@@ -377,6 +399,7 @@ fn parse(bytes: &[u8], header_only: bool) -> Result<Header> {
                     restart_interval,
                     tables,
                     component_tables,
+                    sampling,
                     scan_start: next,
                 });
             }
@@ -553,6 +576,282 @@ fn find_restart(scan: &[u8], from: usize, expected: u8) -> Result<usize> {
     Err(Error::Corrupt(
         "the scan ends before its next restart marker".into(),
     ))
+}
+
+// ------------------------------------------------- Canon sRAW / mRAW
+
+/// A decoded Canon sRAW or mRAW frame, in the "widened component"
+/// layout its entropy coder uses.
+///
+/// The stream is not a textbook subsampled JPEG with a sampling map per
+/// component. Every minimum coded unit is instead a fixed run of
+/// [`SubsampledImage::components`] samples describing one *block* of
+/// output pixels that share a chroma pair: `components - 2` luma, then
+/// Cb, then Cr. A block is two pixels wide, and one or two rows tall
+/// depending on the vertical factor. Putting those blocks back where
+/// they belong needs the container's slice tag, so — as with the 1:1
+/// path — this module hands the samples back in stream order and lets
+/// the CR2 module place them.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SubsampledImage {
+    /// The luma width the frame header declares: the widest the
+    /// reassembled picture can be before the container's slices trim
+    /// it. Always even.
+    pub width: usize,
+    /// The luma height, which is the picture's height.
+    pub height: usize,
+    /// Canon's "sraw parameter": `1` when the luma is sampled 2x1 and
+    /// `3` when it is sampled 2x2. Components `0..=p` of an MCU are
+    /// luma and the last two are Cb and Cr, so `p` doubles as the
+    /// index of the last luma component.
+    pub p: usize,
+    /// Samples one MCU carries, `3 + p`.
+    pub components: usize,
+    /// Output rows one MCU covers: 1 for 2x1, 2 for 2x2.
+    pub block_rows: usize,
+    /// Samples one entropy row holds, `(width / 2) * components`.
+    pub row: usize,
+    /// Entropy rows in `data`, `height / block_rows`.
+    pub rows: usize,
+    pub precision: u32,
+    /// `rows * row` samples, MCU by MCU in stream order.
+    pub data: Vec<u16>,
+}
+
+/// The sampling-factor byte of a lossless JPEG's first component:
+/// `0x11` for every ordinary raw, `0x21` or `0x22` for Canon's sRAW and
+/// mRAW. Lets a container decide which decoder to call without having
+/// to catch an error from [`header`], which refuses subsampled frames.
+pub fn sampling(bytes: &[u8]) -> Result<u8> {
+    Ok(parse(bytes, true)?.sampling[0])
+}
+
+/// Decode a Canon sRAW or mRAW stream. Ordinary 1:1 frames are refused:
+/// they belong to [`decode`].
+pub fn decode_subsampled(bytes: &[u8]) -> Result<SubsampledImage> {
+    let header = parse(bytes, false)?;
+    // Three components (Y, Cb, Cr) is the only shape Canon writes, and
+    // the two chroma planes are never themselves subsampled.
+    if header.components != 3 {
+        return Err(Error::Unsupported(format!(
+            "a subsampled lossless JPEG with {} components; Canon sRAW has three",
+            header.components
+        )));
+    }
+    if header.sampling[1] != 0x11 || header.sampling[2] != 0x11 {
+        return Err(Error::Unsupported(
+            "a lossless JPEG that subsamples its chroma components as well as its luma".into(),
+        ));
+    }
+    if !matches!(header.sampling[0], 0x21 | 0x22) {
+        return Err(Error::Unsupported(format!(
+            "lossless JPEG luma sampling factors {:#04x}; Canon sRAW uses 0x21 or 0x22",
+            header.sampling[0]
+        )));
+    }
+    // Canon writes predictor 1 (plain left) on every subsampled frame,
+    // and the luma chain in `decode_subsampled_scan` *is* that rule.
+    // Any other selection value would need T.81's vertical terms mixed
+    // into the chain, which nothing has written and nothing has been
+    // measured against, so it is refused rather than guessed at.
+    if header.predictor != 1 {
+        return Err(Error::Unsupported(format!(
+            "a subsampled lossless JPEG with predictor {}; Canon sRAW uses 1",
+            header.predictor
+        )));
+    }
+    // No subsampled frame in the corpus carries a DRI. Honouring one
+    // would need a restart that falls mid-row to re-seed the predictors
+    // without disturbing the running row-head values — which double as
+    // the vertical predictor down the first column — and an interval
+    // that does not divide the MCUs per row would otherwise corrupt the
+    // MCU after every restart. Refusing the stream is the only
+    // implementation that cannot be silently wrong.
+    if header.restart_interval != 0 {
+        return Err(Error::Unsupported(format!(
+            "a subsampled lossless JPEG with a restart interval of {} MCUs; no Canon sRAW writes one",
+            header.restart_interval
+        )));
+    }
+    // P = (H*V - 1) & 3, so 2x1 gives 1 and 2x2 gives 3. Canon masks it
+    // to two bits and no other factor pair occurs.
+    let (h, v) = (
+        (header.sampling[0] >> 4) as usize,
+        (header.sampling[0] & 0x0F) as usize,
+    );
+    let p = (h * v - 1) & 3;
+    let components = 3 + p;
+    // 2x2 blocks are two rows tall, 2x1 blocks one.
+    let block_rows = p.div_ceil(2);
+    if header.width % 2 != 0 {
+        return Err(Error::Corrupt(format!(
+            "a subsampled lossless JPEG {} samples wide; blocks are two pixels wide",
+            header.width
+        )));
+    }
+    if !header.height.is_multiple_of(block_rows) {
+        return Err(Error::Corrupt(format!(
+            "a subsampled lossless JPEG {} rows tall, which {block_rows}-row blocks cannot tile",
+            header.height
+        )));
+    }
+    let blocks = header.width / 2;
+    let rows = header.height / block_rows;
+    // The same ceiling the rest of the crate sizes frames with, so a
+    // forged header cannot ask for an unbounded allocation.
+    let samples = crate::frame_samples(blocks, rows, components)?;
+    if samples > MAX_SAMPLES {
+        return Err(Error::Unsupported(format!(
+            "a subsampled lossless JPEG of {samples} samples is larger than this decoder allows"
+        )));
+    }
+    let row = blocks * components;
+
+    let scan = &bytes[header.scan_start..];
+    if (scan.len() as u64).saturating_mul(8) < samples as u64 {
+        return Err(Error::Corrupt(format!(
+            "subsampled lossless JPEG scan holds {} bytes for {samples} samples",
+            scan.len()
+        )));
+    }
+
+    // The scan lists three components; the MCU wants `components` of
+    // them. Canon gives the luma one table and both chroma the other,
+    // so the run is just those three stretched to the MCU's length.
+    let scan_tables = scan_tables(&header)?;
+    let tables: Vec<&HuffTable> = (0..components)
+        .map(|c| {
+            if c <= p {
+                scan_tables[0]
+            } else if c == components - 2 {
+                scan_tables[1]
+            } else {
+                scan_tables[2]
+            }
+        })
+        .collect();
+
+    let mut data = vec![0u16; samples];
+    decode_subsampled_scan(
+        scan,
+        &header,
+        &tables,
+        &Shape {
+            p,
+            components,
+            blocks,
+            rows,
+            row,
+        },
+        &mut data,
+    );
+    if header.point_transform > 0 {
+        for sample in &mut data {
+            *sample <<= header.point_transform;
+        }
+    }
+
+    Ok(SubsampledImage {
+        width: header.width,
+        height: header.height,
+        p,
+        components,
+        block_rows,
+        row,
+        rows,
+        precision: header.precision,
+        data,
+    })
+}
+
+/// The MCU geometry `decode_subsampled_scan` walks.
+struct Shape {
+    p: usize,
+    components: usize,
+    blocks: usize,
+    rows: usize,
+    row: usize,
+}
+
+/// The entropy decode.
+///
+/// Three prediction rules share the loop, and which one applies is what
+/// makes this different from the 1:1 scan:
+///
+/// * The luma samples of an MCU are a chain. Every one of them except
+///   the very first sample of an entropy row predicts from `last_luma`,
+///   the last luma reconstructed — so the `p + 1` luma of a block
+///   continue from the previous block's last luma and the whole row of
+///   luma is one left-to-right chain. The chroma samples never disturb
+///   it.
+/// * Chroma predicts from the same component of the previous MCU,
+///   `components` samples back.
+/// * At the first MCU of a row there is nothing to the left, so the
+///   first luma and both chroma predict from a running value of their
+///   own. Because it is only ever advanced at the first MCU of a row,
+///   it holds what that component held one entropy row above, which is
+///   exactly the vertical prediction T.81 asks for down the first
+///   column. Only those three samples ever read it: the other luma of
+///   the head MCU follow the chain like any other.
+///
+/// The scan's own predictor selection value is 1 (plain left) on every
+/// sRAW Canon has written, and that is what the chain above computes;
+/// [`decode_subsampled`] refuses any other value, and any restart
+/// interval, before this runs, so nothing here can fail.
+fn decode_subsampled_scan(
+    scan: &[u8],
+    header: &Header,
+    tables: &[&HuffTable],
+    shape: &Shape,
+    out: &mut [u16],
+) {
+    let bits = header.precision - header.point_transform;
+    // Samples are kept to `bits` bits, T.81's "modulo 2^P": the
+    // differences were taken that way.
+    let mask = ((1u32 << bits) - 1) as i32;
+    let initial = 1i32 << (bits - 1);
+    let Shape {
+        p,
+        components,
+        blocks,
+        rows,
+        row,
+    } = *shape;
+
+    // The running values the head of each row predicts from: the
+    // first luma, Cb and Cr, in that order.
+    let mut heads = [initial; 3];
+    let mut pump = BitPumpJpeg::new(scan);
+
+    for r in 0..rows {
+        let row_start = r * row;
+        let mut last_luma = 0i32;
+        for col in 0..blocks {
+            // The head of a row has no left neighbour.
+            let head = col == 0;
+            let at = row_start + col * components;
+            for c in 0..components {
+                let diff = tables[c].decode_diff(&mut pump);
+                let prediction = if c <= p && !(head && c == 0) {
+                    last_luma
+                } else if !head {
+                    out[at - components + c] as i32
+                } else {
+                    // Only the first luma (`c == 0`) and the two chroma
+                    // (`components - 2`, `components - 1`) get here.
+                    let slot = if c == 0 { 0 } else { c + 3 - components };
+                    let seed = heads[slot];
+                    heads[slot] = (seed + diff) & mask;
+                    seed
+                };
+                let value = (prediction + diff) & mask;
+                out[at + c] = value as u16;
+                if c <= p {
+                    last_luma = value;
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -801,6 +1100,216 @@ mod tests {
         out.extend_from_slice(&w.out);
         out.extend_from_slice(&[0xFF, 0xD9]);
         out
+    }
+
+    /// Encode a Canon-shaped subsampled frame: three components, the
+    /// luma sampled 2x1 or 2x2, one Huffman table for the luma and
+    /// another for both chroma, and the MCU chain the decoder expects.
+    fn encode_subsampled(p: usize, width: usize, height: usize, samples: &[u16]) -> Vec<u8> {
+        let components = 3 + p;
+        let block_rows = p.div_ceil(2);
+        let (blocks, rows) = (width / 2, height / block_rows);
+        let row = blocks * components;
+        assert_eq!(samples.len(), rows * row, "sample count for the shape");
+        let precision = 15u32;
+        let counts: [u8; 16] = [0, 1, 2, 3, 4, 5, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+        let symbols: Vec<u8> = (0..17u8).collect();
+        let codes = canonical(&counts, &symbols);
+
+        let mut out: Vec<u8> = vec![0xFF, 0xD8];
+        let mut dht = Vec::new();
+        for id in 0..2u8 {
+            dht.push(id);
+            dht.extend_from_slice(&counts);
+            dht.extend_from_slice(&symbols);
+        }
+        out.extend_from_slice(&[0xFF, 0xC4]);
+        out.extend_from_slice(&((dht.len() + 2) as u16).to_be_bytes());
+        out.extend_from_slice(&dht);
+
+        out.extend_from_slice(&[0xFF, 0xC3]);
+        out.extend_from_slice(&17u16.to_be_bytes());
+        out.push(precision as u8);
+        out.extend_from_slice(&(height as u16).to_be_bytes());
+        out.extend_from_slice(&(width as u16).to_be_bytes());
+        out.push(3);
+        let factor = if p == 3 { 0x22 } else { 0x21 };
+        out.extend_from_slice(&[1, factor, 0, 2, 0x11, 0, 3, 0x11, 0]);
+
+        out.extend_from_slice(&[0xFF, 0xDA]);
+        out.extend_from_slice(&12u16.to_be_bytes());
+        out.push(3);
+        out.extend_from_slice(&[1, 0x00, 2, 0x10, 3, 0x10]);
+        // Predictor 1 (plain left), no point transform: what Canon
+        // writes.
+        out.extend_from_slice(&[1, 0x00, 0x00]);
+
+        let mut vertical = [1i32 << (precision - 1); 6];
+        let mut w = BitWriter::new();
+        for r in 0..rows {
+            let mut last_luma = 0i32;
+            for col in 0..blocks {
+                let at = r * row + col * components;
+                for c in 0..components {
+                    let sample = samples[at + c];
+                    let head = col == 0;
+                    let prediction = if c <= p && !(head && c == 0) {
+                        last_luma
+                    } else if !head {
+                        samples[at - components + c] as i32
+                    } else {
+                        // The head of a row carries the vertical chain:
+                        // what this component held one row above.
+                        let seed = vertical[c];
+                        vertical[c] = sample as i32;
+                        seed
+                    };
+                    encode_diff(&mut w, &codes, sample, prediction);
+                    if c <= p {
+                        last_luma = sample as i32;
+                    }
+                }
+            }
+        }
+        w.pad();
+        out.extend_from_slice(&w.out);
+        out.extend_from_slice(&[0xFF, 0xD9]);
+        out
+    }
+
+    #[test]
+    fn round_trip_subsampled_frames() {
+        let mut rng = Rng(0x51A7_0BAD_1234_9876);
+        // Both sampling factors, and the degenerate one-block shapes.
+        for (p, width, height) in [
+            (1usize, 8usize, 5usize),
+            (3, 8, 6),
+            (1, 2, 1),
+            (3, 2, 2),
+            (3, 12, 4),
+            (1, 16, 3),
+        ] {
+            let components = 3 + p;
+            let block_rows = p.div_ceil(2);
+            let len = (height / block_rows) * (width / 2) * components;
+            let samples = random_image(&mut rng, len, 15);
+            let stream = encode_subsampled(p, width, height, &samples);
+            let got = decode_subsampled(&stream).expect("decode subsampled");
+            assert_eq!(got.p, p);
+            assert_eq!(got.components, components);
+            assert_eq!(got.block_rows, block_rows);
+            assert_eq!((got.width, got.height), (width, height));
+            assert_eq!(got.rows, height / block_rows);
+            assert_eq!(got.row, (width / 2) * components);
+            assert_eq!(got.precision, 15);
+            assert_eq!(got.data, samples, "P {p}, {width}x{height}");
+
+            // The sampling byte is readable without decoding, and the
+            // 1:1 entry points still refuse the frame exactly as they
+            // did before this path existed.
+            assert_eq!(sampling(&stream).unwrap(), if p == 3 { 0x22 } else { 0x21 });
+            assert!(matches!(decode(&stream), Err(Error::Unsupported(_))));
+            assert!(matches!(header(&stream), Err(Error::Unsupported(_))));
+        }
+    }
+
+    #[test]
+    fn subsampled_rejects_what_it_is_not() {
+        // An ordinary 1:1 frame belongs to `decode`.
+        let spec = Encode::new(8, 8, 1, 12);
+        let plain = encode(&spec, &[7u16; 64]);
+        assert_eq!(sampling(&plain).unwrap(), 0x11);
+        assert!(matches!(
+            decode_subsampled(&plain),
+            Err(Error::Unsupported(_))
+        ));
+
+        let mut rng = Rng(0x0FF1_CE00_1111_2222);
+        let samples = random_image(&mut rng, 3 * 4 * 6, 15);
+        let stream = encode_subsampled(3, 8, 6, &samples);
+
+        // A sampling factor Canon never writes.
+        let sof = stream.windows(2).position(|w| w == [0xFF, 0xC3]).unwrap();
+        let mut odd = stream.clone();
+        odd[sof + 11] = 0x12;
+        assert!(matches!(
+            decode_subsampled(&odd),
+            Err(Error::Unsupported(_))
+        ));
+        // Subsampled chroma.
+        let mut both = stream.clone();
+        both[sof + 14] = 0x22;
+        assert!(matches!(
+            decode_subsampled(&both),
+            Err(Error::Unsupported(_))
+        ));
+        // An odd luma width cannot be tiled by two-pixel blocks.
+        let mut odd_width = stream.clone();
+        odd_width[sof + 8] = 7;
+        assert!(matches!(
+            decode_subsampled(&odd_width),
+            Err(Error::Corrupt(_))
+        ));
+        // A height 2x2 blocks cannot tile.
+        let mut odd_height = stream.clone();
+        odd_height[sof + 6] = 5;
+        assert!(matches!(
+            decode_subsampled(&odd_height),
+            Err(Error::Corrupt(_))
+        ));
+        // A frame far larger than its scan.
+        let mut huge = stream.clone();
+        huge[sof + 5] = 0xFF;
+        huge[sof + 7] = 0xFF;
+        assert!(decode_subsampled(&huge).is_err());
+
+        // A predictor other than plain left: the luma chain only
+        // computes rule 1, so anything else is refused, not decoded.
+        let sos = stream.windows(2).position(|w| w == [0xFF, 0xDA]).unwrap();
+        // SOS payload: length (2), Ns (1), 3 x (id, table) (6), then Ss.
+        let ss = sos + 2 + 2 + 1 + 6;
+        assert_eq!(stream[ss], 1, "the test encoder writes predictor 1");
+        for predictor in [2u8, 4, 7] {
+            let mut other = stream.clone();
+            other[ss] = predictor;
+            assert!(
+                matches!(decode_subsampled(&other), Err(Error::Unsupported(_))),
+                "predictor {predictor}"
+            );
+        }
+        // A restart interval, which no Canon sRAW carries and this
+        // path does not honour; spliced in ahead of the tables.
+        let mut restarts = stream[..2].to_vec();
+        restarts.extend_from_slice(&[0xFF, 0xDD, 0x00, 0x04, 0x00, 0x10]);
+        restarts.extend_from_slice(&stream[2..]);
+        assert!(matches!(
+            decode_subsampled(&restarts),
+            Err(Error::Unsupported(_))
+        ));
+    }
+
+    #[test]
+    fn subsampled_truncation_never_panics() {
+        let mut rng = Rng(0x2468_ACE0_1357_9BDF);
+        for p in [1usize, 3] {
+            let block_rows = p.div_ceil(2);
+            let len = (6 / block_rows) * 5 * (3 + p);
+            let samples = random_image(&mut rng, len, 15);
+            let stream = encode_subsampled(p, 10, 6, &samples);
+            for cut in 0..stream.len() {
+                let _ = decode_subsampled(&stream[..cut]);
+                let _ = sampling(&stream[..cut]);
+            }
+            for seed in 0..48u64 {
+                let mut rng = Rng(seed.wrapping_mul(0x9E37_79B9_7F4A_7C15) | 1);
+                let mut broken = stream.clone();
+                for _ in 0..8 {
+                    let at = rng.below(broken.len() as u64) as usize;
+                    broken[at] = rng.below(256) as u8;
+                }
+                let _ = decode_subsampled(&broken);
+            }
+        }
     }
 
     /// xorshift64*, so the tests are random but reproducible without a

--- a/docs/web.md
+++ b/docs/web.md
@@ -115,8 +115,9 @@ rather than left to fail.
 ## Known gaps
 
 Camera raws open through the pure-Rust `schist-codec-raw` decoder, the
-same one the desktop uses first. The few codecs it declines — Sigma's
-Foveon data, GoPro's VC-5, a handful of old odd ones — go to a runtime
+same one the desktop uses first. The few things it declines — a couple
+of ancient Sigma and Fuji sensors, Nikon's licensed High Efficiency
+NEF — go to a runtime
 LibRaw on the desktop; a browser has no library to load, so those files
 are refused with a message saying so (their embedded previews still
 show).

--- a/plugins/codecs-common/src/raw.rs
+++ b/plugins/codecs-common/src/raw.rs
@@ -147,13 +147,18 @@ pub fn embedded_preview(bytes: &[u8]) -> anyhow::Result<Option<image::RgbaImage>
     {
         return native_answer.unwrap_or(Ok(None)).map_err(web_refusal);
     }
+    // LibRaw only improves on a native *failure*; a native "no
+    // preview" is definitive (a GoPro GPR has none), and LibRaw not
+    // opening the file at all — it knows fewer formats than the crate
+    // now — must not turn that answer into an error.
     #[cfg(not(target_arch = "wasm32"))]
-    match libraw::embedded_preview(bytes) {
-        Err(missing) if is_missing_library_error(&missing) => match native_answer {
-            Some(answer) => answer.map_err(|err| err.context(format!("{missing}"))),
-            None => Err(missing),
-        },
-        answer => answer,
+    match (libraw::embedded_preview(bytes), native_answer) {
+        (Ok(found), _) => Ok(found),
+        (Err(libraw_err), Some(answer)) => {
+            log::info!("raw: LibRaw preview failed too ({libraw_err:#})");
+            answer.map_err(|err| err.context(format!("{libraw_err}")))
+        }
+        (Err(libraw_err), None) => Err(libraw_err),
     }
 }
 
@@ -184,7 +189,7 @@ impl CodecPlugin for RawCodec {
         let choice = decoder_choice();
         let native = match choice {
             Decoder::LibRaw => None,
-            _ => Some(guarded(|| native::develop_document(bytes))),
+            _ => Some(guarded(|| native::develop_document(bytes, false))),
         };
         let native_err = match native {
             Some(Ok(doc)) => return Ok(doc),
@@ -197,6 +202,12 @@ impl CodecPlugin for RawCodec {
         };
         #[cfg(target_arch = "wasm32")]
         {
+            if native_err
+                .as_ref()
+                .is_some_and(|e| e.downcast_ref::<native::NoColourMatrix>().is_some())
+            {
+                return native::develop_document(bytes, true);
+            }
             return Err(web_refusal(native_err.unwrap_or_else(|| {
                 anyhow::anyhow!("the native decoder was disabled")
             })));
@@ -205,6 +216,19 @@ impl CodecPlugin for RawCodec {
         // diagnosis is the useful one; the missing library is context.
         #[cfg(not(target_arch = "wasm32"))]
         match libraw::develop_document(bytes) {
+            Ok(doc) => Ok(doc),
+            // The native decoder read the file and only lacked a
+            // matrix; if LibRaw cannot help (missing, or a format it
+            // does not know — Foveon on a stock build), camera RGB
+            // beats nothing.
+            Err(libraw_err)
+                if native_err
+                    .as_ref()
+                    .is_some_and(|e| e.downcast_ref::<native::NoColourMatrix>().is_some()) =>
+            {
+                log::info!("raw: LibRaw could not render it either ({libraw_err:#})");
+                native::develop_document(bytes, true)
+            }
             Err(missing) if is_missing_library_error(&missing) => match native_err {
                 Some(native_err) => Err(native_err.context(format!("{missing}"))),
                 None => Err(missing),
@@ -258,19 +282,38 @@ mod native {
     use schist_color::Depth;
     use schist_core::Document;
 
+    /// The one native decline a caller may want to override: the
+    /// frame decoded, but the camera table has no colour matrix for
+    /// the body, so the picture would be camera RGB.
+    #[derive(Debug)]
+    pub(super) struct NoColourMatrix(pub String);
+
+    impl std::fmt::Display for NoColourMatrix {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "no colour matrix for {}", self.0)
+        }
+    }
+
+    impl std::error::Error for NoColourMatrix {}
+
     /// Decode and develop through `schist-codec-raw`, then the same
     /// exposure and encoding as the LibRaw path. A camera the table
-    /// has no colour matrix for is declined (`Err`), so the caller can
-    /// let LibRaw, which may know it, render the colours rather than
-    /// show raw camera RGB.
-    pub(super) fn develop_document(bytes: &[u8]) -> anyhow::Result<Document> {
+    /// has no colour matrix for is declined with `NoColourMatrix`
+    /// unless `camera_rgb` is set, so the caller can let LibRaw, which
+    /// may know it, render the colours — and fall back to camera RGB
+    /// when LibRaw cannot read the file either.
+    pub(super) fn develop_document(bytes: &[u8], camera_rgb: bool) -> anyhow::Result<Document> {
         let raw = schist_codec_raw::decode(bytes).context("decoding")?;
-        anyhow::ensure!(
-            raw.color_matrix.is_some(),
-            "no colour matrix for {} {}",
-            raw.make,
-            raw.model
-        );
+        if raw.color_matrix.is_none() && !camera_rgb {
+            return Err(NoColourMatrix(format!("{} {}", raw.make, raw.model)).into());
+        }
+        if raw.color_matrix.is_none() {
+            log::warn!(
+                "raw: no colour matrix for {} {}; developing in camera RGB",
+                raw.make,
+                raw.model
+            );
+        }
         let developed =
             schist_codec_raw::develop(&raw, &DevelopOptions::default()).context("developing")?;
         let (w, h) = (developed.width as u32, developed.height as u32);
@@ -616,7 +659,7 @@ pub(crate) mod tests {
                 .display()
                 .to_string();
             let started = std::time::Instant::now();
-            let native = native::develop_document(&bytes);
+            let native = native::develop_document(&bytes, false);
             let native_time = started.elapsed();
             let started = std::time::Instant::now();
             let reference = match libraw::develop_document(&bytes) {


### PR DESCRIPTION
## Summary

The last codecs the clean-room crate declined after #98, done the same two-team way (spec writers read the reference under `/tmp` and wrote prose specifications; implementers worked from the specs, the samples and oracle output only) with one addition: a **triage step first** — for each format, can any buildable reference produce a frame to verify against? Based on the squash-merged main.

| codec | result |
|---|---|
| Sigma Foveon X3F, Merrill and Quattro | 6/6 exact, three sensor planes (colour from the camera table); SD9/SD10/SD14 declined, no sample |
| GoPro VC-5 (GPR) | 4/4 exact, ~100 MP/s; oracle from GoPro's Apache-2.0 converter cross-checked against LibRaw |
| Canon sRAW/mRAW | 50D and 7D exact (4/4, planar and full RGB stages); 5D Mark II/III **declined by model** until verified |
| Kodak DC40/DC50 RADC | 1/1 exact |

Two triage findings worth knowing: LibRaw 0.21.2 *does* read X3F (compiled out by default, `USE_X3FTOOLS`), contrary to what the first round concluded; and a reviewer fetched six more subsampled Canon bodies, which is how the 50D-fitted colour stage was caught and gated.

**Deliberately still on the LibRaw fallback:** Fuji SuperCCD (decode is trivial and oracle-verified, but its 45° sensor grid is not representable in `RawImage`/`Cfa` — needs a rotate stage), Nikon Z High Efficiency (licensed intoPIX TicoRAW; nothing reads it without the SDK), Sigma SD9/SD10/SD14 and CR3-container sRAW (no samples).

**Review** (two passes, ~13k mutated inputs, no blind panics): fixed Foveon Huffman bounds (two one-byte panics), an unvalidated Quattro plane table (a 1.8 GB allocation lever), missing Foveon levels/crop, a VC-5 precision assumption, sRAW's slice-count hang and forged-SOF allocation, and its 50D-only colour stage (gains now keyed by ColorData version; hue/matrix gated by model id). Reviewer-flagged for a human: the spec relays reference-derived colour constants for sRAW (the YCbCr matrix and hue rules) that no public document yields — a project-level call on what a spec may carry.

**Plugin:** a body with no colour matrix now develops in camera RGB when LibRaw cannot render it either (Foveon on a stock LibRaw), instead of failing; and a native "no embedded preview" is no longer overridden by a LibRaw open failure (GPR).

## Test plan

- [x] Crate: 403 tests incl. every spec's worked values and per-format corpus comparison (`SCHIST_RAW_CORPUS=/tmp/rawsamples`)
- [x] Plugin sweep over the full corpus (256 files); native-vs-LibRaw comparison: 114 compared, none below 20 dB
- [x] The 1:1 lossless-JPEG path confirmed byte-identical across a 243-file A/B before/after the sRAW change
- [x] `cargo fmt --check`, clippy `-D warnings` on both crates

🤖 Generated with [Claude Code](https://claude.com/claude-code)
