### PR TITLE
fix: live shape previews, dropdown type-ahead, and mixed fonts in one text layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6542,6 +6542,7 @@ dependencies = [
  "schist-color",
  "schist-core",
  "serde",
+ "serde_json",
  "ttf-parser 0.25.1",
 ]
 

--- a/crates/app/src/curve_editor.rs
+++ b/crates/app/src/curve_editor.rs
@@ -264,7 +264,7 @@ pub fn render(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoEleme
         .child(ui::field_row(
             "Channel",
             ui::dropdown(
-                &ws.dropdown_scroll,
+                &ws.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("curve-channel"),
                     is_open: ws.open_popup == Some(Popup::Field("curve-channel")),

--- a/crates/app/src/dialogs/batch.rs
+++ b/crates/app/src/dialogs/batch.rs
@@ -112,7 +112,7 @@ pub(super) fn batch_dialog(
         .child(ui::field_row(
             "Rotate",
             ui::dropdown(
-                &ws.dropdown_scroll,
+                &ws.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("batch-rotate"),
                     is_open: state.open_popup == Some(Popup::Field("batch-rotate")),
@@ -179,7 +179,7 @@ pub(super) fn batch_dialog(
     body = body.child(section("Size")).child(ui::field_row(
         "Upscale",
         ui::dropdown(
-            &ws.dropdown_scroll,
+            &ws.dropdown,
             ui::Dropdown {
                 popup: Popup::Field("batch-upscale"),
                 is_open: state.open_popup == Some(Popup::Field("batch-upscale")),
@@ -217,7 +217,7 @@ pub(super) fn batch_dialog(
                 .items_center()
                 .gap_2()
                 .child(ui::dropdown(
-                    &ws.dropdown_scroll,
+                    &ws.dropdown,
                     ui::Dropdown {
                         popup: Popup::Field(popup),
                         is_open: state.open_popup == Some(Popup::Field(popup)),
@@ -283,7 +283,7 @@ pub(super) fn batch_dialog(
         body = body.child(ui::field_row(
             "Add",
             ui::dropdown(
-                &ws.dropdown_scroll,
+                &ws.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("batch-adj-add"),
                     is_open: state.open_popup == Some(Popup::Field("batch-adj-add")),
@@ -319,7 +319,7 @@ pub(super) fn batch_dialog(
     body = body.child(section("Output")).child(ui::field_row(
         "Save as",
         ui::dropdown(
-            &ws.dropdown_scroll,
+            &ws.dropdown,
             ui::Dropdown {
                 popup: Popup::Field("batch-target"),
                 is_open: state.open_popup == Some(Popup::Field("batch-target")),
@@ -359,7 +359,7 @@ pub(super) fn batch_dialog(
         body = body.child(ui::field_row(
             "Format",
             ui::dropdown(
-                &ws.dropdown_scroll,
+                &ws.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("batch-format"),
                     is_open: state.open_popup == Some(Popup::Field("batch-format")),

--- a/crates/app/src/dialogs/edit.rs
+++ b/crates/app/src/dialogs/edit.rs
@@ -129,7 +129,7 @@ pub(super) fn stroke_dialog(
         .child(ui::field_row(
             "Location",
             ui::dropdown(
-                &ws.dropdown_scroll,
+                &ws.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("stroke-position"),
                     is_open: ws.open_popup == Some(Popup::Field("stroke-position")),
@@ -209,7 +209,7 @@ pub(super) fn fill_dialog(
         .child(ui::field_row(
             "Contents",
             ui::dropdown(
-                &ws.dropdown_scroll,
+                &ws.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("fill-source"),
                     is_open: ws.open_popup == Some(Popup::Field("fill-source")),

--- a/crates/app/src/dialogs/export.rs
+++ b/crates/app/src/dialogs/export.rs
@@ -30,7 +30,7 @@ pub(super) fn export_dialog(
     let mut body = div().flex().flex_col().gap_1().child(ui::field_row(
         "Format",
         ui::dropdown(
-            &ws.dropdown_scroll,
+            &ws.dropdown,
             ui::Dropdown {
                 popup: Popup::Field("export-format"),
                 is_open: state.open_popup == Some(Popup::Field("export-format")),

--- a/crates/app/src/dialogs/mod.rs
+++ b/crates/app/src/dialogs/mod.rs
@@ -76,9 +76,10 @@ struct DialogState {
     /// of the blink shows it.
     field_cursor: usize,
     caret_on: bool,
-    /// Shares the workspace's dropdown scroll state (it clones as a
-    /// handle), so dialog dropdowns open at their current value too.
-    dropdown_scroll: ui::DropdownScroll,
+    /// Shares the workspace's dropdown state (it clones as a handle),
+    /// so dialog dropdowns open at their current value and follow the
+    /// keyboard too.
+    dropdown: ui::DropdownState,
 }
 
 /// Render whichever modal is open, if any.
@@ -92,7 +93,7 @@ pub fn render(ws: &mut Workspace, cx: &mut Context<Workspace>) -> Option<gpui::A
         field_buffer: ws.field_buffer.clone(),
         field_cursor: ws.field_cursor,
         caret_on: ws.caret_on(),
-        dropdown_scroll: ws.dropdown_scroll.clone(),
+        dropdown: ws.dropdown.clone(),
     };
     // Each dialog's primary button registers itself as the default
     // action while it builds, so Enter can fire it.

--- a/crates/app/src/dialogs/new_doc.rs
+++ b/crates/app/src/dialogs/new_doc.rs
@@ -220,7 +220,7 @@ pub(super) fn new_document_dialog(
         .child(ui::field_row(
             "Preset",
             ui::dropdown(
-                &state.dropdown_scroll,
+                &state.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("new-doc-preset"),
                     is_open: state.open_popup == Some(Popup::Field("new-doc-preset")),
@@ -314,7 +314,7 @@ pub(super) fn new_document_dialog(
         .child(ui::field_row(
             "Color Mode",
             ui::dropdown(
-                &state.dropdown_scroll,
+                &state.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("new-doc-mode"),
                     is_open: state.open_popup == Some(Popup::Field("new-doc-mode")),
@@ -336,7 +336,7 @@ pub(super) fn new_document_dialog(
         .child(ui::field_row(
             "Bit Depth",
             ui::dropdown(
-                &state.dropdown_scroll,
+                &state.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("new-doc-depth"),
                     is_open: state.open_popup == Some(Popup::Field("new-doc-depth")),
@@ -361,7 +361,7 @@ pub(super) fn new_document_dialog(
         .child(ui::field_row(
             "Background",
             ui::dropdown(
-                &state.dropdown_scroll,
+                &state.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("new-doc-bg"),
                     is_open: state.open_popup == Some(Popup::Field("new-doc-bg")),

--- a/crates/app/src/dialogs/prefs.rs
+++ b/crates/app/src/dialogs/prefs.rs
@@ -21,7 +21,7 @@ pub(super) fn preferences(
         .child(ui::field_row(
             "Theme",
             ui::dropdown(
-                &ws.dropdown_scroll,
+                &ws.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("pref-theme"),
                     is_open: state.open_popup == Some(Popup::Field("pref-theme")),
@@ -70,7 +70,7 @@ pub(super) fn preferences(
         .child(ui::field_row(
             "Rendering intent",
             ui::dropdown(
-                &ws.dropdown_scroll,
+                &ws.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("pref-intent"),
                     is_open: state.open_popup == Some(Popup::Field("pref-intent")),

--- a/crates/app/src/dialogs/profile.rs
+++ b/crates/app/src/dialogs/profile.rs
@@ -31,7 +31,7 @@ pub(super) fn profile_dialog(
         .child(ui::field_row(
             "Profile",
             ui::dropdown(
-                &state.dropdown_scroll,
+                &state.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("profile-pick"),
                     is_open: state.open_popup == Some(Popup::Field("profile-pick")),

--- a/crates/app/src/dialogs/save_image.rs
+++ b/crates/app/src/dialogs/save_image.rs
@@ -53,7 +53,7 @@ pub(super) fn save_image_dialog(
         .child(ui::field_row(
             "Format",
             ui::dropdown(
-                &ws.dropdown_scroll,
+                &ws.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("save-image-format"),
                     is_open: state.open_popup == Some(Popup::Field("save-image-format")),

--- a/crates/app/src/dialogs/size.rs
+++ b/crates/app/src/dialogs/size.rs
@@ -113,7 +113,7 @@ pub(super) fn image_size(
         .child(ui::field_row(
             "Resample",
             ui::dropdown(
-                &ws.dropdown_scroll,
+                &ws.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("image-size-filter"),
                     is_open: state.open_popup == Some(Popup::Field("image-size-filter")),

--- a/crates/app/src/panels/layers.rs
+++ b/crates/app/src/panels/layers.rs
@@ -66,80 +66,32 @@ pub(super) fn blend_mode_control(
         .and_then(|id| ws.doc.as_ref().and_then(|d| d.tree.find(id)))
         .map(|l| l.blend)
         .unwrap_or(BlendMode::Normal);
-    let is_open = ws.open_popup == Some(Popup::BlendModes);
-    let mut button = div()
-        .relative()
-        .flex()
-        .flex_row()
-        .items_center()
-        .justify_between()
-        .flex_grow()
-        .h(px(20.0))
-        .px_1()
-        .rounded_sm()
-        .bg(gpui::rgb(palette().field_bg))
-        .text_size(px(11.0))
-        .on_mouse_down(
-            MouseButton::Left,
-            cx.listener(|ws, _e, _w, cx| ws.toggle_popup(Popup::BlendModes, cx)),
-        )
-        .child(current.display_name())
-        .child(icon("chevron-down", 11.0, palette().text_dim));
-    if is_open {
-        if let Some(layer_id) = active_layer {
-            let rows: Vec<gpui::AnyElement> = BlendMode::layer_modes()
-                .iter()
-                .map(|&mode| {
-                    let selected = mode == current;
-                    div()
-                        .px_2()
-                        .h(px(20.0))
-                        .flex_none()
-                        .flex()
-                        .items_center()
-                        .text_size(px(11.0))
-                        .when_active(selected)
-                        .hover(move |s| {
-                            if selected {
-                                s
-                            } else {
-                                s.bg(gpui::rgb(palette().hover))
-                            }
-                        })
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(move |ws, _e, _w, cx| {
-                                ws.close_popup(cx);
-                                ws.set_blend_mode(layer_id, mode, cx);
-                            }),
-                        )
-                        .child(mode.display_name())
-                        .into_any_element()
-                })
-                .collect();
-            button = button.child(deferred(
-                div()
-                    .id("blend-modes")
-                    .absolute()
-                    .top(px(22.0))
-                    .left_0()
-                    .w(px(150.0))
-                    .max_h(px(320.0))
-                    .overflow_y_scroll()
-                    .py_1()
-                    .bg(gpui::rgb(palette().popup_bg))
-                    .text_color(gpui::rgb(palette().text))
-                    .border_1()
-                    .border_color(gpui::rgb(palette().edge))
-                    .rounded_sm()
-                    .shadow_lg()
-                    .occlude()
-                    .on_mouse_down_out(cx.listener(|ws, _e, _w, cx| ws.close_popup(cx)))
-                    .children(rows),
-            ));
-        }
-    }
-    button
+    // No layer, no rows: the button still shows but opens nothing.
+    let options = match active_layer {
+        Some(_) => BlendMode::layer_modes()
+            .iter()
+            .map(|&mode| (SharedString::from(mode.display_name()), mode))
+            .collect(),
+        None => Vec::new(),
+    };
+    let spec = ui::Dropdown {
+        popup: Popup::BlendModes,
+        is_open: ws.open_popup == Some(Popup::BlendModes),
+        current,
+        label: current.display_name().into(),
+        width: 0.0,
+        options,
+    };
+    ui::dropdown(
+        &ws.dropdown,
+        spec,
+        |ws, mode, cx| {
+            if let Some(id) = ws.doc.as_ref().and_then(|d| d.active_layer) {
+                ws.set_blend_mode(id, mode, cx);
+            }
+        },
+        cx,
+    )
 }
 
 pub(super) fn layers_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElement {

--- a/crates/app/src/panels/toolbar.rs
+++ b/crates/app/src/panels/toolbar.rs
@@ -152,9 +152,9 @@ pub(super) fn tool_option_control(
             };
             // The font menu's rows are font names, so show each in itself.
             let control = if key == "type-family" {
-                ui::font_dropdown(&ws.dropdown_scroll, spec, on_select, cx).into_any_element()
+                ui::font_dropdown(&ws.dropdown, spec, on_select, cx).into_any_element()
             } else {
-                ui::dropdown(&ws.dropdown_scroll, spec, on_select, cx).into_any_element()
+                ui::dropdown(&ws.dropdown, spec, on_select, cx).into_any_element()
             };
             // Sliders carry their own label; a dropdown does not, and an
             // unlabelled one reading "Point Sample" does not say what it

--- a/crates/app/src/style_dialog.rs
+++ b/crates/app/src/style_dialog.rs
@@ -446,7 +446,7 @@ pub fn render(
         settings = settings.child(ui::field_row(
             "Blend",
             ui::dropdown(
-                &ws.dropdown_scroll,
+                &ws.dropdown,
                 ui::Dropdown {
                     popup: Popup::Field("fx-blend"),
                     is_open: ws.open_popup == Some(Popup::Field("fx-blend")),
@@ -523,7 +523,7 @@ pub fn render(
             settings.child(ui::field_row(
                 "Position",
                 ui::dropdown(
-                    &ws.dropdown_scroll,
+                    &ws.dropdown,
                     ui::Dropdown {
                         popup: Popup::Field("fx-stroke-pos"),
                         is_open: ws.open_popup == Some(Popup::Field("fx-stroke-pos")),
@@ -558,7 +558,7 @@ pub fn render(
             settings.child(ui::field_row(
                 "Style",
                 ui::dropdown(
-                    &ws.dropdown_scroll,
+                    &ws.dropdown,
                     ui::Dropdown {
                         popup: Popup::Field("fx-bevel-style"),
                         is_open: ws.open_popup == Some(Popup::Field("fx-bevel-style")),
@@ -597,7 +597,7 @@ pub fn render(
                 .child(ui::field_row(
                     "Shape",
                     ui::dropdown(
-                        &ws.dropdown_scroll,
+                        &ws.dropdown,
                         ui::Dropdown {
                             popup: Popup::Field("fx-grad-shape"),
                             is_open: ws.open_popup == Some(Popup::Field("fx-grad-shape")),

--- a/crates/app/src/ui.rs
+++ b/crates/app/src/ui.rs
@@ -510,11 +510,13 @@ pub fn type_ahead_target(
 /// built as plain values deep inside a panel or dialog body with no path
 /// back to the workspace, so the open one leaves them here as it renders
 /// and `Workspace::dropdown_key` reads them back.
+type DropdownSelect = dyn Fn(&mut Workspace, usize, &mut Context<Workspace>);
+
 pub struct OpenDropdown {
     pub labels: Vec<SharedString>,
     /// Row of the committed value, where keyboard walking starts from.
     pub current: Option<usize>,
-    select: Rc<dyn Fn(&mut Workspace, usize, &mut Context<Workspace>)>,
+    select: Rc<DropdownSelect>,
 }
 
 impl OpenDropdown {

--- a/crates/app/src/ui.rs
+++ b/crates/app/src/ui.rs
@@ -10,7 +10,7 @@ use gpui::{
     div, px, AppContext as _, Context, InteractiveElement as _, IntoElement, MouseButton,
     ParentElement as _, SharedString, StatefulInteractiveElement as _, Styled as _,
 };
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 /// The chrome colours for one theme. Everything that isn't document
@@ -388,34 +388,154 @@ pub fn checkbox(
         .child(label.into())
 }
 
-/// Scroll state for the open dropdown's option list.
+/// State of the open dropdown's option list: its scroll, the row the
+/// keyboard has walked or typed to, and the type-ahead buffer.
 ///
 /// One instance serves every dropdown because only one popup can be open
 /// at a time. Cloning shares the underlying state, which is how the
 /// per-frame `DialogState` snapshot hands it to dialog widgets.
 #[derive(Clone)]
-pub struct DropdownScroll {
+pub struct DropdownState {
     handle: gpui::ScrollHandle,
     /// Whether the open dropdown has been scrolled to its value yet:
     /// once per opening, after which the list is the user's to scroll.
-    scrolled: std::rc::Rc<std::cell::Cell<bool>>,
+    scrolled: Rc<Cell<bool>>,
+    /// The row the keyboard has landed on. Separate from the committed
+    /// value: walking the list with the arrows or typing a prefix moves
+    /// this, and Enter is what turns it into a choice.
+    highlight: Rc<Cell<Option<usize>>>,
+    /// What has been typed so far, and when the last character arrived.
+    /// A pause ends the word, so "ar" a second later starts afresh at
+    /// the first "a" rather than looking for "arar".
+    typed: Rc<RefCell<(String, Option<std::time::Instant>)>>,
 }
 
-impl Default for DropdownScroll {
+impl Default for DropdownState {
     fn default() -> Self {
-        DropdownScroll {
+        DropdownState {
             handle: gpui::ScrollHandle::new(),
             scrolled: Default::default(),
+            highlight: Default::default(),
+            typed: Default::default(),
         }
     }
 }
 
-impl DropdownScroll {
-    /// Forget the last scroll, so the next dropdown to open gets one
-    /// scroll to its selection. Called whenever a popup opens or closes.
+/// How long a pause ends a type-ahead word. Native lists use about a
+/// second; Cocoa's is a little under.
+const TYPE_AHEAD_PAUSE: std::time::Duration = std::time::Duration::from_millis(1000);
+
+impl DropdownState {
+    /// Forget the last scroll, highlight and typing, so the next dropdown
+    /// to open gets one scroll to its selection and a clean slate. Called
+    /// whenever a popup opens or closes.
     pub fn reset(&self) {
         self.scrolled.set(false);
+        self.highlight.set(None);
+        self.typed.borrow_mut().0.clear();
     }
+
+    /// The row the keyboard is on, if it has moved at all.
+    pub fn highlight(&self) -> Option<usize> {
+        self.highlight.get()
+    }
+
+    /// Put the keyboard on row `ix` and bring it into view.
+    pub fn set_highlight(&self, ix: usize) {
+        self.highlight.set(Some(ix));
+        self.handle.scroll_to_item(ix);
+    }
+
+    /// Add `text` to the type-ahead word and say which row it now names,
+    /// given the row the keyboard is on (`at`) for letter cycling.
+    pub fn type_ahead(
+        &self,
+        text: &str,
+        labels: &[SharedString],
+        at: Option<usize>,
+    ) -> Option<usize> {
+        let now = std::time::Instant::now();
+        let mut typed = self.typed.borrow_mut();
+        let stale = typed
+            .1
+            .is_some_and(|last| now.duration_since(last) > TYPE_AHEAD_PAUSE);
+        if stale {
+            typed.0.clear();
+        }
+        typed.0.push_str(text);
+        typed.1 = Some(now);
+        type_ahead_target(labels, &typed.0, at)
+    }
+
+    /// Drop the type-ahead word (Backspace).
+    pub fn clear_typed(&self) {
+        self.typed.borrow_mut().0.clear();
+    }
+}
+
+/// The row a type-ahead word lands on: the first row whose label starts
+/// with `typed`, ignoring case. When nothing starts with it and the word
+/// is one letter pressed over and over, the presses walk through the
+/// rows that start with that letter instead, from the row the keyboard
+/// is on (`at`), the way every native list does.
+pub fn type_ahead_target(
+    labels: &[impl AsRef<str>],
+    typed: &str,
+    at: Option<usize>,
+) -> Option<usize> {
+    let word = typed.to_lowercase();
+    let mut chars = word.chars();
+    let first = chars.next()?;
+    let starts_with =
+        |ix: usize, prefix: &str| labels[ix].as_ref().to_lowercase().starts_with(prefix);
+    if let Some(ix) = (0..labels.len()).find(|&ix| starts_with(ix, &word)) {
+        return Some(ix);
+    }
+    let repeated = word.chars().count() > 1 && chars.all(|c| c == first);
+    if !repeated {
+        return None;
+    }
+    let letter = first.to_string();
+    let n = labels.len();
+    let from = at.map_or(0, |i| i + 1);
+    (0..n)
+        .map(|k| (from + k) % n)
+        .find(|&ix| starts_with(ix, &letter))
+}
+
+/// The dropdown open in the frame most recently built, so the keystrokes
+/// that arrive between frames can walk and pick its rows.
+///
+/// Like [`DEFAULT_ACTION`]: a dropdown's rows and its select handler are
+/// built as plain values deep inside a panel or dialog body with no path
+/// back to the workspace, so the open one leaves them here as it renders
+/// and `Workspace::dropdown_key` reads them back.
+pub struct OpenDropdown {
+    pub labels: Vec<SharedString>,
+    /// Row of the committed value, where keyboard walking starts from.
+    pub current: Option<usize>,
+    select: Rc<dyn Fn(&mut Workspace, usize, &mut Context<Workspace>)>,
+}
+
+impl OpenDropdown {
+    /// Choose row `ix` as if it had been clicked.
+    pub fn select(&self, ws: &mut Workspace, ix: usize, cx: &mut Context<Workspace>) {
+        (self.select)(ws, ix, cx)
+    }
+}
+
+thread_local! {
+    static OPEN_DROPDOWN: RefCell<Option<Rc<OpenDropdown>>> = const { RefCell::new(None) };
+}
+
+/// Start a frame: no dropdown has rendered open yet.
+pub fn reset_open_dropdown() {
+    OPEN_DROPDOWN.with(|slot| *slot.borrow_mut() = None);
+}
+
+/// The dropdown that rendered open in the last frame, if any.
+pub fn open_dropdown() -> Option<Rc<OpenDropdown>> {
+    OPEN_DROPDOWN.with(|slot| slot.borrow().clone())
 }
 
 /// Placement and state for a [`dropdown`].
@@ -424,13 +544,14 @@ pub struct Dropdown<T> {
     pub is_open: bool,
     pub current: T,
     pub label: SharedString,
+    /// Button width in pixels; zero fills the row it sits in.
     pub width: f32,
     pub options: Vec<(SharedString, T)>,
 }
 
 /// A dropdown button that opens its popup with the given options.
 pub fn dropdown<T: Clone + PartialEq + 'static>(
-    scroll: &DropdownScroll,
+    scroll: &DropdownState,
     spec: Dropdown<T>,
     on_select: impl Fn(&mut Workspace, T, &mut Context<Workspace>) + Clone + 'static,
     cx: &mut Context<Workspace>,
@@ -442,7 +563,7 @@ pub fn dropdown<T: Clone + PartialEq + 'static>(
 /// way Figma's font menu previews its families. Falls back to the UI font
 /// for a family the window's text system cannot resolve.
 pub fn font_dropdown<T: Clone + PartialEq + 'static>(
-    scroll: &DropdownScroll,
+    scroll: &DropdownState,
     spec: Dropdown<T>,
     on_select: impl Fn(&mut Workspace, T, &mut Context<Workspace>) + Clone + 'static,
     cx: &mut Context<Workspace>,
@@ -451,7 +572,7 @@ pub fn font_dropdown<T: Clone + PartialEq + 'static>(
 }
 
 fn dropdown_impl<T: Clone + PartialEq + 'static>(
-    scroll: &DropdownScroll,
+    scroll: &DropdownState,
     spec: Dropdown<T>,
     preview_fonts: bool,
     on_select: impl Fn(&mut Workspace, T, &mut Context<Workspace>) + Clone + 'static,
@@ -472,7 +593,8 @@ fn dropdown_impl<T: Clone + PartialEq + 'static>(
         .flex_row()
         .items_center()
         .justify_between()
-        .w(px(width))
+        .when(width > 0.0, |d| d.w(px(width)))
+        .when(width <= 0.0, |d| d.flex_grow())
         .h(px(20.0))
         .px_1()
         .rounded_sm()
@@ -489,19 +611,39 @@ fn dropdown_impl<T: Clone + PartialEq + 'static>(
             palette().text_dim,
         ));
     if is_open {
+        let current_ix = options.iter().position(|(_, v)| v == current);
         // Open at the current value rather than the top of the list, so
         // re-opening a long menu (fonts, blend modes) shows where you are
         // instead of starting from the beginning. Once per opening: after
         // that the list is the user's to scroll.
         if !scroll.scrolled.replace(true) {
-            if let Some(ix) = options.iter().position(|(_, v)| v == current) {
+            if let Some(ix) = current_ix {
                 scroll.handle.scroll_to_top_of_item(ix);
             }
         }
+        // Leave the rows where the keyboard can find them.
+        {
+            let labels: Vec<SharedString> = options.iter().map(|(t, _)| t.clone()).collect();
+            let values: Vec<T> = options.iter().map(|(_, v)| v.clone()).collect();
+            let on_select = on_select.clone();
+            let open = OpenDropdown {
+                labels,
+                current: current_ix,
+                select: Rc::new(move |ws, ix, cx| {
+                    if let Some(value) = values.get(ix) {
+                        on_select(ws, value.clone(), cx);
+                    }
+                }),
+            };
+            OPEN_DROPDOWN.with(|slot| *slot.borrow_mut() = Some(Rc::new(open)));
+        }
+        let highlight = scroll.highlight();
         let rows: Vec<gpui::AnyElement> = options
             .into_iter()
-            .map(|(text, value)| {
+            .enumerate()
+            .map(|(ix, (text, value))| {
                 let selected = value == *current;
+                let keyed = highlight == Some(ix) && !selected;
                 let on_select = on_select.clone();
                 div()
                     .px_2()
@@ -515,6 +657,8 @@ fn dropdown_impl<T: Clone + PartialEq + 'static>(
                     .when(preview_fonts, |d| d.font_family(text.clone()))
                     .bg(gpui::rgb(if selected {
                         palette().accent
+                    } else if keyed {
+                        palette().hover
                     } else {
                         palette().popup_bg
                     }))
@@ -746,7 +890,45 @@ use gpui::prelude::FluentBuilder as _;
 
 #[cfg(test)]
 mod tests {
-    use super::{caret_left, caret_right};
+    use super::{caret_left, caret_right, type_ahead_target};
+
+    #[test]
+    fn type_ahead_finds_the_first_row_starting_with_the_word() {
+        let rows = [
+            "Normal",
+            "Dissolve",
+            "Darken",
+            "Multiply",
+            "Color Burn",
+            "Lighten",
+        ];
+        assert_eq!(type_ahead_target(&rows, "d", None), Some(1));
+        assert_eq!(type_ahead_target(&rows, "Da", None), Some(2));
+        assert_eq!(type_ahead_target(&rows, "col", Some(5)), Some(4));
+        assert_eq!(type_ahead_target(&rows, "z", None), None);
+        assert_eq!(type_ahead_target(&rows, "", None), None);
+    }
+
+    #[test]
+    fn a_repeated_letter_cycles_through_its_rows() {
+        let rows = [
+            "Normal",
+            "Dissolve",
+            "Darken",
+            "Multiply",
+            "Darker Color",
+            "Lighten",
+        ];
+        // The first press finds the first D; each further press moves on
+        // from wherever the keyboard is, wrapping at the end.
+        assert_eq!(type_ahead_target(&rows, "d", None), Some(1));
+        assert_eq!(type_ahead_target(&rows, "dd", Some(1)), Some(2));
+        assert_eq!(type_ahead_target(&rows, "ddd", Some(2)), Some(4));
+        assert_eq!(type_ahead_target(&rows, "dddd", Some(4)), Some(1));
+        // But a real prefix wins over cycling: "aa" finds Aardvark.
+        let rows = ["Abel", "Aardvark", "Arial"];
+        assert_eq!(type_ahead_target(&rows, "aa", Some(0)), Some(1));
+    }
 
     #[test]
     fn the_caret_moves_by_whole_characters_and_stays_in_bounds() {

--- a/crates/app/src/workspace/chrome.rs
+++ b/crates/app/src/workspace/chrome.rs
@@ -14,16 +14,84 @@ impl Workspace {
             Some(popup)
         };
         // A dropdown that just opened gets one scroll to its selection.
-        self.dropdown_scroll.reset();
+        self.dropdown.reset();
         cx.notify();
     }
 
     pub fn close_popup(&mut self, cx: &mut Context<Self>) {
         self.open_submenu.clear();
-        self.dropdown_scroll.reset();
+        self.dropdown.reset();
         if self.open_popup.take().is_some() {
             cx.notify();
         }
+    }
+
+    /// True while a dropdown list (as opposed to a menu) is open.
+    pub fn dropdown_open(&self) -> bool {
+        matches!(
+            self.open_popup,
+            Some(Popup::BlendModes) | Some(Popup::Field(_))
+        )
+    }
+
+    /// Keystrokes while a dropdown is open: typing jumps to the row that
+    /// starts with what was typed, the arrows walk the rows, Enter picks
+    /// the row the keyboard is on. Escape closes through `CancelGesture`,
+    /// which never reaches a key listener.
+    ///
+    /// Returns true when the keystroke was the dropdown's.
+    pub fn dropdown_key(&mut self, ev: &gpui::KeyDownEvent, cx: &mut Context<Self>) -> bool {
+        if !self.dropdown_open() {
+            return false;
+        }
+        let Some(menu) = crate::ui::open_dropdown() else {
+            return false;
+        };
+        let n = menu.labels.len();
+        if n == 0 {
+            return false;
+        }
+        let at = self.dropdown.highlight().or(menu.current);
+        let mods = &ev.keystroke.modifiers;
+        if mods.control || mods.alt || mods.platform || mods.function {
+            // A shortcut, not typing.
+            return false;
+        }
+        let target = match ev.keystroke.key.as_str() {
+            "down" => Some(at.map_or(0, |i| (i + 1).min(n - 1))),
+            "up" => Some(at.map_or(n - 1, |i| i.saturating_sub(1))),
+            "home" | "pageup" => Some(0),
+            "end" | "pagedown" => Some(n - 1),
+            "enter" => {
+                self.close_popup(cx);
+                if let Some(ix) = at {
+                    menu.select(self, ix, cx);
+                }
+                cx.notify();
+                return true;
+            }
+            "backspace" => {
+                self.dropdown.clear_typed();
+                return true;
+            }
+            "escape" => return false,
+            key => {
+                let text = match key {
+                    "space" => Some(" "),
+                    _ => ev.keystroke.key_char.as_deref(),
+                };
+                let Some(text) = text.filter(|t| !t.is_empty() && !t.chars().any(char::is_control))
+                else {
+                    return false;
+                };
+                self.dropdown.type_ahead(text, &menu.labels, at)
+            }
+        };
+        if let Some(ix) = target {
+            self.dropdown.set_highlight(ix);
+        }
+        cx.notify();
+        true
     }
 
     pub fn record_slider_bounds(&mut self, id: &'static str, bounds: Bounds<Pixels>) {

--- a/crates/app/src/workspace/mod.rs
+++ b/crates/app/src/workspace/mod.rs
@@ -1489,6 +1489,8 @@ pub struct PaintJob {
     /// cover the whole canvas element.
     backdrop: Option<(Bounds<Pixels>, gpui::Hsla)>,
     tiles: Vec<(Bounds<Pixels>, Arc<RenderImage>)>,
+    /// Translucent tool highlights, painted above artwork but below chrome.
+    highlights: Vec<Bounds<Pixels>>,
     outlines: Vec<(Bounds<Pixels>, gpui::Hsla)>,
     polylines: Vec<(Vec<Point<Pixels>>, gpui::Hsla)>,
     /// Marching-ants dashes.

--- a/crates/app/src/workspace/mod.rs
+++ b/crates/app/src/workspace/mod.rs
@@ -241,7 +241,7 @@ pub struct Workspace {
     pub open_popup: Option<Popup>,
     /// Scroll state of the open dropdown's list, so it can open at its
     /// current value instead of the top.
-    pub dropdown_scroll: crate::ui::DropdownScroll,
+    pub dropdown: crate::ui::DropdownState,
     /// Path to the open submenu in the menu bar, e.g. [2, 4] for the fifth
     /// row of the third menu. Empty means none.
     pub open_submenu: Vec<usize>,
@@ -1293,7 +1293,7 @@ impl Workspace {
             pointer_down: false,
             status: "Ready".into(),
             open_popup: None,
-            dropdown_scroll: Default::default(),
+            dropdown: Default::default(),
             open_submenu: Vec::new(),
             native_menu: None,
             rotation: 0.0,

--- a/crates/app/src/workspace/modals.rs
+++ b/crates/app/src/workspace/modals.rs
@@ -576,6 +576,14 @@ impl Workspace {
             self.close_context_menu(cx);
             return;
         }
+        // A dropdown is the innermost thing open, inside a dialog or
+        // not: escape folds it up and leaves whatever it sits in alone.
+        // It used to be checked after the modal, so escape on an open
+        // dropdown in a dialog closed the whole dialog.
+        if self.open_popup.is_some() {
+            self.close_popup(cx);
+            return;
+        }
         // A focused field takes the escape first: it drops focus and
         // leaves the dialog up, which is what `field_key`'s "escape" arm
         // meant to do before `CancelGesture` -- bound in the
@@ -595,10 +603,6 @@ impl Workspace {
         }
         if self.modal.is_some() {
             self.close_modal(cx);
-            return;
-        }
-        if self.open_popup.is_some() {
-            self.close_popup(cx);
             return;
         }
         self.pointer_down = false;

--- a/crates/app/src/workspace/render.rs
+++ b/crates/app/src/workspace/render.rs
@@ -360,7 +360,10 @@ impl Workspace {
             .on_scroll_wheel(cx.listener(|ws, ev, w, cx| ws.on_scroll(ev, w, cx)))
             .on_pinch(cx.listener(|ws, ev, w, cx| ws.on_pinch(ev, w, cx)))
             .on_key_down(cx.listener(|ws, ev: &gpui::KeyDownEvent, window, cx| {
-                if ws.layer_rename_key(ev, cx)
+                // An open dropdown is the innermost thing there is: its
+                // keys go to it before a modal's fields or a tool.
+                if ws.dropdown_key(ev, cx)
+                    || ws.layer_rename_key(ev, cx)
                     || ws.note_edit_key(ev, cx)
                     || ws.ai_model_menu_key(ev, cx)
                     || ws.ai_input_key(ev, cx)
@@ -532,6 +535,8 @@ impl Render for Workspace {
         // Every colour below comes from the palette, so the theme must be
         // selected before any child renders.
         crate::ui::set_light(self.view.theme == Theme::Light);
+        // Whichever dropdown renders open this frame registers itself.
+        crate::ui::reset_open_dropdown();
         if !self.focused_once {
             // The focus handle only exists in the dispatch tree once we've
             // rendered, so this can't happen at construction time.
@@ -549,6 +554,7 @@ impl Render for Workspace {
         let key_context = if self.modal.is_some() {
             "Workspace modal"
         } else if self.tool_captures_keys()
+            || self.dropdown_open()
             || self.layer_rename.is_some()
             || self.note_edit.is_some()
             || self.ai.input_active

--- a/crates/app/src/workspace/render.rs
+++ b/crates/app/src/workspace/render.rs
@@ -239,6 +239,12 @@ impl Workspace {
                         gpui::rgb(0x44AAFF).into(),
                     ));
                 }
+                Overlay::Highlight(r) => {
+                    job.highlights.push(Bounds {
+                        origin: to_screen(r.left as f32, r.top as f32),
+                        size: size(px(r.width() as f32 * zoom), px(r.height() as f32 * zoom)),
+                    });
+                }
                 Overlay::AntsRect(r) => {
                     let (l, t) = (r.left as f32, r.top as f32);
                     let (rt, b) = (r.right as f32, r.bottom as f32);
@@ -445,6 +451,9 @@ impl Workspace {
                         // below selection ants and tool overlays.
                         for (bounds, color) in job.lines {
                             window.paint_quad(gpui::fill(bounds, color));
+                        }
+                        for bounds in job.highlights {
+                            window.paint_quad(gpui::fill(bounds, gpui::rgba(0x3399FF66)));
                         }
                         for (bounds, color) in job.outlines {
                             window.paint_quad(gpui::outline(

--- a/crates/codec-affinity/src/import/text.rs
+++ b/crates/codec-affinity/src/import/text.rs
@@ -175,6 +175,7 @@ impl Walker<'_> {
             tracking: 0.0,
             // Frame text reflows to its box; artistic text never wraps.
             wrap_width: (frame_text && frame_width > 8).then_some(frame_width as f32),
+            runs: Vec::new(),
         };
         let mut raster = match schist_text_engine::rasterize(&spec) {
             Some(r) => r,

--- a/crates/core/src/document.rs
+++ b/crates/core/src/document.rs
@@ -2,7 +2,7 @@
 
 use crate::geom::IntRect;
 use crate::history::{Edit, EditOp, History, LayerProps};
-use crate::layer::{Layer, LayerId, LayerMask, LayerPath, LayerTree};
+use crate::layer::{Layer, LayerId, LayerMask, LayerPath, LayerTree, RawBlock};
 use crate::selection::Selection;
 use crate::tile::{TileBuf, TileCoord, TileMap, TILE_PIXELS};
 use rustc_hash::FxHashMap;
@@ -403,6 +403,21 @@ impl Document {
                 }
                 self.structure_changed();
             }
+            EditOp::LayerExtrasSet {
+                layer,
+                before,
+                after,
+            } => {
+                let want = if dir == Direction::Undo {
+                    before
+                } else {
+                    after
+                };
+                if let Some(l) = self.tree.find_mut(*layer) {
+                    l.extras = want.clone();
+                }
+                self.structure_changed();
+            }
             EditOp::LayerStyleSet {
                 layer,
                 before,
@@ -763,6 +778,22 @@ impl<'a> EditBuilder<'a> {
         });
         let canvas = self.doc.canvas_rect();
         self.damage = self.damage.union(&canvas);
+    }
+
+    /// Replace a layer's preserved blocks, recording the change.
+    pub fn set_extras(&mut self, layer: LayerId, after: Vec<RawBlock>) {
+        let Some(l) = self.doc.tree.find_mut(layer) else {
+            return;
+        };
+        if l.extras == after {
+            return;
+        }
+        let before = std::mem::replace(&mut l.extras, after.clone());
+        self.ops.push(EditOp::LayerExtrasSet {
+            layer,
+            before,
+            after,
+        });
     }
 
     pub fn record_adjustment_params(

--- a/crates/core/src/history.rs
+++ b/crates/core/src/history.rs
@@ -100,6 +100,17 @@ pub enum EditOp {
         before: Option<Box<crate::smart::SmartObject>>,
         after: Option<Box<crate::smart::SmartObject>>,
     },
+    /// A layer's preserved blocks changed.
+    ///
+    /// The type tool keeps a text layer's spec in one of them, and it
+    /// has to undo together with the pixels rendered from it: undoing
+    /// the pixels alone left the glyphs and the text they were set from
+    /// disagreeing.
+    LayerExtrasSet {
+        layer: LayerId,
+        before: Vec<crate::layer::RawBlock>,
+        after: Vec<crate::layer::RawBlock>,
+    },
     /// A layer's effects changed.
     LayerStyleSet {
         layer: LayerId,

--- a/crates/plugin-api/src/lib.rs
+++ b/crates/plugin-api/src/lib.rs
@@ -116,6 +116,9 @@ pub enum Overlay {
     AntsPolygon(Vec<(f32, f32)>),
     /// Solid outline rect (e.g. layer bounds during move).
     Rect(IntRect),
+    /// Translucent selection highlight, drawn above artwork and below
+    /// outline/caret chrome.
+    Highlight(IntRect),
     /// Circle outline (brush cursor), document-space center and radius.
     Circle { cx: f32, cy: f32, r: f32 },
     /// Straight line segment.

--- a/crates/text-engine/Cargo.toml
+++ b/crates/text-engine/Cargo.toml
@@ -12,3 +12,6 @@ fontdb = "0.24"
 ttf-parser = "0.25"
 log.workspace = true
 serde.workspace = true
+
+[dev-dependencies]
+serde_json.workspace = true

--- a/crates/text-engine/src/lib.rs
+++ b/crates/text-engine/src/lib.rs
@@ -1181,6 +1181,37 @@ pub fn caret_at(spec: &TextSpec, byte: usize) -> Option<Caret> {
     })
 }
 
+/// The text position nearest a point in layout coordinates.
+///
+/// `x` and `y` are relative to the same origin as [`Caret`]. The closest
+/// line is used above or below the text, and the closest pen position on
+/// that line is used to its left or right, so a drag can continue beyond
+/// the ink and still select predictably.
+pub fn hit_test(spec: &TextSpec, x: f32, y: f32) -> Option<usize> {
+    let face = load_font(&spec.family, spec.bold, spec.italic)?;
+    let laid = layout(spec, &face);
+    let span = laid.lines.iter().min_by(|a, b| {
+        let distance = |line: &&LineSpan| {
+            if y < line.top {
+                line.top - y
+            } else if y > line.top + line.height {
+                y - (line.top + line.height)
+            } else {
+                0.0
+            }
+        };
+        distance(a).total_cmp(&distance(b))
+    })?;
+
+    laid.chars
+        .iter()
+        .filter(|pos| span.start <= pos.byte && pos.byte < span.end)
+        .map(|pos| (pos.byte, pos.x))
+        .chain(std::iter::once((span.end, span.x + span.width)))
+        .min_by(|(_, ax), (_, bx)| (x - ax).abs().total_cmp(&(x - bx).abs()))
+        .map(|(byte, _)| byte)
+}
+
 /// Nearest char boundary at or below `byte`, clamped to the string.
 fn clamp_to_boundary(text: &str, byte: usize) -> usize {
     let mut at = byte.min(text.len());
@@ -1334,6 +1365,35 @@ mod tests {
     }
 
     #[test]
+    fn hit_testing_picks_the_nearest_caret_on_the_nearest_line() {
+        let s = spec("ab\ncd");
+        let zero = caret_at(&s, 0).unwrap();
+        let one = caret_at(&s, 1).unwrap();
+        let first_end = caret_at(&s, 2).unwrap();
+        let second_start = caret_at(&s, 3).unwrap();
+        let four = caret_at(&s, 4).unwrap();
+
+        let first_y = zero.top + zero.height / 2.0;
+        let second_y = second_start.top + second_start.height / 2.0;
+        assert_eq!(hit_test(&s, zero.x - 100.0, first_y), Some(0));
+        assert_eq!(
+            hit_test(&s, zero.x + (one.x - zero.x) * 0.75, first_y),
+            Some(1)
+        );
+        assert_eq!(hit_test(&s, first_end.x + 100.0, first_y), Some(2));
+        assert_eq!(hit_test(&s, second_start.x - 100.0, second_y), Some(3));
+        assert_eq!(
+            hit_test(
+                &s,
+                second_start.x + (four.x - second_start.x) * 0.75,
+                second_y + 1_000.0,
+            ),
+            Some(4),
+            "a drag below the text stays on its last line"
+        );
+    }
+
+    #[test]
     fn old_specs_load_without_runs_and_new_ones_keep_them() {
         let old = r#"{"text":"Hi","family":"X","size":12.0,"align":"Left","line_height":1.0,"tracking":0.0,"wrap_width":null}"#;
         let spec: TextSpec = serde_json::from_str(old).unwrap();
@@ -1436,11 +1496,11 @@ mod tests {
         s.splice_runs(5..5, 1);
         assert_eq!(s.runs[0].end, 6);
         // Typing before it goes in plain and pushes it along.
-        s.text.insert_str(3, "X");
+        s.text.insert(3, 'X');
         s.splice_runs(3..3, 1);
         assert_eq!((s.runs[0].start, s.runs[0].end), (4, 7));
         // Typing inside it grows it.
-        s.text.insert_str(5, "Y");
+        s.text.insert(5, 'Y');
         s.splice_runs(5..5, 1);
         assert_eq!((s.runs[0].start, s.runs[0].end), (4, 8));
         // Deleting across its start shortens it from the front.

--- a/crates/text-engine/src/lib.rs
+++ b/crates/text-engine/src/lib.rs
@@ -1,8 +1,9 @@
 //! Text layout and rasterization for text layers.
 //!
-//! Scope: system font discovery, a single font/size/colour per layer,
-//! left-to-right line layout with kerning, word wrapping and alignment,
-//! rasterized to an 8-bit coverage mask. Complex shaping (ligature
+//! Scope: system font discovery, one colour per layer with the family,
+//! style and size free to change from character to character (see
+//! [`StyleRun`]), left-to-right line layout with kerning, word wrapping
+//! and alignment, rasterized to an 8-bit coverage mask. Complex shaping (ligature
 //! substitution, bidi, vertical scripts) is out of scope for v1 — those
 //! need a full shaper, which is why parley/swash is the
 //! eventual home for this crate.
@@ -52,6 +53,13 @@ pub struct TextSpec {
     pub tracking: f32,
     /// Wrap width in pixels; `None` means never wrap.
     pub wrap_width: Option<f32>,
+    /// Stretches of `text` set differently from the rest, by byte range.
+    /// Sorted and non-overlapping; whatever they leave uncovered is set
+    /// in the layer's own `family`/`bold`/`italic`/`size`. Empty for
+    /// text in one font, which is also what files written before runs
+    /// existed load as.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub runs: Vec<StyleRun>,
 }
 
 impl Default for TextSpec {
@@ -66,7 +74,290 @@ impl Default for TextSpec {
             line_height: 1.0,
             tracking: 0.0,
             wrap_width: None,
+            runs: Vec::new(),
         }
+    }
+}
+
+/// A range of characters set in something other than the layer's own
+/// font: each field that is `Some` overrides the layer's, the rest
+/// inherit. Byte offsets into `TextSpec::text`.
+#[derive(Debug, Clone, PartialEq, Default, serde::Serialize, serde::Deserialize)]
+pub struct StyleRun {
+    pub start: usize,
+    pub end: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub family: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bold: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub italic: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size: Option<f32>,
+}
+
+impl StyleRun {
+    /// True when this run changes nothing, so it can be dropped.
+    pub fn is_plain(&self) -> bool {
+        self.family.is_none() && self.bold.is_none() && self.italic.is_none() && self.size.is_none()
+    }
+
+    /// The overrides alone, without the range: what an edit applies.
+    pub fn overrides(&self) -> StyleRun {
+        StyleRun {
+            start: 0,
+            end: 0,
+            ..self.clone()
+        }
+    }
+
+    /// Lay `over`'s overrides on top of this run's.
+    pub fn merge(&mut self, over: &StyleRun) {
+        if over.family.is_some() {
+            self.family = over.family.clone();
+        }
+        if over.bold.is_some() {
+            self.bold = over.bold;
+        }
+        if over.italic.is_some() {
+            self.italic = over.italic;
+        }
+        if over.size.is_some() {
+            self.size = over.size;
+        }
+    }
+
+    /// Whether the two runs would set a character the same way.
+    fn same_style(&self, other: &StyleRun) -> bool {
+        self.family == other.family
+            && self.bold == other.bold
+            && self.italic == other.italic
+            && self.size == other.size
+    }
+}
+
+/// The font one character is set in, once the layer's own settings and
+/// any run covering it have been reconciled.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CharStyle {
+    pub family: String,
+    pub bold: bool,
+    pub italic: bool,
+    pub size: f32,
+}
+
+impl CharStyle {
+    /// The style as an override that would reproduce it in full.
+    pub fn as_run(&self) -> StyleRun {
+        StyleRun {
+            start: 0,
+            end: 0,
+            family: Some(self.family.clone()),
+            bold: Some(self.bold),
+            italic: Some(self.italic),
+            size: Some(self.size),
+        }
+    }
+}
+
+impl TextSpec {
+    /// The layer's own font, which uncovered text is set in.
+    pub fn base_style(&self) -> CharStyle {
+        CharStyle {
+            family: self.family.clone(),
+            bold: self.bold,
+            italic: self.italic,
+            size: self.size,
+        }
+    }
+
+    /// The font the character at `byte` is set in.
+    pub fn style_at(&self, byte: usize) -> CharStyle {
+        let mut style = self.base_style();
+        if let Some(run) = self.runs.iter().find(|r| r.start <= byte && byte < r.end) {
+            if let Some(f) = &run.family {
+                style.family = f.clone();
+            }
+            if let Some(b) = run.bold {
+                style.bold = b;
+            }
+            if let Some(i) = run.italic {
+                style.italic = i;
+            }
+            if let Some(s) = run.size {
+                style.size = s;
+            }
+        }
+        style
+    }
+
+    /// Every family the text is set in: the layer's own first, then the
+    /// runs', without repeats.
+    pub fn families(&self) -> Vec<&str> {
+        let mut out = vec![self.family.as_str()];
+        for run in &self.runs {
+            if let Some(f) = &run.family {
+                if !out.contains(&f.as_str()) {
+                    out.push(f);
+                }
+            }
+        }
+        out
+    }
+
+    /// Set `range` in `over`'s overrides, splitting whatever runs it
+    /// cuts through. A range spanning the whole text moves the setting
+    /// onto the layer itself and lifts it from every run, so text set
+    /// in one font stays described as such.
+    pub fn apply_style(&mut self, range: std::ops::Range<usize>, over: &StyleRun) {
+        let len = self.text.len();
+        let range = range.start.min(len)..range.end.min(len);
+        if over.is_plain() {
+            return;
+        }
+        if range.start == 0 && range.end == len {
+            if let Some(f) = &over.family {
+                self.family = f.clone();
+                self.runs.iter_mut().for_each(|r| r.family = None);
+            }
+            if let Some(b) = over.bold {
+                self.bold = b;
+                self.runs.iter_mut().for_each(|r| r.bold = None);
+            }
+            if let Some(i) = over.italic {
+                self.italic = i;
+                self.runs.iter_mut().for_each(|r| r.italic = None);
+            }
+            if let Some(s) = over.size {
+                self.size = s;
+                self.runs.iter_mut().for_each(|r| r.size = None);
+            }
+            self.normalize_runs();
+            return;
+        }
+        if range.is_empty() {
+            return;
+        }
+        // Cut the existing runs at the range's edges, so the ones inside
+        // can take the override while the parts outside keep theirs.
+        let mut runs = Vec::with_capacity(self.runs.len() + 2);
+        for run in self.runs.drain(..) {
+            if run.end <= range.start || run.start >= range.end {
+                runs.push(run);
+                continue;
+            }
+            if run.start < range.start {
+                runs.push(StyleRun {
+                    end: range.start,
+                    ..run.clone()
+                });
+            }
+            let mut inside = StyleRun {
+                start: run.start.max(range.start),
+                end: run.end.min(range.end),
+                ..run.clone()
+            };
+            inside.merge(over);
+            runs.push(inside);
+            if run.end > range.end {
+                runs.push(StyleRun {
+                    start: range.end,
+                    ..run
+                });
+            }
+        }
+        // Whatever the range covers that no run did gets a fresh run.
+        let mut at = range.start;
+        let mut covered: Vec<(usize, usize)> = runs
+            .iter()
+            .filter(|r| r.start >= range.start && r.end <= range.end)
+            .map(|r| (r.start, r.end))
+            .collect();
+        covered.sort_unstable();
+        for (s, e) in covered {
+            if s > at {
+                runs.push(StyleRun {
+                    start: at,
+                    end: s,
+                    ..over.overrides()
+                });
+            }
+            at = at.max(e);
+        }
+        if at < range.end {
+            runs.push(StyleRun {
+                start: at,
+                end: range.end,
+                ..over.overrides()
+            });
+        }
+        self.runs = runs;
+        self.normalize_runs();
+    }
+
+    /// Keep the runs in step with `text` after `range` was replaced by
+    /// `inserted` bytes.
+    ///
+    /// An edge before the edit stays, one after it shifts, one inside
+    /// the replaced span collapses to its start. Text put down at the
+    /// end of a run joins it, the way typing after a bold word stays
+    /// bold; text put down at a run's start goes before it; text
+    /// replacing a selection takes the style of what it replaced.
+    pub fn splice_runs(&mut self, range: std::ops::Range<usize>, inserted: usize) {
+        let removed = range.end.saturating_sub(range.start);
+        let map = |at: usize| -> usize {
+            if at < range.start {
+                at
+            } else if at >= range.end {
+                at - removed + inserted
+            } else {
+                range.start
+            }
+        };
+        for run in &mut self.runs {
+            let (s, e) = (run.start, run.end);
+            run.start = map(s);
+            run.end = map(e);
+            // The run holding the first replaced character takes the
+            // replacement, however much of the run the selection took.
+            if s <= range.start && range.start < e {
+                run.end = run.end.max(range.start + inserted);
+            }
+        }
+        self.normalize_runs();
+    }
+
+    /// Sort the runs, drop the empty and the plain, and join neighbours
+    /// that say the same thing.
+    pub fn normalize_runs(&mut self) {
+        let len = self.text.len();
+        for run in &mut self.runs {
+            run.start = run.start.min(len);
+            run.end = run.end.min(len);
+        }
+        self.runs.retain(|r| r.start < r.end && !r.is_plain());
+        self.runs.sort_by_key(|r| (r.start, r.end));
+        let mut merged: Vec<StyleRun> = Vec::with_capacity(self.runs.len());
+        for run in self.runs.drain(..) {
+            if let Some(last) = merged.last_mut() {
+                if last.end == run.start && last.same_style(&run) {
+                    last.end = run.end;
+                    continue;
+                }
+                // Overlaps only arise from corrupt input; the later run
+                // starts where the earlier one ends.
+                if run.start < last.end {
+                    let mut run = run;
+                    run.start = last.end;
+                    if run.start < run.end {
+                        merged.push(run);
+                    }
+                    continue;
+                }
+            }
+            merged.push(run);
+        }
+        self.runs = merged;
     }
 }
 
@@ -556,10 +847,17 @@ struct PlacedGlyph {
     ch: char,
     x: f32,
     baseline: f32,
+    /// Index into the layout's faces: which font, at which size.
+    face: usize,
 }
 
-/// Break `spec.text` into lines (honouring explicit newlines and wrapping),
-/// then place glyphs along each baseline.
+/// Where a character's pen starts, for caret placement.
+#[derive(Debug, Clone, Copy)]
+struct CharPos {
+    byte: usize,
+    x: f32,
+}
+
 /// Laid-out glyphs, the widest line, the first baseline and the
 /// baseline-to-baseline step.
 struct Layout {
@@ -568,6 +866,63 @@ struct Layout {
     line_advance: f32,
     layout_width: f32,
     lines: Vec<LineSpan>,
+    chars: Vec<CharPos>,
+}
+
+/// The faces a spec sets its text in, one per distinct family, style
+/// and size, and which of them each byte of the text uses. Index 0 is
+/// the layer's own font.
+struct Faces {
+    faces: Vec<(LoadedFace, f32)>,
+    by_byte: Vec<usize>,
+}
+
+impl Faces {
+    fn resolve(spec: &TextSpec, base: &LoadedFace) -> Faces {
+        let base_style = spec.base_style();
+        let mut styles = vec![base_style.clone()];
+        let mut faces = vec![(base.clone(), spec.size)];
+        let mut by_byte = vec![0usize; spec.text.len()];
+        for run in &spec.runs {
+            let (s, e) = (run.start.min(spec.text.len()), run.end.min(spec.text.len()));
+            if s >= e {
+                continue;
+            }
+            let style = spec.style_at(s);
+            if style == base_style {
+                continue;
+            }
+            let ix = match styles.iter().position(|k| *k == style) {
+                Some(ix) => ix,
+                None => {
+                    // A family that cannot be loaded falls back to the
+                    // layer's own face, at the run's size.
+                    let face = load_font(&style.family, style.bold, style.italic)
+                        .unwrap_or_else(|| base.clone());
+                    styles.push(style.clone());
+                    faces.push((face, style.size));
+                    faces.len() - 1
+                }
+            };
+            for b in &mut by_byte[s..e] {
+                *b = ix;
+            }
+        }
+        Faces { faces, by_byte }
+    }
+
+    fn at(&self, byte: usize) -> usize {
+        self.by_byte.get(byte).copied().unwrap_or(0)
+    }
+
+    /// Ascent and natural line step of face `ix`.
+    fn line_metrics(&self, ix: usize) -> (f32, f32) {
+        let (face, size) = &self.faces[ix];
+        face.font
+            .horizontal_line_metrics(*size)
+            .map(|m| (m.ascent, m.new_line_size))
+            .unwrap_or((size * 0.8, size * 1.2))
+    }
 }
 
 /// One laid-out line, and the byte range of `TextSpec::text` it covers.
@@ -598,26 +953,39 @@ pub struct Caret {
     pub height: f32,
 }
 
-fn layout(spec: &TextSpec, face: &LoadedFace) -> Layout {
-    let font = &face.font;
-    let metrics = font.horizontal_line_metrics(spec.size);
-    let (ascent, line_gap) = metrics
-        .map(|m| (m.ascent, m.new_line_size))
-        .unwrap_or((spec.size * 0.8, spec.size * 1.2));
-    let line_advance = line_gap * spec.line_height.max(0.1);
-
+fn layout(spec: &TextSpec, base: &LoadedFace) -> Layout {
+    let faces = Faces::resolve(spec, base);
     // A face with GPOS kerning speaks through it alone; the legacy
     // `kern` table is only consulted when there is no GPOS to read.
-    let gpos = GposKern::new(&face.data, face.index, spec.size);
-    let advance = |ch: char, prev: Option<char>| -> f32 {
-        let m = font.metrics(ch, spec.size);
+    // Kerning is looked up per face, and only between neighbours set in
+    // the same face at the same size: a pair that straddles a font
+    // change has no table to consult.
+    let kerns: Vec<Option<GposKern>> = faces
+        .faces
+        .iter()
+        .map(|(face, size)| GposKern::new(&face.data, face.index, *size))
+        .collect();
+    let advance = |ch: char, prev: Option<(char, usize)>, ix: usize| -> f32 {
+        let (face, size) = &faces.faces[ix];
+        let m = face.font.metrics(ch, *size);
         let kern = prev
-            .and_then(|p| match &gpos {
+            .filter(|(_, pix)| *pix == ix)
+            .and_then(|(p, _)| match &kerns[ix] {
                 Some(g) => g.kern(p, ch),
-                None => font.horizontal_kern(p, ch, spec.size),
+                None => face.font.horizontal_kern(p, ch, *size),
             })
             .unwrap_or(0.0);
         m.advance_width + kern + spec.tracking
+    };
+    // Advance of `word` starting at byte `from`, after `prev`.
+    let measure_word = |word: &str, from: usize, mut prev: Option<(char, usize)>| -> f32 {
+        let mut width = 0.0;
+        for (i, ch) in word.char_indices() {
+            let ix = faces.at(from + i);
+            width += advance(ch, prev, ix);
+            prev = Some((ch, ix));
+        }
+        width
     };
 
     // Split into wrapped lines, carrying each line's byte range in
@@ -635,18 +1003,13 @@ fn layout(spec: &TextSpec, face: &LoadedFace) -> Layout {
     for raw_line in spec.text.split('\n') {
         let mut current = String::new();
         let mut width = 0.0f32;
-        let mut prev: Option<char> = None;
+        let mut prev: Option<(char, usize)> = None;
         let mut start = line_start;
         let mut at = line_start;
         // Wrap on word boundaries; a single over-long word is left to
         // overflow rather than being broken mid-word.
         for word in raw_line.split_inclusive(' ') {
-            let mut word_width = 0.0;
-            let mut p = prev;
-            for ch in word.chars() {
-                word_width += advance(ch, p);
-                p = Some(ch);
-            }
+            let mut word_width = measure_word(word, at, prev);
             let wraps = spec
                 .wrap_width
                 .is_some_and(|w| !current.is_empty() && width + word_width > w);
@@ -661,17 +1024,15 @@ fn layout(spec: &TextSpec, face: &LoadedFace) -> Layout {
                 width = 0.0;
                 // Re-measure the word with no kerning context: it now
                 // starts a line, so there is no preceding glyph.
-                let mut p = None;
-                word_width = 0.0;
-                for ch in word.chars() {
-                    word_width += advance(ch, p);
-                    p = Some(ch);
-                }
+                word_width = measure_word(word, at, None);
             }
             current.push_str(word);
             width += word_width;
+            prev = word
+                .char_indices()
+                .last()
+                .map(|(i, ch)| (ch, faces.at(at + i)));
             at += word.len();
-            prev = word.chars().last();
         }
         lines.push(Line {
             text: current,
@@ -685,9 +1046,34 @@ fn layout(spec: &TextSpec, face: &LoadedFace) -> Layout {
 
     let max_width = lines.iter().map(|l| l.width).fold(0.0f32, f32::max);
     let mut placed = Vec::new();
+    let mut chars = Vec::new();
     let mut spans = Vec::with_capacity(lines.len());
+    let mut first_baseline = 0.0;
+    let mut first_advance = 0.0;
+    let mut top = 0.0f32;
     for (i, line) in lines.iter().enumerate() {
-        let baseline = ascent + i as f32 * line_advance;
+        // A line is as tall as the tallest face on it, and an empty line
+        // as tall as the layer's own font.
+        let mut used: Vec<usize> = line
+            .text
+            .char_indices()
+            .map(|(k, _)| faces.at(line.start + k))
+            .collect();
+        used.sort_unstable();
+        used.dedup();
+        if used.is_empty() {
+            used.push(0);
+        }
+        let (ascent, line_gap) = used
+            .iter()
+            .map(|&ix| faces.line_metrics(ix))
+            .fold((0.0f32, 0.0f32), |(a, g), (fa, fg)| (a.max(fa), g.max(fg)));
+        let line_advance = line_gap * spec.line_height.max(0.1);
+        let baseline = top + ascent;
+        if i == 0 {
+            first_baseline = ascent;
+            first_advance = line_advance;
+        }
         let start_x = match spec.align {
             Align::Left => 0.0,
             Align::Center => (max_width - line.width) / 2.0,
@@ -698,25 +1084,35 @@ fn layout(spec: &TextSpec, face: &LoadedFace) -> Layout {
             end: line.end,
             x: start_x,
             width: line.width,
-            top: i as f32 * line_advance,
+            top,
             height: line_advance,
         });
         let mut x = start_x;
-        let mut prev: Option<char> = None;
-        for ch in line.text.chars() {
+        let mut prev: Option<(char, usize)> = None;
+        for (k, ch) in line.text.char_indices() {
+            let byte = line.start + k;
+            let ix = faces.at(byte);
+            chars.push(CharPos { byte, x });
             if !ch.is_whitespace() {
-                placed.push(PlacedGlyph { ch, x, baseline });
+                placed.push(PlacedGlyph {
+                    ch,
+                    x,
+                    baseline,
+                    face: ix,
+                });
             }
-            x += advance(ch, prev);
-            prev = Some(ch);
+            x += advance(ch, prev, ix);
+            prev = Some((ch, ix));
         }
+        top += line_advance;
     }
     Layout {
         glyphs: placed,
-        first_baseline: ascent,
-        line_advance,
+        first_baseline,
+        line_advance: first_advance,
         layout_width: max_width,
         lines: spans,
+        chars,
     }
 }
 
@@ -762,9 +1158,20 @@ pub fn caret_at(spec: &TextSpec, byte: usize) -> Option<Caret> {
         });
 
     let upto = byte.clamp(span.start, span.end);
-    let prefix = spec.text.get(span.start..upto).unwrap_or("");
+    // The pen position of the character the caret sits before, or the
+    // line's end after its last one. Same pass as the glyphs, so a
+    // caret between two fonts lands exactly where the ink changes.
+    let x = if upto >= span.end {
+        span.x + span.width
+    } else {
+        laid.chars
+            .iter()
+            .find(|c| c.byte == upto)
+            .map(|c| c.x)
+            .unwrap_or(span.x + span.width)
+    };
     Some(Caret {
-        x: span.x + measure(spec, &face, prefix),
+        x,
         top: span.top,
         height: if span.height > 0.0 {
             span.height
@@ -772,29 +1179,6 @@ pub fn caret_at(spec: &TextSpec, byte: usize) -> Option<Caret> {
             spec.size
         },
     })
-}
-
-/// Advance width of `text` laid out with `spec`'s font and tracking.
-///
-/// Used for caret placement, so it has to agree with `layout`'s advance
-/// exactly, kerning included.
-fn measure(spec: &TextSpec, face: &LoadedFace, text: &str) -> f32 {
-    let font = &face.font;
-    let gpos = GposKern::new(&face.data, face.index, spec.size);
-    let mut width = 0.0;
-    let mut prev: Option<char> = None;
-    for ch in text.chars() {
-        let m = font.metrics(ch, spec.size);
-        let kern = prev
-            .and_then(|p| match &gpos {
-                Some(g) => g.kern(p, ch),
-                None => font.horizontal_kern(p, ch, spec.size),
-            })
-            .unwrap_or(0.0);
-        width += m.advance_width + kern + spec.tracking;
-        prev = Some(ch);
-    }
-    width
 }
 
 /// Nearest char boundary at or below `byte`, clamped to the string.
@@ -822,7 +1206,7 @@ pub fn rasterize(spec: &TextSpec) -> Option<TextRaster> {
             cap_height: face.cap_ratio.map(|r| r * spec.size),
         });
     }
-    let font = &face.font;
+    let faces = Faces::resolve(spec, &face);
     let Layout {
         glyphs: placed,
         first_baseline,
@@ -845,7 +1229,8 @@ pub fn rasterize(spec: &TextSpec) -> Option<TextRaster> {
     let mut rasterized = Vec::with_capacity(placed.len());
     let mut bounds = IntRect::EMPTY;
     for g in &placed {
-        let (metrics, bitmap) = font.rasterize(g.ch, spec.size);
+        let (font, size) = &faces.faces[g.face];
+        let (metrics, bitmap) = font.font.rasterize(g.ch, *size);
         if metrics.width == 0 || metrics.height == 0 {
             continue;
         }
@@ -908,6 +1293,173 @@ mod tests {
 
     fn ink(r: &TextRaster) -> usize {
         r.coverage.iter().filter(|&&v| v > 0).count()
+    }
+
+    fn run(start: usize, end: usize) -> StyleRun {
+        StyleRun {
+            start,
+            end,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn a_run_sets_part_of_the_text_in_another_size() {
+        let plain = spec("AB");
+        let mut mixed = spec("AB");
+        mixed.runs.push(StyleRun {
+            size: Some(96.0),
+            ..run(1, 2)
+        });
+        let small = rasterize(&plain).unwrap();
+        let big_b = rasterize(&mixed).unwrap();
+        assert!(big_b.bounds.width() > small.bounds.width() + 10);
+        assert!(big_b.bounds.height() > small.bounds.height() + 10);
+        // The A is untouched, so the caret between the two letters has
+        // not moved; the caret after the B has, by a lot.
+        let between = caret_at(&mixed, 1).unwrap().x;
+        assert!((between - caret_at(&plain, 1).unwrap().x).abs() < 0.01);
+        assert!(caret_at(&mixed, 2).unwrap().x > caret_at(&plain, 2).unwrap().x + 20.0);
+        // Both lines of a two-line layout are placed, and the tall B's
+        // line is taller than a plain one.
+        let mut two = spec("AB\nA");
+        two.runs.push(StyleRun {
+            size: Some(96.0),
+            ..run(1, 2)
+        });
+        let spans = line_spans(&two);
+        assert_eq!(spans.len(), 2);
+        assert!(spans[0].height > spans[1].height + 10.0);
+        assert!((spans[1].top - spans[0].height).abs() < 0.01);
+    }
+
+    #[test]
+    fn old_specs_load_without_runs_and_new_ones_keep_them() {
+        let old = r#"{"text":"Hi","family":"X","size":12.0,"align":"Left","line_height":1.0,"tracking":0.0,"wrap_width":null}"#;
+        let spec: TextSpec = serde_json::from_str(old).unwrap();
+        assert!(spec.runs.is_empty());
+        let mut with = spec.clone();
+        with.runs.push(StyleRun {
+            family: Some("Y".into()),
+            bold: Some(true),
+            ..run(0, 1)
+        });
+        let json = serde_json::to_string(&with).unwrap();
+        assert!(json.contains("\"runs\""));
+        assert!(
+            !json.contains("italic\":null"),
+            "unset overrides stay out: {json}"
+        );
+        assert_eq!(serde_json::from_str::<TextSpec>(&json).unwrap(), with);
+        // A plain spec writes no runs key at all, so the block is
+        // byte-for-byte what it was before runs existed.
+        assert!(!serde_json::to_string(&spec).unwrap().contains("runs"));
+    }
+
+    #[test]
+    fn styling_a_range_splits_the_runs_it_cuts_through() {
+        let mut s = spec("hello world");
+        s.family = "Base".into();
+        s.apply_style(
+            0..5,
+            &StyleRun {
+                bold: Some(true),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            s.runs,
+            vec![StyleRun {
+                bold: Some(true),
+                ..run(0, 5)
+            }]
+        );
+        // A family over "llo wo" cuts the bold run and covers the gap.
+        s.apply_style(
+            2..8,
+            &StyleRun {
+                family: Some("Other".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            s.runs,
+            vec![
+                StyleRun {
+                    bold: Some(true),
+                    ..run(0, 2)
+                },
+                StyleRun {
+                    bold: Some(true),
+                    family: Some("Other".into()),
+                    ..run(2, 5)
+                },
+                StyleRun {
+                    family: Some("Other".into()),
+                    ..run(5, 8)
+                },
+            ]
+        );
+        assert_eq!(s.style_at(3).family, "Other");
+        assert!(s.style_at(3).bold);
+        assert_eq!(s.style_at(9).family, "Base");
+        assert_eq!(s.families(), vec!["Base", "Other"]);
+        // The whole text moves the setting onto the layer and lifts it
+        // from the runs; the bold stays where it was.
+        s.apply_style(
+            0..s.text.len(),
+            &StyleRun {
+                family: Some("All".into()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(s.family, "All");
+        assert_eq!(
+            s.runs,
+            vec![StyleRun {
+                bold: Some(true),
+                ..run(0, 5)
+            }]
+        );
+        assert_eq!(s.families(), vec!["All"]);
+    }
+
+    #[test]
+    fn editing_the_text_keeps_the_runs_in_step() {
+        let mut s = spec("ab cd");
+        s.runs.push(StyleRun {
+            bold: Some(true),
+            ..run(3, 5)
+        });
+        // Typing after the bold word stays bold.
+        s.text.push('e');
+        s.splice_runs(5..5, 1);
+        assert_eq!(s.runs[0].end, 6);
+        // Typing before it goes in plain and pushes it along.
+        s.text.insert_str(3, "X");
+        s.splice_runs(3..3, 1);
+        assert_eq!((s.runs[0].start, s.runs[0].end), (4, 7));
+        // Typing inside it grows it.
+        s.text.insert_str(5, "Y");
+        s.splice_runs(5..5, 1);
+        assert_eq!((s.runs[0].start, s.runs[0].end), (4, 8));
+        // Deleting across its start shortens it from the front.
+        s.text.replace_range(2..6, "");
+        s.splice_runs(2..6, 0);
+        assert_eq!((s.runs[0].start, s.runs[0].end), (2, 4));
+        // Deleting it entirely drops it.
+        s.text.replace_range(2..4, "");
+        s.splice_runs(2..4, 0);
+        assert!(s.runs.is_empty());
+        // Typing over a selection that starts inside a run keeps its style.
+        let mut s = spec("abcdef");
+        s.runs.push(StyleRun {
+            italic: Some(true),
+            ..run(2, 4)
+        });
+        s.text.replace_range(3..5, "XYZ");
+        s.splice_runs(3..5, 3);
+        assert_eq!((s.runs[0].start, s.runs[0].end), (2, 6));
     }
 
     #[test]

--- a/plugins/tools-type/src/lib.rs
+++ b/plugins/tools-type/src/lib.rs
@@ -1,7 +1,9 @@
 //! Type tool (T): editable text layers.
 //!
 //! A text layer is a raster layer plus a `PsTx` block in its preserved-PSD
-//! extras holding the JSON [`TextSpec`] it was rendered from. That block
+//! extras holding the JSON [`TextSpec`] it was rendered from, character
+//! runs and all: select a word and pick a font, and only that word
+//! changes. That block
 //! rides through save/load untouched (the PSD writer re-emits unknown
 //! blocks verbatim), so text stays re-editable across sessions while
 //! Photoshop still sees ordinary pixels.
@@ -14,7 +16,7 @@ use schist_plugin_api::{
     EditorState, Modifiers, OptionValue, Overlay, PluginManifest, PluginRegistry, PointerInput,
     ToolCtx, ToolOption, ToolPlugin,
 };
-use schist_text_engine::{rasterize, Align, TextSpec};
+use schist_text_engine::{rasterize, Align, StyleRun, TextSpec};
 
 /// Additional-layer-info key under which the text spec is preserved.
 pub const TEXT_BLOCK_KEY: [u8; 4] = *b"PsTx";
@@ -113,9 +115,11 @@ pub fn families_used(doc: &Document) -> Vec<String> {
             let Some(stored) = read_stored(layer) else {
                 continue;
             };
-            let family = stored.spec.family.trim();
-            if !family.is_empty() && !out.iter().any(|f| f == family) {
-                out.push(family.to_string());
+            for family in stored.spec.families() {
+                let family = family.trim();
+                if !family.is_empty() && !out.iter().any(|f| f == family) {
+                    out.push(family.to_string());
+                }
             }
         }
     }
@@ -135,8 +139,13 @@ pub fn rerender_family(doc: &mut Document, family: &str) -> usize {
             if let Some(children) = layer.children() {
                 collect(children, family, out);
             }
-            if read_stored(layer).is_some_and(|s| s.spec.family.trim().eq_ignore_ascii_case(family))
-            {
+            let uses = |s: &StoredText| {
+                s.spec
+                    .families()
+                    .iter()
+                    .any(|f| f.trim().eq_ignore_ascii_case(family))
+            };
+            if read_stored(layer).is_some_and(|s| uses(&s)) {
                 out.push(layer.id);
             }
         }
@@ -173,6 +182,11 @@ struct Editing {
     stored: StoredText,
     /// Pixels before this session, for undo capture on commit.
     original: TileMap,
+    /// The layer's preserved blocks and name before this session, so the
+    /// commit can record them changing alongside the pixels and a
+    /// cancel can put them back.
+    original_extras: Vec<RawBlock>,
+    original_name: String,
     /// True once the layer was created by this session (so cancelling
     /// removes it entirely).
     created: bool,
@@ -246,6 +260,8 @@ impl TypeTool {
         let mut layer = Layer::new_raster("Text");
         write_stored(&mut layer, &stored);
         let id = layer.id;
+        let original_extras = layer.extras.clone();
+        let original_name = layer.name.clone();
         let path = match ctx.doc.active_layer.and_then(|a| ctx.doc.tree.path_of(a)) {
             Some(mut p) => {
                 *p.0.last_mut().unwrap() += 1;
@@ -261,6 +277,8 @@ impl TypeTool {
             layer: id,
             stored,
             original: TileMap::new(),
+            original_extras,
+            original_name,
             created: true,
             dirty: false,
             caret: 0,
@@ -287,6 +305,20 @@ impl TypeTool {
         session.stored.color = fg;
         session.dirty = true;
         true
+    }
+
+    /// Show the font at the caret in the options bar: the selection's
+    /// first character, or the character before an insertion point, the
+    /// way every editor's font menu follows the cursor.
+    fn sync_bar(&mut self) {
+        let Some(session) = &self.editing else {
+            return;
+        };
+        let style = session.caret_style();
+        self.spec.family = style.family;
+        self.spec.bold = style.bold;
+        self.spec.italic = style.italic;
+        self.spec.size = style.size;
     }
 
     /// Pick an existing text layer under the cursor, if any.
@@ -344,17 +376,20 @@ impl ToolPlugin for TypeTool {
         }
         match Self::text_layer_at(ctx.doc, input.x, input.y) {
             Some((layer, stored)) => {
-                let original = ctx
-                    .doc
-                    .tree
-                    .find(layer)
+                let found = ctx.doc.tree.find(layer);
+                let original = found
                     .and_then(|l| l.as_raster())
                     .map(|r| r.tiles.clone())
                     .unwrap_or_default();
+                let original_extras = found.map(|l| l.extras.clone()).unwrap_or_default();
+                let original_name = found.map(|l| l.name.clone()).unwrap_or_default();
                 ctx.doc.active_layer = Some(layer);
-                // Show this layer's own type settings in the bar.
+                // Show this layer's own type settings in the bar. Its
+                // runs stay with it: the bar describes one font at a
+                // time, the one at the caret.
                 self.spec = TextSpec {
                     text: String::new(),
+                    runs: Vec::new(),
                     ..stored.spec.clone()
                 };
                 let end = stored.spec.text.len();
@@ -362,11 +397,14 @@ impl ToolPlugin for TypeTool {
                     layer,
                     stored,
                     original,
+                    original_extras,
+                    original_name,
                     created: false,
                     dirty: false,
                     caret: end,
                     anchor: end,
                 });
+                self.sync_bar();
                 // A colour picked since this text was set applies to it now,
                 // so the eyedropper works on text like on anything else.
                 if self.adopt_foreground(ctx.state) {
@@ -436,11 +474,7 @@ impl ToolPlugin for TypeTool {
                             session.prev_boundary(session.caret)
                         };
                         if to != session.caret {
-                            session
-                                .stored
-                                .spec
-                                .text
-                                .replace_range(to..session.caret, "");
+                            session.replace(to..session.caret, "");
                             session.caret = to;
                             session.anchor = to;
                         }
@@ -455,11 +489,7 @@ impl ToolPlugin for TypeTool {
                             session.next_boundary(session.caret)
                         };
                         if to != session.caret {
-                            session
-                                .stored
-                                .spec
-                                .text
-                                .replace_range(session.caret..to, "");
+                            session.replace(session.caret..to, "");
                         }
                     }
                     changed = true;
@@ -493,6 +523,7 @@ impl ToolPlugin for TypeTool {
         if changed || recolored {
             self.refresh(ctx.doc);
         }
+        self.sync_bar();
         if !handled {
             return false;
         }
@@ -571,17 +602,47 @@ impl ToolPlugin for TypeTool {
         }
     }
 
-    /// Push the bar's settings onto the text being edited, so a font or
+    /// Push the bar's setting onto the text being edited, so a font or
     /// size change shows up immediately rather than on the next click.
-    fn on_option_changed(&mut self, ctx: &mut ToolCtx, _key: &str) {
+    ///
+    /// Font, style and size are character settings: with a selection
+    /// they apply to just those characters, so one layer can mix
+    /// families (issue #99); with none they apply to the whole layer.
+    /// Alignment, leading and tracking belong to the layer either way.
+    fn on_option_changed(&mut self, ctx: &mut ToolCtx, key: &str) {
         let Some(session) = &mut self.editing else {
             return;
         };
-        let text = std::mem::take(&mut session.stored.spec.text);
-        session.stored.spec = TextSpec {
-            text,
-            ..self.spec.clone()
+        let over = match key {
+            "type-family" => StyleRun {
+                family: Some(self.spec.family.clone()),
+                ..Default::default()
+            },
+            "type-style" => StyleRun {
+                bold: Some(self.spec.bold),
+                italic: Some(self.spec.italic),
+                ..Default::default()
+            },
+            "type-size" => StyleRun {
+                size: Some(self.spec.size),
+                ..Default::default()
+            },
+            _ => {
+                let spec = &mut session.stored.spec;
+                spec.align = self.spec.align;
+                spec.line_height = self.spec.line_height;
+                spec.tracking = self.spec.tracking;
+                StyleRun::default()
+            }
         };
+        if !over.is_plain() {
+            let range = if session.has_selection() {
+                session.selection()
+            } else {
+                0..session.stored.spec.text.len()
+            };
+            session.stored.spec.apply_style(range, &over);
+        }
         session.dirty = true;
         self.adopt_foreground(ctx.state);
         self.refresh(ctx.doc);
@@ -614,19 +675,25 @@ impl ToolPlugin for TypeTool {
             }
             return;
         }
-        // Re-apply through the edit builder so undo restores the pre-edit
-        // pixels in one step.
+        // Put the layer back as it stood before the session, then
+        // re-apply everything through the edit builder so one undo
+        // restores the pre-edit pixels, spec and name together. Undoing
+        // the pixels alone left the layer's text disagreeing with its
+        // glyphs, so the next click into it edited the wrong words.
         let (tiles, _) = render_tiles(ctx.doc, &session.stored);
-        if let Some(raster) = ctx
-            .doc
-            .tree
-            .find_mut(session.layer)
-            .and_then(|l| l.as_raster_mut())
-        {
+        let name = display_name(&session.stored.spec.text);
+        let Some(layer) = ctx.doc.tree.find_mut(session.layer) else {
+            return;
+        };
+        if let Some(raster) = layer.as_raster_mut() {
             raster.tiles = session.original.clone();
         }
+        layer.name = session.original_name.clone();
+        let extras = std::mem::replace(&mut layer.extras, session.original_extras.clone());
         let mut edit = ctx.doc.begin_edit("Edit Text");
         edit.replace_layer_tiles(session.layer, tiles);
+        edit.set_extras(session.layer, extras);
+        edit.change_props(session.layer, |l| l.name = name);
         edit.commit();
     }
 
@@ -640,13 +707,12 @@ impl ToolPlugin for TypeTool {
             .find(session.layer)
             .map(|l| l.content_bounds())
             .unwrap_or(IntRect::EMPTY);
-        if let Some(raster) = ctx
-            .doc
-            .tree
-            .find_mut(session.layer)
-            .and_then(|l| l.as_raster_mut())
-        {
-            raster.tiles = session.original.clone();
+        if let Some(layer) = ctx.doc.tree.find_mut(session.layer) {
+            if let Some(raster) = layer.as_raster_mut() {
+                raster.tiles = session.original.clone();
+            }
+            layer.extras = session.original_extras.clone();
+            layer.name = session.original_name.clone();
         }
         ctx.doc.add_damage(before);
         if session.created {
@@ -741,13 +807,33 @@ impl Editing {
         &self.stored.spec.text
     }
 
+    /// Replace `range` of the text with `s`, keeping the style runs in
+    /// step so a word typed after a bold one stays bold.
+    fn replace(&mut self, range: std::ops::Range<usize>, s: &str) {
+        self.stored.spec.text.replace_range(range.clone(), s);
+        self.stored.spec.splice_runs(range, s.len());
+    }
+
+    /// The font at the caret: the selection's first character, or the
+    /// character before an insertion point.
+    fn caret_style(&self) -> schist_text_engine::CharStyle {
+        let at = if self.has_selection() {
+            self.selection().start
+        } else if self.caret > 0 {
+            self.prev_boundary(self.caret)
+        } else {
+            0
+        };
+        self.stored.spec.style_at(at)
+    }
+
     /// Collapse the selection, returning true if anything was removed.
     fn delete_selection(&mut self) -> bool {
         let range = self.selection();
         if range.is_empty() {
             return false;
         }
-        self.stored.spec.text.replace_range(range.clone(), "");
+        self.replace(range.clone(), "");
         self.caret = range.start;
         self.anchor = range.start;
         true
@@ -757,7 +843,7 @@ impl Editing {
     fn insert(&mut self, s: &str) {
         self.delete_selection();
         let at = self.caret.min(self.stored.spec.text.len());
-        self.stored.spec.text.insert_str(at, s);
+        self.replace(at..at, s);
         self.caret = at + s.len();
         self.anchor = self.caret;
     }
@@ -928,7 +1014,14 @@ pub fn set_align(tool: &mut TypeTool, doc: &mut Document, align: Align) {
 /// Set the font size of the layer currently being edited.
 pub fn set_size(tool: &mut TypeTool, doc: &mut Document, size: f32) {
     if let Some(session) = &mut tool.editing {
-        session.stored.spec.size = size.clamp(4.0, 800.0);
+        let len = session.stored.spec.text.len();
+        session.stored.spec.apply_style(
+            0..len,
+            &StyleRun {
+                size: Some(size.clamp(4.0, 800.0)),
+                ..Default::default()
+            },
+        );
         session.dirty = true;
     }
     tool.refresh(doc);
@@ -942,7 +1035,14 @@ pub fn editing_family(tool: &TypeTool) -> Option<String> {
 /// Set the font family of the layer currently being edited.
 pub fn set_family(tool: &mut TypeTool, doc: &mut Document, family: String) {
     if let Some(session) = &mut tool.editing {
-        session.stored.spec.family = family;
+        let len = session.stored.spec.text.len();
+        session.stored.spec.apply_style(
+            0..len,
+            &StyleRun {
+                family: Some(family),
+                ..Default::default()
+            },
+        );
         session.dirty = true;
     }
     tool.refresh(doc);
@@ -1007,15 +1107,144 @@ mod tests {
 
         // Size, alignment and style all land on the live session.
         tool.set_option("type-size", OptionValue::Num(96.0));
-        tool.set_option("type-align", OptionValue::Choice(2));
-        tool.set_option("type-style", OptionValue::Choice(3));
         tool.on_option_changed(&mut ctx, "type-size");
+        tool.set_option("type-align", OptionValue::Choice(2));
+        tool.on_option_changed(&mut ctx, "type-align");
+        tool.set_option("type-style", OptionValue::Choice(3));
+        tool.on_option_changed(&mut ctx, "type-style");
 
         let session = tool.editing.as_ref().expect("still editing");
         assert_eq!(session.stored.spec.size, 96.0);
         assert_eq!(session.stored.spec.align, Align::Right);
         assert!(session.stored.spec.bold && session.stored.spec.italic);
         assert_eq!(session.stored.spec.text, "Hi", "the typing survives");
+    }
+
+    fn select(tool: &mut TypeTool, anchor: usize, caret: usize) {
+        let session = tool.editing.as_mut().expect("editing");
+        session.anchor = anchor;
+        session.caret = caret;
+        tool.sync_bar();
+    }
+
+    fn shown(tool: &TypeTool, key: &str) -> OptionValue {
+        tool.options()
+            .into_iter()
+            .find(|o| o.key == key)
+            .expect("an option")
+            .value
+    }
+
+    #[test]
+    fn a_selected_word_takes_its_own_size_and_typing_after_it_keeps_it() {
+        let mut d = doc();
+        let mut state = EditorState::default();
+        let mut tool = TypeTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+        type_text(&mut tool, &mut ctx, "Hi there");
+        let plain = d.tree.layers[1].tight_bounds();
+
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+        select(&mut tool, 3, 8);
+        tool.set_option("type-size", OptionValue::Num(96.0));
+        tool.on_option_changed(&mut ctx, "type-size");
+        {
+            let spec = &tool.editing.as_ref().unwrap().stored.spec;
+            assert_eq!(spec.size, 48.0, "the layer's own size is untouched");
+            assert_eq!(spec.runs.len(), 1);
+            assert_eq!((spec.runs[0].start, spec.runs[0].end), (3, 8));
+            assert_eq!(spec.runs[0].size, Some(96.0));
+        }
+        assert!(
+            d.tree.layers[1].tight_bounds().height() > plain.height() + 10,
+            "the big word shows on the canvas"
+        );
+
+        // Typing after the big word continues in it, and the bar says so.
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+        select(&mut tool, 8, 8);
+        tool.on_key(&mut ctx, "!", Some("!"), Modifiers::default());
+        let spec = &tool.editing.as_ref().unwrap().stored.spec;
+        assert_eq!(spec.text, "Hi there!");
+        assert_eq!((spec.runs[0].start, spec.runs[0].end), (3, 9));
+        assert_eq!(shown(&tool, "type-size").num(), 96.0);
+        // The caret back in the small text shows the small size.
+        select(&mut tool, 1, 1);
+        assert_eq!(shown(&tool, "type-size").num(), 48.0);
+    }
+
+    #[test]
+    fn with_nothing_selected_the_bar_restyles_the_whole_layer() {
+        let mut d = doc();
+        let mut state = EditorState::default();
+        let mut tool = TypeTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+        type_text(&mut tool, &mut ctx, "Hi there");
+        select(&mut tool, 3, 8);
+        tool.set_option("type-style", OptionValue::Choice(1));
+        tool.on_option_changed(&mut ctx, "type-style");
+        select(&mut tool, 8, 8);
+        tool.set_option("type-size", OptionValue::Num(20.0));
+        tool.on_option_changed(&mut ctx, "type-size");
+        let spec = &tool.editing.as_ref().unwrap().stored.spec;
+        assert_eq!(spec.size, 20.0);
+        assert!(!spec.bold, "the layer's own style is unchanged");
+        assert_eq!(spec.runs.len(), 1, "the bold word keeps its bold");
+        assert_eq!(spec.runs[0].bold, Some(true));
+        assert_eq!(spec.runs[0].size, None);
+    }
+
+    #[test]
+    fn undo_restores_the_text_and_name_with_the_pixels() {
+        let mut d = doc();
+        let mut state = EditorState::default();
+        let mut tool = TypeTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+        type_text(&mut tool, &mut ctx, "Hi");
+        tool.on_commit(&mut ctx);
+        let layer = d.tree.layers[1].id;
+        assert_eq!(read_stored(&d.tree.layers[1]).unwrap().spec.text, "Hi");
+
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(30.0, 80.0));
+        assert_eq!(tool.editing.as_ref().unwrap().layer, layer, "resumed");
+        select(&mut tool, 0, 2);
+        tool.set_option("type-size", OptionValue::Num(96.0));
+        tool.on_option_changed(&mut ctx, "type-size");
+        type_text(&mut tool, &mut ctx, "Yo");
+        tool.on_commit(&mut ctx);
+        assert_eq!(read_stored(&d.tree.layers[1]).unwrap().spec.text, "Yo");
+        assert_eq!(d.tree.layers[1].name, "Yo");
+
+        assert_eq!(d.undo().as_deref(), Some("Edit Text"));
+        let stored = read_stored(&d.tree.layers[1]).unwrap();
+        assert_eq!(stored.spec.text, "Hi", "the spec undoes with the pixels");
+        assert_eq!(stored.spec.size, 48.0);
+        assert_eq!(d.tree.layers[1].name, "Hi");
+        d.redo();
+        assert_eq!(read_stored(&d.tree.layers[1]).unwrap().spec.text, "Yo");
+        assert_eq!(d.tree.layers[1].name, "Yo");
     }
 
     #[test]

--- a/plugins/tools-type/src/lib.rs
+++ b/plugins/tools-type/src/lib.rs
@@ -839,12 +839,16 @@ impl ToolPlugin for TypeTool {
                 };
                 if let (Some(l), Some(r)) = (left, right) {
                     if r > l {
-                        out.push(Overlay::Rect(IntRect::new(
+                        let highlight = IntRect::new(
                             (ox + l).floor() as i32,
                             (oy + span.top).floor() as i32,
                             (ox + r).ceil() as i32,
                             (oy + span.top + span.height).ceil() as i32,
-                        )));
+                        )
+                        .intersect(&bounds);
+                        if !highlight.is_empty() {
+                            out.push(Overlay::Highlight(highlight));
+                        }
                     }
                 }
             }
@@ -1278,6 +1282,23 @@ mod tests {
         tool.on_pointer_up(&mut ctx, input(ox + to.x, y));
 
         assert_eq!(tool.editing.as_ref().unwrap().selection(), 3..8);
+        let bounds = ctx
+            .doc
+            .tree
+            .find(ctx.doc.active_layer.unwrap())
+            .unwrap()
+            .tight_bounds();
+        let highlights: Vec<_> = tool
+            .overlays(ctx.doc, ctx.state)
+            .into_iter()
+            .filter_map(|overlay| match overlay {
+                Overlay::Highlight(rect) => Some(rect),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(highlights.len(), 1);
+        assert_eq!(highlights[0], highlights[0].intersect(&bounds));
+
         let base = tool.editing.as_ref().unwrap().stored.spec.family.clone();
         tool.spec.family = "A different family".into();
         tool.on_option_changed(&mut ctx, "type-family");

--- a/plugins/tools-type/src/lib.rs
+++ b/plugins/tools-type/src/lib.rs
@@ -16,7 +16,7 @@ use schist_plugin_api::{
     EditorState, Modifiers, OptionValue, Overlay, PluginManifest, PluginRegistry, PointerInput,
     ToolCtx, ToolOption, ToolPlugin,
 };
-use schist_text_engine::{rasterize, Align, StyleRun, TextSpec};
+use schist_text_engine::{hit_test, line_spans, rasterize, Align, StyleRun, TextSpec};
 
 /// Additional-layer-info key under which the text spec is preserved.
 pub const TEXT_BLOCK_KEY: [u8; 4] = *b"PsTx";
@@ -219,6 +219,8 @@ const ALIGNMENTS: &[&str] = &["Left", "Center", "Right"];
 #[derive(Default)]
 pub struct TypeTool {
     editing: Option<Editing>,
+    /// A canvas drag is extending the editing session's selection.
+    selecting: bool,
     /// What new text starts as, and what the options bar shows when
     /// nothing is being edited. Editing a layer adopts its spec, so the
     /// bar always describes the text you are looking at.
@@ -321,6 +323,40 @@ impl TypeTool {
         self.spec.size = style.size;
     }
 
+    /// Whether a point is in the layout box of `stored`.
+    ///
+    /// Ink bounds omit spaces and empty lines, but both are valid places
+    /// to put a text caret, so text hit-testing uses the layout rather than
+    /// pixels alone.
+    fn contains_text(stored: &StoredText, x: f32, y: f32) -> bool {
+        const SLOP: f32 = 4.0;
+        let x = x - stored.origin.0 as f32;
+        let y = y - stored.origin.1 as f32;
+        line_spans(&stored.spec).iter().any(|line| {
+            x >= line.x - SLOP
+                && x <= line.x + line.width + SLOP
+                && y >= line.top - SLOP
+                && y <= line.top + line.height + SLOP
+        })
+    }
+
+    /// Move the current session's caret to a document-space point.
+    fn point_caret(&mut self, x: f32, y: f32, extend: bool) {
+        let Some(session) = &mut self.editing else {
+            return;
+        };
+        let local_x = x - session.stored.origin.0 as f32;
+        let local_y = y - session.stored.origin.1 as f32;
+        let Some(at) = hit_test(&session.stored.spec, local_x, local_y) else {
+            return;
+        };
+        session.caret = at;
+        if !extend {
+            session.anchor = at;
+        }
+        self.sync_bar();
+    }
+
     /// Pick an existing text layer under the cursor, if any.
     fn text_layer_at(doc: &Document, x: f32, y: f32) -> Option<(LayerId, StoredText)> {
         let (px, py) = (x.round() as i32, y.round() as i32);
@@ -329,7 +365,9 @@ impl TypeTool {
             let Some(stored) = read_stored(layer) else {
                 continue;
             };
-            if layer.tight_bounds().inflated(4).contains(px, py) {
+            if layer.tight_bounds().inflated(4).contains(px, py)
+                || Self::contains_text(&stored, x, y)
+            {
                 hit = Some((layer.id, stored));
             }
         }
@@ -370,6 +408,22 @@ impl ToolPlugin for TypeTool {
     }
 
     fn on_pointer_down(&mut self, ctx: &mut ToolCtx, input: PointerInput) {
+        self.selecting = false;
+
+        // A click in the text already being edited places the caret there;
+        // dragging from it selects text. Previously every click committed
+        // and reopened the layer with its caret at the end, so issue #99's
+        // per-selection font controls were not reachable with a mouse.
+        let in_current = self
+            .editing
+            .as_ref()
+            .is_some_and(|session| Self::contains_text(&session.stored, input.x, input.y));
+        if in_current {
+            self.point_caret(input.x, input.y, input.modifiers.shift);
+            self.selecting = true;
+            return;
+        }
+
         // Clicking away from the current text commits it first.
         if self.editing.is_some() {
             self.on_commit(ctx);
@@ -392,7 +446,9 @@ impl ToolPlugin for TypeTool {
                     runs: Vec::new(),
                     ..stored.spec.clone()
                 };
-                let end = stored.spec.text.len();
+                let local_x = input.x - stored.origin.0 as f32;
+                let local_y = input.y - stored.origin.1 as f32;
+                let at = hit_test(&stored.spec, local_x, local_y).unwrap_or(stored.spec.text.len());
                 self.editing = Some(Editing {
                     layer,
                     stored,
@@ -401,9 +457,10 @@ impl ToolPlugin for TypeTool {
                     original_name,
                     created: false,
                     dirty: false,
-                    caret: end,
-                    anchor: end,
+                    caret: at,
+                    anchor: at,
                 });
+                self.selecting = true;
                 self.sync_bar();
                 // A colour picked since this text was set applies to it now,
                 // so the eyedropper works on text like on anything else.
@@ -411,12 +468,25 @@ impl ToolPlugin for TypeTool {
                     self.refresh(ctx.doc);
                 }
             }
-            None => self.start_new(ctx, input.x, input.y),
+            None => {
+                self.start_new(ctx, input.x, input.y);
+                self.selecting = true;
+            }
         }
     }
 
-    fn on_pointer_move(&mut self, _ctx: &mut ToolCtx, _input: PointerInput) {}
-    fn on_pointer_up(&mut self, _ctx: &mut ToolCtx, _input: PointerInput) {}
+    fn on_pointer_move(&mut self, _ctx: &mut ToolCtx, input: PointerInput) {
+        if self.selecting {
+            self.point_caret(input.x, input.y, true);
+        }
+    }
+
+    fn on_pointer_up(&mut self, _ctx: &mut ToolCtx, input: PointerInput) {
+        if self.selecting {
+            self.point_caret(input.x, input.y, true);
+            self.selecting = false;
+        }
+    }
 
     fn on_key(
         &mut self,
@@ -428,6 +498,7 @@ impl ToolPlugin for TypeTool {
         if self.editing.is_none() {
             return false;
         }
+        self.selecting = false;
         // The colour panel can be clicked mid-session; the next keystroke
         // is where its choice reaches the text.
         let recolored = self.adopt_foreground(ctx.state);
@@ -649,6 +720,7 @@ impl ToolPlugin for TypeTool {
     }
 
     fn on_commit(&mut self, ctx: &mut ToolCtx) {
+        self.selecting = false;
         let Some(session) = self.editing.take() else {
             return;
         };
@@ -698,6 +770,7 @@ impl ToolPlugin for TypeTool {
     }
 
     fn on_cancel(&mut self, ctx: &mut ToolCtx) {
+        self.selecting = false;
         let Some(session) = self.editing.take() else {
             return;
         };
@@ -1184,6 +1257,39 @@ mod tests {
     }
 
     #[test]
+    fn dragging_over_a_word_lets_it_take_its_own_font() {
+        let mut d = doc();
+        let mut state = EditorState::default();
+        let mut tool = TypeTool::default();
+        let mut ctx = ToolCtx {
+            doc: &mut d,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(20.0, 60.0));
+        type_text(&mut tool, &mut ctx, "Hi there");
+
+        let session = tool.editing.as_ref().unwrap();
+        let (ox, oy) = session.origin_f32();
+        let from = schist_text_engine::caret_at(&session.stored.spec, 3).unwrap();
+        let to = schist_text_engine::caret_at(&session.stored.spec, 8).unwrap();
+        let y = oy + from.top + from.height / 2.0;
+        tool.on_pointer_down(&mut ctx, input(ox + from.x, y));
+        tool.on_pointer_move(&mut ctx, input(ox + to.x, y));
+        tool.on_pointer_up(&mut ctx, input(ox + to.x, y));
+
+        assert_eq!(tool.editing.as_ref().unwrap().selection(), 3..8);
+        let base = tool.editing.as_ref().unwrap().stored.spec.family.clone();
+        tool.spec.family = "A different family".into();
+        tool.on_option_changed(&mut ctx, "type-family");
+
+        let spec = &tool.editing.as_ref().unwrap().stored.spec;
+        assert_eq!(spec.family, base, "the layer's base font stays put");
+        assert_eq!(spec.runs.len(), 1);
+        assert_eq!((spec.runs[0].start, spec.runs[0].end), (3, 8));
+        assert_eq!(spec.runs[0].family.as_deref(), Some("A different family"));
+    }
+
+    #[test]
     fn with_nothing_selected_the_bar_restyles_the_whole_layer() {
         let mut d = doc();
         let mut state = EditorState::default();
@@ -1384,7 +1490,7 @@ mod tests {
         };
         tool.on_pointer_down(
             &mut ctx,
-            input(bounds.left as f32 + 2.0, bounds.top as f32 + 2.0),
+            input(bounds.right as f32 + 2.0, bounds.top as f32 + 2.0),
         );
         assert!(is_editing(&tool), "resumed editing the existing layer");
         type_text(&mut tool, &mut ctx, "C");

--- a/plugins/tools-vector/src/lib.rs
+++ b/plugins/tools-vector/src/lib.rs
@@ -8,7 +8,7 @@
 pub mod paths;
 
 use schist_color::Rgba;
-use schist_core::{Document, IntRect, Layer, LayerPath, TileCoord, TILE_SIZE};
+use schist_core::{Document, IntRect, Layer, LayerId, LayerPath, TileCoord, TILE_SIZE};
 use schist_plugin_api::{
     EditorState, OptionValue, Overlay, PluginManifest, PluginRegistry, PointerInput, ToolCtx,
     ToolOption, ToolPlugin,
@@ -97,41 +97,66 @@ fn rasterize_into(
     }
 }
 
-/// Insert a live shape layer. Its pixels are left empty: the app's
-/// re-rasterization pass fills them in from the shape on the next frame,
-/// and again whenever the shape changes.
-pub(crate) fn commit_shape_layer(doc: &mut Document, shape: schist_core::VectorShape, name: &str) {
+/// A live shape layer, rasterized straight away rather than waiting for
+/// the next frame's refresh, so the shape appears the moment it is drawn.
+pub(crate) fn shape_layer(doc: &Document, shape: schist_core::VectorShape, name: &str) -> Layer {
     let mut layer = Layer::new_raster(name);
-    // Rasterize straight away rather than waiting for the next frame's
-    // refresh, so the shape appears the moment it is drawn.
     let key = shape.key();
     if let Some(raster) = layer.as_raster_mut() {
         raster.tiles = render_shape(&shape, doc.depth, doc.canvas_rect());
     }
     layer.shape_key = key;
     layer.shape = Some(Box::new(shape));
+    layer
+}
+
+/// Where a new shape layer goes: at the top of the stack for a live shape
+/// (`above_active` false), or just above the active layer for pixels.
+fn insert_path(doc: &Document, above_active: bool) -> LayerPath {
+    let above = above_active
+        .then(|| doc.active_layer.and_then(|a| doc.tree.path_of(a)))
+        .flatten();
+    match above {
+        Some(mut p) => {
+            *p.0.last_mut().unwrap() += 1;
+            p
+        }
+        None => LayerPath(vec![doc.tree.layers.len()]),
+    }
+}
+
+/// Insert a finished layer as a single undoable edit and make it active.
+pub(crate) fn commit_layer(doc: &mut Document, layer: Layer, path: LayerPath, edit: &str) {
     let id = layer.id;
-    let path = schist_core::LayerPath(vec![doc.tree.layers.len()]);
-    let mut edit = doc.begin_edit(format!("{name} Layer"));
+    let mut edit = doc.begin_edit(edit.to_string());
     edit.insert_layer(path, layer);
     edit.commit();
     doc.active_layer = Some(id);
 }
 
-pub(crate) fn commit_shape(
-    doc: &mut Document,
+/// Insert a live shape layer.
+pub(crate) fn commit_shape_layer(doc: &mut Document, shape: schist_core::VectorShape, name: &str) {
+    let layer = shape_layer(doc, shape, name);
+    let path = insert_path(doc, false);
+    commit_layer(doc, layer, path, &format!("{name} Layer"));
+}
+
+/// A path rasterized onto a fresh layer, clipped to the selection. `None`
+/// when nothing would be painted (off canvas, or entirely deselected).
+pub(crate) fn rasterized_layer(
+    doc: &Document,
     path: &Path,
     color: Rgba,
     rule: FillRule,
     name: &str,
-) {
+) -> Option<Layer> {
     let bounds = path.bounds().intersect(&doc.canvas_rect());
     if bounds.is_empty() {
-        return;
+        return None;
     }
     let mask = schist_vector::rasterize(path, bounds, rule);
     let w = bounds.width() as usize;
-    let selection = doc.selection.clone();
+    let selection = &doc.selection;
     let depth = doc.depth;
 
     let mut layer = Layer::new_raster(name);
@@ -162,22 +187,75 @@ pub(crate) fn commit_shape(
         }
         tiles.prune_blank();
     }
-    if layer.as_raster().unwrap().tiles.is_empty() {
+    (!layer.as_raster().unwrap().tiles.is_empty()).then_some(layer)
+}
+
+pub(crate) fn commit_shape(
+    doc: &mut Document,
+    path: &Path,
+    color: Rgba,
+    rule: FillRule,
+    name: &str,
+) {
+    let Some(layer) = rasterized_layer(doc, path, color, rule, name) else {
         return;
+    };
+    let path = insert_path(doc, true);
+    commit_layer(doc, layer, path, name);
+}
+
+/// The layer a shape tool shows while its shape is being dragged out.
+///
+/// Affinity and Photoshop draw the actual shape under the cursor, fill
+/// and all, not a marching outline of where it will go. The preview is
+/// the very layer the drag would commit, rebuilt on every move and kept
+/// outside history: it sits in the tree so the compositor paints it like
+/// anything else, and on release it is lifted out and re-inserted as the
+/// one undoable edit. Cancelling just drops it.
+#[derive(Default)]
+pub(crate) struct DragPreview {
+    layer: Option<LayerId>,
+}
+
+impl DragPreview {
+    pub(crate) fn is_showing(&self) -> bool {
+        self.layer.is_some()
     }
 
-    let id = layer.id;
-    let path_index = match doc.active_layer.and_then(|a| doc.tree.path_of(a)) {
-        Some(mut p) => {
-            *p.0.last_mut().unwrap() += 1;
-            p
+    /// Replace the preview with `fresh`, or remove it when the drag would
+    /// commit nothing. The layer keeps its id across updates so the layers
+    /// panel sees one layer growing, not a new one every frame.
+    pub(crate) fn show(&mut self, doc: &mut Document, fresh: Option<Layer>, above_active: bool) {
+        let (path, id) = match self.discard(doc) {
+            Some((path, old)) => (path, Some(old.id)),
+            None => (insert_path(doc, above_active), None),
+        };
+        let Some(mut layer) = fresh else {
+            return;
+        };
+        if let Some(id) = id {
+            layer.id = id;
         }
-        None => LayerPath(vec![doc.tree.layers.len()]),
-    };
-    let mut edit = doc.begin_edit(name.to_string());
-    edit.insert_layer(path_index, layer);
-    edit.commit();
-    doc.active_layer = Some(id);
+        doc.add_damage(layer.content_bounds());
+        self.layer = Some(layer.id);
+        doc.tree.insert_at(&path, layer);
+    }
+
+    /// Lift the preview out of the tree, undamaging its pixels, and hand
+    /// it back with the position it occupied.
+    pub(crate) fn discard(&mut self, doc: &mut Document) -> Option<(LayerPath, Layer)> {
+        let id = self.layer.take()?;
+        let (path, layer) = doc.tree.remove(id)?;
+        doc.add_damage(layer.content_bounds());
+        Some((path, layer))
+    }
+
+    /// Turn the preview into the committed layer.
+    pub(crate) fn commit(&mut self, doc: &mut Document, edit: &str) {
+        if let Some((path, layer)) = self.discard(doc) {
+            commit_layer(doc, layer, path, edit);
+        }
+    }
 }
 
 fn drag_rect(ax: f32, ay: f32, bx: f32, by: f32, square: bool) -> IntRect {
@@ -229,6 +307,7 @@ pub struct ShapeTool {
     anchor: Option<(f32, f32)>,
     current: Option<(f32, f32)>,
     square: bool,
+    preview: DragPreview,
 }
 
 impl ShapeTool {
@@ -243,7 +322,45 @@ impl ShapeTool {
             anchor: None,
             current: None,
             square: false,
+            preview: DragPreview::default(),
         }
+    }
+
+    /// The layer this drag would commit: a live shape layer in Shape mode,
+    /// plain selection-clipped pixels otherwise.
+    fn build_layer(
+        &self,
+        doc: &Document,
+        from: (f32, f32),
+        to: (f32, f32),
+        colour: Rgba,
+    ) -> Option<Layer> {
+        if self.vector {
+            // A live shape layer: the path is kept and the pixels are
+            // derived from it, so it stays editable and stays sharp.
+            if let Some(shape) = self.vector_shape(from, to, colour) {
+                return Some(shape_layer(doc, shape, self.kind.label()));
+            }
+        }
+        let path = self.path_for(from, to);
+        // Stroke outlines self-overlap at joins, so every shape fills with
+        // the nonzero rule.
+        rasterized_layer(doc, &path, colour, FillRule::NonZero, self.kind.label())
+    }
+
+    /// Show the shape as it stands at `to`, once the drag is a drag.
+    fn update_preview(&mut self, ctx: &mut ToolCtx, to: (f32, f32)) {
+        let Some(anchor) = self.anchor else {
+            return;
+        };
+        if (to.0 - anchor.0).abs() < 0.5 && (to.1 - anchor.1).abs() < 0.5 {
+            // Still a click; a click commits nothing, so it previews
+            // nothing either.
+            self.preview.show(ctx.doc, None, !self.vector);
+            return;
+        }
+        let fresh = self.build_layer(ctx.doc, anchor, to, ctx.state.foreground);
+        self.preview.show(ctx.doc, fresh, !self.vector);
     }
 
     /// Where the drag actually ends, after Shift constrains it. Rectangles,
@@ -479,40 +596,45 @@ impl ToolPlugin for ShapeTool {
         self.square = input.modifiers.shift;
     }
 
-    fn on_pointer_move(&mut self, _ctx: &mut ToolCtx, input: PointerInput) {
-        if self.anchor.is_some() {
-            self.current = Some((input.x, input.y));
-            self.square = input.modifiers.shift;
+    fn on_pointer_move(&mut self, ctx: &mut ToolCtx, input: PointerInput) {
+        if self.anchor.is_none() {
+            return;
+        }
+        let to = (input.x, input.y);
+        let unchanged = self.current == Some(to) && self.square == input.modifiers.shift;
+        self.current = Some(to);
+        self.square = input.modifiers.shift;
+        if !unchanged || !self.preview.is_showing() {
+            self.update_preview(ctx, to);
         }
     }
 
     fn on_pointer_up(&mut self, ctx: &mut ToolCtx, input: PointerInput) {
-        let Some(anchor) = self.anchor.take() else {
+        if self.anchor.is_none() {
             return;
-        };
-        self.current = None;
-        let to = (input.x, input.y);
-        if (to.0 - anchor.0).abs() < 0.5 && (to.1 - anchor.1).abs() < 0.5 {
-            return; // a click, not a drag
         }
-        let color = ctx.state.foreground;
-        if self.vector {
-            // A live shape layer: the path is kept and the pixels are
-            // derived from it, so it stays editable and stays sharp.
-            if let Some(shape) = self.vector_shape(anchor, to, color) {
-                commit_shape_layer(ctx.doc, shape, self.kind.label());
-                return;
-            }
-        }
-        let path = self.path_for(anchor, to);
-        // Stroke outlines self-overlap at joins, so every shape fills with
-        // the nonzero rule.
-        commit_shape(ctx.doc, &path, color, FillRule::NonZero, self.kind.label());
-    }
-
-    fn on_cancel(&mut self, _ctx: &mut ToolCtx) {
+        // The release usually lands where the last move did, in which case
+        // the preview already is the layer to commit.
+        self.on_pointer_move(ctx, input);
         self.anchor = None;
         self.current = None;
+        let name = self.kind.label();
+        let edit = if self.vector {
+            format!("{name} Layer")
+        } else {
+            name.to_string()
+        };
+        self.preview.commit(ctx.doc, &edit);
+    }
+
+    fn on_cancel(&mut self, ctx: &mut ToolCtx) {
+        self.anchor = None;
+        self.current = None;
+        self.preview.discard(ctx.doc);
+    }
+
+    fn on_deactivate(&mut self, ctx: &mut ToolCtx) {
+        self.on_cancel(ctx);
     }
 
     fn options(&self) -> Vec<ToolOption> {
@@ -552,26 +674,18 @@ impl ToolPlugin for ShapeTool {
         }
     }
 
-    fn overlays(&self, _doc: &Document, state: &EditorState) -> Vec<Overlay> {
+    fn overlays(&self, _doc: &Document, _state: &EditorState) -> Vec<Overlay> {
+        // The shape itself is on the canvas while it is dragged; the
+        // overlay is just the box it is being fitted into, the way
+        // Affinity outlines a shape's bounds mid-drag. A line has no
+        // useful box.
         let (Some(a), Some(c)) = (self.anchor, self.current) else {
             return Vec::new();
         };
-        match self.kind {
-            ShapeKind::Line => {
-                let c = self.constrained(a, c);
-                vec![Overlay::Line {
-                    x1: a.0,
-                    y1: a.1,
-                    x2: c.0,
-                    y2: c.1,
-                }]
-            }
-            _ => {
-                let r = drag_rect(a.0, a.1, c.0, c.1, self.square);
-                let _ = state;
-                vec![Overlay::Rect(r)]
-            }
+        if self.kind == ShapeKind::Line {
+            return Vec::new();
         }
+        vec![Overlay::Rect(drag_rect(a.0, a.1, c.0, c.1, self.square))]
     }
 }
 
@@ -861,6 +975,108 @@ mod tests {
         assert_eq!(top_px(&doc, 60, 60)[3], 0);
         doc.undo();
         assert_eq!(doc.tree.layers.len(), 1, "undo removes the shape layer");
+    }
+
+    #[test]
+    fn shape_shows_on_the_canvas_while_it_is_dragged() {
+        let mut doc = doc();
+        let mut state = red();
+        let mut tool = ShapeTool::new(ShapeKind::Ellipse);
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(10.0, 10.0));
+        assert_eq!(ctx.doc.tree.layers.len(), 1, "a click previews nothing");
+        tool.on_pointer_move(&mut ctx, input(50.0, 50.0));
+        assert_eq!(ctx.doc.tree.layers.len(), 2, "the drag is on the canvas");
+        assert_eq!(top_px(ctx.doc, 30, 30), [255, 0, 0, 255]);
+        assert_eq!(top_px(ctx.doc, 12, 12)[3], 0, "an ellipse, not its box");
+        assert!(!ctx.doc.take_damage().is_empty(), "the preview repaints");
+
+        // Dragging on rebuilds the same layer rather than piling up new ones.
+        let id = ctx.doc.tree.layers[1].id;
+        tool.on_pointer_move(&mut ctx, input(90.0, 90.0));
+        assert_eq!(ctx.doc.tree.layers.len(), 2);
+        assert_eq!(ctx.doc.tree.layers[1].id, id);
+        assert_eq!(top_px(ctx.doc, 50, 50), [255, 0, 0, 255]);
+
+        tool.on_pointer_up(&mut ctx, input(90.0, 90.0));
+        assert_eq!(doc.tree.layers.len(), 2);
+        assert!(
+            doc.tree.layers[1].shape.is_some(),
+            "committed as a live shape"
+        );
+        assert_eq!(doc.undo().as_deref(), Some("Ellipse Layer"));
+        assert_eq!(doc.tree.layers.len(), 1, "one edit for the whole drag");
+        assert_eq!(doc.undo(), None, "the preview left nothing in history");
+    }
+
+    #[test]
+    fn cancelling_a_drag_removes_the_preview() {
+        let mut doc = doc();
+        let mut state = red();
+        let mut tool = ShapeTool::new(ShapeKind::Rectangle);
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(10.0, 10.0));
+        tool.on_pointer_move(&mut ctx, input(50.0, 50.0));
+        assert_eq!(ctx.doc.tree.layers.len(), 2);
+        tool.on_cancel(&mut ctx);
+        assert_eq!(ctx.doc.tree.layers.len(), 1);
+        assert_eq!(doc.undo(), None);
+        // Nor does a drag that ends back where it started leave anything.
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(10.0, 10.0));
+        tool.on_pointer_move(&mut ctx, input(50.0, 50.0));
+        tool.on_pointer_up(&mut ctx, input(10.0, 10.0));
+        assert_eq!(doc.tree.layers.len(), 1);
+    }
+
+    #[test]
+    fn pixel_mode_previews_the_clipped_pixels() {
+        let mut doc = doc();
+        doc.selection.activate();
+        doc.selection
+            .apply_shape(IntRect::new(0, 0, 50, 100), SelectOp::Replace, |_, _| 255);
+        let mut state = red();
+        let mut tool = ShapeTool::new(ShapeKind::Rectangle);
+        tool.set_option("shape-mode", OptionValue::Choice(1));
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(10.0, 10.0));
+        tool.on_pointer_move(&mut ctx, input(90.0, 90.0));
+        assert_eq!(ctx.doc.tree.layers.len(), 2);
+        assert_eq!(top_px(ctx.doc, 30, 30), [255, 0, 0, 255]);
+        assert_eq!(top_px(ctx.doc, 70, 70)[3], 0, "outside the selection");
+        assert!(ctx.doc.tree.layers[1].shape.is_none());
+        tool.on_pointer_up(&mut ctx, input(90.0, 90.0));
+        assert_eq!(doc.undo().as_deref(), Some("Rectangle"));
+        assert_eq!(doc.tree.layers.len(), 1);
+    }
+
+    #[test]
+    fn custom_shape_previews_while_dragged() {
+        let mut doc = doc();
+        let mut state = red();
+        let mut tool = paths::CustomShapeTool::new();
+        let mut ctx = ToolCtx {
+            doc: &mut doc,
+            state: &mut state,
+        };
+        tool.on_pointer_down(&mut ctx, input(10.0, 10.0));
+        tool.on_pointer_move(&mut ctx, input(90.0, 90.0));
+        assert_eq!(ctx.doc.tree.layers.len(), 2);
+        assert_eq!(top_px(ctx.doc, 50, 50), [255, 0, 0, 255]);
+        tool.on_cancel(&mut ctx);
+        assert_eq!(doc.tree.layers.len(), 1);
     }
 
     #[test]

--- a/plugins/tools-vector/src/paths.rs
+++ b/plugins/tools-vector/src/paths.rs
@@ -565,6 +565,7 @@ pub struct CustomShapeTool {
     anchor: Option<(f32, f32)>,
     current: Option<(f32, f32)>,
     keep_ratio: bool,
+    preview: crate::DragPreview,
 }
 
 impl CustomShapeTool {
@@ -574,7 +575,45 @@ impl CustomShapeTool {
             anchor: None,
             current: None,
             keep_ratio: false,
+            preview: crate::DragPreview::default(),
         }
+    }
+
+    /// The layer this drag would commit, or `None` while it is still a
+    /// click.
+    fn build_layer(
+        &self,
+        doc: &Document,
+        from: (f32, f32),
+        to: (f32, f32),
+        colour: schist_color::Rgba,
+    ) -> Option<schist_core::Layer> {
+        if (to.0 - from.0).abs() < 2.0 && (to.1 - from.1).abs() < 2.0 {
+            return None;
+        }
+        let outline = self.outline(from, to);
+        let mut b = PathBuilder::new();
+        b.move_to(outline[0].0, outline[0].1);
+        for p in &outline[1..] {
+            b.line_to(p.0, p.1);
+        }
+        b.close();
+        crate::rasterized_layer(
+            doc,
+            &b.build(0.25),
+            colour,
+            schist_vector::FillRule::NonZero,
+            "Custom Shape",
+        )
+    }
+
+    /// Show the shape as it stands at `to`. See [`crate::DragPreview`].
+    fn update_preview(&mut self, ctx: &mut ToolCtx, to: (f32, f32)) {
+        let Some(from) = self.anchor else {
+            return;
+        };
+        let fresh = self.build_layer(ctx.doc, from, to, ctx.state.foreground);
+        self.preview.show(ctx.doc, fresh, true);
     }
 
     fn outline(&self, from: (f32, f32), to: (f32, f32)) -> Vec<(f32, f32)> {
@@ -634,47 +673,58 @@ impl ToolPlugin for CustomShapeTool {
         self.keep_ratio = input.modifiers.shift;
     }
 
-    fn on_pointer_move(&mut self, _ctx: &mut ToolCtx, input: PointerInput) {
-        if self.anchor.is_some() {
-            self.current = Some((input.x, input.y));
-            self.keep_ratio = input.modifiers.shift;
+    fn on_pointer_move(&mut self, ctx: &mut ToolCtx, input: PointerInput) {
+        if self.anchor.is_none() {
+            return;
+        }
+        let to = (input.x, input.y);
+        let unchanged = self.current == Some(to) && self.keep_ratio == input.modifiers.shift;
+        self.current = Some(to);
+        self.keep_ratio = input.modifiers.shift;
+        if !unchanged || !self.preview.is_showing() {
+            self.update_preview(ctx, to);
         }
     }
 
     fn on_pointer_up(&mut self, ctx: &mut ToolCtx, input: PointerInput) {
-        let Some(from) = self.anchor.take() else {
-            return;
-        };
-        self.current = None;
-        let to = (input.x, input.y);
-        if (to.0 - from.0).abs() < 2.0 && (to.1 - from.1).abs() < 2.0 {
+        if self.anchor.is_none() {
             return;
         }
-        let outline = self.outline(from, to);
-        let mut b = PathBuilder::new();
-        b.move_to(outline[0].0, outline[0].1);
-        for p in &outline[1..] {
-            b.line_to(p.0, p.1);
-        }
-        b.close();
-        let color = ctx.state.foreground;
-        crate::commit_shape(
-            ctx.doc,
-            &b.build(0.25),
-            color,
-            schist_vector::FillRule::NonZero,
-            "Custom Shape",
-        );
-    }
-
-    fn on_cancel(&mut self, _ctx: &mut ToolCtx) {
+        self.on_pointer_move(ctx, input);
         self.anchor = None;
         self.current = None;
+        self.preview.commit(ctx.doc, "Custom Shape");
+    }
+
+    fn on_cancel(&mut self, ctx: &mut ToolCtx) {
+        self.anchor = None;
+        self.current = None;
+        self.preview.discard(ctx.doc);
+    }
+
+    fn on_deactivate(&mut self, ctx: &mut ToolCtx) {
+        self.on_cancel(ctx);
     }
 
     fn overlays(&self, _doc: &Document, _state: &EditorState) -> Vec<Overlay> {
+        // The shape itself is on the canvas while it is dragged; the
+        // overlay is the box it is being fitted into.
         match (self.anchor, self.current) {
-            (Some(a), Some(c)) => vec![Overlay::AntsPolygon(self.outline(a, c))],
+            (Some(a), Some(c)) => {
+                let (x0, y0) = (a.0.min(c.0), a.1.min(c.1));
+                let (mut w, mut h) = ((c.0 - a.0).abs(), (c.1 - a.1).abs());
+                if self.keep_ratio {
+                    let s = w.min(h);
+                    w = s;
+                    h = s;
+                }
+                vec![Overlay::Rect(IntRect::new(
+                    x0.round() as i32,
+                    y0.round() as i32,
+                    (x0 + w).round() as i32,
+                    (y0 + h).round() as i32,
+                ))]
+            }
             _ => Vec::new(),
         }
     }


### PR DESCRIPTION
Closes #99, #100 and #101.

## Shape tools (#101)
The rectangle, ellipse, polygon, line and custom shape tools now show the real shape, fill and all, while it is being dragged out. The preview is the very layer the drag would commit, rebuilt on each move and kept outside history (`DragPreview` in `plugins/tools-vector`); on release it is re-inserted as the single undoable edit, and cancelling or switching tool drops it. The old overlay drew a rectangle for every kind.

## Dropdowns (#100)
Every dropdown follows the keyboard while open: typing jumps to the first row starting with what was typed (a one-second pause starts a new word; a letter pressed repeatedly cycles through its rows), Up/Down/Home/End walk the rows, Enter picks the highlighted one. The open dropdown publishes its rows through a thread-local the way dialogs publish their default action (`ui::open_dropdown`). The layers panel's hand-rolled blend-mode menu now uses the shared widget. Escape on a dropdown inside a dialog now closes the dropdown rather than the whole dialog.

## Text layers (#99)
`TextSpec` gains `runs`: byte ranges that override the layer's family, style or size, so one layer can mix fonts. The engine resolves one face per distinct style, kerns only within a face, sizes each line to its tallest face and places the caret from the same pass as the glyphs. In the type tool a selection takes the bar's font, style or size for just those characters; with nothing selected the whole layer changes as before; typing after a styled word continues in it, and the bar follows the caret. Plain specs serialize byte-for-byte as before, so existing files load unchanged. A new `LayerExtrasSet` history op makes "Edit Text" undo the spec and layer name together with the pixels (they previously drifted apart after an undo).

## Verification
- `cargo check --workspace --all-targets` clean; tests pass in `schist-core`, `schist-text-engine`, `schist-tools-vector`, `schist-tools-type` and `schist-app` (new tests for each feature).
- Driven headlessly in the release build (Xvfb + lavapipe): rectangle drag shows the filled shape at every pointer position; `m` in the blend menu jumps to Multiply, Down + Enter commits Color Burn; `b` picks Bold and `d`/`dd`/`ddd` cycle the DejaVu families in the font menu; "hi there" renders with "there" in a different family on one layer.

## Left out
- Per-run *colour* (needs per-run coverage from the engine; colour stays per layer).
- Affinity import still flattens a text object's character runs to the first one; the runs are in the file, so wiring them up is a follow-up.
- The wasm build was not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
