### PR TITLE
feat: Picasa-style People album for the gallery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6381,6 +6381,7 @@ name = "schist-gallery"
 version = "0.11.0"
 dependencies = [
  "anyhow",
+ "image",
  "kamadak-exif",
  "schist-neural",
  "serde",

--- a/crates/app/src/dialogs/mod.rs
+++ b/crates/app/src/dialogs/mod.rs
@@ -222,6 +222,16 @@ pub fn render(ws: &mut Workspace, cx: &mut Context<Workspace>) -> Option<gpui::A
         #[cfg(not(target_arch = "wasm32"))]
         Modal::SearchModels => crate::workspace::search_models_dialog(cx).into_any_element(),
         #[cfg(not(target_arch = "wasm32"))]
+        Modal::PeopleModels => crate::workspace::people_models_dialog(cx).into_any_element(),
+        #[cfg(target_arch = "wasm32")]
+        Modal::PeopleModels => return None,
+        #[cfg(not(target_arch = "wasm32"))]
+        Modal::PersonName { index, name } => {
+            crate::workspace::person_name_dialog(ws, index, name, cx).into_any_element()
+        }
+        #[cfg(target_arch = "wasm32")]
+        Modal::PersonName { .. } => return None,
+        #[cfg(not(target_arch = "wasm32"))]
         Modal::SaveImageAs {
             path,
             codec,

--- a/crates/app/src/telemetry.rs
+++ b/crates/app/src/telemetry.rs
@@ -1,5 +1,9 @@
 use rand::RngExt;
-use std::{fs, path::PathBuf, thread, time};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    thread, time,
+};
 
 /// Where the daily ping goes.
 const TELEMETRY_URL: &str = "https://telemetry.schist.app/v1/ping";
@@ -10,7 +14,7 @@ const NO_TELEMETRY_FILE: &str = "no_telemetry";
 
 /// Whether the ping is on, as far as the marker file is concerned. The
 /// SCHIST_NO_TELEMETRY variable can still switch it off on top of this.
-pub fn enabled(schist_folder: &PathBuf) -> bool {
+pub fn enabled(schist_folder: &Path) -> bool {
     !matches!(fs::exists(schist_folder.join(NO_TELEMETRY_FILE)), Ok(true))
 }
 
@@ -40,7 +44,10 @@ fn payload(telemetry_id: &str) -> serde_json::Value {
             .with_cpu(CpuRefreshKind::new())
             .with_memory(MemoryRefreshKind::new().with_ram()),
     );
-    let cpu = system.cpus().first().map(|cpu| cpu.brand().trim().to_string());
+    let cpu = system
+        .cpus()
+        .first()
+        .map(|cpu| cpu.brand().trim().to_string());
     let gpu = crate::workspace::gpu_info().map(|gpu| {
         serde_json::json!({
             "name": gpu.name,
@@ -72,7 +79,7 @@ fn send_telemetry(telemetry_id: &str) -> bool {
         .is_ok()
 }
 
-fn telemetry_turn(schist_folder: &PathBuf) {
+fn telemetry_turn(schist_folder: &Path) {
     // Check if the magic file exists that nukes telemetry.
     if !enabled(schist_folder) {
         return;

--- a/crates/app/src/workspace/library.rs
+++ b/crates/app/src/workspace/library.rs
@@ -147,6 +147,32 @@ pub enum PersonFilter {
     Unnamed,
 }
 
+/// What the sidebar has narrowed the gallery to, resolved once.
+enum Scope {
+    All,
+    Folder(PathBuf),
+    Bucket(FxHashSet<PathBuf>),
+}
+
+/// What the sidebar's people counts were computed against.
+#[derive(Clone, PartialEq)]
+struct SummaryKey {
+    index_gen: u64,
+    people_rev: u64,
+    bucket_filter: Option<usize>,
+    folder_filter: Option<PathBuf>,
+    map_filter: Option<GeoBounds>,
+    smart_synced: Option<(u64, u64)>,
+}
+
+/// The sidebar's people numbers, within the scope on show.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct PeopleSummary {
+    /// Per person, in `people` order: their photos in scope.
+    pub photo_counts: Vec<usize>,
+    pub unnamed_faces: usize,
+}
+
 /// One face as the viewer shows it: the box, who it is (if anyone),
 /// who it might be, and whether the detector or the user drew it.
 #[derive(Clone, Debug, PartialEq)]
@@ -191,6 +217,9 @@ pub struct Viewer {
     pub name: String,
     /// Face crops cut from the decoded picture, by face key.
     pub crops: FxHashMap<String, Arc<RenderImage>>,
+    /// Where the photo sits in the grid's order, `(index, of)`, worked
+    /// out once on opening rather than per frame.
+    pub position: Option<(usize, usize)>,
 }
 
 /// A drag of gallery photos, headed for a folder or a bucket.
@@ -319,6 +348,16 @@ pub struct Library {
     avatar_ticker: bool,
     /// The people the current query named, for the results header.
     pub search_people: Vec<String>,
+    /// Every scanned entry by path — `entry_of` is asked per tagged
+    /// photo per frame, and a walk of the sections for each was a
+    /// visible stutter on a big library.
+    by_path: FxHashMap<PathBuf, Entry>,
+    /// Bumped by every save (people, buckets, denials), so the sidebar's
+    /// people summary knows to recount.
+    people_rev: u64,
+    /// The sidebar's counts, computed once per change rather than once
+    /// per frame, with the key they were computed for.
+    people_summary: Option<(SummaryKey, PeopleSummary)>,
     /// How the grid is grouped, persisted. Date by default: a camera
     /// roll is a diary before it is a directory tree.
     pub group_by: GroupBy,
@@ -510,6 +549,9 @@ impl Library {
             avatar_queue: Vec::new(),
             avatar_ticker: false,
             search_people: Vec::new(),
+            by_path: FxHashMap::default(),
+            people_rev: 0,
+            people_summary: None,
             group_by: file
                 .group_by
                 .as_deref()
@@ -543,7 +585,9 @@ impl Library {
         }
     }
 
-    fn save(&self) {
+    fn save(&mut self) {
+        // Whatever was saved, the sidebar's counts may have moved.
+        self.people_rev += 1;
         // Unit tests build libraries from thin air; writing them over
         // the developer's own library.json would be a surprise.
         if cfg!(test) {
@@ -1370,10 +1414,19 @@ pub(super) const PERSON_BOOST: f32 = 1.0;
 impl Library {
     /// The entry for a photo, if the scan knows it.
     pub fn entry_of(&self, path: &Path) -> Option<&Entry> {
-        self.sections
+        self.by_path.get(path)
+    }
+
+    /// Take a fresh scan on board, and rebuild the by-path index the
+    /// per-frame lookups lean on. The only way `sections` should be set.
+    pub fn set_sections(&mut self, sections: Vec<Section>) {
+        self.by_path = sections
             .iter()
             .flat_map(|s| s.entries.iter())
-            .find(|e| e.path == path)
+            .map(|e| (e.path.clone(), e.clone()))
+            .collect();
+        self.sections = sections;
+        self.people_rev += 1;
     }
 
     /// The detector's faces in a photo, if it has been looked at.
@@ -1529,21 +1582,33 @@ impl Library {
     /// Put every unnamed face that closely matches a named person with
     /// them, as automatic tags — skipping faces the user has dismissed
     /// or denied that name. Returns how many were added. Called after a
-    /// hand-made tag and whenever detections arrive.
+    /// hand-made tag (the whole library: the person's mean moved) and
+    /// when a snapshot is restored.
     pub fn auto_tag_all(&mut self) -> usize {
+        let paths: Vec<PathBuf> = self.faces.keys().cloned().collect();
+        self.auto_tag_paths(&paths)
+    }
+
+    /// The auto-tag pass over some photos only — the ones a loader batch
+    /// just found faces in. Nothing else changed, so nothing else can
+    /// have started matching.
+    pub fn auto_tag_paths(&mut self, paths: &[PathBuf]) -> usize {
         let centroids = self.person_centroids();
-        if centroids.is_empty() {
+        if centroids.is_empty() || paths.is_empty() {
             return 0;
         }
+        let claimed = self.claimed_by_photo();
         let mut additions: Vec<(usize, TaggedFace)> = Vec::new();
-        for (path, faces) in &self.faces {
+        for path in paths {
+            let Some(faces) = self.faces.get(path) else {
+                continue;
+            };
+            let taken = claimed.get(path.as_path());
             for face in faces {
                 let Some(embed) = face.vector() else {
                     continue;
                 };
-                if self.is_ignored(path, &face.rect)
-                    || self.people.iter().any(|p| p.tagged(path, &face.rect))
-                {
+                if taken.is_some_and(|t| t.iter().any(|r| r.same_face(&face.rect))) {
                     continue;
                 }
                 let Some((index, cosine)) =
@@ -1576,6 +1641,14 @@ impl Library {
     /// The auto-tag pass, persisted when it changed anything.
     pub(super) fn auto_tag_and_save(&mut self) {
         if self.auto_tag_all() > 0 {
+            self.save();
+        }
+    }
+
+    /// The auto-tag pass over a batch's photos, persisted when it
+    /// changed anything.
+    pub(super) fn auto_tag_paths_and_save(&mut self, paths: &[PathBuf]) {
+        if self.auto_tag_paths(paths) > 0 {
             self.save();
         }
     }
@@ -1711,22 +1784,26 @@ impl Library {
         }
     }
 
-    /// Whether a photo is inside what the sidebar has narrowed the
-    /// gallery to — the bucket on show, else the folder, else anything
-    /// — and past the map filter. The People rows count and show
-    /// within this, so a person's number is theirs *in this bucket*.
-    pub fn in_scope(&self, path: &Path) -> bool {
-        if !self.passes_map(path) {
-            return false;
-        }
+    /// What the sidebar has narrowed the gallery to — the bucket on
+    /// show, else the folder, else anything — built once per pass so a
+    /// bucket's membership is a set lookup, not a scan per photo.
+    fn scope(&self) -> Scope {
         if let Some(bucket) = self.bucket_filter.and_then(|i| self.buckets.get(i)) {
-            return bucket.photos.contains(&path.to_path_buf())
-                || bucket.matches.iter().any(|p| p == path);
+            return Scope::Bucket(bucket.contents().into_iter().collect());
         }
         match &self.folder_filter {
-            Some(root) => path.starts_with(root),
-            None => true,
+            Some(root) => Scope::Folder(root.clone()),
+            None => Scope::All,
         }
+    }
+
+    fn scope_allows(&self, scope: &Scope, path: &Path) -> bool {
+        self.passes_map(path)
+            && match scope {
+                Scope::All => true,
+                Scope::Folder(root) => path.starts_with(root),
+                Scope::Bucket(set) => set.contains(path),
+            }
     }
 
     /// What the scope is called, for the People headers: the bucket's
@@ -1746,6 +1823,11 @@ impl Library {
     /// the scan still knows and the scope (bucket, folder, map) lets
     /// through.
     pub fn person_photos(&self, index: usize) -> Vec<Entry> {
+        let scope = self.scope();
+        self.person_photos_in(index, &scope)
+    }
+
+    fn person_photos_in(&self, index: usize, scope: &Scope) -> Vec<Entry> {
         let Some(person) = self.people.get(index) else {
             return Vec::new();
         };
@@ -1753,42 +1835,103 @@ impl Library {
             .photos()
             .iter()
             .filter_map(|p| self.entry_of(p).cloned())
-            .filter(|e| self.in_scope(&e.path))
+            .filter(|e| self.scope_allows(scope, &e.path))
             .collect()
+    }
+
+    /// Every claimed face by photo — the tags and the dismissals — so a
+    /// pass over the detections asks "is this one spoken for" against
+    /// the handful in its own photo rather than every tag in the library.
+    fn claimed_by_photo(&self) -> FxHashMap<&Path, Vec<FaceRect>> {
+        let mut claimed: FxHashMap<&Path, Vec<FaceRect>> = FxHashMap::default();
+        for face in self
+            .people
+            .iter()
+            .flat_map(|p| p.faces.iter())
+            .chain(self.ignored_faces.iter())
+        {
+            claimed
+                .entry(face.photo.as_path())
+                .or_default()
+                .push(face.rect);
+        }
+        claimed
     }
 
     /// Photos with a detected face nobody has named or dismissed, in
     /// scan order, within the scope.
     pub fn unnamed_photos(&self) -> Vec<Entry> {
+        let scope = self.scope();
+        let claimed = self.claimed_by_photo();
         self.sections
             .iter()
             .flat_map(|s| s.entries.iter())
-            .filter(|e| self.in_scope(&e.path))
-            .filter(|e| self.has_unnamed_face(&e.path))
+            .filter(|e| self.scope_allows(&scope, &e.path))
+            .filter(|e| {
+                self.faces.get(&e.path).is_some_and(|faces| {
+                    let taken = claimed.get(e.path.as_path());
+                    faces
+                        .iter()
+                        .any(|f| !taken.is_some_and(|t| t.iter().any(|r| r.same_face(&f.rect))))
+                })
+            })
             .cloned()
             .collect()
     }
 
-    fn has_unnamed_face(&self, path: &Path) -> bool {
-        self.faces.get(path).is_some_and(|faces| {
-            faces.iter().any(|f| {
-                !self.is_ignored(path, &f.rect)
-                    && !self.people.iter().any(|p| p.tagged(path, &f.rect))
-            })
-        })
-    }
-
     /// How many detected faces are still unnamed, within the scope.
     pub fn unnamed_face_count(&self) -> usize {
+        let scope = self.scope();
+        self.unnamed_face_count_in(&scope, &self.claimed_by_photo())
+    }
+
+    fn unnamed_face_count_in(
+        &self,
+        scope: &Scope,
+        claimed: &FxHashMap<&Path, Vec<FaceRect>>,
+    ) -> usize {
         self.faces
             .iter()
-            .filter(|(path, _)| self.in_scope(path))
-            .flat_map(|(path, faces)| faces.iter().map(move |f| (path, f)))
-            .filter(|(path, f)| {
-                !self.is_ignored(path, &f.rect)
-                    && !self.people.iter().any(|p| p.tagged(path, &f.rect))
+            .filter(|(path, _)| self.scope_allows(scope, path))
+            .map(|(path, faces)| {
+                let taken = claimed.get(path.as_path());
+                faces
+                    .iter()
+                    .filter(|f| !taken.is_some_and(|t| t.iter().any(|r| r.same_face(&f.rect))))
+                    .count()
             })
-            .count()
+            .sum()
+    }
+
+    /// The sidebar's People numbers — each person's photos in scope and
+    /// the unnamed tally — recounted only when something they depend on
+    /// moved, and otherwise handed back from the last count. The sidebar
+    /// asks every frame; a library of thousands cannot be walked every
+    /// frame.
+    pub(super) fn people_summary(&mut self) -> PeopleSummary {
+        let key = SummaryKey {
+            index_gen: self.index_gen,
+            people_rev: self.people_rev,
+            bucket_filter: self.bucket_filter,
+            folder_filter: self.folder_filter.clone(),
+            map_filter: self.map_filter,
+            smart_synced: self.smart_synced,
+        };
+        if let Some((cached_key, summary)) = &self.people_summary {
+            if *cached_key == key {
+                return summary.clone();
+            }
+        }
+        let scope = self.scope();
+        let claimed = self.claimed_by_photo();
+        let summary = PeopleSummary {
+            photo_counts: (0..self.people.len())
+                .map(|i| self.person_photos_in(i, &scope).len())
+                .collect(),
+            unnamed_faces: self.unnamed_face_count_in(&scope, &claimed),
+        };
+        self.people_summary = Some((key, summary.clone()));
+        summary
     }
 
     /// The people a search query names, each with their photos.
@@ -2478,7 +2621,7 @@ impl Workspace {
     /// Re-walk the watched folders on a background thread.
     pub fn library_rescan(&mut self, cx: &mut Context<Self>) {
         if self.library.folders.is_empty() {
-            self.library.sections = Vec::new();
+            self.library.set_sections(Vec::new());
             return;
         }
         if self.library.scanning {
@@ -2494,7 +2637,7 @@ impl Workspace {
                 .await;
             this.update(cx, |ws, cx| {
                 ws.library.scanning = false;
-                ws.library.sections = sections;
+                ws.library.set_sections(sections);
                 ws.maybe_load_index_snapshot(cx);
                 cx.notify();
             })
@@ -2602,7 +2745,7 @@ impl Workspace {
             let keep = this.update(cx, |ws, cx| {
                 ws.library.index_gen += 1;
                 let visible_work = results.iter().any(|(_, _, for_index, _)| !for_index);
-                let mut new_faces = false;
+                let mut new_faces: Vec<PathBuf> = Vec::new();
                 for (key, mtime, for_index, outcome) in results {
                     if let Some(score) = outcome.score {
                         ws.library.flagged.insert(key.clone(), is_explicit(score));
@@ -2616,8 +2759,10 @@ impl Workspace {
                     }
                     ws.library.places.insert(key.clone(), outcome.meta.place);
                     if let Some(faces) = outcome.faces {
+                        if !faces.is_empty() {
+                            new_faces.push(key.clone());
+                        }
                         ws.library.faces.insert(key.clone(), faces);
-                        new_faces = true;
                     }
                     if outcome.needs_heif && ws.library.heif_needed.is_none() {
                         ws.library.heif_needed = Some(key.clone());
@@ -2634,8 +2779,8 @@ impl Workspace {
                 }
                 // Faces just found may belong to people already named:
                 // put them there, as Picasa filled its albums.
-                if new_faces {
-                    ws.library.auto_tag_and_save();
+                if !new_faces.is_empty() {
+                    ws.library.auto_tag_paths_and_save(&new_faces);
                 }
                 // The batch may have pushed the map over budget; shed
                 // whatever scrolled away longest ago.
@@ -4046,7 +4191,7 @@ mod tests {
         lib.people.clear();
         lib.ignored_faces.clear();
         lib.denied_faces.clear();
-        lib.sections = vec![Section {
+        lib.set_sections(vec![Section {
             dir: PathBuf::from("/p"),
             entries: photos
                 .iter()
@@ -4056,7 +4201,7 @@ mod tests {
                     edited: false,
                 })
                 .collect(),
-        }];
+        }]);
         lib
     }
 
@@ -4231,6 +4376,10 @@ mod tests {
         lib.person_filter = Some(PersonFilter::Person(0));
         assert_eq!(lib.person_photos(0).len(), 2);
         assert_eq!(lib.unnamed_face_count(), 1);
+        // The cached summary agrees, and follows the bucket below.
+        let summary = lib.people_summary();
+        assert_eq!(summary.photo_counts, vec![2]);
+        assert_eq!(summary.unnamed_faces, 1);
         // A bucket holding only b: Ann has one photo in it, and the
         // header says where.
         lib.buckets.push(Bucket {
@@ -4244,6 +4393,8 @@ mod tests {
         assert_eq!(lib.person_photos(0).len(), 1);
         assert_eq!(lib.grouped()[0].0, "People \u{b7} Ann \u{b7} in Trip");
         assert_eq!(lib.unnamed_face_count(), 0, "c is not in the bucket");
+        assert_eq!(lib.people_summary().photo_counts, vec![1]);
+        assert_eq!(lib.people_summary().unnamed_faces, 0);
         lib.bucket_filter = None;
         // A folder that holds nothing of hers.
         lib.folder_filter = Some(PathBuf::from("/elsewhere"));
@@ -4368,10 +4519,10 @@ mod tests {
             mtime: 0,
             edited: false,
         };
-        lib.sections = vec![Section {
+        lib.set_sections(vec![Section {
             dir: PathBuf::from("/p"),
             entries: vec![mk("a"), mk("b"), mk("c")],
-        }];
+        }]);
         lib.flagged.insert(PathBuf::from("/p/a.jpg"), true);
         lib.flagged.insert(PathBuf::from("/p/b.jpg"), false);
         assert_eq!(lib.verdict(Path::new("/p/a.jpg")), "flagged");

--- a/crates/app/src/workspace/library.rs
+++ b/crates/app/src/workspace/library.rs
@@ -47,6 +47,12 @@ pub(super) const VIEW_EDGE: u32 = 1600;
 const EMBED_EDGE: u32 = 1024;
 /// Faces smaller than this in the thumbnail are texture, not people.
 const MIN_FACE_PX: f32 = 12.0;
+/// A face at least this wide in the thumbnail is cropped for the
+/// recogniser straight from the thumbnail; smaller ones — a group
+/// photo's — earn a larger decode of the original. The recogniser's
+/// frame is 112 px, so this is a modest upsample at worst, and it
+/// spares a portrait library a second full decode of every photo.
+const EMBED_FROM_THUMB_PX: f32 = 72.0;
 /// The face avatars in the sidebar and the people panel, in pixels.
 pub(super) const AVATAR_PX: u32 = 64;
 
@@ -701,7 +707,7 @@ impl Library {
         let embeds = schist_neural::installed("embed-image");
         let scores = nsfw_installed();
         let detector = schist_neural::installed("face");
-        let recogniser = schist_neural::installed("face-embed");
+        let recogniser = recogniser_ready();
         let jobs: Vec<ThumbJob> = self
             .sections
             .iter()
@@ -719,7 +725,7 @@ impl Library {
                         && self
                             .faces
                             .get(&e.path)
-                            .is_some_and(|f| f.iter().any(|x| x.embed.is_none())))
+                            .is_some_and(|f| f.iter().any(|x| !x.embedded())))
             })
             .take(THUMB_BATCH)
             .map(|e| ThumbJob {
@@ -1405,8 +1411,7 @@ impl Library {
             .get(path)?
             .iter()
             .find(|f| f.rect.same_face(rect))?
-            .embed
-            .as_deref()
+            .vector()
     }
 
     /// One vector per person with any recognised face: the unit mean
@@ -1455,7 +1460,7 @@ impl Library {
             {
                 continue;
             }
-            let suggestion = face.embed.as_deref().and_then(|embed| {
+            let suggestion = face.vector().and_then(|embed| {
                 best_match(embed, centroids.iter().map(|(i, c)| (*i, c.as_slice())))
             });
             views.push(FaceView {
@@ -1533,7 +1538,7 @@ impl Library {
         let mut additions: Vec<(usize, TaggedFace)> = Vec::new();
         for (path, faces) in &self.faces {
             for face in faces {
-                let Some(embed) = face.embed.as_deref() else {
+                let Some(embed) = face.vector() else {
                     continue;
                 };
                 if self.is_ignored(path, &face.rect)
@@ -1950,6 +1955,12 @@ fn load_thumb(job: &ThumbJob) -> ThumbOutcome {
         }
     }
     let mut needs_heif = false;
+    // A larger decode kept from a thumbnail render, for the recogniser's
+    // crops: one decode of the original serves both, where a second one
+    // per photo with faces was the cost of a fresh library.
+    let mut big: Option<(u32, u32, Vec<u8>)> = None;
+    let recogniser_wanted =
+        schist_neural::installed("face") && schist_neural::installed("face-embed");
     let rgba: Option<(u32, u32, Vec<u8>)> = if let Some(cached) = cache
         .as_ref()
         .and_then(|p| std::fs::read(p).ok())
@@ -1958,15 +1969,27 @@ fn load_thumb(job: &ThumbJob) -> ThumbOutcome {
         let img = cached.into_rgba8();
         Some((img.width(), img.height(), img.into_raw()))
     } else {
-        match schist_preview::render_file(&job.source, THUMB_EDGE) {
+        let edge = if recogniser_wanted {
+            EMBED_EDGE
+        } else {
+            THUMB_EDGE
+        };
+        match schist_preview::render_file(&job.source, edge) {
             Ok(preview) => {
-                if let (Some(path), Ok(png)) = (&cache, preview.to_png()) {
+                let thumb = if edge == THUMB_EDGE {
+                    preview
+                } else {
+                    let scaled = thumbnail_of(&preview);
+                    big = Some((preview.width, preview.height, preview.rgba));
+                    scaled
+                };
+                if let (Some(path), Ok(png)) = (&cache, thumb.to_png()) {
                     if let Some(dir) = path.parent() {
                         let _ = std::fs::create_dir_all(dir);
                     }
                     let _ = std::fs::write(path, png);
                 }
-                Some((preview.width, preview.height, preview.rgba))
+                Some((thumb.width, thumb.height, thumb.rgba))
             }
             Err(err) => {
                 needs_heif = schist_codecs_common::heif::download_would_help(&err);
@@ -1986,7 +2009,7 @@ fn load_thumb(job: &ThumbJob) -> ThumbOutcome {
         None => None,
     };
     let faces = match &rgba {
-        Some((w, h, rgba)) => detect_faces(&cache, &job.source, *w, *h, rgba),
+        Some((w, h, rgba)) => detect_faces(&cache, &job.source, *w, *h, rgba, big.as_ref()),
         // Undecodable: nobody in it, as far as anyone can tell.
         None if schist_neural::installed("face") => Some(Vec::new()),
         None => None,
@@ -2010,10 +2033,56 @@ fn load_thumb(job: &ThumbJob) -> ThumbOutcome {
 /// already has its vector. Otherwise the photo is looked at again.
 fn faces_settled(cached: Option<&[DetectedFace]>) -> bool {
     match cached {
-        Some(faces) => {
-            !schist_neural::installed("face-embed") || faces.iter().all(|f| f.embed.is_some())
-        }
+        Some(faces) => !recogniser_ready() || faces.iter().all(|f| f.embedded()),
         None => false,
+    }
+}
+
+/// The recogniser is installed but would not load this session (a
+/// damaged file, say). Without this every face would stay "owed a
+/// vector" and the indexer would ask for it on every pass, forever;
+/// with it the recogniser counts as absent until the next launch, when
+/// a repaired file gets its turn. Set by the loader thread that found
+/// out, read wherever "is the recogniser here" is asked — cheaply,
+/// with no model load on the UI thread.
+static RECOGNISER_BROKEN: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Whether the recogniser is installed and not known to be broken.
+fn recogniser_ready() -> bool {
+    schist_neural::installed("face-embed")
+        && !RECOGNISER_BROKEN.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// The recogniser, loaded — or the note that it will not be.
+fn recogniser() -> Option<Arc<schist_neural::Model>> {
+    if !recogniser_ready() {
+        return None;
+    }
+    let model = schist_neural::get("face-embed");
+    if model.is_none() {
+        log::warn!("face recogniser is installed but did not load; faces go unrecognised");
+        RECOGNISER_BROKEN.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+    model
+}
+
+/// The thumbnail-sized version of a larger preview.
+fn thumbnail_of(preview: &schist_preview::Preview) -> schist_preview::Preview {
+    let scale = THUMB_EDGE as f32 / preview.width.max(preview.height).max(1) as f32;
+    let (w, h) = (
+        ((preview.width as f32 * scale).round() as u32).max(1),
+        ((preview.height as f32 * scale).round() as u32).max(1),
+    );
+    let rgba = image::RgbaImage::from_raw(preview.width, preview.height, preview.rgba.clone())
+        .map(|img| {
+            image::imageops::resize(&img, w, h, image::imageops::FilterType::Triangle).into_raw()
+        })
+        .unwrap_or_else(|| preview.rgba.clone());
+    schist_preview::Preview {
+        width: w,
+        height: h,
+        rgba,
+        source: preview.source,
     }
 }
 
@@ -2030,11 +2099,13 @@ fn detect_faces(
     width: u32,
     height: u32,
     rgba: &[u8],
+    big: Option<&(u32, u32, Vec<u8>)>,
 ) -> Option<Vec<DetectedFace>> {
     let cached = read_faces_cache(cache);
     if faces_settled(cached.as_deref()) {
         return cached;
     }
+    let had_cache = cached.is_some();
     let detector = match schist_neural::get("face") {
         Some(model) => model,
         // Installed but not loading (a damaged file, say): count the
@@ -2084,22 +2155,45 @@ fn detect_faces(
                 .collect()
         }
     };
-    if !faces.is_empty() {
-        if let Some(model) = schist_neural::get("face-embed") {
-            // A bigger decode for the crops; the thumbnail if that fails.
-            let big = schist_preview::render_file(source, EMBED_EDGE).ok();
-            let (bw, bh, big_rgba): (u32, u32, &[u8]) = match &big {
-                Some(p) => (p.width, p.height, &p.rgba),
+    let owed = faces.iter().any(|f| !f.embedded());
+    if owed {
+        if let Some(model) = recogniser() {
+            let (side, _) = model.spec.input.dims();
+            // Big faces crop fine from the thumbnail. Small ones want a
+            // larger decode: the one kept from rendering the thumbnail
+            // when there is one, else one made now — the only time a
+            // photo is decoded twice — and the thumbnail if that fails.
+            let needs_big = faces
+                .iter()
+                .any(|f| !f.embedded() && (f.rect.w * width as f32) < EMBED_FROM_THUMB_PX);
+            let decoded;
+            let (bw, bh, big_rgba): (u32, u32, &[u8]) = match big {
+                Some((w, h, px)) => (*w, *h, px),
+                None if needs_big => {
+                    decoded = schist_preview::render_file(source, EMBED_EDGE).ok();
+                    match &decoded {
+                        Some(p) => (p.width, p.height, &p.rgba),
+                        None => (width, height, rgba),
+                    }
+                }
                 None => (width, height, rgba),
             };
-            let (side, _) = model.spec.input.dims();
-            for face in faces.iter_mut().filter(|f| f.embed.is_none()) {
-                face.embed = face_crop_rgb(big_rgba, bw, bh, &face.rect, EMBED_GROW, side as u32)
-                    .and_then(|crop| schist_neural::embed_face(&model, &crop).ok());
+            for face in faces.iter_mut().filter(|f| !f.embedded()) {
+                // A failure is recorded as an empty vector: tried, could
+                // not, and not to be asked again every pass.
+                face.embed = Some(
+                    face_crop_rgb(big_rgba, bw, bh, &face.rect, EMBED_GROW, side as u32)
+                        .and_then(|crop| schist_neural::embed_face(&model, &crop).ok())
+                        .unwrap_or_default(),
+                );
             }
         }
     }
-    write_faces_cache(cache, &faces);
+    // Written when something was learned; a cached look that only
+    // waited on a recogniser that is not here is left as it was.
+    if !had_cache || faces.iter().any(|f| f.embedded()) {
+        write_faces_cache(cache, &faces);
+    }
     Some(faces)
 }
 
@@ -2477,8 +2571,13 @@ impl Workspace {
                 this.update(cx, |ws, _| {
                     ws.library.ticker = false;
                     // The loader going idle is "indexing caught up":
-                    // the moment to persist what it learned.
+                    // the moment to persist what it learned, and to
+                    // let the face models go — a hundred megabytes
+                    // between them, reloaded in a third of a second
+                    // when the next photo or named face needs them.
                     ws.library.save_index_snapshot();
+                    schist_neural::release("face");
+                    schist_neural::release("face-embed");
                 })
                 .ok();
                 return;
@@ -4095,6 +4194,31 @@ mod tests {
         assert!(lib
             .detected_faces(Path::new("/p/b.jpg"))
             .is_some_and(|f| f.len() == 2));
+    }
+
+    #[test]
+    fn a_recorded_embedding_failure_is_settled_and_never_a_vector() {
+        let tried = found(face_at(0.1), Some(Vec::new()));
+        assert!(tried.embedded());
+        assert_eq!(tried.vector(), None);
+        let owed = found(face_at(0.1), None);
+        assert!(!owed.embedded());
+        // A photo whose faces all had their turn is never re-queued,
+        // whatever the recogniser's state; one still owed is — while a
+        // recogniser is here to pay it.
+        assert!(faces_settled(Some(std::slice::from_ref(&tried))) || !recogniser_ready());
+        assert!(!faces_settled(None));
+        let mut lib = library_with(&["/p/a.jpg", "/p/b.jpg"]);
+        lib.faces.insert(
+            "/p/a.jpg".into(),
+            vec![found(face_at(0.1), Some(vec![1.0, 0.0]))],
+        );
+        lib.faces.insert("/p/b.jpg".into(), vec![tried]);
+        lib.tag_face(Path::new("/p/a.jpg"), face_at(0.1), "Ann");
+        // Nothing to compare: no suggestion, no automatic tag.
+        let b = lib.faces_in(Path::new("/p/b.jpg"));
+        assert_eq!(b[0].person, None);
+        assert_eq!(b[0].suggestion, None);
     }
 
     #[test]

--- a/crates/app/src/workspace/library.rs
+++ b/crates/app/src/workspace/library.rs
@@ -1072,18 +1072,24 @@ impl Library {
     pub fn grouped(&self) -> Vec<(String, String, Vec<Entry>)> {
         // A person on show replaces the grouping too: their photos in
         // the order the faces were named.
+        // Inside the bucket or folder on show, when there is one: the
+        // People rows narrow what is already there, and say so.
         if let Some(filter) = self.person_filter {
+            let scope = self
+                .scope_label()
+                .map(|s| format!(" \u{b7} in {s}"))
+                .unwrap_or_default();
             return match filter {
                 PersonFilter::Person(i) => match self.people.get(i) {
                     Some(person) => vec![(
-                        format!("People \u{b7} {}", person.name),
+                        format!("People \u{b7} {}{scope}", person.name),
                         String::new(),
                         self.person_photos(i),
                     )],
                     None => Vec::new(),
                 },
                 PersonFilter::Unnamed => vec![(
-                    "Unnamed faces".to_string(),
+                    format!("Unnamed faces{scope}"),
                     String::new(),
                     self.unnamed_photos(),
                 )],
@@ -1700,8 +1706,40 @@ impl Library {
         }
     }
 
+    /// Whether a photo is inside what the sidebar has narrowed the
+    /// gallery to — the bucket on show, else the folder, else anything
+    /// — and past the map filter. The People rows count and show
+    /// within this, so a person's number is theirs *in this bucket*.
+    pub fn in_scope(&self, path: &Path) -> bool {
+        if !self.passes_map(path) {
+            return false;
+        }
+        if let Some(bucket) = self.bucket_filter.and_then(|i| self.buckets.get(i)) {
+            return bucket.photos.contains(&path.to_path_buf())
+                || bucket.matches.iter().any(|p| p == path);
+        }
+        match &self.folder_filter {
+            Some(root) => path.starts_with(root),
+            None => true,
+        }
+    }
+
+    /// What the scope is called, for the People headers: the bucket's
+    /// name or the folder's, `None` for the whole library.
+    pub fn scope_label(&self) -> Option<String> {
+        if let Some(bucket) = self.bucket_filter.and_then(|i| self.buckets.get(i)) {
+            return Some(bucket.name.clone());
+        }
+        self.folder_filter.as_ref().map(|root| {
+            root.file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| root.display().to_string())
+        })
+    }
+
     /// One person's photos, in the order their faces were named, that
-    /// the scan still knows and the map filter lets through.
+    /// the scan still knows and the scope (bucket, folder, map) lets
+    /// through.
     pub fn person_photos(&self, index: usize) -> Vec<Entry> {
         let Some(person) = self.people.get(index) else {
             return Vec::new();
@@ -1710,16 +1748,17 @@ impl Library {
             .photos()
             .iter()
             .filter_map(|p| self.entry_of(p).cloned())
-            .filter(|e| self.passes_map(&e.path))
+            .filter(|e| self.in_scope(&e.path))
             .collect()
     }
 
     /// Photos with a detected face nobody has named or dismissed, in
-    /// scan order.
+    /// scan order, within the scope.
     pub fn unnamed_photos(&self) -> Vec<Entry> {
-        self.visible_sections()
+        self.sections
+            .iter()
             .flat_map(|s| s.entries.iter())
-            .filter(|e| self.passes_map(&e.path))
+            .filter(|e| self.in_scope(&e.path))
             .filter(|e| self.has_unnamed_face(&e.path))
             .cloned()
             .collect()
@@ -1734,10 +1773,11 @@ impl Library {
         })
     }
 
-    /// How many detected faces are still unnamed, across the library.
+    /// How many detected faces are still unnamed, within the scope.
     pub fn unnamed_face_count(&self) -> usize {
         self.faces
             .iter()
+            .filter(|(path, _)| self.in_scope(path))
             .flat_map(|(path, faces)| faces.iter().map(move |f| (path, f)))
             .filter(|(path, f)| {
                 !self.is_ignored(path, &f.rect)
@@ -4055,6 +4095,36 @@ mod tests {
         assert!(lib
             .detected_faces(Path::new("/p/b.jpg"))
             .is_some_and(|f| f.len() == 2));
+    }
+
+    #[test]
+    fn a_person_on_show_stays_inside_the_bucket_or_folder() {
+        let mut lib = library_with(&["/p/a.jpg", "/p/b.jpg", "/p/c.jpg"]);
+        lib.faces
+            .insert("/p/c.jpg".into(), vec![found(face_at(0.1), None)]);
+        lib.tag_face(Path::new("/p/a.jpg"), face_at(0.1), "Ann");
+        lib.tag_face(Path::new("/p/b.jpg"), face_at(0.1), "Ann");
+        lib.person_filter = Some(PersonFilter::Person(0));
+        assert_eq!(lib.person_photos(0).len(), 2);
+        assert_eq!(lib.unnamed_face_count(), 1);
+        // A bucket holding only b: Ann has one photo in it, and the
+        // header says where.
+        lib.buckets.push(Bucket {
+            name: "Trip".into(),
+            photos: vec![PathBuf::from("/p/b.jpg")],
+            query: None,
+            area: None,
+            matches: Vec::new(),
+        });
+        lib.bucket_filter = Some(0);
+        assert_eq!(lib.person_photos(0).len(), 1);
+        assert_eq!(lib.grouped()[0].0, "People \u{b7} Ann \u{b7} in Trip");
+        assert_eq!(lib.unnamed_face_count(), 0, "c is not in the bucket");
+        lib.bucket_filter = None;
+        // A folder that holds nothing of hers.
+        lib.folder_filter = Some(PathBuf::from("/elsewhere"));
+        assert!(lib.person_photos(0).is_empty());
+        assert_eq!(lib.scope_label().as_deref(), Some("elsewhere"));
     }
 
     #[test]

--- a/crates/app/src/workspace/library.rs
+++ b/crates/app/src/workspace/library.rs
@@ -147,6 +147,8 @@ pub enum PersonFilter {
 pub struct FaceView {
     pub rect: FaceRect,
     pub person: Option<usize>,
+    /// The recogniser put it with this person, nobody confirmed it.
+    pub auto: bool,
     /// The recogniser's best guess and its cosine, for an unnamed face.
     pub suggestion: Option<(usize, f32)>,
     pub detected: bool,
@@ -295,6 +297,9 @@ pub struct Library {
     /// Detected faces waved away — not a face, or not worth naming —
     /// so they stop being offered. Persisted.
     pub ignored_faces: Vec<TaggedFace>,
+    /// Faces the user said are not the person the recogniser (or an
+    /// earlier tag) made them, so they are not put back. Persisted.
+    pub denied_faces: Vec<DeniedFace>,
     /// Showing one person's photos (or the unnamed faces) instead of
     /// the folders.
     pub person_filter: Option<PersonFilter>,
@@ -492,6 +497,7 @@ impl Library {
             faces: FxHashMap::default(),
             people: file.people,
             ignored_faces: file.ignored_faces,
+            denied_faces: file.denied_faces,
             person_filter: None,
             viewer: None,
             avatars: FxHashMap::default(),
@@ -554,6 +560,7 @@ impl Library {
                 .collect(),
             people: self.people.clone(),
             ignored_faces: self.ignored_faces.clone(),
+            denied_faces: self.denied_faces.clone(),
         };
         if let Err(err) = file.save() {
             log::warn!("gallery: library.json not saved: {err:#}");
@@ -766,6 +773,7 @@ impl Library {
         json!({
             "people": self.people.iter().enumerate().map(|(i, p)| json!({
                 "index": i, "name": p.name, "photos": p.photos().len(), "faces": p.faces.len(),
+                "auto_faces": p.faces.iter().filter(|f| f.auto).count(),
                 "viewing": self.person_filter == Some(PersonFilter::Person(i)),
             })).collect::<Vec<_>>(),
             "unnamed_faces": self.unnamed_face_count(),
@@ -941,6 +949,8 @@ impl Library {
             }
         }
         self.index_gen += 1;
+        // Restored detections may match people named since.
+        self.auto_tag_and_save();
     }
 
     /// Write the index to its snapshot file (on a plain thread — pure
@@ -1400,9 +1410,12 @@ impl Library {
             .iter()
             .enumerate()
             .filter_map(|(i, person)| {
+                // Hand-named faces only: an automatic tag that is
+                // wrong must not steer the next guess.
                 let vectors = person
                     .faces
                     .iter()
+                    .filter(|f| !f.auto)
                     .filter_map(|f| self.face_embedding(&f.photo, &f.rect));
                 Some((i, centroid(vectors)?))
             })
@@ -1423,6 +1436,7 @@ impl Library {
                 views.push(FaceView {
                     rect: face.rect,
                     person: Some(i),
+                    auto: face.auto,
                     suggestion: None,
                     detected: detected.iter().any(|d| d.rect.same_face(&face.rect)),
                 });
@@ -1441,6 +1455,7 @@ impl Library {
             views.push(FaceView {
                 rect: face.rect,
                 person: None,
+                auto: false,
                 suggestion,
                 detected: true,
             });
@@ -1458,17 +1473,24 @@ impl Library {
             .collect()
     }
 
-    /// Name a face: it joins the person called `name` — created when
-    /// nobody is — leaving whoever had it before, and any dismissal.
-    /// Returns the person's index; `None` for an empty name.
-    pub fn tag_face(&mut self, path: &Path, rect: FaceRect, name: &str) -> Option<usize> {
+    /// Name a face by hand: it joins the person called `name` — created
+    /// when nobody is — leaving whoever had it before, and any dismissal
+    /// or denial of this name. Then the recogniser learns from it: every
+    /// unnamed face in the library that now matches the person closely
+    /// enough is put with them too, as an automatic tag. Returns the
+    /// person's index and how many faces followed; `None` for an empty
+    /// name.
+    pub fn tag_face(&mut self, path: &Path, rect: FaceRect, name: &str) -> Option<(usize, usize)> {
         let name = name.trim();
         if name.is_empty() {
             return None;
         }
-        self.untag_face_quietly(path, &rect);
+        self.untag_face_quietly(path, &rect, false);
         self.ignored_faces
             .retain(|f| !(f.photo == path && f.rect.same_face(&rect)));
+        self.denied_faces.retain(|d| {
+            !(d.photo == path && d.rect.same_face(&rect) && d.name.eq_ignore_ascii_case(name))
+        });
         let index = match self
             .people
             .iter()
@@ -1486,26 +1508,104 @@ impl Library {
         self.people[index].faces.push(TaggedFace {
             photo: path.to_path_buf(),
             rect,
+            auto: false,
         });
+        let followed = self.auto_tag_all();
         self.save();
-        Some(index)
+        Some((index, followed))
     }
 
-    /// Take the name off a face. A person left with no faces goes too.
-    pub fn untag_face(&mut self, path: &Path, rect: &FaceRect) {
-        if self.untag_face_quietly(path, rect) {
+    /// Put every unnamed face that closely matches a named person with
+    /// them, as automatic tags — skipping faces the user has dismissed
+    /// or denied that name. Returns how many were added. Called after a
+    /// hand-made tag and whenever detections arrive.
+    pub fn auto_tag_all(&mut self) -> usize {
+        let centroids = self.person_centroids();
+        if centroids.is_empty() {
+            return 0;
+        }
+        let mut additions: Vec<(usize, TaggedFace)> = Vec::new();
+        for (path, faces) in &self.faces {
+            for face in faces {
+                let Some(embed) = face.embed.as_deref() else {
+                    continue;
+                };
+                if self.is_ignored(path, &face.rect)
+                    || self.people.iter().any(|p| p.tagged(path, &face.rect))
+                {
+                    continue;
+                }
+                let Some((index, cosine)) =
+                    best_match(embed, centroids.iter().map(|(i, c)| (*i, c.as_slice())))
+                else {
+                    continue;
+                };
+                if cosine < AUTO_COSINE
+                    || self.is_denied(path, &face.rect, &self.people[index].name)
+                {
+                    continue;
+                }
+                additions.push((
+                    index,
+                    TaggedFace {
+                        photo: path.clone(),
+                        rect: face.rect,
+                        auto: true,
+                    },
+                ));
+            }
+        }
+        let count = additions.len();
+        for (index, tag) in additions {
+            self.people[index].faces.push(tag);
+        }
+        count
+    }
+
+    /// The auto-tag pass, persisted when it changed anything.
+    pub(super) fn auto_tag_and_save(&mut self) {
+        if self.auto_tag_all() > 0 {
             self.save();
         }
     }
 
-    fn untag_face_quietly(&mut self, path: &Path, rect: &FaceRect) -> bool {
+    fn is_denied(&self, path: &Path, rect: &FaceRect, name: &str) -> bool {
+        self.denied_faces
+            .iter()
+            .any(|d| d.photo == path && d.rect.same_face(rect) && d.name.eq_ignore_ascii_case(name))
+    }
+
+    /// Take the name off a face, and remember that it is not that
+    /// person, so the recogniser does not put it straight back. A
+    /// person left with no faces goes too.
+    pub fn untag_face(&mut self, path: &Path, rect: &FaceRect) {
+        if self.untag_face_quietly(path, rect, true) {
+            self.save();
+        }
+    }
+
+    fn untag_face_quietly(&mut self, path: &Path, rect: &FaceRect, deny: bool) -> bool {
         let mut changed = false;
+        let mut denied: Vec<DeniedFace> = Vec::new();
         for person in &mut self.people {
             let before = person.faces.len();
-            person
-                .faces
-                .retain(|f| !(f.photo == path && f.rect.same_face(rect)));
+            person.faces.retain(|f| {
+                let hit = f.photo == path && f.rect.same_face(rect);
+                if hit && deny {
+                    denied.push(DeniedFace {
+                        photo: path.to_path_buf(),
+                        rect: *rect,
+                        name: person.name.clone(),
+                    });
+                }
+                !hit
+            });
             changed |= person.faces.len() != before;
+        }
+        for d in denied {
+            if !self.is_denied(&d.photo, &d.rect, &d.name) {
+                self.denied_faces.push(d);
+            }
         }
         if changed {
             let mut i = 0;
@@ -1522,11 +1622,12 @@ impl Library {
 
     /// Dismiss a detected face: not a face, or nobody worth naming.
     pub fn ignore_face(&mut self, path: &Path, rect: FaceRect) {
-        self.untag_face_quietly(path, &rect);
+        self.untag_face_quietly(path, &rect, false);
         if !self.is_ignored(path, &rect) {
             self.ignored_faces.push(TaggedFace {
                 photo: path.to_path_buf(),
                 rect,
+                auto: false,
             });
         }
         self.save();
@@ -1548,6 +1649,16 @@ impl Library {
         {
             let faces = std::mem::take(&mut self.people[index].faces);
             self.people[other].faces.extend(faces);
+            // Denials of the old name now mean the merged one.
+            let (old, new) = (
+                self.people[index].name.clone(),
+                self.people[other].name.clone(),
+            );
+            for d in &mut self.denied_faces {
+                if d.name.eq_ignore_ascii_case(&old) {
+                    d.name = new.clone();
+                }
+            }
             let target = if other > index { other - 1 } else { other };
             let viewing = self.person_filter == Some(PersonFilter::Person(index));
             self.remove_person_at(index);
@@ -1557,7 +1668,12 @@ impl Library {
                 self.person_filter = Some(PersonFilter::Person(target));
             }
         } else {
-            self.people[index].name = name.to_string();
+            let old = std::mem::replace(&mut self.people[index].name, name.to_string());
+            for d in &mut self.denied_faces {
+                if d.name.eq_ignore_ascii_case(&old) {
+                    d.name = name.to_string();
+                }
+            }
         }
         self.save();
     }
@@ -2347,6 +2463,7 @@ impl Workspace {
             let keep = this.update(cx, |ws, cx| {
                 ws.library.index_gen += 1;
                 let visible_work = results.iter().any(|(_, _, for_index, _)| !for_index);
+                let mut new_faces = false;
                 for (key, mtime, for_index, outcome) in results {
                     if let Some(score) = outcome.score {
                         ws.library.flagged.insert(key.clone(), is_explicit(score));
@@ -2361,6 +2478,7 @@ impl Workspace {
                     ws.library.places.insert(key.clone(), outcome.meta.place);
                     if let Some(faces) = outcome.faces {
                         ws.library.faces.insert(key.clone(), faces);
+                        new_faces = true;
                     }
                     if outcome.needs_heif && ws.library.heif_needed.is_none() {
                         ws.library.heif_needed = Some(key.clone());
@@ -2374,6 +2492,11 @@ impl Workspace {
                         };
                         ws.library.thumbs.insert(key, (mtime, state));
                     }
+                }
+                // Faces just found may belong to people already named:
+                // put them there, as Picasa filled its albums.
+                if new_faces {
+                    ws.library.auto_tag_and_save();
                 }
                 // The batch may have pushed the map over budget; shed
                 // whatever scrolled away longest ago.
@@ -3783,6 +3906,7 @@ mod tests {
         let mut lib = Library::load();
         lib.people.clear();
         lib.ignored_faces.clear();
+        lib.denied_faces.clear();
         lib.sections = vec![Section {
             dir: PathBuf::from("/p"),
             entries: photos
@@ -3819,8 +3943,9 @@ mod tests {
             vec![found(face_at(0.1), None), found(face_at(0.6), None)],
         );
         assert_eq!(lib.unnamed_face_count(), 2);
-        let ann = lib.tag_face(a, face_at(0.1), "Ann").expect("named");
+        let (ann, followed) = lib.tag_face(a, face_at(0.1), "Ann").expect("named");
         assert_eq!(lib.people[ann].name, "Ann");
+        assert_eq!(followed, 0, "no vectors, nothing to learn from");
         assert_eq!(lib.unnamed_face_count(), 1);
         assert_eq!(
             lib.tag_face(a, face_at(0.1), "   "),
@@ -3829,7 +3954,7 @@ mod tests {
         );
         // A box drawn a hair off the detection is the same face, and
         // renaming it moves it: Ann is left with no faces and goes.
-        let bob = lib.tag_face(a, face_at(0.11), "bob").expect("named");
+        let (bob, _) = lib.tag_face(a, face_at(0.11), "bob").expect("named");
         assert_eq!(lib.people.len(), 1);
         assert_eq!(lib.people[bob].name, "bob");
         // The tag comes first, then the unclaimed detection.
@@ -3915,17 +4040,82 @@ mod tests {
             .iter()
             .all(|f| f.suggestion.is_none()));
         lib.tag_face(Path::new("/p/a.jpg"), face_at(0.1), "Ann");
+        // The close match (cosine 0.9) was taken outright as an automatic
+        // tag; the face at 0.6 points the other way and is nobody's.
         let views = lib.faces_in(Path::new("/p/b.jpg"));
-        assert_eq!(views[0].suggestion.map(|(i, _)| i), Some(0));
+        assert_eq!(views[0].person, Some(0));
+        assert!(views[0].auto);
+        assert_eq!(views[1].person, None);
         assert_eq!(views[1].suggestion, None);
         // A face learned by hand joins the detections and the centroid.
         lib.learn_face(Path::new("/p/b.jpg"), face_at(0.6), vec![0.0, -1.0]);
         lib.tag_face(Path::new("/p/b.jpg"), face_at(0.6), "Bob");
         let views = lib.faces_in(Path::new("/p/b.jpg"));
-        assert_eq!(views.iter().filter(|v| v.person.is_some()).count(), 1);
+        assert_eq!(views.iter().filter(|v| v.person.is_some()).count(), 2);
         assert!(lib
             .detected_faces(Path::new("/p/b.jpg"))
             .is_some_and(|f| f.len() == 2));
+    }
+
+    #[test]
+    fn naming_a_face_teaches_the_recogniser_and_denials_stick() {
+        let mut lib = library_with(&["/p/a.jpg", "/p/b.jpg", "/p/c.jpg", "/p/d.jpg"]);
+        // a: Ann's face. b: a close match (0.95). c: a weak match (0.47,
+        // a question rather than an answer). d: somebody else entirely.
+        lib.faces.insert(
+            "/p/a.jpg".into(),
+            vec![found(face_at(0.1), Some(vec![1.0, 0.0]))],
+        );
+        lib.faces.insert(
+            "/p/b.jpg".into(),
+            vec![found(face_at(0.1), Some(vec![0.95, 0.312]))],
+        );
+        lib.faces.insert(
+            "/p/c.jpg".into(),
+            vec![found(face_at(0.1), Some(vec![0.47, 0.883]))],
+        );
+        lib.faces.insert(
+            "/p/d.jpg".into(),
+            vec![found(face_at(0.1), Some(vec![-1.0, 0.0]))],
+        );
+        let (ann, followed) = lib
+            .tag_face(Path::new("/p/a.jpg"), face_at(0.1), "Ann")
+            .unwrap();
+        assert_eq!(followed, 1, "b followed, c is only a question, d is nobody");
+        assert_eq!(lib.person_photos(ann).len(), 2);
+        let b = lib.faces_in(Path::new("/p/b.jpg"));
+        assert_eq!(b[0].person, Some(ann));
+        assert!(b[0].auto);
+        let c = lib.faces_in(Path::new("/p/c.jpg"));
+        assert_eq!(c[0].person, None);
+        assert_eq!(c[0].suggestion.map(|(i, _)| i), Some(ann));
+        // The automatic tag does not steer the mean: still Ann's own vector.
+        assert_eq!(lib.person_centroids()[0].1, vec![1.0, 0.0]);
+        // "Not them": the face leaves and stays out, even after another
+        // pass — but can still be named by hand, which clears the denial.
+        lib.untag_face(Path::new("/p/b.jpg"), &face_at(0.1));
+        assert_eq!(lib.person_photos(ann).len(), 1);
+        assert_eq!(lib.auto_tag_all(), 0);
+        assert_eq!(lib.denied_faces.len(), 1);
+        lib.tag_face(Path::new("/p/b.jpg"), face_at(0.1), "ann");
+        assert!(lib.denied_faces.is_empty());
+        let b_tag = lib.people[ann]
+            .faces
+            .iter()
+            .find(|f| f.photo == Path::new("/p/b.jpg"))
+            .expect("b is Ann's again");
+        assert!(!b_tag.auto, "named by hand this time");
+        // With two hand-named faces Ann's mean moved towards c, which
+        // now clears the bar and follows automatically.
+        assert!(lib.people[ann]
+            .faces
+            .iter()
+            .any(|f| f.auto && f.photo == Path::new("/p/c.jpg")));
+        // Renaming carries the denials along.
+        lib.untag_face(Path::new("/p/b.jpg"), &face_at(0.1));
+        lib.rename_person(ann, "Ann Example");
+        assert_eq!(lib.denied_faces[0].name, "Ann Example");
+        assert_eq!(lib.auto_tag_all(), 0);
     }
 
     #[test]

--- a/crates/app/src/workspace/library.rs
+++ b/crates/app/src/workspace/library.rs
@@ -38,6 +38,17 @@ const THUMB_KEEP_PARKED: usize = 256;
 const SCROLLBAR_INSET: f32 = 4.0;
 /// How many recently opened files the start screen lists.
 const RECENTS_KEPT: usize = 10;
+/// Longest edge the viewer decodes a photo at: enough to fill a
+/// window, little enough to decode in the time a click takes.
+pub(super) const VIEW_EDGE: u32 = 1600;
+/// Longest edge the recogniser's face crops are cut from. A face in a
+/// 256 px thumbnail is twenty pixels wide, which is not a face; the
+/// detector is happy with the thumbnail, the recogniser is not.
+const EMBED_EDGE: u32 = 1024;
+/// Faces smaller than this in the thumbnail are texture, not people.
+const MIN_FACE_PX: f32 = 12.0;
+/// The face avatars in the sidebar and the people panel, in pixels.
+pub(super) const AVATAR_PX: u32 = 64;
 
 /// A thumbnail's place in the pipeline.
 pub enum Thumb {
@@ -117,6 +128,61 @@ pub enum GalleryContext {
     /// Freeze the clicked marker's members independently of selection or zoom.
     MapCluster(Vec<PathBuf>),
     Bucket(usize),
+    Person(usize),
+}
+
+/// What the sidebar's People rows show instead of the folders.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PersonFilter {
+    /// One person's photos.
+    Person(usize),
+    /// Photos with detected faces nobody has named yet — Picasa's
+    /// "Unnamed" album, where the naming gets done.
+    Unnamed,
+}
+
+/// One face as the viewer shows it: the box, who it is (if anyone),
+/// who it might be, and whether the detector or the user drew it.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FaceView {
+    pub rect: FaceRect,
+    pub person: Option<usize>,
+    /// The recogniser's best guess and its cosine, for an unnamed face.
+    pub suggestion: Option<(usize, f32)>,
+    pub detected: bool,
+}
+
+/// The photo the viewer has decoded, at up to [`VIEW_EDGE`] px: the
+/// pixels stay, for face crops and for the recogniser's look at a
+/// face drawn by hand.
+pub struct ViewImage {
+    pub width: u32,
+    pub height: u32,
+    pub rgba: Arc<Vec<u8>>,
+    pub render: Arc<RenderImage>,
+}
+
+/// The viewer: one photo on show instead of the grid, its faces to
+/// name. Session-only, like the selection.
+pub struct Viewer {
+    pub path: PathBuf,
+    pub image: Option<ViewImage>,
+    pub loading: bool,
+    /// Where the picture landed last paint, in window coordinates —
+    /// what turns a pointer position into a fraction of the photo.
+    pub image_bounds: Bounds<Pixels>,
+    /// The picture's room, recorded each paint so the fit can be
+    /// worked out before the image element is built.
+    pub area: Bounds<Pixels>,
+    /// A box being dragged out: where the press was and where the
+    /// pointer is, as fractions of the photo.
+    pub drawing: Option<((f32, f32), (f32, f32))>,
+    /// The face being named.
+    pub pick: Option<FaceRect>,
+    /// The name field's live text.
+    pub name: String,
+    /// Face crops cut from the decoded picture, by face key.
+    pub crops: FxHashMap<String, Arc<RenderImage>>,
 }
 
 /// A drag of gallery photos, headed for a folder or a bucket.
@@ -221,6 +287,27 @@ pub struct Library {
     /// photo groups under — the other two readings of the same EXIF.
     taken: FxHashMap<PathBuf, String>,
     places: FxHashMap<PathBuf, Option<String>>,
+    /// The faces the detector found per photo, filled by the loader;
+    /// an empty list is a photo it looked at and found nobody in.
+    faces: FxHashMap<PathBuf, Vec<DetectedFace>>,
+    /// The people: every name given to a face. Persisted.
+    pub people: Vec<PersonFile>,
+    /// Detected faces waved away — not a face, or not worth naming —
+    /// so they stop being offered. Persisted.
+    pub ignored_faces: Vec<TaggedFace>,
+    /// Showing one person's photos (or the unnamed faces) instead of
+    /// the folders.
+    pub person_filter: Option<PersonFilter>,
+    /// The photo on show instead of the grid, if any.
+    pub viewer: Option<Viewer>,
+    /// Face avatars for the sidebar and the people panel, by face key;
+    /// `None` while one is being cut, or after the cut failed.
+    avatars: FxHashMap<String, Option<Arc<RenderImage>>>,
+    /// Avatars waiting to be cut out of thumbnails.
+    avatar_queue: Vec<(String, PathBuf, FaceRect)>,
+    avatar_ticker: bool,
+    /// The people the current query named, for the results header.
+    pub search_people: Vec<String>,
     /// How the grid is grouped, persisted. Date by default: a camera
     /// roll is a diary before it is a directory tree.
     pub group_by: GroupBy,
@@ -402,6 +489,15 @@ impl Library {
             positions: FxHashMap::default(),
             taken: FxHashMap::default(),
             places: FxHashMap::default(),
+            faces: FxHashMap::default(),
+            people: file.people,
+            ignored_faces: file.ignored_faces,
+            person_filter: None,
+            viewer: None,
+            avatars: FxHashMap::default(),
+            avatar_queue: Vec::new(),
+            avatar_ticker: false,
+            search_people: Vec::new(),
             group_by: file
                 .group_by
                 .as_deref()
@@ -436,6 +532,11 @@ impl Library {
     }
 
     fn save(&self) {
+        // Unit tests build libraries from thin air; writing them over
+        // the developer's own library.json would be a surprise.
+        if cfg!(test) {
+            return;
+        }
         let file = LibraryFile {
             folders: self.folders.clone(),
             recents: self.recents.clone(),
@@ -451,6 +552,8 @@ impl Library {
                     area: b.area.clone(),
                 })
                 .collect(),
+            people: self.people.clone(),
+            ignored_faces: self.ignored_faces.clone(),
         };
         if let Err(err) = file.save() {
             log::warn!("gallery: library.json not saved: {err:#}");
@@ -571,10 +674,13 @@ impl Library {
     /// Thumbnails shrink to a parked handful — the PNGs are on disk,
     /// so reopening costs a moment of decode, not a rebuild.
     pub(super) fn shed_memory(&mut self) {
-        for id in ["nsfw", "embed-image", "embed-text"] {
+        for id in ["nsfw", "embed-image", "embed-text", "face", "face-embed"] {
             schist_neural::release(id);
         }
         self.engine_warmed = false;
+        // The viewer's decode is the biggest single picture in memory,
+        // and a photo on show in a gallery that has closed is nobody's.
+        self.viewer = None;
         self.evict_thumbs(THUMB_KEEP_PARKED);
         // Leaving the gallery is also a fine moment to persist what
         // indexing learned, in case the loader never went idle.
@@ -587,6 +693,8 @@ impl Library {
     fn refill_index_queue(&mut self) -> bool {
         let embeds = schist_neural::installed("embed-image");
         let scores = nsfw_installed();
+        let detector = schist_neural::installed("face");
+        let recogniser = schist_neural::installed("face-embed");
         let jobs: Vec<ThumbJob> = self
             .sections
             .iter()
@@ -597,6 +705,14 @@ impl Library {
                     // A scorer installed after the position pass ran
                     // still has every photo to see.
                     || (scores && !self.flagged.contains_key(&e.path))
+                    || (detector && !self.faces.contains_key(&e.path))
+                    // Faces found before the recogniser arrived are
+                    // still owed their vectors.
+                    || (recogniser
+                        && self
+                            .faces
+                            .get(&e.path)
+                            .is_some_and(|f| f.iter().any(|x| x.embed.is_none())))
             })
             .take(THUMB_BATCH)
             .map(|e| ThumbJob {
@@ -637,6 +753,26 @@ impl Library {
             "map_filter": self.map_filter_label(),
             "index": {"embedded": indexed, "total": total,
                       "search_models_installed": schist_neural::embed::ready()},
+            "people": self.people_json(),
+            "viewing": self.viewer.as_ref().map(|v| v.path.display().to_string()),
+        })
+    }
+
+    /// The People album as JSON: each name with its counts, the
+    /// unnamed tally, which models are here, and what is on show.
+    pub(super) fn people_json(&self) -> serde_json::Value {
+        use serde_json::json;
+        let (looked, total) = self.faces_progress();
+        json!({
+            "people": self.people.iter().enumerate().map(|(i, p)| json!({
+                "index": i, "name": p.name, "photos": p.photos().len(), "faces": p.faces.len(),
+                "viewing": self.person_filter == Some(PersonFilter::Person(i)),
+            })).collect::<Vec<_>>(),
+            "unnamed_faces": self.unnamed_face_count(),
+            "viewing_unnamed": self.person_filter == Some(PersonFilter::Unnamed),
+            "detector_installed": schist_neural::installed("face"),
+            "recogniser_installed": schist_neural::installed("face-embed"),
+            "photos_looked_at": looked, "photos_total": total,
         })
     }
 
@@ -650,6 +786,8 @@ impl Library {
             "edited": entry.edited,
             "selected": self.is_selected(&entry.path),
             "flagged": self.flagged.get(&entry.path).copied(),
+            "people": self.names_in(&entry.path),
+            "unnamed_faces": self.faces_in(&entry.path).iter().filter(|f| f.person.is_none()).count(),
         })
     }
 
@@ -757,13 +895,9 @@ impl Library {
                     taken: self.taken.get(&e.path).cloned(),
                     place: self.places.get(&e.path).cloned(),
                     flagged: self.flagged.get(&e.path).copied(),
+                    faces: self.faces.get(&e.path).cloned(),
                 };
-                let empty = row.embed.is_none()
-                    && row.gps.is_none()
-                    && row.taken.is_none()
-                    && row.place.is_none()
-                    && row.flagged.is_none();
-                (!empty).then_some(row)
+                (!row.is_empty()).then_some(row)
             })
             .collect()
     }
@@ -800,7 +934,10 @@ impl Library {
                 self.places.entry(row.path.clone()).or_insert(place);
             }
             if let Some(flagged) = row.flagged {
-                self.flagged.entry(row.path).or_insert(flagged);
+                self.flagged.entry(row.path.clone()).or_insert(flagged);
+            }
+            if let Some(faces) = row.faces {
+                self.faces.entry(row.path).or_insert(faces);
             }
         }
         self.index_gen += 1;
@@ -923,6 +1060,25 @@ impl Library {
     /// The visible photos grouped the way `group_by` asks:
     /// (title, subtitle, entries) per group.
     pub fn grouped(&self) -> Vec<(String, String, Vec<Entry>)> {
+        // A person on show replaces the grouping too: their photos in
+        // the order the faces were named.
+        if let Some(filter) = self.person_filter {
+            return match filter {
+                PersonFilter::Person(i) => match self.people.get(i) {
+                    Some(person) => vec![(
+                        format!("People \u{b7} {}", person.name),
+                        String::new(),
+                        self.person_photos(i),
+                    )],
+                    None => Vec::new(),
+                },
+                PersonFilter::Unnamed => vec![(
+                    "Unnamed faces".to_string(),
+                    String::new(),
+                    self.unnamed_photos(),
+                )],
+            };
+        }
         // A bucket on show replaces the grouping: the hand-picked
         // photos in the order they were dropped in, then whatever its
         // rule matched, best first.
@@ -1184,6 +1340,399 @@ impl Library {
     }
 }
 
+/// How far above the towers' cosines a named person's photos sit: a
+/// name is not a hint but an answer.
+pub(super) const PERSON_BOOST: f32 = 1.0;
+
+/// The People album: what the detector found, whom the user named.
+impl Library {
+    /// The entry for a photo, if the scan knows it.
+    pub fn entry_of(&self, path: &Path) -> Option<&Entry> {
+        self.sections
+            .iter()
+            .flat_map(|s| s.entries.iter())
+            .find(|e| e.path == path)
+    }
+
+    /// The detector's faces in a photo, if it has been looked at.
+    pub fn detected_faces(&self, path: &Path) -> Option<&[DetectedFace]> {
+        self.faces.get(path).map(Vec::as_slice)
+    }
+
+    /// How many photos the detector has looked at, of how many.
+    pub fn faces_progress(&self) -> (usize, usize) {
+        let total = self.sections.iter().map(|s| s.entries.len()).sum();
+        let looked = self
+            .sections
+            .iter()
+            .flat_map(|s| s.entries.iter())
+            .filter(|e| self.faces.contains_key(&e.path))
+            .count();
+        (looked, total)
+    }
+
+    fn is_ignored(&self, path: &Path, rect: &FaceRect) -> bool {
+        self.ignored_faces
+            .iter()
+            .any(|f| f.photo == path && f.rect.same_face(rect))
+    }
+
+    /// Who a face in a photo is tagged as, if anyone.
+    pub fn person_of(&self, path: &Path, rect: &FaceRect) -> Option<usize> {
+        self.people.iter().position(|p| p.tagged(path, rect))
+    }
+
+    /// The recogniser's vector for a face: that of the detection it
+    /// sits on, when there is one.
+    fn face_embedding(&self, path: &Path, rect: &FaceRect) -> Option<&[f32]> {
+        self.faces
+            .get(path)?
+            .iter()
+            .find(|f| f.rect.same_face(rect))?
+            .embed
+            .as_deref()
+    }
+
+    /// One vector per person with any recognised face: the unit mean
+    /// of their tagged faces' vectors.
+    fn person_centroids(&self) -> Vec<(usize, Vec<f32>)> {
+        self.people
+            .iter()
+            .enumerate()
+            .filter_map(|(i, person)| {
+                let vectors = person
+                    .faces
+                    .iter()
+                    .filter_map(|f| self.face_embedding(&f.photo, &f.rect));
+                Some((i, centroid(vectors)?))
+            })
+            .collect()
+    }
+
+    /// Every face in a photo as the viewer shows it: the tagged ones
+    /// first (the user's word), then the detections nobody has claimed
+    /// or dismissed, each with the recogniser's guess. Left to right.
+    pub fn faces_in(&self, path: &Path) -> Vec<FaceView> {
+        let detected = self.faces.get(path).map(Vec::as_slice).unwrap_or(&[]);
+        let mut views: Vec<FaceView> = Vec::new();
+        for (i, person) in self.people.iter().enumerate() {
+            for face in person.faces.iter().filter(|f| f.photo == path) {
+                if views.iter().any(|v| v.rect.same_face(&face.rect)) {
+                    continue;
+                }
+                views.push(FaceView {
+                    rect: face.rect,
+                    person: Some(i),
+                    suggestion: None,
+                    detected: detected.iter().any(|d| d.rect.same_face(&face.rect)),
+                });
+            }
+        }
+        let centroids = self.person_centroids();
+        for face in detected {
+            if views.iter().any(|v| v.rect.same_face(&face.rect))
+                || self.is_ignored(path, &face.rect)
+            {
+                continue;
+            }
+            let suggestion = face.embed.as_deref().and_then(|embed| {
+                best_match(embed, centroids.iter().map(|(i, c)| (*i, c.as_slice())))
+            });
+            views.push(FaceView {
+                rect: face.rect,
+                person: None,
+                suggestion,
+                detected: true,
+            });
+        }
+        views.sort_by(|a, b| a.rect.x.total_cmp(&b.rect.x));
+        views
+    }
+
+    /// The names tagged in a photo, in tag order.
+    pub fn names_in(&self, path: &Path) -> Vec<String> {
+        self.people
+            .iter()
+            .filter(|p| p.faces.iter().any(|f| f.photo == path))
+            .map(|p| p.name.clone())
+            .collect()
+    }
+
+    /// Name a face: it joins the person called `name` — created when
+    /// nobody is — leaving whoever had it before, and any dismissal.
+    /// Returns the person's index; `None` for an empty name.
+    pub fn tag_face(&mut self, path: &Path, rect: FaceRect, name: &str) -> Option<usize> {
+        let name = name.trim();
+        if name.is_empty() {
+            return None;
+        }
+        self.untag_face_quietly(path, &rect);
+        self.ignored_faces
+            .retain(|f| !(f.photo == path && f.rect.same_face(&rect)));
+        let index = match self
+            .people
+            .iter()
+            .position(|p| p.name.eq_ignore_ascii_case(name))
+        {
+            Some(index) => index,
+            None => {
+                self.people.push(PersonFile {
+                    name: name.to_string(),
+                    faces: Vec::new(),
+                });
+                self.people.len() - 1
+            }
+        };
+        self.people[index].faces.push(TaggedFace {
+            photo: path.to_path_buf(),
+            rect,
+        });
+        self.save();
+        Some(index)
+    }
+
+    /// Take the name off a face. A person left with no faces goes too.
+    pub fn untag_face(&mut self, path: &Path, rect: &FaceRect) {
+        if self.untag_face_quietly(path, rect) {
+            self.save();
+        }
+    }
+
+    fn untag_face_quietly(&mut self, path: &Path, rect: &FaceRect) -> bool {
+        let mut changed = false;
+        for person in &mut self.people {
+            let before = person.faces.len();
+            person
+                .faces
+                .retain(|f| !(f.photo == path && f.rect.same_face(rect)));
+            changed |= person.faces.len() != before;
+        }
+        if changed {
+            let mut i = 0;
+            while i < self.people.len() {
+                if self.people[i].faces.is_empty() {
+                    self.remove_person_at(i);
+                } else {
+                    i += 1;
+                }
+            }
+        }
+        changed
+    }
+
+    /// Dismiss a detected face: not a face, or nobody worth naming.
+    pub fn ignore_face(&mut self, path: &Path, rect: FaceRect) {
+        self.untag_face_quietly(path, &rect);
+        if !self.is_ignored(path, &rect) {
+            self.ignored_faces.push(TaggedFace {
+                photo: path.to_path_buf(),
+                rect,
+            });
+        }
+        self.save();
+    }
+
+    /// Rename a person. Renaming to a name somebody else already has
+    /// merges the two — the usual way "Ann" and "Ann Example" become
+    /// one album.
+    pub fn rename_person(&mut self, index: usize, name: &str) {
+        let name = name.trim();
+        if name.is_empty() || index >= self.people.len() {
+            return;
+        }
+        if let Some(other) = self
+            .people
+            .iter()
+            .position(|p| p.name.eq_ignore_ascii_case(name))
+            .filter(|&other| other != index)
+        {
+            let faces = std::mem::take(&mut self.people[index].faces);
+            self.people[other].faces.extend(faces);
+            let target = if other > index { other - 1 } else { other };
+            let viewing = self.person_filter == Some(PersonFilter::Person(index));
+            self.remove_person_at(index);
+            if viewing {
+                // The sidebar was on the person who just merged away:
+                // follow them into the merged album.
+                self.person_filter = Some(PersonFilter::Person(target));
+            }
+        } else {
+            self.people[index].name = name.to_string();
+        }
+        self.save();
+    }
+
+    /// Forget a person: every face they were tagged in goes back to
+    /// being unnamed.
+    pub fn delete_person(&mut self, index: usize) {
+        if index < self.people.len() {
+            self.remove_person_at(index);
+            self.save();
+        }
+    }
+
+    /// Drop a person and keep the sidebar's choice pointing at the
+    /// same person (or nobody) as the indices shift.
+    fn remove_person_at(&mut self, index: usize) {
+        self.people.remove(index);
+        match self.person_filter {
+            Some(PersonFilter::Person(f)) if f == index => self.person_filter = None,
+            Some(PersonFilter::Person(f)) if f > index => {
+                self.person_filter = Some(PersonFilter::Person(f - 1));
+            }
+            _ => {}
+        }
+    }
+
+    /// One person's photos, in the order their faces were named, that
+    /// the scan still knows and the map filter lets through.
+    pub fn person_photos(&self, index: usize) -> Vec<Entry> {
+        let Some(person) = self.people.get(index) else {
+            return Vec::new();
+        };
+        person
+            .photos()
+            .iter()
+            .filter_map(|p| self.entry_of(p).cloned())
+            .filter(|e| self.passes_map(&e.path))
+            .collect()
+    }
+
+    /// Photos with a detected face nobody has named or dismissed, in
+    /// scan order.
+    pub fn unnamed_photos(&self) -> Vec<Entry> {
+        self.visible_sections()
+            .flat_map(|s| s.entries.iter())
+            .filter(|e| self.passes_map(&e.path))
+            .filter(|e| self.has_unnamed_face(&e.path))
+            .cloned()
+            .collect()
+    }
+
+    fn has_unnamed_face(&self, path: &Path) -> bool {
+        self.faces.get(path).is_some_and(|faces| {
+            faces.iter().any(|f| {
+                !self.is_ignored(path, &f.rect)
+                    && !self.people.iter().any(|p| p.tagged(path, &f.rect))
+            })
+        })
+    }
+
+    /// How many detected faces are still unnamed, across the library.
+    pub fn unnamed_face_count(&self) -> usize {
+        self.faces
+            .iter()
+            .flat_map(|(path, faces)| faces.iter().map(move |f| (path, f)))
+            .filter(|(path, f)| {
+                !self.is_ignored(path, &f.rect)
+                    && !self.people.iter().any(|p| p.tagged(path, &f.rect))
+            })
+            .count()
+    }
+
+    /// The people a search query names, each with their photos.
+    pub fn people_hits(&self, query: &str) -> Vec<(String, Vec<PathBuf>)> {
+        self.people
+            .iter()
+            .filter(|p| name_matches_query(&p.name, query))
+            .map(|p| (p.name.clone(), p.photos()))
+            .collect()
+    }
+
+    /// Names beginning with what has been typed, for the name field's
+    /// completions — everyone, when nothing has.
+    pub fn names_starting(&self, prefix: &str) -> Vec<(usize, String)> {
+        let prefix = prefix.trim().to_lowercase();
+        self.people
+            .iter()
+            .enumerate()
+            .filter(|(_, p)| prefix.is_empty() || p.name.to_lowercase().starts_with(&prefix))
+            .map(|(i, p)| (i, p.name.clone()))
+            .collect()
+    }
+
+    /// Where the sidebar's face avatars stand: `Some(Some)` ready,
+    /// `Some(None)` cutting or failed, `None` never asked for.
+    pub(super) fn avatar_state(&self, key: &str) -> Option<Option<Arc<RenderImage>>> {
+        self.avatars.get(key).cloned()
+    }
+
+    /// Ask for an avatar to be cut from a photo's thumbnail. Returns
+    /// whether it was newly queued.
+    pub(super) fn request_avatar(&mut self, key: String, path: PathBuf, rect: FaceRect) -> bool {
+        if self.avatars.contains_key(&key) {
+            return false;
+        }
+        self.avatars.insert(key.clone(), None);
+        self.avatar_queue.push((key, path, rect));
+        true
+    }
+
+    pub(super) fn forget_avatar(&mut self, key: &str) {
+        self.avatars.remove(key);
+    }
+
+    pub(super) fn take_avatar_jobs(&mut self) -> Vec<(String, PathBuf, FaceRect)> {
+        std::mem::take(&mut self.avatar_queue)
+    }
+
+    pub(super) fn avatar_ticking(&mut self, on: bool) -> bool {
+        std::mem::replace(&mut self.avatar_ticker, on)
+    }
+
+    pub(super) fn store_avatar(&mut self, key: String, image: Option<Arc<RenderImage>>) {
+        self.avatars.insert(key, image);
+    }
+
+    /// Learn a face's vector from the viewer's own decode: a face drawn
+    /// by hand has no detection to carry one, and without it the
+    /// recogniser cannot suggest the person elsewhere. Appended to the
+    /// photo's detections and cached with them.
+    pub(super) fn learn_face(&mut self, path: &Path, rect: FaceRect, embed: Vec<f32>) {
+        let faces = self.faces.entry(path.to_path_buf()).or_default();
+        match faces.iter_mut().find(|f| f.rect.same_face(&rect)) {
+            Some(face) => face.embed = Some(embed),
+            None => faces.push(DetectedFace {
+                rect,
+                embed: Some(embed),
+            }),
+        }
+        if let Some(entry) = self.entry_of(path).cloned() {
+            let cache = thumb_cache_path(&thumb_source(&entry.path, entry.edited), entry.mtime);
+            write_faces_cache(
+                &cache,
+                self.faces.get(path).map(Vec::as_slice).unwrap_or(&[]),
+            );
+        }
+        self.index_gen += 1;
+    }
+
+    /// Put a photo at the front of the index queue: the viewer wants
+    /// its faces now, not when the loader gets round to it. Returns
+    /// whether anything was queued.
+    pub(super) fn prioritize_index(&mut self, path: &Path) -> bool {
+        if self.faces.contains_key(path) || !schist_neural::installed("face") {
+            return false;
+        }
+        if self.queue.iter().any(|j| j.key == path) {
+            return false;
+        }
+        let Some(entry) = self.entry_of(path).cloned() else {
+            return false;
+        };
+        self.queue.insert(
+            0,
+            ThumbJob {
+                key: entry.path.clone(),
+                source: thumb_source(&entry.path, entry.edited),
+                mtime: entry.mtime,
+                for_index: true,
+            },
+        );
+        true
+    }
+}
+
 /// RGBA straight bytes as the BGRA frame `RenderImage` wants.
 pub(super) fn rgba_to_render_image(
     width: u32,
@@ -1210,6 +1759,9 @@ struct ThumbOutcome {
     embedding: Option<Vec<f32>>,
     /// Position, capture time and grouping city, from the EXIF.
     meta: PhotoMeta,
+    /// The faces the detector found, when the detector is installed
+    /// (or a cached look from when it was).
+    faces: Option<Vec<DetectedFace>>,
     /// The decode failed for want of the HEIC support download.
     needs_heif: bool,
 }
@@ -1225,15 +1777,18 @@ fn load_thumb(job: &ThumbJob) -> ThumbOutcome {
     if job.for_index {
         let cached_embed = read_embed_cache(&cache);
         let cached_score = read_score_cache(&cache);
+        let cached_faces = read_faces_cache(&cache);
         let embeds_wanted = schist_neural::installed("embed-image");
         if (cached_embed.is_some() || !embeds_wanted)
             && (cached_score.is_some() || !nsfw_installed())
+            && (faces_settled(cached_faces.as_deref()) || !schist_neural::installed("face"))
         {
             return ThumbOutcome {
                 img: None,
                 score: cached_score,
                 embedding: cached_embed,
                 meta: photo_meta(&cache, &job.key),
+                faces: cached_faces,
                 needs_heif: false,
             };
         }
@@ -1274,6 +1829,12 @@ fn load_thumb(job: &ThumbJob) -> ThumbOutcome {
         None if schist_neural::installed("embed-image") => Some(Vec::new()),
         None => None,
     };
+    let faces = match &rgba {
+        Some((w, h, rgba)) => detect_faces(&cache, &job.source, *w, *h, rgba),
+        // Undecodable: nobody in it, as far as anyone can tell.
+        None if schist_neural::installed("face") => Some(Vec::new()),
+        None => None,
+    };
     ThumbOutcome {
         img: if job.for_index {
             None
@@ -1283,8 +1844,107 @@ fn load_thumb(job: &ThumbJob) -> ThumbOutcome {
         score,
         embedding,
         meta: photo_meta(&cache, &job.key),
+        faces,
         needs_heif,
     }
+}
+
+/// Whether a cached look at a photo's faces is all it is going to be:
+/// there is one, and either the recogniser is absent or every face
+/// already has its vector. Otherwise the photo is looked at again.
+fn faces_settled(cached: Option<&[DetectedFace]>) -> bool {
+    match cached {
+        Some(faces) => {
+            !schist_neural::installed("face-embed") || faces.iter().all(|f| f.embed.is_some())
+        }
+        None => false,
+    }
+}
+
+/// The faces in a photo, cached beside its thumbnail (`.faces`).
+/// `None` when the detector is not installed and nothing was cached.
+///
+/// Detection runs on the thumbnail — the detector's own frame is
+/// 320x240, so a thumbnail is already more than it looks at. The
+/// recogniser, when installed, gets its crops from a larger decode of
+/// the source instead, since a face in a 256 px thumbnail is a smudge.
+fn detect_faces(
+    cache: &Option<PathBuf>,
+    source: &Path,
+    width: u32,
+    height: u32,
+    rgba: &[u8],
+) -> Option<Vec<DetectedFace>> {
+    let cached = read_faces_cache(cache);
+    if faces_settled(cached.as_deref()) {
+        return cached;
+    }
+    let detector = match schist_neural::get("face") {
+        Some(model) => model,
+        // Installed but not loading (a damaged file, say): count the
+        // photo as looked at for this session, so the indexer moves on
+        // instead of asking again every pass — but cache nothing, so
+        // a repaired model gets its turn next launch.
+        None => return cached.or_else(|| Some(Vec::new())),
+    };
+    let mut faces: Vec<DetectedFace> = match cached {
+        // The boxes stand; only the vectors are owed.
+        Some(cached) => cached,
+        None => {
+            let rgb: Vec<f32> = rgba
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .flat_map(|px| {
+                    [
+                        px[0] as f32 / 255.0,
+                        px[1] as f32 / 255.0,
+                        px[2] as f32 / 255.0,
+                    ]
+                })
+                .collect();
+            let found = match schist_neural::faces(&detector, &rgb, width as usize, height as usize)
+            {
+                Ok(found) => found,
+                Err(err) => {
+                    log::warn!("face detection failed for {}: {err:#}", source.display());
+                    return None;
+                }
+            };
+            found
+                .iter()
+                .filter(|f| f.width >= MIN_FACE_PX && f.height >= MIN_FACE_PX)
+                .map(|f| DetectedFace {
+                    rect: FaceRect::from_pixels(
+                        f.x,
+                        f.y,
+                        f.width,
+                        f.height,
+                        width as f32,
+                        height as f32,
+                    ),
+                    embed: None,
+                })
+                .collect()
+        }
+    };
+    if !faces.is_empty() {
+        if let Some(model) = schist_neural::get("face-embed") {
+            // A bigger decode for the crops; the thumbnail if that fails.
+            let big = schist_preview::render_file(source, EMBED_EDGE).ok();
+            let (bw, bh, big_rgba): (u32, u32, &[u8]) = match &big {
+                Some(p) => (p.width, p.height, &p.rgba),
+                None => (width, height, rgba),
+            };
+            let (side, _) = model.spec.input.dims();
+            for face in faces.iter_mut().filter(|f| f.embed.is_none()) {
+                face.embed = face_crop_rgb(big_rgba, bw, bh, &face.rect, EMBED_GROW, side as u32)
+                    .and_then(|crop| schist_neural::embed_face(&model, &crop).ok());
+            }
+        }
+    }
+    write_faces_cache(cache, &faces);
+    Some(faces)
 }
 
 /// The photo's search embedding, cached beside the thumbnail. `None`
@@ -1699,6 +2359,9 @@ impl Workspace {
                         ws.library.taken.insert(key.clone(), taken);
                     }
                     ws.library.places.insert(key.clone(), outcome.meta.place);
+                    if let Some(faces) = outcome.faces {
+                        ws.library.faces.insert(key.clone(), faces);
+                    }
                     if outcome.needs_heif && ws.library.heif_needed.is_none() {
                         ws.library.heif_needed = Some(key.clone());
                     }
@@ -2140,6 +2803,15 @@ impl Workspace {
             // p_2 padding both sides, gap_2 between cells.
             (((width - 16.0 + 8.0) / (cell + 8.0)).floor() as isize).max(1)
         };
+        if ev.keystroke.key == "space" {
+            // Space is the quick look: the lead photo, big, with its
+            // faces to name.
+            let Some(lead) = self.library.lead_selected().cloned() else {
+                return false;
+            };
+            self.open_viewer(lead, cx);
+            return true;
+        }
         let step: isize = match ev.keystroke.key.as_str() {
             "left" => -1,
             "right" => 1,
@@ -2278,6 +2950,7 @@ impl Workspace {
         self.library.search_selected = false;
         self.library.search_results = None;
         self.library.search_place = None;
+        self.library.search_people.clear();
         self.library.search_scoped = None;
         self.library.search_seq += 1;
         cx.notify();
@@ -2298,12 +2971,16 @@ impl Workspace {
         if query.is_empty() {
             self.library.search_results = None;
             self.library.search_place = None;
+            self.library.search_people.clear();
             cx.notify();
             return;
         }
         let cached = self.library.query_cache.get(&query).cloned();
         let scope = self.library.search_scope();
         let snapshot = self.library.search_snapshot();
+        // The third reading of the query: who it names. A person's
+        // photos are pulled in whole, above anything the towers rank.
+        let people_hits = self.library.people_hits(&query);
         cx.spawn(async move |this, cx| {
             let ranked = cx
                 .background_executor()
@@ -2321,7 +2998,7 @@ impl Workspace {
                             },
                         ),
                     };
-                    if answer.text.is_none() && answer.place.is_none() {
+                    if answer.text.is_none() && answer.place.is_none() && people_hits.is_empty() {
                         return None;
                     }
                     // Scores keyed by borrowed path; only what survives
@@ -2330,6 +3007,13 @@ impl Workspace {
                     // of the kept two hundred by the rest of the library.
                     let in_scope = |path: &PathBuf| scope.as_ref().is_none_or(|s| s.contains(path));
                     let mut scored: FxHashMap<&PathBuf, f32> = FxHashMap::default();
+                    for (_, paths) in &people_hits {
+                        for path in paths {
+                            if in_scope(path) {
+                                *scored.entry(path).or_insert(0.0) += PERSON_BOOST;
+                            }
+                        }
+                    }
                     if let Some(text) = &answer.text {
                         for (path, v) in snapshot.vectors.iter() {
                             if !in_scope(path) {
@@ -2352,10 +3036,13 @@ impl Workspace {
                     }
                     let floor = if answer.text.is_some() {
                         SEARCH_FLOOR
-                    } else {
+                    } else if answer.place.is_some() {
                         // Location-only search (no text model): being
                         // near the place is the whole of the score.
                         GEO_BOOST * 0.3
+                    } else {
+                        // A name alone: the person's photos, nothing else.
+                        PERSON_BOOST * 0.5
                     };
                     let mut scored: Vec<(&PathBuf, f32)> = scored.into_iter().collect();
                     scored.sort_by(|a, b| b.1.total_cmp(&a.1));
@@ -2366,11 +3053,12 @@ impl Workspace {
                         .map(|(path, score)| (path.clone(), score))
                         .collect();
                     let place_name = answer.place.as_ref().map(|p| p.name.clone());
-                    Some((ranked, place_name, fresh.then_some((query, answer))))
+                    let names: Vec<String> = people_hits.into_iter().map(|(n, _)| n).collect();
+                    Some((ranked, place_name, names, fresh.then_some((query, answer))))
                 })
                 .await;
             this.update(cx, |ws, cx| {
-                let Some((ranked, place_name, fresh)) = ranked else {
+                let Some((ranked, place_name, names, fresh)) = ranked else {
                     return;
                 };
                 if let Some((query, answer)) = fresh {
@@ -2384,6 +3072,7 @@ impl Workspace {
                 if ws.library.search_seq == seq {
                     ws.library.search_results = Some(ranked);
                     ws.library.search_place = place_name;
+                    ws.library.search_people = names;
                     cx.notify();
                 }
             })
@@ -2427,14 +3116,23 @@ impl Workspace {
             }
         };
         let snapshot = self.library.search_snapshot();
+        let people_hits = self.library.people_hits(&query);
         let in_scope = |path: &PathBuf| scope.as_ref().is_none_or(|s| s.contains(path));
         let mut scored: FxHashMap<&PathBuf, f32> = FxHashMap::default();
+        for (_, paths) in &people_hits {
+            for path in paths {
+                if in_scope(path) {
+                    *scored.entry(path).or_insert(0.0) += PERSON_BOOST;
+                }
+            }
+        }
         if let Some(text) = &answer.text {
             for (path, v) in snapshot.vectors.iter() {
                 if !in_scope(path) {
                     continue;
                 }
-                scored.insert(path, v.iter().zip(text.iter()).map(|(a, b)| a * b).sum());
+                *scored.entry(path).or_insert(0.0) +=
+                    v.iter().zip(text.iter()).map(|(a, b)| a * b).sum::<f32>();
             }
         }
         if let Some(place) = &answer.place {
@@ -2450,8 +3148,10 @@ impl Workspace {
         }
         let floor = if answer.text.is_some() {
             SEARCH_FLOOR
-        } else {
+        } else if answer.place.is_some() {
             GEO_BOOST * 0.3
+        } else {
+            PERSON_BOOST * 0.5
         };
         let mut ranked: Vec<(PathBuf, f32)> = scored
             .into_iter()
@@ -2461,6 +3161,7 @@ impl Workspace {
         ranked.sort_by(|a, b| b.1.total_cmp(&a.1));
         ranked.truncate(SEARCH_KEPT);
         self.library.search_place = answer.place.as_ref().map(|p| p.name.clone());
+        self.library.search_people = people_hits.into_iter().map(|(n, _)| n).collect();
         self.library.search_results = Some(ranked.clone());
         cx.notify();
         ranked
@@ -3041,6 +3742,7 @@ mod tests {
                 taken: Some("2026-09-01 12:00:00".into()),
                 place: Some(Some("New York City".into())),
                 flagged: Some(true),
+                faces: None,
             },
             IndexRow {
                 path: PathBuf::from("/p/bare.jpg"),
@@ -3050,6 +3752,7 @@ mod tests {
                 taken: None,
                 place: Some(None),
                 flagged: Some(false),
+                faces: None,
             },
         ];
         let dir = std::env::temp_dir().join(format!("schist-idx-test-{}", std::process::id()));
@@ -3074,6 +3777,155 @@ mod tests {
         // A torn file is a miss, not a crash.
         assert!(parse_index_snapshot(&bytes[..bytes.len() - 3]).is_none());
         assert!(parse_index_snapshot(b"not an index").is_none());
+    }
+
+    fn library_with(photos: &[&str]) -> Library {
+        let mut lib = Library::load();
+        lib.people.clear();
+        lib.ignored_faces.clear();
+        lib.sections = vec![Section {
+            dir: PathBuf::from("/p"),
+            entries: photos
+                .iter()
+                .map(|p| Entry {
+                    path: PathBuf::from(p),
+                    mtime: 1,
+                    edited: false,
+                })
+                .collect(),
+        }];
+        lib
+    }
+
+    fn face_at(x: f32) -> FaceRect {
+        FaceRect {
+            x,
+            y: 0.2,
+            w: 0.2,
+            h: 0.2,
+        }
+    }
+
+    fn found(rect: FaceRect, embed: Option<Vec<f32>>) -> DetectedFace {
+        DetectedFace { rect, embed }
+    }
+
+    #[test]
+    fn naming_a_face_makes_a_person_and_a_face_has_one_name_at_a_time() {
+        let mut lib = library_with(&["/p/a.jpg", "/p/b.jpg"]);
+        let a = Path::new("/p/a.jpg");
+        lib.faces.insert(
+            a.to_path_buf(),
+            vec![found(face_at(0.1), None), found(face_at(0.6), None)],
+        );
+        assert_eq!(lib.unnamed_face_count(), 2);
+        let ann = lib.tag_face(a, face_at(0.1), "Ann").expect("named");
+        assert_eq!(lib.people[ann].name, "Ann");
+        assert_eq!(lib.unnamed_face_count(), 1);
+        assert_eq!(
+            lib.tag_face(a, face_at(0.1), "   "),
+            None,
+            "blank names are nothing"
+        );
+        // A box drawn a hair off the detection is the same face, and
+        // renaming it moves it: Ann is left with no faces and goes.
+        let bob = lib.tag_face(a, face_at(0.11), "bob").expect("named");
+        assert_eq!(lib.people.len(), 1);
+        assert_eq!(lib.people[bob].name, "bob");
+        // The tag comes first, then the unclaimed detection.
+        let views = lib.faces_in(a);
+        assert_eq!(views.len(), 2);
+        assert_eq!(views[0].person, Some(bob));
+        assert!(views[0].detected);
+        assert_eq!(views[1].person, None);
+        assert_eq!(lib.names_in(a), vec!["bob".to_string()]);
+        // Waving the other away stops it being offered.
+        lib.ignore_face(a, face_at(0.6));
+        assert_eq!(lib.faces_in(a).len(), 1);
+        assert_eq!(lib.unnamed_face_count(), 0);
+        // Naming an ignored face un-ignores it; names match any case.
+        lib.tag_face(a, face_at(0.6), "BOB");
+        assert!(lib.ignored_faces.is_empty());
+        assert_eq!(lib.people.len(), 1);
+        assert_eq!(lib.people[0].faces.len(), 2);
+        assert_eq!(lib.person_photos(0).len(), 1, "one photo, two faces");
+        lib.untag_face(a, &face_at(0.6));
+        assert_eq!(lib.people[0].faces.len(), 1);
+    }
+
+    #[test]
+    fn renaming_to_an_existing_name_merges_and_the_filter_follows() {
+        let mut lib = library_with(&["/p/a.jpg", "/p/b.jpg"]);
+        lib.tag_face(Path::new("/p/a.jpg"), face_at(0.1), "Ann");
+        lib.tag_face(Path::new("/p/b.jpg"), face_at(0.1), "Annie");
+        lib.person_filter = Some(PersonFilter::Person(1));
+        lib.rename_person(1, "ann");
+        assert_eq!(lib.people.len(), 1);
+        assert_eq!(lib.people[0].faces.len(), 2);
+        assert_eq!(lib.person_filter, Some(PersonFilter::Person(0)));
+        let groups = lib.grouped();
+        assert_eq!(groups[0].0, "People \u{b7} Ann");
+        assert_eq!(groups[0].2.len(), 2);
+        lib.rename_person(0, "Ann Example");
+        assert_eq!(lib.people[0].name, "Ann Example");
+        lib.delete_person(0);
+        assert!(lib.people.is_empty());
+        assert_eq!(lib.person_filter, None);
+    }
+
+    #[test]
+    fn the_unnamed_album_and_a_name_search_read_the_same_tags() {
+        let mut lib = library_with(&["/p/a.jpg", "/p/b.jpg", "/p/c.jpg"]);
+        lib.faces
+            .insert("/p/a.jpg".into(), vec![found(face_at(0.1), None)]);
+        lib.faces
+            .insert("/p/b.jpg".into(), vec![found(face_at(0.1), None)]);
+        lib.faces.insert("/p/c.jpg".into(), Vec::new());
+        lib.person_filter = Some(PersonFilter::Unnamed);
+        assert_eq!(lib.grouped()[0].2.len(), 2);
+        lib.tag_face(Path::new("/p/a.jpg"), face_at(0.1), "Ann Example");
+        assert_eq!(lib.grouped()[0].2.len(), 1);
+        let hits = lib.people_hits("ann");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].1, vec![PathBuf::from("/p/a.jpg")]);
+        assert!(lib.people_hits("beach").is_empty());
+        assert_eq!(lib.names_starting("an").len(), 1);
+        assert_eq!(lib.names_starting("").len(), 1);
+        assert!(lib.names_starting("zed").is_empty());
+        assert_eq!(lib.faces_progress(), (3, 3));
+    }
+
+    #[test]
+    fn a_recognised_face_is_suggested_from_the_named_ones() {
+        let mut lib = library_with(&["/p/a.jpg", "/p/b.jpg"]);
+        lib.faces.insert(
+            "/p/a.jpg".into(),
+            vec![found(face_at(0.1), Some(vec![1.0, 0.0]))],
+        );
+        lib.faces.insert(
+            "/p/b.jpg".into(),
+            vec![
+                found(face_at(0.1), Some(vec![0.9, 0.436])),
+                found(face_at(0.6), Some(vec![0.0, -1.0])),
+            ],
+        );
+        // Nobody named yet: nothing to suggest.
+        assert!(lib
+            .faces_in(Path::new("/p/b.jpg"))
+            .iter()
+            .all(|f| f.suggestion.is_none()));
+        lib.tag_face(Path::new("/p/a.jpg"), face_at(0.1), "Ann");
+        let views = lib.faces_in(Path::new("/p/b.jpg"));
+        assert_eq!(views[0].suggestion.map(|(i, _)| i), Some(0));
+        assert_eq!(views[1].suggestion, None);
+        // A face learned by hand joins the detections and the centroid.
+        lib.learn_face(Path::new("/p/b.jpg"), face_at(0.6), vec![0.0, -1.0]);
+        lib.tag_face(Path::new("/p/b.jpg"), face_at(0.6), "Bob");
+        let views = lib.faces_in(Path::new("/p/b.jpg"));
+        assert_eq!(views.iter().filter(|v| v.person.is_some()).count(), 1);
+        assert!(lib
+            .detected_faces(Path::new("/p/b.jpg"))
+            .is_some_and(|f| f.len() == 2));
     }
 
     #[test]

--- a/crates/app/src/workspace/library.rs
+++ b/crates/app/src/workspace/library.rs
@@ -358,6 +358,24 @@ pub struct Library {
     /// The sidebar's counts, computed once per change rather than once
     /// per frame, with the key they were computed for.
     people_summary: Option<(SummaryKey, PeopleSummary)>,
+    /// Last launch's whole-library counts, shown until the index
+    /// snapshot has been read back — otherwise the numbers creep up
+    /// batch by batch as the caches are re-read, which reads as a leak.
+    summary_seed: Option<PeopleSummary>,
+    /// What was last written to the summary file, so it is rewritten
+    /// only when the numbers moved.
+    summary_written: Option<PeopleSummary>,
+    /// The index snapshot has been read back (or found missing): the
+    /// idle indexer waits for this, so it never re-reads per-photo
+    /// caches for what the snapshot is about to hand over in one go.
+    index_restored: bool,
+    /// The indexer has gone idle since the snapshot came back: every
+    /// photo has been looked at, and the live counts are the truth.
+    /// Until then the sidebar shows last launch's numbers — a snapshot
+    /// written before the last photos were indexed (the app was quit
+    /// mid-way) would otherwise leave the tally creeping up from a
+    /// fraction as the caches are re-read.
+    index_caught_up: bool,
     /// How the grid is grouped, persisted. Date by default: a camera
     /// roll is a diary before it is a directory tree.
     pub group_by: GroupBy,
@@ -482,6 +500,22 @@ impl Library {
     /// Load the persisted folder list and recents.
     pub fn load() -> Library {
         let file = LibraryFile::load();
+        let people = file.people;
+        // Last launch's counts, lined up with this launch's people by name.
+        let summary_seed = PeopleSummaryFile::load().map(|saved| PeopleSummary {
+            photo_counts: people
+                .iter()
+                .map(|p| {
+                    saved
+                        .photo_counts
+                        .iter()
+                        .find(|(name, _)| name.eq_ignore_ascii_case(&p.name))
+                        .map(|(_, n)| *n)
+                        .unwrap_or(0)
+                })
+                .collect(),
+            unnamed_faces: saved.unnamed_faces,
+        });
         Library {
             open: false,
             folders: file.folders,
@@ -540,7 +574,7 @@ impl Library {
             taken: FxHashMap::default(),
             places: FxHashMap::default(),
             faces: FxHashMap::default(),
-            people: file.people,
+            people,
             ignored_faces: file.ignored_faces,
             denied_faces: file.denied_faces,
             person_filter: None,
@@ -552,6 +586,10 @@ impl Library {
             by_path: FxHashMap::default(),
             people_rev: 0,
             people_summary: None,
+            summary_seed,
+            summary_written: None,
+            index_restored: false,
+            index_caught_up: false,
             group_by: file
                 .group_by
                 .as_deref()
@@ -748,6 +786,11 @@ impl Library {
     /// embedding (when the model to make one is here) or an EXIF
     /// position probe. Returns whether anything queued.
     fn refill_index_queue(&mut self) -> bool {
+        // Not before the snapshot is back: it hands over in one read
+        // what this would re-derive photo by photo from the caches.
+        if !self.index_restored {
+            return false;
+        }
         let embeds = schist_neural::installed("embed-image");
         let scores = nsfw_installed();
         let detector = schist_neural::installed("face");
@@ -1922,6 +1965,16 @@ impl Library {
                 return summary.clone();
             }
         }
+        let unscoped = self.bucket_filter.is_none()
+            && self.folder_filter.is_none()
+            && self.map_filter.is_none();
+        // Until the indexer has caught up, the live count would be a
+        // fraction of the truth climbing towards it: show last time's.
+        if !self.index_caught_up && unscoped {
+            if let Some(seed) = &self.summary_seed {
+                return seed.clone();
+            }
+        }
         let scope = self.scope();
         let claimed = self.claimed_by_photo();
         let summary = PeopleSummary {
@@ -1931,7 +1984,37 @@ impl Library {
             unnamed_faces: self.unnamed_face_count_in(&scope, &claimed),
         };
         self.people_summary = Some((key, summary.clone()));
+        if unscoped && self.index_caught_up && self.summary_written.as_ref() != Some(&summary) {
+            let file = PeopleSummaryFile {
+                unnamed_faces: summary.unnamed_faces,
+                photo_counts: self
+                    .people
+                    .iter()
+                    .zip(&summary.photo_counts)
+                    .map(|(p, n)| (p.name.clone(), *n))
+                    .collect(),
+            };
+            if cfg!(test) || file.save().is_ok() {
+                self.summary_written = Some(summary.clone());
+            }
+        }
         summary
+    }
+
+    /// The snapshot has been read back (or there was none): the idle
+    /// indexer may start.
+    pub(super) fn mark_index_restored(&mut self) {
+        self.index_restored = true;
+        self.people_rev += 1;
+    }
+
+    /// The indexer went idle with the snapshot in: the live counts are
+    /// complete, and the sidebar switches to them.
+    pub(super) fn mark_index_caught_up(&mut self) {
+        if self.index_restored && !self.index_caught_up {
+            self.index_caught_up = true;
+            self.people_rev += 1;
+        }
     }
 
     /// The people a search query names, each with their photos.
@@ -2660,11 +2743,15 @@ impl Workspace {
                 .background_executor()
                 .spawn(async move { read_index_snapshot() })
                 .await;
-            let Some(rows) = rows else { return };
             this.update(cx, |ws, cx| {
-                ws.library.apply_index_rows(rows);
-                // Nothing new to learn is nothing new to write back.
-                ws.library.index_saved_gen = ws.library.index_gen;
+                if let Some(rows) = rows {
+                    ws.library.apply_index_rows(rows);
+                    // Nothing new to learn is nothing new to write back.
+                    ws.library.index_saved_gen = ws.library.index_gen;
+                }
+                ws.library.mark_index_restored();
+                // The indexer was waiting on this.
+                ws.kick_thumb_loader(cx);
                 cx.notify();
             })
             .ok();
@@ -2685,8 +2772,9 @@ impl Workspace {
     /// running. Called from the gallery render, the same way the canvas
     /// kicks tile prefetch from paint.
     pub(super) fn kick_thumb_loader(&mut self, cx: &mut Context<Self>) {
-        // The map can open before any grid cell has queued a thumbnail.
-        if self.library.map_view && !self.library.ticker && self.library.queue.is_empty() {
+        // The map can open before any grid cell has queued a thumbnail,
+        // and the snapshot can land after the loader last went idle.
+        if !self.library.ticker && self.library.queue.is_empty() {
             self.library.refill_index_queue();
         }
         if !self.library.wants_thumbs() {
@@ -2711,16 +2799,21 @@ impl Workspace {
                 if refilled {
                     continue;
                 }
-                this.update(cx, |ws, _| {
+                this.update(cx, |ws, cx| {
                     ws.library.ticker = false;
                     // The loader going idle is "indexing caught up":
-                    // the moment to persist what it learned, and to
-                    // let the face models go — a hundred megabytes
+                    // the sidebar's counts become live, the moment to
+                    // persist what it learned, and to let the face
+                    // models go — a hundred megabytes
                     // between them, reloaded in a third of a second
                     // when the next photo or named face needs them.
                     ws.library.save_index_snapshot();
                     schist_neural::release("face");
                     schist_neural::release("face-embed");
+                    if ws.library.index_restored && !ws.library.index_caught_up {
+                        ws.library.mark_index_caught_up();
+                        cx.notify();
+                    }
                 })
                 .ok();
                 return;
@@ -4191,6 +4284,9 @@ mod tests {
         lib.people.clear();
         lib.ignored_faces.clear();
         lib.denied_faces.clear();
+        lib.summary_seed = None;
+        lib.index_restored = true;
+        lib.index_caught_up = true;
         lib.set_sections(vec![Section {
             dir: PathBuf::from("/p"),
             entries: photos
@@ -4364,6 +4460,41 @@ mod tests {
         let b = lib.faces_in(Path::new("/p/b.jpg"));
         assert_eq!(b[0].person, None);
         assert_eq!(b[0].suggestion, None);
+    }
+
+    #[test]
+    fn last_launch_counts_hold_until_the_snapshot_is_back() {
+        let mut lib = library_with(&["/p/a.jpg", "/p/b.jpg"]);
+        lib.tag_face(Path::new("/p/a.jpg"), face_at(0.1), "Ann");
+        // Launch state: nothing indexed yet, last time's numbers on file.
+        lib.index_restored = false;
+        lib.index_caught_up = false;
+        lib.summary_seed = Some(PeopleSummary {
+            photo_counts: vec![4],
+            unnamed_faces: 9,
+        });
+        assert_eq!(lib.people_summary().unnamed_faces, 9);
+        assert_eq!(lib.people_summary().photo_counts, vec![4]);
+        assert!(
+            !lib.refill_index_queue(),
+            "the indexer waits for the snapshot"
+        );
+        // A scope asks a live question even before then.
+        lib.folder_filter = Some(PathBuf::from("/p"));
+        assert_eq!(lib.people_summary().photo_counts, vec![1]);
+        lib.folder_filter = None;
+        // The snapshot lands, but the indexer has not finished: still
+        // last time's numbers. Once it idles, live ones — written down.
+        lib.mark_index_restored();
+        assert!(lib.refill_index_queue(), "now it may index");
+        assert_eq!(lib.people_summary().unnamed_faces, 9);
+        lib.faces
+            .insert("/p/b.jpg".into(), vec![found(face_at(0.1), None)]);
+        lib.mark_index_caught_up();
+        let live = lib.people_summary();
+        assert_eq!(live.unnamed_faces, 1);
+        assert_eq!(live.photo_counts, vec![1]);
+        assert_eq!(lib.summary_written, Some(live));
     }
 
     #[test]

--- a/crates/app/src/workspace/library_mcp.rs
+++ b/crates/app/src/workspace/library_mcp.rs
@@ -124,6 +124,19 @@ pub(super) fn tool_defs() -> Vec<Value> {
             &[],
         ),
         def(
+            "gallery_people",
+            "The People album: every named person with their photo and face counts, how many \
+             detected faces are still unnamed, and whether the face models are installed. Given \
+             a name, lists that person's photos instead (and shows them in the grid). Faces are \
+             named in the app: View a photo, click a face, type a name.",
+            json!({
+                "person": {"type": "string", "description": "A person's name, for their photos."},
+                "offset": {"type": "integer", "minimum": 0, "default": 0},
+                "limit": {"type": "integer", "minimum": 1, "maximum": 500, "default": 50},
+            }),
+            &[],
+        ),
+        def(
             "gallery_open",
             "Open a photo in the editor (its edit sidecar if it has one). The document tools \
              then apply to it; the gallery is Cmd/Ctrl+Shift+G away.",
@@ -322,6 +335,37 @@ impl Workspace {
                     "photos": self.library.buckets[index].contents().len(),
                 })))
             }
+            "gallery_people" => match str_arg(args, "person") {
+                Some(name) => {
+                    let index = self
+                        .library
+                        .people
+                        .iter()
+                        .position(|p| p.name.eq_ignore_ascii_case(name.trim()))
+                        .ok_or_else(|| anyhow::anyhow!("nobody named {name:?}"))?;
+                    let offset = args.get("offset").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+                    let limit = args
+                        .get("limit")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(50)
+                        .clamp(1, 500) as usize;
+                    self.show_person(Some(super::library::PersonFilter::Person(index)), cx);
+                    let entries = self.library.person_photos(index);
+                    let rows: Vec<Value> = entries
+                        .iter()
+                        .skip(offset)
+                        .take(limit)
+                        .map(|e| self.library.entry_json(e))
+                        .collect();
+                    Ok(text(json!({
+                        "person": self.library.people[index].name,
+                        "total": entries.len(),
+                        "offset": offset,
+                        "photos": rows,
+                    })))
+                }
+                None => Ok(text(self.library.people_json())),
+            },
             "gallery_group_by" => {
                 let by = str_arg(args, "by").ok_or_else(|| anyhow::anyhow!("by is required"))?;
                 let group = GroupBy::from_key(by)

--- a/crates/app/src/workspace/library_people.rs
+++ b/crates/app/src/workspace/library_people.rs
@@ -29,6 +29,11 @@ impl Workspace {
         // The viewer takes the grid's place; the world map would hide it.
         self.library.map_view = false;
         self.viewer_unpick();
+        let flat = self.gallery_flat_order();
+        let position = flat
+            .iter()
+            .position(|p| p == &path)
+            .map(|at| (at, flat.len()));
         self.library.viewer = Some(Viewer {
             path: path.clone(),
             image: None,
@@ -39,6 +44,7 @@ impl Workspace {
             pick: None,
             name: String::new(),
             crops: FxHashMap::default(),
+            position,
         });
         // Its faces first, if the detector has not been this way yet:
         // the person is looking at this photo now.

--- a/crates/app/src/workspace/library_people.rs
+++ b/crates/app/src/workspace/library_people.rs
@@ -266,7 +266,7 @@ impl Workspace {
         let carried = self.library.detected_faces(path).is_some_and(|faces| {
             faces
                 .iter()
-                .any(|f| f.rect.same_face(&rect) && f.embed.is_some())
+                .any(|f| f.rect.same_face(&rect) && f.vector().is_some())
         });
         if carried {
             return;

--- a/crates/app/src/workspace/library_people.rs
+++ b/crates/app/src/workspace/library_people.rs
@@ -199,10 +199,26 @@ impl Workspace {
         };
         if !typed.trim().is_empty() {
             self.learn_face_if_needed(&path, rect);
-            self.library.tag_face(&path, rect, &typed);
+            if let Some((index, followed)) = self.library.tag_face(&path, rect, &typed) {
+                self.report_tag(index, followed);
+            }
         }
         self.viewer_unpick();
         cx.notify();
+    }
+
+    /// Say what a name did in the tray: who, and how many other faces
+    /// the recogniser put with them on the strength of it.
+    fn report_tag(&mut self, index: usize, followed: usize) {
+        let Some(name) = self.library.people.get(index).map(|p| p.name.clone()) else {
+            return;
+        };
+        self.status = match followed {
+            0 => format!("Named {name}"),
+            1 => format!("Named {name} \u{b7} 1 more face matched automatically"),
+            n => format!("Named {name} \u{b7} {n} more faces matched automatically"),
+        }
+        .into();
     }
 
     /// Name a face as an existing person — a completion or a "yes" to
@@ -215,7 +231,9 @@ impl Workspace {
             return;
         };
         self.learn_face_if_needed(&path, rect);
-        self.library.tag_face(&path, rect, &name);
+        if let Some((index, followed)) = self.library.tag_face(&path, rect, &name) {
+            self.report_tag(index, followed);
+        }
         self.viewer_unpick();
         cx.notify();
     }

--- a/crates/app/src/workspace/library_people.rs
+++ b/crates/app/src/workspace/library_people.rs
@@ -448,12 +448,11 @@ impl Workspace {
     }
 
     /// The sidebar's People rows: show a person's photos (or the
-    /// unnamed faces) in the grid, or go back to the folders.
+    /// unnamed faces) in the grid — inside the bucket or folder on
+    /// show, when there is one — or go back to what was there.
     pub fn show_person(&mut self, filter: Option<PersonFilter>, cx: &mut Context<Self>) {
         self.library.person_filter = filter;
         self.library.map_view = false;
-        self.library.folder_filter = None;
-        self.library.bucket_filter = None;
         // A person chosen while a photo is up wants the grid of them.
         if self.library.viewer.is_some() {
             self.close_viewer(cx);

--- a/crates/app/src/workspace/library_people.rs
+++ b/crates/app/src/workspace/library_people.rs
@@ -1,0 +1,562 @@
+//! The People album's moving parts: the viewer (one photo, big, with
+//! its faces to name), the face avatars the sidebar wears, and the
+//! keys and clicks that drive them. What the album *is* — the
+//! detections, the tags, the suggestions — lives on `Library`; this is
+//! what the window does with it.
+//!
+//! Picasa's flow, kept: open a photo, the faces it found are boxed;
+//! click one, type a name, Enter. A face the detector missed is drawn
+//! by dragging a box. Once a person has a few faces the recogniser
+//! starts offering "Is this …?" on the rest.
+
+use super::library::{PersonFilter, ViewImage, Viewer, AVATAR_PX, VIEW_EDGE};
+use super::*;
+use schist_gallery::*;
+use std::path::Path;
+
+/// The two models the People album runs on — the detector that finds
+/// faces and the recogniser that tells them apart — offered as a pair.
+pub(crate) const PEOPLE_MODELS: [&str; 2] = ["face", "face-embed"];
+
+impl Workspace {
+    /// Show one photo instead of the grid, its faces ready to name.
+    pub fn open_viewer(&mut self, path: PathBuf, cx: &mut Context<Self>) {
+        let Some(entry) = self.library.entry_of(&path).cloned() else {
+            return;
+        };
+        self.library.select_single(path.clone());
+        self.library.context = None;
+        // The viewer takes the grid's place; the world map would hide it.
+        self.library.map_view = false;
+        self.viewer_unpick();
+        self.library.viewer = Some(Viewer {
+            path: path.clone(),
+            image: None,
+            loading: false,
+            image_bounds: Bounds::default(),
+            area: Bounds::default(),
+            drawing: None,
+            pick: None,
+            name: String::new(),
+            crops: FxHashMap::default(),
+        });
+        // Its faces first, if the detector has not been this way yet:
+        // the person is looking at this photo now.
+        if self.library.prioritize_index(&path) {
+            self.kick_thumb_loader(cx);
+        }
+        self.load_view_image(entry, cx);
+        cx.notify();
+    }
+
+    /// Back to the grid.
+    pub fn close_viewer(&mut self, cx: &mut Context<Self>) {
+        self.viewer_unpick();
+        self.library.viewer = None;
+        cx.notify();
+    }
+
+    /// The next (or previous) photo in the grid's order.
+    pub fn viewer_step(&mut self, delta: isize, cx: &mut Context<Self>) {
+        let Some(current) = self.library.viewer.as_ref().map(|v| v.path.clone()) else {
+            return;
+        };
+        let flat = self.gallery_flat_order();
+        let Some(at) = flat.iter().position(|p| p == &current) else {
+            return;
+        };
+        let next = (at as isize + delta).clamp(0, flat.len() as isize - 1) as usize;
+        if next != at {
+            self.open_viewer(flat[next].clone(), cx);
+        }
+    }
+
+    /// Decode the photo for the viewer off the UI thread — the edit
+    /// sidecar when there is one, as the thumbnail does.
+    fn load_view_image(&mut self, entry: Entry, cx: &mut Context<Self>) {
+        if let Some(viewer) = &mut self.library.viewer {
+            viewer.loading = true;
+        }
+        let source = thumb_source(&entry.path, entry.edited);
+        let key = entry.path.clone();
+        cx.spawn(async move |this, cx| {
+            let decoded = cx
+                .background_executor()
+                .spawn(async move {
+                    match schist_preview::render_file(&source, VIEW_EDGE) {
+                        Ok(preview) => Some((preview.width, preview.height, preview.rgba)),
+                        Err(err) => {
+                            log::warn!("viewer decode failed for {}: {err:#}", source.display());
+                            None
+                        }
+                    }
+                })
+                .await;
+            this.update(cx, |ws, cx| {
+                let Some(viewer) = &mut ws.library.viewer else {
+                    return;
+                };
+                // The viewer moved on while this decoded.
+                if viewer.path != key {
+                    return;
+                }
+                viewer.loading = false;
+                if let Some((width, height, rgba)) = decoded {
+                    if let Some(render) =
+                        super::library::rgba_to_render_image(width, height, rgba.clone())
+                    {
+                        viewer.image = Some(ViewImage {
+                            width,
+                            height,
+                            rgba: Arc::new(rgba),
+                            render,
+                        });
+                        viewer.crops.clear();
+                    }
+                }
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    /// A face cut from the viewer's own decode, cached per face for the
+    /// people panel. `None` until the decode lands.
+    pub(super) fn viewer_crop(&mut self, rect: &FaceRect) -> Option<Arc<RenderImage>> {
+        let viewer = self.library.viewer.as_mut()?;
+        let key = rect.key();
+        if let Some(img) = viewer.crops.get(&key) {
+            return Some(img.clone());
+        }
+        let image = viewer.image.as_ref()?;
+        let rgba = face_crop_rgba(
+            &image.rgba,
+            image.width,
+            image.height,
+            rect,
+            AVATAR_GROW,
+            AVATAR_PX,
+        )?;
+        let img = super::library::rgba_to_render_image(AVATAR_PX, AVATAR_PX, rgba)?;
+        viewer.crops.insert(key, img.clone());
+        Some(img)
+    }
+
+    /// Choose a face to name: the name field takes the keyboard,
+    /// seeded with whatever it is called now.
+    pub(super) fn viewer_pick(&mut self, rect: FaceRect) {
+        let Some(path) = self.library.viewer.as_ref().map(|v| v.path.clone()) else {
+            return;
+        };
+        let current = self
+            .library
+            .person_of(&path, &rect)
+            .and_then(|i| self.library.people.get(i))
+            .map(|p| p.name.clone())
+            .unwrap_or_default();
+        if let Some(viewer) = &mut self.library.viewer {
+            viewer.pick = Some(rect);
+            viewer.name = current.clone();
+            viewer.drawing = None;
+        }
+        self.focus_field("face-name", current);
+    }
+
+    /// Let go of the face being named, keyboard included.
+    pub(super) fn viewer_unpick(&mut self) {
+        if let Some(viewer) = &mut self.library.viewer {
+            viewer.pick = None;
+            viewer.name.clear();
+            viewer.drawing = None;
+        }
+        if self.focused_field == Some("face-name") {
+            self.focused_field = None;
+            self.field_buffer.clear();
+            self.field_cursor = 0;
+        }
+    }
+
+    /// Enter in the name field: the typed name goes on the picked face.
+    /// An empty name just lets go.
+    pub(super) fn viewer_commit_name(&mut self, cx: &mut Context<Self>) {
+        let typed = if self.focused_field == Some("face-name") {
+            self.field_buffer.clone()
+        } else {
+            self.library
+                .viewer
+                .as_ref()
+                .map(|v| v.name.clone())
+                .unwrap_or_default()
+        };
+        let Some((path, rect)) = self
+            .library
+            .viewer
+            .as_ref()
+            .and_then(|v| Some((v.path.clone(), v.pick?)))
+        else {
+            return;
+        };
+        if !typed.trim().is_empty() {
+            self.learn_face_if_needed(&path, rect);
+            self.library.tag_face(&path, rect, &typed);
+        }
+        self.viewer_unpick();
+        cx.notify();
+    }
+
+    /// Name a face as an existing person — a completion or a "yes" to
+    /// the recogniser's suggestion.
+    pub(super) fn viewer_name_as(&mut self, rect: FaceRect, person: usize, cx: &mut Context<Self>) {
+        let (Some(path), Some(name)) = (
+            self.library.viewer.as_ref().map(|v| v.path.clone()),
+            self.library.people.get(person).map(|p| p.name.clone()),
+        ) else {
+            return;
+        };
+        self.learn_face_if_needed(&path, rect);
+        self.library.tag_face(&path, rect, &name);
+        self.viewer_unpick();
+        cx.notify();
+    }
+
+    /// Wave a detected face away.
+    pub(super) fn viewer_ignore(&mut self, rect: FaceRect, cx: &mut Context<Self>) {
+        let Some(path) = self.library.viewer.as_ref().map(|v| v.path.clone()) else {
+            return;
+        };
+        self.library.ignore_face(&path, rect);
+        self.viewer_unpick();
+        cx.notify();
+    }
+
+    /// Take the name off a face.
+    pub(super) fn viewer_untag(&mut self, rect: FaceRect, cx: &mut Context<Self>) {
+        let Some(path) = self.library.viewer.as_ref().map(|v| v.path.clone()) else {
+            return;
+        };
+        self.library.untag_face(&path, &rect);
+        self.viewer_unpick();
+        cx.notify();
+    }
+
+    /// A face being named that no detection carries a vector for — one
+    /// drawn by hand, or found before the recogniser was installed —
+    /// gets one from the viewer's decode, so the person can be
+    /// suggested elsewhere. A few dozen milliseconds, once per face.
+    fn learn_face_if_needed(&mut self, path: &Path, rect: FaceRect) {
+        let carried = self.library.detected_faces(path).is_some_and(|faces| {
+            faces
+                .iter()
+                .any(|f| f.rect.same_face(&rect) && f.embed.is_some())
+        });
+        if carried {
+            return;
+        }
+        let Some(model) = schist_neural::get("face-embed") else {
+            return;
+        };
+        let Some(image) = self.library.viewer.as_ref().and_then(|v| v.image.as_ref()) else {
+            return;
+        };
+        let (side, _) = model.spec.input.dims();
+        let Some(crop) = face_crop_rgb(
+            &image.rgba,
+            image.width,
+            image.height,
+            &rect,
+            EMBED_GROW,
+            side as u32,
+        ) else {
+            return;
+        };
+        match schist_neural::embed_face(&model, &crop) {
+            Ok(embed) => self.library.learn_face(path, rect, embed),
+            Err(err) => log::warn!("face embedding failed for {}: {err:#}", path.display()),
+        }
+    }
+
+    /// A pointer position as a fraction of the photo, from where the
+    /// picture landed last paint.
+    fn viewer_fraction(&self, position: Point<Pixels>) -> Option<(f32, f32)> {
+        let bounds = self.library.viewer.as_ref()?.image_bounds;
+        let (w, h) = (f32::from(bounds.size.width), f32::from(bounds.size.height));
+        if w <= 0.0 || h <= 0.0 {
+            return None;
+        }
+        Some((
+            ((f32::from(position.x) - f32::from(bounds.origin.x)) / w).clamp(0.0, 1.0),
+            ((f32::from(position.y) - f32::from(bounds.origin.y)) / h).clamp(0.0, 1.0),
+        ))
+    }
+
+    /// A press on the picture: on a face, that face is picked; anywhere
+    /// else starts drawing a box for one the detector missed.
+    pub(super) fn viewer_mouse_down(&mut self, position: Point<Pixels>, cx: &mut Context<Self>) {
+        let Some((fx, fy)) = self.viewer_fraction(position) else {
+            return;
+        };
+        let Some(path) = self.library.viewer.as_ref().map(|v| v.path.clone()) else {
+            return;
+        };
+        log::debug!(
+            "viewer press at {position:?} -> ({fx:.3}, {fy:.3}) in {:?}",
+            self.library.viewer.as_ref().map(|v| v.image_bounds)
+        );
+        let hit = self
+            .library
+            .faces_in(&path)
+            .into_iter()
+            .find(|f| f.rect.contains(fx, fy));
+        match hit {
+            Some(face) => self.viewer_pick(face.rect),
+            None => {
+                self.viewer_unpick();
+                if let Some(viewer) = &mut self.library.viewer {
+                    viewer.drawing = Some(((fx, fy), (fx, fy)));
+                }
+            }
+        }
+        cx.notify();
+    }
+
+    pub(super) fn viewer_mouse_move(
+        &mut self,
+        position: Point<Pixels>,
+        pressed: bool,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(viewer) = &mut self.library.viewer else {
+            return;
+        };
+        if viewer.drawing.is_none() {
+            return;
+        }
+        if !pressed {
+            // The button went up somewhere we never heard about.
+            viewer.drawing = None;
+            cx.notify();
+            return;
+        }
+        let Some((fx, fy)) = self.viewer_fraction(position) else {
+            return;
+        };
+        if let Some(drawing) = self
+            .library
+            .viewer
+            .as_mut()
+            .and_then(|v| v.drawing.as_mut())
+        {
+            drawing.1 = (fx, fy);
+            cx.notify();
+        }
+    }
+
+    /// The box is done: big enough to be a face, it is picked for
+    /// naming; a mere click clears the pick instead.
+    pub(super) fn viewer_mouse_up(&mut self, cx: &mut Context<Self>) {
+        let Some(viewer) = &mut self.library.viewer else {
+            return;
+        };
+        let Some(((x0, y0), (x1, y1))) = viewer.drawing.take() else {
+            return;
+        };
+        let bounds = viewer.image_bounds;
+        let rect = FaceRect {
+            x: x0,
+            y: y0,
+            w: x1 - x0,
+            h: y1 - y0,
+        }
+        .clamped();
+        // Under a dozen pixels either way is a click, not a face.
+        if rect.w * f32::from(bounds.size.width) < 12.0
+            || rect.h * f32::from(bounds.size.height) < 12.0
+        {
+            cx.notify();
+            return;
+        }
+        self.viewer_pick(rect);
+        cx.notify();
+    }
+
+    /// The viewer's keys. Returns whether it took the keystroke: with
+    /// a face picked the name field has them all; otherwise the arrows
+    /// walk the photos and Space closes what Space opened.
+    pub(super) fn gallery_viewer_key(
+        &mut self,
+        ev: &gpui::KeyDownEvent,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        if self.library.viewer.is_none() {
+            return false;
+        }
+        if self.focused_field == Some("face-name") {
+            match ev.keystroke.key.as_str() {
+                "enter" | "tab" => self.viewer_commit_name(cx),
+                key => {
+                    self.field_key(key, ev.keystroke.key_char.as_deref());
+                }
+            }
+            cx.notify();
+            return true;
+        }
+        match ev.keystroke.key.as_str() {
+            "left" | "up" => self.viewer_step(-1, cx),
+            "right" | "down" => self.viewer_step(1, cx),
+            "space" => self.close_viewer(cx),
+            _ => return false,
+        }
+        true
+    }
+
+    /// Escape in the gallery, innermost first: a search, then a face
+    /// being named, then the viewer itself. Returns whether anything
+    /// was there to leave.
+    pub fn gallery_escape(&mut self, cx: &mut Context<Self>) -> bool {
+        if self.gallery_search_clear(cx) {
+            return true;
+        }
+        let Some(viewer) = &self.library.viewer else {
+            return false;
+        };
+        if viewer.pick.is_some() || viewer.drawing.is_some() {
+            self.viewer_unpick();
+        } else {
+            self.library.viewer = None;
+        }
+        cx.notify();
+        true
+    }
+
+    /// The sidebar's People rows: show a person's photos (or the
+    /// unnamed faces) in the grid, or go back to the folders.
+    pub fn show_person(&mut self, filter: Option<PersonFilter>, cx: &mut Context<Self>) {
+        self.library.person_filter = filter;
+        self.library.map_view = false;
+        self.library.folder_filter = None;
+        self.library.bucket_filter = None;
+        // A person chosen while a photo is up wants the grid of them.
+        if self.library.viewer.is_some() {
+            self.close_viewer(cx);
+        }
+        cx.notify();
+    }
+
+    /// Offer the two People models, licences first.
+    pub fn open_people_models(&mut self, cx: &mut Context<Self>) {
+        self.open_modal(Modal::PeopleModels, cx);
+    }
+
+    /// The rename dialog, its field already taking typing.
+    pub fn rename_person_prompt(&mut self, index: usize, cx: &mut Context<Self>) {
+        let Some(name) = self.library.people.get(index).map(|p| p.name.clone()) else {
+            return;
+        };
+        self.open_modal(
+            Modal::PersonName {
+                index,
+                name: name.clone(),
+            },
+            cx,
+        );
+        self.focus_field("person-name", name);
+    }
+
+    /// The avatar for a face: from the cut cache, or queued to be cut
+    /// from the photo's thumbnail. `None` until it is ready.
+    pub(super) fn face_avatar(
+        &mut self,
+        path: &Path,
+        rect: &FaceRect,
+        cx: &mut Context<Self>,
+    ) -> Option<Arc<RenderImage>> {
+        let key = format!("{}|{}", path.display(), rect.key());
+        match self.library.avatar_state(&key) {
+            Some(state) => state,
+            None => {
+                if self.library.request_avatar(key, path.to_path_buf(), *rect) {
+                    self.kick_avatar_loader(cx);
+                }
+                None
+            }
+        }
+    }
+
+    /// Cut the queued avatars on the background executor, a batch at a
+    /// time, until the queue is empty. One task at a time.
+    fn kick_avatar_loader(&mut self, cx: &mut Context<Self>) {
+        if self.library.avatar_ticking(true) {
+            return;
+        }
+        cx.spawn(async move |this, cx| loop {
+            let jobs: Vec<(String, PathBuf, u64, FaceRect)> = match this.update(cx, |ws, _| {
+                let mut jobs = Vec::new();
+                for (key, path, rect) in ws.library.take_avatar_jobs() {
+                    match ws.library.entry_of(&path).cloned() {
+                        Some(entry) => jobs.push((
+                            key,
+                            thumb_source(&entry.path, entry.edited),
+                            entry.mtime,
+                            rect,
+                        )),
+                        // Asked before the scan knew the photo (the
+                        // sidebar draws before the folders are walked):
+                        // forget the request, so the next frame asks again.
+                        None => ws.library.forget_avatar(&key),
+                    }
+                }
+                jobs
+            }) {
+                Ok(jobs) => jobs,
+                Err(_) => return,
+            };
+            if jobs.is_empty() {
+                this.update(cx, |ws, _| {
+                    ws.library.avatar_ticking(false);
+                })
+                .ok();
+                return;
+            }
+            let cut = cx
+                .background_executor()
+                .spawn(async move {
+                    jobs.into_iter()
+                        .map(|(key, source, mtime, rect)| (key, cut_avatar(&source, mtime, &rect)))
+                        .collect::<Vec<_>>()
+                })
+                .await;
+            let kept = this.update(cx, |ws, cx| {
+                for (key, image) in cut {
+                    ws.library.store_avatar(key, image);
+                }
+                cx.notify();
+            });
+            if kept.is_err() {
+                return;
+            }
+        })
+        .detach();
+    }
+}
+
+/// Cut a face avatar from a photo's cached thumbnail — rendering the
+/// thumbnail when the cache has none yet. Blocking.
+fn cut_avatar(source: &Path, mtime: u64, rect: &FaceRect) -> Option<Arc<RenderImage>> {
+    let cached = thumb_cache_path(source, mtime)
+        .and_then(|p| std::fs::read(p).ok())
+        .and_then(|bytes| image::load_from_memory(&bytes).ok())
+        .map(|img| {
+            let img = img.into_rgba8();
+            (img.width(), img.height(), img.into_raw())
+        });
+    let (width, height, rgba) = match cached {
+        Some(thumb) => thumb,
+        None => {
+            let preview = schist_preview::render_file(source, THUMB_EDGE).ok()?;
+            (preview.width, preview.height, preview.rgba)
+        }
+    };
+    let crop = face_crop_rgba(&rgba, width, height, rect, AVATAR_GROW, AVATAR_PX)?;
+    super::library::rgba_to_render_image(AVATAR_PX, AVATAR_PX, crop)
+}

--- a/crates/app/src/workspace/library_people_view.rs
+++ b/crates/app/src/workspace/library_people_view.rs
@@ -66,6 +66,10 @@ pub(super) fn people_rows(
     let mut rows: Vec<gpui::AnyElement> = vec![heading("PEOPLE").into_any_element()];
     let detector = schist_neural::installed("face");
     let recogniser = schist_neural::installed("face-embed");
+    // Their photos in the bucket or folder on show, not in the world:
+    // the number beside a name answers "how many of these are hers".
+    // Counted once per change, not per frame.
+    let summary = ws.library.people_summary();
     let people: Vec<PersonRow> = ws
         .library
         .people
@@ -75,10 +79,7 @@ pub(super) fn people_rows(
             (
                 i,
                 p.name.clone(),
-                // Their photos in the bucket or folder on show, not in
-                // the world: the number beside a name answers "how many
-                // of these are hers".
-                ws.library.person_photos(i).len(),
+                summary.photo_counts.get(i).copied().unwrap_or(0),
                 p.faces.first().map(|f| (f.photo.clone(), f.rect)),
             )
         })
@@ -135,7 +136,7 @@ pub(super) fn people_rows(
                 .into_any_element(),
         );
     }
-    let unnamed = ws.library.unnamed_face_count();
+    let unnamed = summary.unnamed_faces;
     if unnamed > 0 {
         let selected = viewing == Some(PersonFilter::Unnamed);
         rows.push(
@@ -320,10 +321,9 @@ pub(super) fn viewer(ws: &mut Workspace, cx: &mut Context<Workspace>) -> gpui::A
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_default();
-    let flat = ws.gallery_flat_order();
-    let at = flat.iter().position(|p| p == &path);
-    let position = at
-        .map(|i| format!("{} of {}", i + 1, flat.len()))
+    let position = v
+        .position
+        .map(|(at, of)| format!("{} of {of}", at + 1))
         .unwrap_or_default();
     let edit_path = path.clone();
     let header = div()

--- a/crates/app/src/workspace/library_people_view.rs
+++ b/crates/app/src/workspace/library_people_view.rs
@@ -444,6 +444,7 @@ fn picture_element(
         let picked = pick.is_some_and(|p| p.same_face(&face.rect));
         let color = box_color(face, picked);
         let label = match (face.person, face.suggestion) {
+            (Some(i), _) if face.auto => names.get(i).map(|n| format!("{n} \u{b7} auto")),
             (Some(i), _) => names.get(i).cloned(),
             (None, Some((i, _))) => names.get(i).map(|n| format!("{n}?")),
             (None, None) => None,
@@ -587,6 +588,7 @@ fn people_panel(
         let fresh = FaceView {
             rect,
             person: None,
+            auto: false,
             suggestion: None,
             detected: false,
         };
@@ -732,7 +734,7 @@ fn face_row(
             ));
         if named.is_some() {
             actions = actions.child(small_button(
-                "Remove name",
+                if face.auto { "Not them" } else { "Remove name" },
                 false,
                 move |ws, cx| ws.viewer_untag(rect, cx),
                 cx,
@@ -766,6 +768,23 @@ fn face_row(
                         .text_color(gpui::rgb(pal().text))
                         .child(SharedString::from(name)),
                 );
+                if face.auto {
+                    // The recogniser's doing: say so, and offer the
+                    // one-click "no" a guess deserves.
+                    top = top
+                        .child(
+                            div()
+                                .text_size(px(10.0))
+                                .text_color(gpui::rgb(pal().text_dim))
+                                .child("auto"),
+                        )
+                        .child(small_button(
+                            "Not them",
+                            false,
+                            move |ws, cx| ws.viewer_untag(rect, cx),
+                            cx,
+                        ));
+                }
             }
             (None, Some((index, name))) => {
                 top = top.child(

--- a/crates/app/src/workspace/library_people_view.rs
+++ b/crates/app/src/workspace/library_people_view.rs
@@ -75,7 +75,10 @@ pub(super) fn people_rows(
             (
                 i,
                 p.name.clone(),
-                p.photos().len(),
+                // Their photos in the bucket or folder on show, not in
+                // the world: the number beside a name answers "how many
+                // of these are hers".
+                ws.library.person_photos(i).len(),
                 p.faces.first().map(|f| (f.photo.clone(), f.rect)),
             )
         })

--- a/crates/app/src/workspace/library_people_view.rs
+++ b/crates/app/src/workspace/library_people_view.rs
@@ -205,7 +205,9 @@ pub(super) fn people_rows(
             .child(label)
             .into_any_element()
     };
-    if !detector {
+    if people_models_downloading(ws) {
+        rows.push(people_download_progress(ws).into_any_element());
+    } else if !detector {
         rows.push(link("+ Find faces\u{2026}", cx));
     } else if !recogniser {
         rows.push(link("+ Recognise faces\u{2026}", cx));
@@ -226,6 +228,72 @@ pub(super) fn people_rows(
         );
     }
     rows
+}
+
+/// Whether either People model is on its way down.
+pub(super) fn people_models_downloading(ws: &Workspace) -> bool {
+    ws.model_downloads
+        .iter()
+        .any(|d| PEOPLE_MODELS.contains(&d.id))
+}
+
+/// The People models' download as a bar in the sidebar, the search
+/// bar's twin: the two files counted as one, an installed one wholly
+/// got, so the bar runs once from nothing to done.
+fn people_download_progress(ws: &Workspace) -> impl IntoElement {
+    let mut got = 0u64;
+    let mut total = 0u64;
+    for id in PEOPLE_MODELS {
+        let Some(spec) = schist_neural::spec(id) else {
+            continue;
+        };
+        total += spec.bytes as u64;
+        got += if schist_neural::installed(id) {
+            spec.bytes as u64
+        } else {
+            ws.model_downloads
+                .iter()
+                .find(|d| d.id == id)
+                .map(|d| d.got.load(std::sync::atomic::Ordering::Relaxed))
+                .unwrap_or(0)
+        };
+    }
+    let mb = |bytes: u64| bytes as f64 / (1 << 20) as f64;
+    let ratio = if total == 0 {
+        0.0
+    } else {
+        (got as f64 / total as f64).clamp(0.0, 1.0) as f32
+    };
+    div()
+        .flex()
+        .flex_col()
+        .gap_1()
+        .px_2()
+        .py_1()
+        .child(
+            div()
+                .text_size(px(10.0))
+                .text_color(gpui::rgb(pal().text_dim))
+                .child(SharedString::from(format!(
+                    "Downloading face models\u{2026} {:.0} of {:.0} MB",
+                    mb(got),
+                    mb(total)
+                ))),
+        )
+        .child(
+            div()
+                .w_full()
+                .h(px(4.0))
+                .rounded_sm()
+                .bg(gpui::rgb(pal().chrome_edge))
+                .child(
+                    div()
+                        .h_full()
+                        .w(gpui::relative(ratio))
+                        .rounded_sm()
+                        .bg(gpui::rgb(pal().select_border)),
+                ),
+        )
 }
 
 /// The viewer: one photo, big, its faces boxed, and the people panel
@@ -547,7 +615,9 @@ fn people_panel(
                 .text_color(gpui::rgb(pal().text_dim))
                 .child("PEOPLE IN THIS PHOTO"),
         );
-    if !detector {
+    if people_models_downloading(ws) {
+        col = col.child(people_download_progress(ws));
+    } else if !detector {
         col = col
             .child(
                 div()

--- a/crates/app/src/workspace/library_people_view.rs
+++ b/crates/app/src/workspace/library_people_view.rs
@@ -1,0 +1,1065 @@
+//! The People album on screen: the sidebar's rows, the viewer with its
+//! face boxes and people panel, and the two dialogs (the models to
+//! install, a person's rename). Drawn on the gallery's palette, like
+//! the rest of the room.
+
+use super::library::{FaceView, GalleryContext, PersonFilter, AVATAR_PX};
+use super::library_people::PEOPLE_MODELS;
+use super::library_view::{bucket_field, gallery_button, pal};
+use super::*;
+use gpui::{img, StatefulInteractiveElement as _};
+use schist_gallery::FaceRect;
+use std::path::Path;
+
+/// The colour of a face box by its state: named, picked, guessed, or
+/// merely found.
+fn box_color(face: &FaceView, picked: bool) -> u32 {
+    if picked {
+        pal().select_border
+    } else if face.person.is_some() {
+        pal().green
+    } else if face.suggestion.is_some() {
+        0xE0A030
+    } else {
+        0xFFFFFF
+    }
+}
+
+/// A small section heading in the sidebar's style.
+fn heading(text: &'static str) -> impl IntoElement {
+    div()
+        .px_2()
+        .pt_2()
+        .pb_1()
+        .text_size(px(11.0))
+        .text_color(gpui::rgb(pal().text_dim))
+        .child(text)
+}
+
+/// A round avatar, or a grey disc while the cut is on its way.
+fn avatar(image: Option<Arc<RenderImage>>, size: f32) -> gpui::AnyElement {
+    let frame = div()
+        .w(px(size))
+        .h(px(size))
+        .flex_none()
+        .rounded_full()
+        .overflow_hidden()
+        .bg(gpui::rgb(pal().cell_edge));
+    match image {
+        Some(image) => frame
+            .child(img(image).w(px(size)).h(px(size)))
+            .into_any_element(),
+        None => frame.into_any_element(),
+    }
+}
+
+/// One sidebar row's worth of a person: index, name, photo count, and
+/// the face the avatar is cut from.
+type PersonRow = (usize, String, usize, Option<(PathBuf, FaceRect)>);
+
+/// The sidebar's PEOPLE section: a row per person, the unnamed faces,
+/// and — until the models are here — the way to get them.
+pub(super) fn people_rows(
+    ws: &mut Workspace,
+    cx: &mut Context<Workspace>,
+) -> Vec<gpui::AnyElement> {
+    let mut rows: Vec<gpui::AnyElement> = vec![heading("PEOPLE").into_any_element()];
+    let detector = schist_neural::installed("face");
+    let recogniser = schist_neural::installed("face-embed");
+    let people: Vec<PersonRow> = ws
+        .library
+        .people
+        .iter()
+        .enumerate()
+        .map(|(i, p)| {
+            (
+                i,
+                p.name.clone(),
+                p.photos().len(),
+                p.faces.first().map(|f| (f.photo.clone(), f.rect)),
+            )
+        })
+        .collect();
+    let viewing = ws.library.person_filter;
+    let any_people = !people.is_empty();
+    for (index, name, count, face) in people {
+        let image = face.and_then(|(path, rect)| ws.face_avatar(&path, &rect, cx));
+        let selected = viewing == Some(PersonFilter::Person(index));
+        rows.push(
+            div()
+                .id(SharedString::from(format!("person-{index}")))
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap_2()
+                .px_2()
+                .h(px(26.0))
+                .text_size(px(12.0))
+                .cursor_pointer()
+                .bg(gpui::rgb(if selected {
+                    pal().sidebar_selected
+                } else {
+                    pal().chrome_bg
+                }))
+                .hover(|s| s.bg(gpui::rgb(pal().sidebar_selected)))
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
+                        let next = if ws.library.person_filter == Some(PersonFilter::Person(index))
+                        {
+                            None
+                        } else {
+                            Some(PersonFilter::Person(index))
+                        };
+                        ws.show_person(next, cx);
+                    }),
+                )
+                .on_mouse_down(
+                    MouseButton::Right,
+                    cx.listener(move |ws, ev: &MouseDownEvent, _w, cx| {
+                        ws.library.context = Some((ev.position, GalleryContext::Person(index)));
+                        cx.notify();
+                    }),
+                )
+                .child(avatar(image, 20.0))
+                .child(div().flex_grow().truncate().child(SharedString::from(name)))
+                .child(
+                    div()
+                        .text_size(px(10.0))
+                        .text_color(gpui::rgb(pal().text_dim))
+                        .child(format!("{count}")),
+                )
+                .into_any_element(),
+        );
+    }
+    let unnamed = ws.library.unnamed_face_count();
+    if unnamed > 0 {
+        let selected = viewing == Some(PersonFilter::Unnamed);
+        rows.push(
+            div()
+                .id("person-unnamed")
+                .flex()
+                .flex_row()
+                .items_center()
+                .gap_2()
+                .px_2()
+                .h(px(26.0))
+                .text_size(px(12.0))
+                .cursor_pointer()
+                .bg(gpui::rgb(if selected {
+                    pal().sidebar_selected
+                } else {
+                    pal().chrome_bg
+                }))
+                .hover(|s| s.bg(gpui::rgb(pal().sidebar_selected)))
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(|ws, _e: &MouseDownEvent, _w, cx| {
+                        let next = if ws.library.person_filter == Some(PersonFilter::Unnamed) {
+                            None
+                        } else {
+                            Some(PersonFilter::Unnamed)
+                        };
+                        ws.show_person(next, cx);
+                    }),
+                )
+                .child(
+                    div()
+                        .w(px(20.0))
+                        .h(px(20.0))
+                        .flex_none()
+                        .rounded_full()
+                        .border_1()
+                        .border_color(gpui::rgb(pal().text_dim))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .text_size(px(11.0))
+                        .text_color(gpui::rgb(pal().text_dim))
+                        .child("?"),
+                )
+                .child(div().flex_grow().truncate().child("Unnamed faces"))
+                .child(
+                    div()
+                        .text_size(px(10.0))
+                        .text_color(gpui::rgb(pal().text_dim))
+                        .child(format!("{unnamed}")),
+                )
+                .into_any_element(),
+        );
+    }
+    let link = |label: &'static str, cx: &mut Context<Workspace>| {
+        div()
+            .px_2()
+            .h(px(24.0))
+            .flex()
+            .items_center()
+            .text_size(px(12.0))
+            .text_color(gpui::rgb(pal().header))
+            .cursor_pointer()
+            .hover(|s| s.bg(gpui::rgb(pal().sidebar_selected)))
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|ws, _e: &MouseDownEvent, _w, cx| ws.open_people_models(cx)),
+            )
+            .child(label)
+            .into_any_element()
+    };
+    if !detector {
+        rows.push(link("+ Find faces\u{2026}", cx));
+    } else if !recogniser {
+        rows.push(link("+ Recognise faces\u{2026}", cx));
+    } else if !any_people && unnamed == 0 {
+        let (looked, total) = ws.library.faces_progress();
+        rows.push(
+            div()
+                .px_2()
+                .py_1()
+                .text_size(px(11.0))
+                .text_color(gpui::rgb(pal().text_dim))
+                .child(if looked < total {
+                    format!("Looking for faces\u{2026} {looked}/{total}")
+                } else {
+                    "Faces appear here as photos are indexed.".to_string()
+                })
+                .into_any_element(),
+        );
+    }
+    rows
+}
+
+/// The viewer: one photo, big, its faces boxed, and the people panel
+/// beside it. Replaces the grid while a photo is on show.
+pub(super) fn viewer(ws: &mut Workspace, cx: &mut Context<Workspace>) -> gpui::AnyElement {
+    let Some(v) = &ws.library.viewer else {
+        return div().into_any_element();
+    };
+    let path = v.path.clone();
+    let loading = v.loading;
+    let image = v
+        .image
+        .as_ref()
+        .map(|i| (i.width, i.height, i.render.clone()));
+    let area = v.area;
+    let drawing = v.drawing;
+    let pick = v.pick;
+    let faces = ws.library.faces_in(&path);
+    let names: Vec<String> = ws.library.people.iter().map(|p| p.name.clone()).collect();
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let flat = ws.gallery_flat_order();
+    let at = flat.iter().position(|p| p == &path);
+    let position = at
+        .map(|i| format!("{} of {}", i + 1, flat.len()))
+        .unwrap_or_default();
+    let edit_path = path.clone();
+    let header = div()
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap_2()
+        .h(px(36.0))
+        .flex_none()
+        .px_2()
+        .bg(gpui::rgb(pal().chrome_bg))
+        .border_b_1()
+        .border_color(gpui::rgb(pal().chrome_edge))
+        .child(gallery_button(
+            "\u{2039} Back to photos",
+            false,
+            |ws, _w, cx| ws.close_viewer(cx),
+            cx,
+        ))
+        .child(gallery_button(
+            "\u{25c0}",
+            false,
+            |ws, _w, cx| ws.viewer_step(-1, cx),
+            cx,
+        ))
+        .child(gallery_button(
+            "\u{25b6}",
+            false,
+            |ws, _w, cx| ws.viewer_step(1, cx),
+            cx,
+        ))
+        .child(
+            div()
+                .text_size(px(12.0))
+                .text_color(gpui::rgb(pal().text))
+                .truncate()
+                .child(file_name),
+        )
+        .child(
+            div()
+                .text_size(px(11.0))
+                .text_color(gpui::rgb(pal().text_dim))
+                .child(position),
+        )
+        .child(div().flex_grow())
+        .child(gallery_button(
+            "Edit",
+            true,
+            move |ws, _w, cx| ws.open_from_gallery(edit_path.clone(), cx),
+            cx,
+        ));
+    // The picture fits its room, which was measured last paint; the
+    // first frame has no room yet and shows nothing for one frame.
+    let picture_entity = cx.entity();
+    let mut picture = div()
+        .flex_grow()
+        .min_w(px(0.0))
+        .min_h(px(0.0))
+        .relative()
+        .flex()
+        .items_center()
+        .justify_center()
+        .overflow_hidden()
+        .bg(gpui::rgb(if crate::ui::is_light() {
+            0xDADAD4
+        } else {
+            0x161616
+        }))
+        .child(
+            canvas(
+                move |bounds, _window, cx| {
+                    picture_entity.update(cx, |ws, _| {
+                        if let Some(viewer) = &mut ws.library.viewer {
+                            viewer.area = bounds;
+                        }
+                    });
+                },
+                |_, _, _, _| {},
+            )
+            .absolute()
+            .top_0()
+            .left_0()
+            .size_full(),
+        );
+    match image {
+        Some((width, height, render)) => {
+            let (aw, ah) = (f32::from(area.size.width), f32::from(area.size.height));
+            if aw > 0.0 && ah > 0.0 {
+                let scale = ((aw - 16.0) / width as f32).min((ah - 16.0) / height as f32);
+                let scale = scale.clamp(0.01, 1.0);
+                let (fw, fh) = (width as f32 * scale, height as f32 * scale);
+                picture = picture.child(picture_element(
+                    fw, fh, render, &faces, &names, pick, drawing, cx,
+                ));
+            }
+        }
+        None => {
+            picture = picture.child(
+                div()
+                    .text_size(px(12.0))
+                    .text_color(gpui::rgb(pal().text_dim))
+                    .child(if loading {
+                        "Loading\u{2026}"
+                    } else {
+                        "This photo could not be decoded."
+                    }),
+            );
+        }
+    }
+    let panel = people_panel(ws, &path, &faces, pick, cx);
+    div()
+        .flex()
+        .flex_col()
+        .flex_grow()
+        .min_h(px(0.0))
+        .min_w(px(0.0))
+        .child(header)
+        .child(
+            div()
+                .flex()
+                .flex_row()
+                .flex_grow()
+                .min_h(px(0.0))
+                .min_w(px(0.0))
+                .child(picture)
+                .child(panel),
+        )
+        .into_any_element()
+}
+
+/// The photo itself, sized to fit, with a box per face and the box
+/// being drawn. Presses on it pick faces or start boxes.
+#[allow(clippy::too_many_arguments)]
+fn picture_element(
+    fw: f32,
+    fh: f32,
+    render: Arc<RenderImage>,
+    faces: &[FaceView],
+    names: &[String],
+    pick: Option<FaceRect>,
+    drawing: Option<((f32, f32), (f32, f32))>,
+    cx: &mut Context<Workspace>,
+) -> gpui::AnyElement {
+    let bounds_entity = cx.entity();
+    let mut el = div()
+        .w(px(fw))
+        .h(px(fh))
+        .relative()
+        .flex_none()
+        .cursor(gpui::CursorStyle::Crosshair)
+        .child(img(render).w(px(fw)).h(px(fh)))
+        .child(
+            canvas(
+                move |bounds, _window, cx| {
+                    bounds_entity.update(cx, |ws, _| {
+                        if let Some(viewer) = &mut ws.library.viewer {
+                            viewer.image_bounds = bounds;
+                        }
+                    });
+                },
+                |_, _, _, _| {},
+            )
+            // Pinned: an absolute element with no offsets sits at its
+            // static position — after the picture, in flow — and this
+            // one recorded its bounds a whole picture too low.
+            .absolute()
+            .top_0()
+            .left_0()
+            .size_full(),
+        )
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(|ws, ev: &MouseDownEvent, _w, cx| {
+                ws.viewer_mouse_down(ev.position, cx);
+            }),
+        )
+        .on_mouse_move(cx.listener(|ws, ev: &gpui::MouseMoveEvent, _w, cx| {
+            ws.viewer_mouse_move(
+                ev.position,
+                ev.pressed_button == Some(MouseButton::Left),
+                cx,
+            );
+        }))
+        .on_mouse_up(
+            MouseButton::Left,
+            cx.listener(|ws, _ev: &gpui::MouseUpEvent, _w, cx| ws.viewer_mouse_up(cx)),
+        );
+    for face in faces {
+        let picked = pick.is_some_and(|p| p.same_face(&face.rect));
+        let color = box_color(face, picked);
+        let label = match (face.person, face.suggestion) {
+            (Some(i), _) => names.get(i).cloned(),
+            (None, Some((i, _))) => names.get(i).map(|n| format!("{n}?")),
+            (None, None) => None,
+        };
+        let (x, y, w, h) = (
+            face.rect.x * fw,
+            face.rect.y * fh,
+            face.rect.w * fw,
+            face.rect.h * fh,
+        );
+        let mut boxed = div()
+            .absolute()
+            .left(px(x))
+            .top(px(y))
+            .w(px(w))
+            .h(px(h))
+            .border_2()
+            .border_color(gpui::rgb(color))
+            .rounded_sm();
+        if let Some(label) = label {
+            boxed = boxed.child(
+                div()
+                    .absolute()
+                    .top(px(h))
+                    .left(px(-2.0))
+                    .px_1()
+                    .rounded_b_sm()
+                    .bg(gpui::rgb(color))
+                    .text_size(px(10.0))
+                    .text_color(gpui::rgb(if color == 0xFFFFFF {
+                        0x000000
+                    } else {
+                        0xFFFFFF
+                    }))
+                    .whitespace_nowrap()
+                    .child(SharedString::from(label)),
+            );
+        }
+        el = el.child(boxed);
+    }
+    // A hand-drawn face that is not yet a tag shows as the picked box.
+    if let Some(rect) = pick.filter(|p| !faces.iter().any(|f| f.rect.same_face(p))) {
+        el = el.child(
+            div()
+                .absolute()
+                .left(px(rect.x * fw))
+                .top(px(rect.y * fh))
+                .w(px(rect.w * fw))
+                .h(px(rect.h * fh))
+                .border_2()
+                .border_color(gpui::rgb(pal().select_border))
+                .rounded_sm(),
+        );
+    }
+    if let Some(((x0, y0), (x1, y1))) = drawing {
+        let (l, t) = (x0.min(x1) * fw, y0.min(y1) * fh);
+        let (w, h) = ((x1 - x0).abs() * fw, (y1 - y0).abs() * fh);
+        el = el.child(
+            div()
+                .absolute()
+                .left(px(l))
+                .top(px(t))
+                .w(px(w))
+                .h(px(h))
+                .border_1()
+                .border_dashed()
+                .border_color(gpui::rgb(0xFFFFFF)),
+        );
+    }
+    el.into_any_element()
+}
+
+/// The panel beside the picture: every face in it, with its name, the
+/// recogniser's guess, or a field to type into.
+fn people_panel(
+    ws: &mut Workspace,
+    path: &Path,
+    faces: &[FaceView],
+    pick: Option<FaceRect>,
+    cx: &mut Context<Workspace>,
+) -> gpui::AnyElement {
+    let detector = schist_neural::installed("face");
+    let looked = ws.library.detected_faces(path).is_some();
+    let mut col = div()
+        .id("people-panel")
+        .w(px(240.0))
+        .flex_none()
+        .flex()
+        .flex_col()
+        .gap_2()
+        .p_2()
+        .min_h(px(0.0))
+        .overflow_y_scroll()
+        .bg(gpui::rgb(pal().chrome_bg))
+        .border_l_1()
+        .border_color(gpui::rgb(pal().chrome_edge))
+        .child(
+            div()
+                .text_size(px(11.0))
+                .text_color(gpui::rgb(pal().text_dim))
+                .child("PEOPLE IN THIS PHOTO"),
+        );
+    if !detector {
+        col = col
+            .child(
+                div()
+                    .text_size(px(12.0))
+                    .text_color(gpui::rgb(pal().text))
+                    .child(
+                        "Faces are found by a small model that is downloaded once. \
+                         Boxes can still be drawn by hand.",
+                    ),
+            )
+            .child(gallery_button(
+                "Find faces\u{2026}",
+                true,
+                |ws, _w, cx| ws.open_people_models(cx),
+                cx,
+            ));
+    } else if !looked {
+        col = col.child(
+            div()
+                .text_size(px(12.0))
+                .text_color(gpui::rgb(pal().text_dim))
+                .child("Looking for faces\u{2026}"),
+        );
+    } else if faces.is_empty() && pick.is_none() {
+        col = col.child(
+            div()
+                .text_size(px(12.0))
+                .text_color(gpui::rgb(pal().text_dim))
+                .child("No faces found. Drag a box round one to add a person by hand."),
+        );
+    }
+    for face in faces {
+        let picked = pick.is_some_and(|p| p.same_face(&face.rect));
+        col = col.child(face_row(ws, face, picked, cx));
+    }
+    // A box just drawn, not yet a face anyone knows.
+    if let Some(rect) = pick.filter(|p| !faces.iter().any(|f| f.rect.same_face(p))) {
+        let fresh = FaceView {
+            rect,
+            person: None,
+            suggestion: None,
+            detected: false,
+        };
+        col = col.child(face_row(ws, &fresh, true, cx));
+    }
+    col = col.child(
+        div()
+            .pt_2()
+            .text_size(px(11.0))
+            .text_color(gpui::rgb(pal().text_dim))
+            .child(
+                "Click a face to name it; Enter saves. Drag on the photo to mark a face \
+                 the detector missed. \u{2190} \u{2192} move between photos, Esc goes back.",
+            ),
+    );
+    col.into_any_element()
+}
+
+/// A small text button on the gallery palette.
+fn small_button(
+    label: impl Into<SharedString>,
+    primary: bool,
+    on_click: impl Fn(&mut Workspace, &mut Context<Workspace>) + 'static,
+    cx: &mut Context<Workspace>,
+) -> impl IntoElement {
+    div()
+        .px_2()
+        .h(px(20.0))
+        .flex()
+        .items_center()
+        .rounded_sm()
+        .text_size(px(11.0))
+        .cursor_pointer()
+        .bg(gpui::rgb(if primary {
+            pal().green
+        } else {
+            pal().button_bg
+        }))
+        .text_color(gpui::rgb(if primary { 0xFFFFFF } else { pal().text }))
+        .hover(move |s| {
+            s.bg(gpui::rgb(if primary {
+                pal().green_hover
+            } else {
+                pal().button_hover
+            }))
+        })
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
+                cx.stop_propagation();
+                on_click(ws, cx)
+            }),
+        )
+        .child(label.into())
+}
+
+/// One face in the panel: its crop, and its name, guess, or field.
+fn face_row(
+    ws: &mut Workspace,
+    face: &FaceView,
+    picked: bool,
+    cx: &mut Context<Workspace>,
+) -> gpui::AnyElement {
+    let crop = ws.viewer_crop(&face.rect);
+    let rect = face.rect;
+    let named = face
+        .person
+        .and_then(|i| ws.library.people.get(i))
+        .map(|p| p.name.clone());
+    let guess = face
+        .suggestion
+        .and_then(|(i, _)| ws.library.people.get(i).map(|p| (i, p.name.clone())));
+    let mut row = div()
+        .flex()
+        .flex_col()
+        .gap_1()
+        .p_1()
+        .rounded_md()
+        .bg(gpui::rgb(if picked {
+            pal().sidebar_selected
+        } else {
+            pal().button_bg
+        }));
+    let pick_rect = rect;
+    let mut top = div()
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap_2()
+        .cursor_pointer()
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
+                ws.viewer_pick(pick_rect);
+                cx.notify();
+            }),
+        )
+        .child(avatar(crop, AVATAR_PX as f32 * 0.75));
+    if picked {
+        top = top.child(name_field(ws, cx));
+        row = row.child(top);
+        // Completions: the names that begin with what is typed, so a
+        // known person is one click, not a whole name.
+        let typed = ws.field_buffer.clone();
+        let completions: Vec<(usize, String)> = ws
+            .library
+            .names_starting(&typed)
+            .into_iter()
+            .filter(|(_, n)| !n.eq_ignore_ascii_case(typed.trim()))
+            .take(5)
+            .collect();
+        for (index, name) in completions {
+            row = row.child(
+                div()
+                    .pl(px(56.0))
+                    .h(px(20.0))
+                    .flex()
+                    .items_center()
+                    .text_size(px(12.0))
+                    .text_color(gpui::rgb(pal().header))
+                    .cursor_pointer()
+                    .hover(|s| s.bg(gpui::rgb(pal().button_hover)))
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
+                            cx.stop_propagation();
+                            ws.viewer_name_as(rect, index, cx);
+                        }),
+                    )
+                    .child(SharedString::from(name)),
+            );
+        }
+        let mut actions = div()
+            .flex()
+            .flex_row()
+            .gap_1()
+            .pl(px(56.0))
+            .child(small_button(
+                "Save",
+                true,
+                |ws, cx| ws.viewer_commit_name(cx),
+                cx,
+            ));
+        if named.is_some() {
+            actions = actions.child(small_button(
+                "Remove name",
+                false,
+                move |ws, cx| ws.viewer_untag(rect, cx),
+                cx,
+            ));
+        } else if face.detected {
+            actions = actions.child(small_button(
+                "Not a face",
+                false,
+                move |ws, cx| ws.viewer_ignore(rect, cx),
+                cx,
+            ));
+        }
+        actions = actions.child(small_button(
+            "Cancel",
+            false,
+            |ws, cx| {
+                ws.viewer_unpick();
+                cx.notify();
+            },
+            cx,
+        ));
+        row = row.child(actions);
+    } else {
+        match (named, guess) {
+            (Some(name), _) => {
+                top = top.child(
+                    div()
+                        .flex_grow()
+                        .truncate()
+                        .text_size(px(12.0))
+                        .text_color(gpui::rgb(pal().text))
+                        .child(SharedString::from(name)),
+                );
+            }
+            (None, Some((index, name))) => {
+                top = top.child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .gap_1()
+                        .flex_grow()
+                        .child(
+                            div()
+                                .text_size(px(12.0))
+                                .text_color(gpui::rgb(pal().text))
+                                .child(SharedString::from(format!("Is this {name}?"))),
+                        )
+                        .child(
+                            div()
+                                .flex()
+                                .flex_row()
+                                .gap_1()
+                                .child(small_button(
+                                    "Yes",
+                                    true,
+                                    move |ws, cx| ws.viewer_name_as(rect, index, cx),
+                                    cx,
+                                ))
+                                .child(small_button(
+                                    "Someone else",
+                                    false,
+                                    move |ws, cx| {
+                                        ws.viewer_pick(rect);
+                                        cx.notify();
+                                    },
+                                    cx,
+                                )),
+                        ),
+                );
+            }
+            (None, None) => {
+                top = top.child(
+                    div()
+                        .flex_grow()
+                        .text_size(px(12.0))
+                        .text_color(gpui::rgb(pal().text_dim))
+                        .child("Add a name\u{2026}"),
+                );
+            }
+        }
+        row = row.child(top);
+    }
+    row.into_any_element()
+}
+
+/// The name field in the people panel: the search box's caret and
+/// palette, the dialog fields' buffer.
+fn name_field(ws: &Workspace, cx: &mut Context<Workspace>) -> impl IntoElement {
+    let focused = ws.focused_field == Some("face-name");
+    let current = ws
+        .library
+        .viewer
+        .as_ref()
+        .map(|v| v.name.clone())
+        .unwrap_or_default();
+    let typed = if focused {
+        ws.field_buffer.clone()
+    } else {
+        current.clone()
+    };
+    let cursor = ws.field_cursor.min(typed.len());
+    let caret_on = ws.caret_on();
+    div()
+        .flex_grow()
+        .h(px(24.0))
+        .px_2()
+        .flex()
+        .flex_row()
+        .items_center()
+        .rounded_md()
+        .bg(gpui::rgb(pal().grid_bg))
+        .border_1()
+        .border_color(gpui::rgb(if focused {
+            pal().select_border
+        } else {
+            pal().chrome_edge
+        }))
+        .text_size(px(12.0))
+        .text_color(gpui::rgb(pal().text))
+        .cursor(gpui::CursorStyle::IBeam)
+        .overflow_hidden()
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
+                cx.stop_propagation();
+                if ws.focused_field != Some("face-name") {
+                    ws.focus_field("face-name", current.clone());
+                }
+                cx.notify();
+            }),
+        )
+        .child(if focused {
+            div()
+                .flex()
+                .flex_row()
+                .items_center()
+                .child(crate::ui::caret_run(
+                    typed[..cursor].to_string(),
+                    typed[cursor..].to_string(),
+                    caret_on,
+                    pal().text,
+                ))
+                .children(typed.is_empty().then(|| {
+                    div()
+                        .text_color(gpui::rgb(pal().text_dim))
+                        .child("Who is this?")
+                }))
+                .into_any_element()
+        } else if typed.is_empty() {
+            div()
+                .text_color(gpui::rgb(pal().text_dim))
+                .child("Who is this?")
+                .into_any_element()
+        } else {
+            div().child(SharedString::from(typed)).into_any_element()
+        })
+}
+
+fn model_link(
+    id: &'static str,
+    label: &'static str,
+    url: &'static str,
+    cx: &mut Context<Workspace>,
+) -> impl IntoElement {
+    div()
+        .id(id)
+        .cursor_pointer()
+        .text_color(gpui::rgb(crate::ui::palette().accent))
+        .hover(|style| style.text_color(gpui::rgb(crate::ui::palette().accent_hover)))
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |_ws, _event, _window, cx| cx.open_url(url)),
+        )
+        .child(label)
+}
+
+/// The licences behind the People album, and the button that accepts
+/// them. One dialog for both models: whichever is missing is fetched.
+pub(crate) fn people_models_dialog(cx: &mut Context<Workspace>) -> impl IntoElement {
+    let specs: Vec<&'static schist_neural::ModelSpec> = PEOPLE_MODELS
+        .iter()
+        .filter(|id| !schist_neural::installed(id))
+        .filter_map(|id| schist_neural::spec(id))
+        .collect();
+    let total: usize = specs.iter().map(|s| s.bytes).sum();
+    let mut body = div().flex().flex_col().gap_2().w(px(460.0)).child(
+        div()
+            .text_size(px(12.0))
+            .text_color(gpui::rgb(crate::ui::palette().text))
+            .child(
+                "Finding the people in your photos needs two small models, \
+                 downloaded once and kept on this machine. They run locally: \
+                 no photo ever leaves it. The detector finds faces; the \
+                 recogniser tells them apart, so once you have named someone \
+                 a few times it can suggest them elsewhere.",
+            ),
+    );
+    for spec in &specs {
+        body = body.child(div().text_size(px(12.0)).child(SharedString::from(format!(
+            "{} \u{b7} {:.1} MB \u{b7} {}",
+            spec.name,
+            spec.bytes as f64 / (1 << 20) as f64,
+            spec.license
+        ))));
+    }
+    body = body.child(
+        div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap_1()
+            .text_size(px(11.0))
+            .text_color(gpui::rgb(crate::ui::palette().text_dim))
+            .child(model_link(
+                "ultraface-source",
+                "UltraFace (ONNX Model Zoo)",
+                "https://github.com/onnx/models/tree/main/validated/vision/body_analysis/ultraface",
+                cx,
+            ))
+            .child("\u{b7}")
+            .child(model_link(
+                "sface-source",
+                "SFace (OpenCV Zoo)",
+                "https://github.com/opencv/opencv_zoo/tree/main/models/face_recognition_sface",
+                cx,
+            )),
+    );
+    body = body.child(
+        div()
+            .pt_1()
+            .text_size(px(11.0))
+            .text_color(gpui::rgb(crate::ui::palette().text_dim))
+            .child(SharedString::from(format!(
+                "Downloading installs {} ({:.1} MB) and accepts the licences. They can be \
+                 removed again under Gallery \u{25b8} Manage Models\u{2026}",
+                if specs.len() == 1 { "it" } else { "both" },
+                total as f64 / (1 << 20) as f64
+            ))),
+    );
+    let actions = div()
+        .flex()
+        .flex_row()
+        .gap_2()
+        .child(crate::ui::button(
+            "Cancel",
+            false,
+            |ws, _w, cx| ws.close_modal(cx),
+            cx,
+        ))
+        .child(crate::ui::button(
+            "Agree and Download",
+            true,
+            |ws, _w, cx| {
+                for id in PEOPLE_MODELS {
+                    if !schist_neural::installed(id) {
+                        ws.download_model(id, cx);
+                    }
+                }
+                ws.close_modal(cx);
+            },
+            cx,
+        ));
+    crate::ui::modal_frame("People", 500.0, body, actions)
+}
+
+/// Rename a person. Renaming to a name somebody else has merges them.
+pub(crate) fn person_name_dialog(
+    ws: &mut Workspace,
+    index: usize,
+    name: String,
+    cx: &mut Context<Workspace>,
+) -> impl IntoElement {
+    let field = bucket_field("person-name", name, "Name".to_string(), ws, cx);
+    let live = if ws.focused_field == Some("person-name") {
+        ws.field_buffer.clone()
+    } else {
+        ws.library
+            .people
+            .get(index)
+            .map(|p| p.name.clone())
+            .unwrap_or_default()
+    };
+    let merges = ws
+        .library
+        .people
+        .iter()
+        .enumerate()
+        .any(|(i, p)| i != index && p.name.eq_ignore_ascii_case(live.trim()));
+    let body = div()
+        .flex()
+        .flex_col()
+        .gap_2()
+        .child(crate::ui::field_row("Name", field))
+        .child(
+            div()
+                .text_size(px(11.0))
+                .text_color(gpui::rgb(crate::ui::palette().text_dim))
+                .child(if merges {
+                    format!(
+                        "Somebody is already called \u{201c}{}\u{201d}: saving merges the two.",
+                        live.trim()
+                    )
+                } else {
+                    "Renaming to a name somebody else already has merges the two people.".into()
+                }),
+        );
+    let actions = div()
+        .flex()
+        .flex_row()
+        .gap_2()
+        .child(crate::ui::button(
+            "Cancel",
+            false,
+            |ws, _w, cx| ws.close_modal(cx),
+            cx,
+        ))
+        .child(crate::ui::button(
+            "Save",
+            true,
+            |ws, _w, cx| {
+                ws.commit_focused_field();
+                if let Some(Modal::PersonName { index, name }) = ws.modal.clone() {
+                    ws.library.rename_person(index, &name);
+                }
+                ws.close_modal(cx);
+            },
+            cx,
+        ));
+    crate::ui::modal_frame("Rename Person", 420.0, body, actions)
+}

--- a/crates/app/src/workspace/library_view.rs
+++ b/crates/app/src/workspace/library_view.rs
@@ -16,28 +16,28 @@ use gpui::{
 };
 
 /// The gallery's chrome colours for one theme.
-struct GalleryPalette {
+pub(super) struct GalleryPalette {
     /// Behind the thumbnails.
-    grid_bg: u32,
+    pub(super) grid_bg: u32,
     /// The top strip and sidebar.
-    chrome_bg: u32,
-    chrome_edge: u32,
-    tray_bg: u32,
-    sidebar_selected: u32,
+    pub(super) chrome_bg: u32,
+    pub(super) chrome_edge: u32,
+    pub(super) tray_bg: u32,
+    pub(super) sidebar_selected: u32,
     /// Folder headers and the add-folder link — Picasa's blue.
-    header: u32,
-    text: u32,
-    text_dim: u32,
-    cell_edge: u32,
+    pub(super) header: u32,
+    pub(super) text: u32,
+    pub(super) text_dim: u32,
+    pub(super) cell_edge: u32,
     /// Cell border under the pointer.
-    cell_hover: u32,
-    select_border: u32,
-    select_fill: u32,
-    button_bg: u32,
-    button_hover: u32,
+    pub(super) cell_hover: u32,
+    pub(super) select_border: u32,
+    pub(super) select_fill: u32,
+    pub(super) button_bg: u32,
+    pub(super) button_hover: u32,
     /// The green action buttons and the "edited" badge.
-    green: u32,
-    green_hover: u32,
+    pub(super) green: u32,
+    pub(super) green_hover: u32,
 }
 
 /// Picasa: white grid, warm grey chrome.
@@ -80,7 +80,7 @@ const GALLERY_DARK: GalleryPalette = GalleryPalette {
     green_hover: 0x6DB33F,
 };
 
-fn pal() -> &'static GalleryPalette {
+pub(super) fn pal() -> &'static GalleryPalette {
     if crate::ui::is_light() {
         &GALLERY_LIGHT
     } else {
@@ -101,6 +101,8 @@ impl Workspace {
                 .child(sidebar(self, cx))
                 .child(if self.library.map_view {
                     world_map(self, cx).into_any_element()
+                } else if self.library.viewer.is_some() {
+                    super::library_people_view::viewer(self, cx)
                 } else {
                     grid(self, cx).into_any_element()
                 })
@@ -141,7 +143,10 @@ impl Workspace {
                     cx.stop_propagation();
                     return;
                 }
-                if ws.gallery_search_key(ev, cx) || ws.gallery_nav_key(ev, cx) {
+                if ws.gallery_viewer_key(ev, cx)
+                    || ws.gallery_search_key(ev, cx)
+                    || ws.gallery_nav_key(ev, cx)
+                {
                     cx.stop_propagation();
                 }
             }))
@@ -218,7 +223,7 @@ fn drag_out_listener(cx: &mut Context<Workspace>) -> impl IntoElement {
     .size_0()
 }
 
-fn gallery_button(
+pub(super) fn gallery_button(
     label: &'static str,
     green: bool,
     on_click: impl Fn(&mut Workspace, &mut Window, &mut Context<Workspace>) + 'static,
@@ -375,16 +380,30 @@ fn search_slot(ws: &mut Workspace, cx: &mut Context<Workspace>) -> gpui::AnyElem
     if schist_neural::embed::ready() {
         return search_box(ws, cx).into_any_element();
     }
-    if search_models_downloading(ws) {
-        return search_download_progress(ws).into_any_element();
+    let offer = if search_models_downloading(ws) {
+        search_download_progress(ws).into_any_element()
+    } else {
+        gallery_button(
+            "Enable photo search\u{2026}",
+            false,
+            |ws, _w, cx| ws.open_modal(Modal::SearchModels, cx),
+            cx,
+        )
+        .into_any_element()
+    };
+    if ws.library.people.is_empty() {
+        return offer;
     }
-    gallery_button(
-        "Enable photo search\u{2026}",
-        false,
-        |ws, _w, cx| ws.open_modal(Modal::SearchModels, cx),
-        cx,
-    )
-    .into_any_element()
+    // Without the towers the box still searches names and places, so
+    // once anyone has been named it is worth having beside the offer.
+    div()
+        .flex()
+        .flex_row()
+        .items_center()
+        .gap_2()
+        .child(search_box(ws, cx))
+        .child(offer)
+        .into_any_element()
 }
 
 /// The download of the two Search models, as a bar in the top strip.
@@ -453,7 +472,9 @@ fn search_box(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoEleme
     let active = ws.library.search_active;
     let text = ws.library.search.clone();
     let (indexed, total) = ws.library.index_progress();
-    let placeholder: SharedString = if indexed < total {
+    let placeholder: SharedString = if !schist_neural::embed::ready() {
+        "Search people and places\u{2026}".into()
+    } else if indexed < total {
         format!("Search ({indexed}/{total} indexed)").into()
     } else {
         "Search photos\u{2026}".into()
@@ -878,6 +899,7 @@ fn sidebar(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElement 
                 )
                 .child("+ New bucket"),
         )
+        .children(super::library_people_view::people_rows(ws, cx))
 }
 
 /// One bucket in the sidebar: a drop target, a view of its contents on
@@ -921,6 +943,7 @@ fn bucket_row(
                     Some(index)
                 };
                 ws.library.folder_filter = None;
+                ws.library.person_filter = None;
                 cx.notify();
             }),
         )
@@ -977,6 +1000,7 @@ fn sidebar_row(
             cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
                 ws.library.folder_filter = filter.clone();
                 ws.library.bucket_filter = None;
+                ws.library.person_filter = None;
                 cx.notify();
             }),
         )
@@ -1060,6 +1084,9 @@ fn gallery_sections(ws: &Workspace) -> Vec<(String, String, Vec<super::library::
             };
             if let Some(place) = &ws.library.search_place {
                 title.push_str(&format!(" · near {place}"));
+            }
+            if !ws.library.search_people.is_empty() {
+                title.push_str(&format!(" · with {}", ws.library.search_people.join(", ")));
             }
             vec![(title, String::new(), entries)]
         } else {
@@ -1484,6 +1511,10 @@ fn grid(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElement {
                         Some(_) => {
                             "This bucket is empty. Drag photos onto its row in the sidebar \
                          to add them."
+                        }
+                        None if ws.library.person_filter.is_some() => {
+                            "Nothing here yet. Faces appear as photos are indexed; \
+                         click a photo, then a face, to say who it is."
                         }
                         None if scanning => "Scanning folders\u{2026}",
                         None => {
@@ -1927,6 +1958,16 @@ fn tray(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElement {
                 "Edit",
                 true,
                 move |ws, _w, cx| ws.open_from_gallery(open.clone(), cx),
+                cx,
+            )
+        }))
+        .children(selected.as_ref().map(|entry| {
+            // The quick look — the photo big, its faces to name.
+            let view = entry.path.clone();
+            gallery_button(
+                "View",
+                false,
+                move |ws, _w, cx| ws.open_viewer(view.clone(), cx),
                 cx,
             )
         }))
@@ -2819,7 +2860,7 @@ pub(crate) fn search_models_dialog(cx: &mut Context<Workspace>) -> impl IntoElem
 
 /// One text field of the bucket dialog: the layer-name pattern, with a
 /// dimmed placeholder while nothing is typed.
-fn bucket_field(
+pub(super) fn bucket_field(
     id: &'static str,
     value: String,
     placeholder: String,
@@ -3137,6 +3178,15 @@ fn gallery_context_menu(
                         ws.open_from_gallery(open.clone(), cx);
                     }),
                 );
+                let view = path.clone();
+                row(
+                    "View & name people".into(),
+                    &mut rows,
+                    cx,
+                    std::rc::Rc::new(move |ws, _w, cx| {
+                        ws.open_viewer(view.clone(), cx);
+                    }),
+                );
             }
             {
                 let reveal = path.clone();
@@ -3366,6 +3416,44 @@ fn gallery_context_menu(
                 cx,
                 std::rc::Rc::new(move |ws, _w, _cx| {
                     ws.library.delete_bucket(index);
+                }),
+            );
+        }
+        GalleryContext::Person(index) => {
+            let (name, faces) = ws
+                .library
+                .people
+                .get(index)
+                .map(|p| (p.name.clone(), p.faces.len()))
+                .unwrap_or_default();
+            row(
+                format!("Show {name}"),
+                &mut rows,
+                cx,
+                std::rc::Rc::new(move |ws, _w, cx| {
+                    ws.show_person(Some(super::library::PersonFilter::Person(index)), cx);
+                }),
+            );
+            row(
+                "Rename\u{2026}".into(),
+                &mut rows,
+                cx,
+                std::rc::Rc::new(move |ws, _w, cx| {
+                    ws.rename_person_prompt(index, cx);
+                }),
+            );
+            sep(&mut rows);
+            // The faces go back to unnamed; nothing is deleted.
+            row(
+                if faces == 1 {
+                    "Forget person (1 face)".to_string()
+                } else {
+                    format!("Forget person ({faces} faces)")
+                },
+                &mut rows,
+                cx,
+                std::rc::Rc::new(move |ws, _w, _cx| {
+                    ws.library.delete_person(index);
                 }),
             );
         }

--- a/crates/app/src/workspace/library_view.rs
+++ b/crates/app/src/workspace/library_view.rs
@@ -943,7 +943,6 @@ fn bucket_row(
                     Some(index)
                 };
                 ws.library.folder_filter = None;
-                ws.library.person_filter = None;
                 cx.notify();
             }),
         )
@@ -1000,7 +999,6 @@ fn sidebar_row(
             cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
                 ws.library.folder_filter = filter.clone();
                 ws.library.bucket_filter = None;
-                ws.library.person_filter = None;
                 cx.notify();
             }),
         )

--- a/crates/app/src/workspace/mod.rs
+++ b/crates/app/src/workspace/mod.rs
@@ -65,6 +65,10 @@ mod library_mcp;
 #[cfg(not(target_arch = "wasm32"))]
 mod library_ops;
 #[cfg(not(target_arch = "wasm32"))]
+mod library_people;
+#[cfg(not(target_arch = "wasm32"))]
+mod library_people_view;
+#[cfg(not(target_arch = "wasm32"))]
 mod library_view;
 mod modals;
 mod notes;
@@ -79,6 +83,8 @@ mod viewport;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use library_geo::MapSlot;
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) use library_people_view::{people_models_dialog, person_name_dialog};
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) use library_view::map_element;
 #[cfg(not(target_arch = "wasm32"))]
@@ -148,10 +154,7 @@ pub fn schist_folder() -> Option<PathBuf> {
 /// Where view preferences are stored.
 #[cfg(not(target_arch = "wasm32"))]
 fn prefs_path() -> Option<PathBuf> {
-    match schist_folder() {
-        Some(x) => Some(x.join("preferences.json")),
-        None => None,
-    }
+    schist_folder().map(|folder| folder.join("preferences.json"))
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -449,12 +452,14 @@ impl Workspace {
         }
     }
 
-    /// Whether the gallery's search box is taking typing, for the key
-    /// context. Always false on the web, with the gallery itself.
+    /// Whether the gallery's search box — or the viewer's name field —
+    /// is taking typing, for the key context. Always false on the web,
+    /// with the gallery itself.
     pub fn gallery_typing(&self) -> bool {
         #[cfg(not(target_arch = "wasm32"))]
         {
             self.gallery_search_active()
+                || (self.library.open && self.focused_field == Some("face-name"))
         }
         #[cfg(target_arch = "wasm32")]
         {
@@ -1130,6 +1135,12 @@ pub enum Modal {
     /// The gallery's offer to install the two Search models, with the
     /// licences to agree to first. Desktop-only, like the gallery.
     SearchModels,
+    /// The same offer for the two People models — the face detector
+    /// and the face recogniser.
+    PeopleModels,
+    /// Rename one of the gallery's people (`index` into the people
+    /// list); a name somebody else has merges the two.
+    PersonName { index: usize, name: String },
     /// Save one gallery photo as a flat image: format, quality where the
     /// format takes one, and a scale to shrink it by. `size` is the
     /// source's pixel size when it could be read up front, so the

--- a/crates/app/src/workspace/modals.rs
+++ b/crates/app/src/workspace/modals.rs
@@ -245,7 +245,9 @@ impl Workspace {
         let textual = id == "layer-name"
             || id == "new-doc-name"
             || id == "bucket-name"
-            || id == "bucket-query";
+            || id == "bucket-query"
+            || id == "face-name"
+            || id == "person-name";
         let hex = id == "cp-hex";
         // The caret belongs to the textual fields; keep it on the rails
         // in case the buffer changed underneath it.
@@ -352,6 +354,23 @@ impl Workspace {
         if id == "new-doc-name" {
             self.update_modal(|m| {
                 if let Modal::NewDocument { name, .. } = m {
+                    *name = buffer;
+                }
+            });
+            return;
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        if id == "face-name" {
+            // The viewer's name field: the live text rides on the
+            // viewer, so the panel can offer completions as it grows.
+            if let Some(viewer) = &mut self.library.viewer {
+                viewer.name = buffer;
+            }
+            return;
+        }
+        if id == "person-name" {
+            self.update_modal(|m| {
+                if let Modal::PersonName { name, .. } = m {
                     *name = buffer;
                 }
             });
@@ -472,6 +491,8 @@ impl Workspace {
             | Modal::NewFilePicker
             | Modal::MapFilter
             | Modal::SearchModels
+            | Modal::PeopleModels
+            | Modal::PersonName { .. }
             | Modal::SaveImageAs { .. }
             | Modal::BatchProcess { .. }
             // Handled above, before the numeric parse, like the other

--- a/crates/app/src/workspace/render.rs
+++ b/crates/app/src/workspace/render.rs
@@ -753,10 +753,11 @@ impl Render for Workspace {
                 cx.notify();
             }))
             .on_action(cx.listener(|ws, _: &CancelGesture, _w, cx| {
-                // Escape leaves the gallery's search before anything
-                // else — it is the innermost thing open.
+                // Escape leaves the gallery's search, a face being
+                // named, or the viewer before anything else — they are
+                // the innermost things open.
                 #[cfg(not(target_arch = "wasm32"))]
-                if ws.gallery_open() && ws.gallery_search_clear(cx) {
+                if ws.gallery_open() && ws.gallery_escape(cx) {
                     return;
                 }
                 ws.cancel_gesture(cx);

--- a/crates/gallery/Cargo.toml
+++ b/crates/gallery/Cargo.toml
@@ -7,6 +7,9 @@ description = "The photo gallery's on-disk model: watched folders, buckets, the 
 
 [dependencies]
 schist-neural.workspace = true
+# Cutting face crops out of thumbnails, for the recogniser and the
+# People avatars.
+image.workspace = true
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/gallery/src/headless.rs
+++ b/crates/gallery/src/headless.rs
@@ -105,8 +105,56 @@ impl Gallery {
                 "content_model_installed": crate::scores::nsfw_installed(),
             },
             "content": {"flagged": count("flagged"), "clean": count("clean"), "unscored": count("unscored")},
+            "people": self.people_json(),
             "note": "Read from the gallery's files on disk; the app is what indexes. Selection and grouping belong to the app's window.",
         })
+    }
+
+    /// The people album: each name with how many photos and faces
+    /// carry it, plus how many detected faces nobody has named.
+    pub fn people_json(&self) -> Value {
+        let people: Vec<Value> = self
+            .file
+            .people
+            .iter()
+            .map(|p| json!({"name": p.name, "photos": p.photos().len(), "faces": p.faces.len()}))
+            .collect();
+        let unnamed = self
+            .index
+            .values()
+            .filter_map(|row| Some((row.path.as_path(), row.faces.as_ref()?)))
+            .flat_map(|(path, faces)| faces.iter().map(move |f| (path, f)))
+            .filter(|(path, face)| {
+                !self.file.people.iter().any(|p| p.tagged(path, &face.rect))
+                    && !self
+                        .file
+                        .ignored_faces
+                        .iter()
+                        .any(|i| i.photo == *path && i.rect.same_face(&face.rect))
+            })
+            .count();
+        json!({
+            "people": people,
+            "unnamed_faces": unnamed,
+            "detector_installed": schist_neural::installed("face"),
+            "recogniser_installed": schist_neural::installed("face-embed"),
+        })
+    }
+
+    /// One person's photos, in tag order.
+    pub fn person_photos(&self, name: &str) -> Option<Vec<Entry>> {
+        let person = self
+            .file
+            .people
+            .iter()
+            .find(|p| p.name.eq_ignore_ascii_case(name.trim()))?;
+        Some(
+            person
+                .photos()
+                .iter()
+                .filter_map(|p| self.entry(p).cloned())
+                .collect(),
+        )
     }
 
     /// Photos in scan order — the lot, one folder, or one bucket.

--- a/crates/gallery/src/index.rs
+++ b/crates/gallery/src/index.rs
@@ -3,6 +3,7 @@
 //! probing thousands of per-photo caches.
 
 use crate::paths::index_snapshot_path;
+use crate::people::{decode_faces_at, encode_faces_body, DetectedFace};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -19,12 +20,32 @@ pub struct IndexRow {
     pub taken: Option<String>,
     pub place: Option<Option<String>>,
     pub flagged: Option<bool>,
+    /// The faces the detector found — `Some(empty)` for a photo it
+    /// looked at and found none in — each with the recogniser's
+    /// vector when that model was installed at the time.
+    pub faces: Option<Vec<DetectedFace>>,
 }
 
-pub const INDEX_MAGIC: &[u8; 8] = b"SCHIDX1\n";
+impl IndexRow {
+    /// Whether nothing was ever learned about the photo.
+    pub fn is_empty(&self) -> bool {
+        self.embed.is_none()
+            && self.gps.is_none()
+            && self.taken.is_none()
+            && self.place.is_none()
+            && self.flagged.is_none()
+            && self.faces.is_none()
+    }
+}
+
+/// The first format: one presence-flags byte per row.
+pub const INDEX_MAGIC_V1: &[u8; 8] = b"SCHIDX1\n";
+/// The second: a further flags byte per row, for the faces. Written
+/// always; both are read.
+pub const INDEX_MAGIC: &[u8; 8] = b"SCHIDX2\n";
 
 /// Serialize the index rows: magic, a count, then per row the path,
-/// mtime, a presence-flags byte and the present fields, all
+/// mtime, two presence-flags bytes and the present fields, all
 /// little-endian. Hand-rolled because 10 MB of f32s deserves neither
 /// JSON nor a new dependency. Non-UTF-8 paths are skipped — they
 /// cannot round-trip through this file, and re-indexing them is only
@@ -77,6 +98,11 @@ pub fn write_index_snapshot_to(path: &Path, rows: &[IndexRow]) -> anyhow::Result
             }
         }
         out.push(flags);
+        let mut flags2 = 0u8;
+        if row.faces.is_some() {
+            flags2 |= 1;
+        }
+        out.push(flags2);
         if let Some(embed) = &row.embed {
             out.extend_from_slice(&(embed.len() as u16).to_le_bytes());
             for v in embed.iter() {
@@ -92,6 +118,9 @@ pub fn write_index_snapshot_to(path: &Path, rows: &[IndexRow]) -> anyhow::Result
         }
         if let Some(Some(place)) = &row.place {
             put_str(&mut out, place);
+        }
+        if let Some(faces) = &row.faces {
+            out.extend_from_slice(&encode_faces_body(faces));
         }
     }
     // Atomically: a crash mid-write must not leave a torn file.
@@ -115,9 +144,11 @@ pub fn parse_index_snapshot(bytes: &[u8]) -> Option<Vec<IndexRow>> {
         *at += n;
         Some(slice)
     };
-    if take(&mut at, 8)? != INDEX_MAGIC {
-        return None;
-    }
+    let version = match take(&mut at, 8)? {
+        m if m == INDEX_MAGIC_V1 => 1,
+        m if m == INDEX_MAGIC => 2,
+        _ => return None,
+    };
     let count = u32::from_le_bytes(take(&mut at, 4)?.try_into().ok()?) as usize;
     let get_str = |at: &mut usize| -> Option<String> {
         let len = u16::from_le_bytes(take(at, 2)?.try_into().ok()?) as usize;
@@ -130,6 +161,11 @@ pub fn parse_index_snapshot(bytes: &[u8]) -> Option<Vec<IndexRow>> {
         let path = PathBuf::from(get_str(&mut at)?);
         let mtime = u64::from_le_bytes(take(&mut at, 8)?.try_into().ok()?);
         let flags = take(&mut at, 1)?[0];
+        let flags2 = if version >= 2 {
+            take(&mut at, 1)?[0]
+        } else {
+            0
+        };
         let embed = if flags & 1 != 0 {
             let dim = u16::from_le_bytes(take(&mut at, 2)?.try_into().ok()?) as usize;
             let raw = take(&mut at, dim * 4)?;
@@ -168,6 +204,13 @@ pub fn parse_index_snapshot(bytes: &[u8]) -> Option<Vec<IndexRow>> {
             None
         };
         let flagged = (flags & 64 != 0).then_some(flags & 128 != 0);
+        let faces = if flags2 & 1 != 0 {
+            let mut faces = Vec::new();
+            decode_faces_at(bytes, &mut at, &mut faces, false)?;
+            Some(faces)
+        } else {
+            None
+        };
         rows.push(IndexRow {
             path,
             mtime,
@@ -176,6 +219,7 @@ pub fn parse_index_snapshot(bytes: &[u8]) -> Option<Vec<IndexRow>> {
             taken,
             place,
             flagged,
+            faces,
         });
     }
     Some(rows)
@@ -196,6 +240,26 @@ mod tests {
                 taken: Some("2026-09-01 12:00:00".into()),
                 place: Some(Some("New York City".into())),
                 flagged: Some(true),
+                faces: Some(vec![
+                    DetectedFace {
+                        rect: crate::people::FaceRect {
+                            x: 0.1,
+                            y: 0.2,
+                            w: 0.3,
+                            h: 0.4,
+                        },
+                        embed: Some(vec![0.5, -0.5]),
+                    },
+                    DetectedFace {
+                        rect: crate::people::FaceRect {
+                            x: 0.6,
+                            y: 0.2,
+                            w: 0.1,
+                            h: 0.1,
+                        },
+                        embed: None,
+                    },
+                ]),
             },
             IndexRow {
                 path: PathBuf::from("/p/bare.jpg"),
@@ -205,6 +269,17 @@ mod tests {
                 taken: None,
                 place: Some(None),
                 flagged: Some(false),
+                faces: Some(Vec::new()),
+            },
+            IndexRow {
+                path: PathBuf::from("/p/unlooked.jpg"),
+                mtime: 11,
+                embed: None,
+                gps: Some(None),
+                taken: None,
+                place: None,
+                flagged: None,
+                faces: None,
             },
             IndexRow {
                 path: PathBuf::from("/p/zero.jpg"),
@@ -214,6 +289,7 @@ mod tests {
                 taken: Some("2026-09-02 12:00:00".into()),
                 place: Some(None),
                 flagged: Some(false),
+                faces: None,
             },
         ];
         let dir = std::env::temp_dir().join(format!("schist-idx-test-{}", std::process::id()));
@@ -223,7 +299,7 @@ mod tests {
         let bytes = std::fs::read(&file).unwrap();
         let _ = std::fs::remove_dir_all(&dir);
         let back = parse_index_snapshot(&bytes).expect("parses");
-        assert_eq!(back.len(), 3);
+        assert_eq!(back.len(), 4);
         assert_eq!(back[0].path, rows[0].path);
         assert_eq!(back[0].mtime, 7);
         assert_eq!(back[0].embed.as_deref(), Some(&vec![0.25f32, -1.0, 3.5]));
@@ -236,9 +312,33 @@ mod tests {
         assert_eq!(back[1].flagged, Some(false));
         assert_eq!(back[1].embed, None);
         // Still probed, so the loader will not keep re-indexing this photo.
-        assert_eq!(back[2].gps, Some(None));
-        assert_eq!(back[2].taken.as_deref(), Some("2026-09-02 12:00:00"));
+        assert_eq!(back[3].gps, Some(None));
+        assert_eq!(back[3].taken.as_deref(), Some("2026-09-02 12:00:00"));
+        assert_eq!(back[0].faces, rows[0].faces);
+        assert_eq!(back[1].faces, Some(Vec::new()));
+        assert_eq!(back[2].faces, None);
+        assert_eq!(back[3].faces, None);
         assert!(parse_index_snapshot(&bytes[..bytes.len() - 3]).is_none());
         assert!(parse_index_snapshot(b"not an index").is_none());
+    }
+
+    #[test]
+    fn a_first_format_snapshot_still_reads() {
+        // Hand-assembled v1 bytes: one row, position only.
+        let mut bytes: Vec<u8> = Vec::new();
+        bytes.extend_from_slice(INDEX_MAGIC_V1);
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        let path = "/p/old.jpg";
+        bytes.extend_from_slice(&(path.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(path.as_bytes());
+        bytes.extend_from_slice(&5u64.to_le_bytes());
+        bytes.push(2 | 4); // gps probed and present
+        bytes.extend_from_slice(&51.5f64.to_le_bytes());
+        bytes.extend_from_slice(&(-0.1f64).to_le_bytes());
+        let rows = parse_index_snapshot(&bytes).expect("v1 parses");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].gps, Some(Some((51.5, -0.1))));
+        assert_eq!(rows[0].faces, None);
+        assert!(!rows[0].is_empty());
     }
 }

--- a/crates/gallery/src/lib.rs
+++ b/crates/gallery/src/lib.rs
@@ -2,10 +2,11 @@
 //! `schist-mcp` server.
 //!
 //! Everything the gallery persists is a file the user can look at:
-//! `library.json` (watched folders, buckets, recents), the index
-//! snapshot (`index.v1`: one row per photo — search embedding, EXIF
-//! position and capture time, nearest city, content-filter verdict),
-//! and the caches beside each thumbnail. The app builds and maintains
+//! `library.json` (watched folders, buckets, recents, the people and
+//! their tagged faces), the index snapshot (`index.v1`: one row per
+//! photo — search embedding, EXIF position and capture time, nearest
+//! city, content-filter verdict, detected faces), and the caches
+//! beside each thumbnail. The app builds and maintains
 //! them; a headless server reads them to answer for the gallery when
 //! the app is not running. Both go through here, so the formats have
 //! one owner.
@@ -19,6 +20,7 @@ pub mod headless;
 pub mod index;
 pub mod meta;
 pub mod paths;
+pub mod people;
 pub mod persist;
 pub mod scan;
 pub mod scores;
@@ -28,6 +30,7 @@ pub use geo::*;
 pub use index::*;
 pub use meta::*;
 pub use paths::*;
+pub use people::*;
 pub use persist::*;
 pub use scan::*;
 pub use scores::*;

--- a/crates/gallery/src/paths.rs
+++ b/crates/gallery/src/paths.rs
@@ -46,6 +46,13 @@ pub fn index_snapshot_path() -> Option<PathBuf> {
     Some(state_dir()?.join("schist/index.v1"))
 }
 
+/// Where the People sidebar's last counts live between runs, so the
+/// numbers are right from the first frame rather than creeping up as
+/// the index is read back.
+pub fn people_summary_path() -> Option<PathBuf> {
+    Some(state_dir()?.join("schist/people.json"))
+}
+
 /// The PSD sidecar an edit of `original` saves into.
 pub fn backing_psd(original: &Path) -> Option<PathBuf> {
     let dir = original.parent()?;

--- a/crates/gallery/src/people.rs
+++ b/crates/gallery/src/people.rs
@@ -103,11 +103,25 @@ impl FaceRect {
 }
 
 /// One face the detector found, with what the recogniser made of it —
-/// `None` when the recogniser was not installed at the time.
+/// `None` when the recogniser was not installed at the time, an empty
+/// vector when it was and could not (so the photo is not asked again).
 #[derive(Clone, Debug, PartialEq)]
 pub struct DetectedFace {
     pub rect: FaceRect,
     pub embed: Option<Vec<f32>>,
+}
+
+impl DetectedFace {
+    /// The recogniser's vector, when there is a real one.
+    pub fn vector(&self) -> Option<&[f32]> {
+        self.embed.as_deref().filter(|v| !v.is_empty())
+    }
+
+    /// Whether the recogniser has had its turn — a vector, or a
+    /// recorded failure.
+    pub fn embedded(&self) -> bool {
+        self.embed.is_some()
+    }
 }
 
 /// A face in a photo, as the user's tags refer to it.

--- a/crates/gallery/src/people.rs
+++ b/crates/gallery/src/people.rs
@@ -115,6 +115,21 @@ pub struct DetectedFace {
 pub struct TaggedFace {
     pub photo: PathBuf,
     pub rect: FaceRect,
+    /// Put here by the recogniser rather than by hand. Automatic tags
+    /// count as the person everywhere but in their own mean vector —
+    /// one wrong guess must not pull the next guess after it.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub auto: bool,
+}
+
+/// A face the user said is *not* this person: the recogniser will not
+/// put it back. Kept by name, so the same face may still be offered
+/// as somebody else.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct DeniedFace {
+    pub photo: PathBuf,
+    pub rect: FaceRect,
+    pub name: String,
 }
 
 /// A named person and every face tagged as them, as `library.json`
@@ -151,6 +166,13 @@ impl PersonFile {
 pub const EMBED_GROW: f32 = 1.1;
 /// The avatars' grow factor — a portrait, not a passport photo.
 pub const AVATAR_GROW: f32 = 1.5;
+
+/// The recogniser's cosine above which an unnamed face is put with the
+/// person outright, as an automatic tag. Between [`SUGGEST_COSINE`] and
+/// this it is only offered. On the test portraits the same person's
+/// weakest pair scored 0.48 — that one becomes a question, the rest
+/// are answered.
+pub const AUTO_COSINE: f32 = 0.5;
 
 /// The recogniser's cosine above which two faces are suggested to be
 /// the same person. SFace's authors publish 0.363 for aligned crops;
@@ -501,14 +523,17 @@ mod tests {
                 TaggedFace {
                     photo: "/a.jpg".into(),
                     rect: rect(0.1, 0.1, 0.1, 0.1),
+                    auto: false,
                 },
                 TaggedFace {
                     photo: "/b.jpg".into(),
                     rect: rect(0.1, 0.1, 0.1, 0.1),
+                    auto: true,
                 },
                 TaggedFace {
                     photo: "/a.jpg".into(),
                     rect: rect(0.5, 0.5, 0.1, 0.1),
+                    auto: false,
                 },
             ],
         };

--- a/crates/gallery/src/people.rs
+++ b/crates/gallery/src/people.rs
@@ -1,0 +1,545 @@
+//! People: the faces the detector finds in each photo, and the names
+//! given to them — Picasa's People album.
+//!
+//! Two kinds of record. *Detected* faces are what the models found:
+//! a box per face and, when the recogniser is installed, a vector that
+//! says who it looks like. They are derived — cached beside the
+//! thumbnail and carried in the index snapshot — and never edited.
+//! *Tagged* faces are the user's: a box in a photo with a person's
+//! name on it, persisted in `library.json`. A tag usually sits on a
+//! detected box, but a face the detector missed can be drawn by hand,
+//! so the two are matched by overlap rather than by identity.
+//!
+//! Boxes are fractions of the photo, not pixels: the same face is the
+//! same box in the 256 px thumbnail, the 1600 px viewer and the
+//! original, and an edit that does not crop leaves every tag valid.
+
+use std::path::{Path, PathBuf};
+
+/// A face's box, as fractions of the photo's width and height.
+#[derive(Clone, Copy, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct FaceRect {
+    pub x: f32,
+    pub y: f32,
+    pub w: f32,
+    pub h: f32,
+}
+
+/// Two boxes overlapping by more than this (intersection over union)
+/// are the same face: a tag drawn over a detection claims it.
+pub const SAME_FACE_IOU: f32 = 0.3;
+
+impl FaceRect {
+    /// From pixel coordinates in a `width`x`height` image.
+    pub fn from_pixels(x: f32, y: f32, w: f32, h: f32, width: f32, height: f32) -> FaceRect {
+        FaceRect {
+            x: x / width,
+            y: y / height,
+            w: w / width,
+            h: h / height,
+        }
+        .clamped()
+    }
+
+    /// Kept inside the photo, with a positive size.
+    pub fn clamped(self) -> FaceRect {
+        let x0 = self.x.clamp(0.0, 1.0);
+        let y0 = self.y.clamp(0.0, 1.0);
+        let x1 = (self.x + self.w).clamp(0.0, 1.0);
+        let y1 = (self.y + self.h).clamp(0.0, 1.0);
+        FaceRect {
+            x: x0.min(x1),
+            y: y0.min(y1),
+            w: (x1 - x0).abs(),
+            h: (y1 - y0).abs(),
+        }
+    }
+
+    /// Whether a point (in the same fractions) falls inside.
+    pub fn contains(&self, fx: f32, fy: f32) -> bool {
+        fx >= self.x && fy >= self.y && fx <= self.x + self.w && fy <= self.y + self.h
+    }
+
+    /// Intersection over union with another box, 0 when apart.
+    pub fn overlap(&self, other: &FaceRect) -> f32 {
+        let x = (self.x + self.w).min(other.x + other.w) - self.x.max(other.x);
+        let y = (self.y + self.h).min(other.y + other.h) - self.y.max(other.y);
+        if x <= 0.0 || y <= 0.0 {
+            return 0.0;
+        }
+        let inter = x * y;
+        let union = self.w * self.h + other.w * other.h - inter;
+        if union <= 0.0 {
+            0.0
+        } else {
+            inter / union
+        }
+    }
+
+    /// Whether this and `other` are one face, by overlap.
+    pub fn same_face(&self, other: &FaceRect) -> bool {
+        self.overlap(other) > SAME_FACE_IOU
+    }
+
+    /// The square the recogniser and the avatars crop: centred on the
+    /// box, its longer side times `grow`, in a `width`x`height` image,
+    /// as pixel `(x, y, side)` kept inside the image.
+    pub fn crop_square(&self, grow: f32, width: u32, height: u32) -> (u32, u32, u32) {
+        let (w, h) = (width as f32, height as f32);
+        let side = (self.w * w).max(self.h * h) * grow;
+        let side = side.min(w).min(h).max(1.0);
+        let cx = (self.x + self.w / 2.0) * w;
+        let cy = (self.y + self.h / 2.0) * h;
+        let x0 = (cx - side / 2.0).round().clamp(0.0, w - side);
+        let y0 = (cy - side / 2.0).round().clamp(0.0, h - side);
+        (x0 as u32, y0 as u32, side.round().max(1.0) as u32)
+    }
+
+    /// A stable text key, for caches keyed by face: quantised to a
+    /// thousandth, so the same box read back from JSON matches.
+    pub fn key(&self) -> String {
+        format!("{:.3},{:.3},{:.3},{:.3}", self.x, self.y, self.w, self.h)
+    }
+}
+
+/// One face the detector found, with what the recogniser made of it —
+/// `None` when the recogniser was not installed at the time.
+#[derive(Clone, Debug, PartialEq)]
+pub struct DetectedFace {
+    pub rect: FaceRect,
+    pub embed: Option<Vec<f32>>,
+}
+
+/// A face in a photo, as the user's tags refer to it.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct TaggedFace {
+    pub photo: PathBuf,
+    pub rect: FaceRect,
+}
+
+/// A named person and every face tagged as them, as `library.json`
+/// holds it.
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct PersonFile {
+    pub name: String,
+    #[serde(default)]
+    pub faces: Vec<TaggedFace>,
+}
+
+impl PersonFile {
+    /// The photos this person appears in, each once, in tag order.
+    pub fn photos(&self) -> Vec<PathBuf> {
+        let mut out: Vec<PathBuf> = Vec::new();
+        for face in &self.faces {
+            if !out.contains(&face.photo) {
+                out.push(face.photo.clone());
+            }
+        }
+        out
+    }
+
+    pub fn tagged(&self, photo: &Path, rect: &FaceRect) -> bool {
+        self.faces
+            .iter()
+            .any(|f| f.photo == photo && f.rect.same_face(rect))
+    }
+}
+
+/// The recogniser's grow factor: the detector's box is the face,
+/// forehead to chin; the recogniser was trained on crops with a little
+/// air round that.
+pub const EMBED_GROW: f32 = 1.1;
+/// The avatars' grow factor — a portrait, not a passport photo.
+pub const AVATAR_GROW: f32 = 1.5;
+
+/// The recogniser's cosine above which two faces are suggested to be
+/// the same person. SFace's authors publish 0.363 for aligned crops;
+/// ours are plain squares round the detector's box, which spreads the
+/// scores (on the test portraits the same person scored 0.48–0.79,
+/// different people up to 0.44), so the bar sits above the overlap.
+/// The user confirms every suggestion, so a miss costs a click.
+pub const SUGGEST_COSINE: f32 = 0.45;
+
+/// The unit-length mean of some unit vectors — what a person's faces
+/// add up to. `None` when there are none.
+pub fn centroid<'a>(vectors: impl Iterator<Item = &'a [f32]>) -> Option<Vec<f32>> {
+    let mut sum: Vec<f32> = Vec::new();
+    let mut n = 0usize;
+    for v in vectors {
+        if sum.is_empty() {
+            sum = vec![0.0; v.len()];
+        }
+        if sum.len() != v.len() {
+            continue;
+        }
+        for (s, x) in sum.iter_mut().zip(v) {
+            *s += x;
+        }
+        n += 1;
+    }
+    if n == 0 {
+        return None;
+    }
+    let norm = sum.iter().map(|v| v * v).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for v in &mut sum {
+            *v /= norm;
+        }
+    }
+    Some(sum)
+}
+
+/// The best-matching person for a face: the index and cosine of the
+/// centroid nearest `embed`, when it clears [`SUGGEST_COSINE`].
+pub fn best_match<'a>(
+    embed: &[f32],
+    centroids: impl Iterator<Item = (usize, &'a [f32])>,
+) -> Option<(usize, f32)> {
+    let mut best: Option<(usize, f32)> = None;
+    for (index, c) in centroids {
+        if c.len() != embed.len() {
+            continue;
+        }
+        let cos: f32 = c.iter().zip(embed).map(|(a, b)| a * b).sum();
+        if cos >= SUGGEST_COSINE && best.is_none_or(|(_, b)| cos > b) {
+            best = Some((index, cos));
+        }
+    }
+    best
+}
+
+/// Whether a search query names a person: the query is the name, or
+/// one of the name's words (a first name), or the name appears in the
+/// query ("astrid at the beach"). Case-insensitive, whole words.
+pub fn name_matches_query(name: &str, query: &str) -> bool {
+    let name = name.trim().to_lowercase();
+    let query = query.trim().to_lowercase();
+    if name.is_empty() || query.is_empty() {
+        return false;
+    }
+    if name == query {
+        return true;
+    }
+    let words = |s: &str| -> Vec<String> {
+        s.split(|c: char| !c.is_alphanumeric())
+            .filter(|w| !w.is_empty())
+            .map(str::to_string)
+            .collect()
+    };
+    let name_words = words(&name);
+    let query_words = words(&query);
+    if query_words.is_empty() {
+        return false;
+    }
+    // Every word of the query is a word of the name (one word: a first
+    // name; two: the full name in either order).
+    if query_words.iter().all(|q| name_words.contains(q)) {
+        return true;
+    }
+    // Or the whole name sits inside the query, as words.
+    name_words
+        .windows(name_words.len())
+        .next()
+        .is_some_and(|_| {
+            query_words
+                .windows(name_words.len())
+                .any(|w| w == name_words.as_slice())
+        })
+}
+
+const FACES_MAGIC: &[u8; 8] = b"SCHFACE1";
+
+/// The detected faces as bytes: magic, a count, then per face the box
+/// and its embedding (a zero length when there is none). Little-endian
+/// throughout, like the index snapshot.
+pub fn encode_faces(faces: &[DetectedFace]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(8 + 2 + faces.len() * (16 + 2 + 512));
+    out.extend_from_slice(FACES_MAGIC);
+    out.extend_from_slice(&(faces.len().min(u16::MAX as usize) as u16).to_le_bytes());
+    for face in faces.iter().take(u16::MAX as usize) {
+        for v in [face.rect.x, face.rect.y, face.rect.w, face.rect.h] {
+            out.extend_from_slice(&v.to_le_bytes());
+        }
+        let embed = face.embed.as_deref().unwrap_or(&[]);
+        out.extend_from_slice(&(embed.len() as u16).to_le_bytes());
+        for v in embed {
+            out.extend_from_slice(&v.to_le_bytes());
+        }
+    }
+    out
+}
+
+/// The inverse of [`encode_faces`]; `None` for foreign or torn bytes.
+pub fn decode_faces(bytes: &[u8]) -> Option<Vec<DetectedFace>> {
+    let mut at = 0usize;
+    let mut faces = Vec::new();
+    decode_faces_at(bytes, &mut at, &mut faces, true)?;
+    Some(faces)
+}
+
+/// Read faces from `bytes` at `*at`, advancing it: the magic when
+/// `with_magic`, a count, then the faces. Shared with the index
+/// snapshot, which embeds the same shape per row without the magic.
+pub fn decode_faces_at(
+    bytes: &[u8],
+    at: &mut usize,
+    out: &mut Vec<DetectedFace>,
+    with_magic: bool,
+) -> Option<()> {
+    let take = |at: &mut usize, n: usize| -> Option<&[u8]> {
+        let slice = bytes.get(*at..*at + n)?;
+        *at += n;
+        Some(slice)
+    };
+    if with_magic && take(at, 8)? != FACES_MAGIC {
+        return None;
+    }
+    let count = u16::from_le_bytes(take(at, 2)?.try_into().ok()?) as usize;
+    let get_f32 =
+        |at: &mut usize| -> Option<f32> { Some(f32::from_le_bytes(take(at, 4)?.try_into().ok()?)) };
+    for _ in 0..count {
+        let rect = FaceRect {
+            x: get_f32(at)?,
+            y: get_f32(at)?,
+            w: get_f32(at)?,
+            h: get_f32(at)?,
+        };
+        let dim = u16::from_le_bytes(take(at, 2)?.try_into().ok()?) as usize;
+        let embed = if dim == 0 {
+            None
+        } else {
+            let raw = take(at, dim * 4)?;
+            Some(
+                raw.as_chunks::<4>()
+                    .0
+                    .iter()
+                    .map(|c| f32::from_le_bytes(*c))
+                    .collect::<Vec<f32>>(),
+            )
+        };
+        out.push(DetectedFace { rect, embed });
+    }
+    Some(())
+}
+
+/// The bytes [`encode_faces`] puts after its magic, for the index row.
+pub fn encode_faces_body(faces: &[DetectedFace]) -> Vec<u8> {
+    encode_faces(faces)[8..].to_vec()
+}
+
+/// The cached detections beside a thumbnail (`.faces`).
+pub fn read_faces_cache(cache: &Option<PathBuf>) -> Option<Vec<DetectedFace>> {
+    let bytes = std::fs::read(cache.as_ref()?.with_extension("faces")).ok()?;
+    decode_faces(&bytes)
+}
+
+pub fn write_faces_cache(cache: &Option<PathBuf>, faces: &[DetectedFace]) {
+    if let Some(path) = cache {
+        if let Some(dir) = path.parent() {
+            let _ = std::fs::create_dir_all(dir);
+        }
+        let _ = std::fs::write(path.with_extension("faces"), encode_faces(faces));
+    }
+}
+
+/// Cut the square round a face out of an RGBA image and resample it to
+/// `side` pixels: the recogniser's input and the avatars' pixels.
+/// Returns straight RGBA, `side * side * 4` bytes.
+pub fn face_crop_rgba(
+    rgba: &[u8],
+    width: u32,
+    height: u32,
+    rect: &FaceRect,
+    grow: f32,
+    side: u32,
+) -> Option<Vec<u8>> {
+    let img = image::RgbaImage::from_raw(width, height, rgba.to_vec())?;
+    let (x, y, edge) = rect.crop_square(grow, width, height);
+    let edge = edge.min(width - x).min(height - y).max(1);
+    let crop = image::imageops::crop_imm(&img, x, y, edge, edge).to_image();
+    let filter = if edge > side {
+        image::imageops::FilterType::Triangle
+    } else {
+        image::imageops::FilterType::CatmullRom
+    };
+    Some(image::imageops::resize(&crop, side, side, filter).into_raw())
+}
+
+/// The same crop as interleaved RGB in 0..=1, the recogniser's diet.
+pub fn face_crop_rgb(
+    rgba: &[u8],
+    width: u32,
+    height: u32,
+    rect: &FaceRect,
+    grow: f32,
+    side: u32,
+) -> Option<Vec<f32>> {
+    let crop = face_crop_rgba(rgba, width, height, rect, grow, side)?;
+    Some(
+        crop.as_chunks::<4>()
+            .0
+            .iter()
+            .flat_map(|px| {
+                [
+                    px[0] as f32 / 255.0,
+                    px[1] as f32 / 255.0,
+                    px[2] as f32 / 255.0,
+                ]
+            })
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(x: f32, y: f32, w: f32, h: f32) -> FaceRect {
+        FaceRect { x, y, w, h }
+    }
+
+    #[test]
+    fn boxes_overlap_by_intersection_over_union() {
+        let a = rect(0.1, 0.1, 0.2, 0.2);
+        assert!((a.overlap(&a) - 1.0).abs() < 1e-6);
+        assert_eq!(a.overlap(&rect(0.5, 0.5, 0.1, 0.1)), 0.0);
+        // Half of each: a third of the union.
+        assert!((a.overlap(&rect(0.2, 0.1, 0.2, 0.2)) - 1.0 / 3.0).abs() < 1e-6);
+        assert!(a.same_face(&rect(0.12, 0.1, 0.2, 0.2)));
+        assert!(!a.same_face(&rect(0.25, 0.25, 0.2, 0.2)));
+    }
+
+    #[test]
+    fn clamping_keeps_a_box_inside_the_photo() {
+        let r = rect(-0.1, 0.9, 0.3, 0.3).clamped();
+        let close = |a: f32, b: f32| (a - b).abs() < 1e-6;
+        assert!(close(r.x, 0.0) && close(r.y, 0.9) && close(r.w, 0.2) && close(r.h, 0.1));
+        // A box dragged up-and-left still has positive size.
+        let r = rect(0.5, 0.5, -0.2, -0.1).clamped();
+        assert!((r.x - 0.3).abs() < 1e-6 && (r.w - 0.2).abs() < 1e-6);
+        assert!((r.y - 0.4).abs() < 1e-6 && (r.h - 0.1).abs() < 1e-6);
+    }
+
+    #[test]
+    fn the_crop_square_stays_inside_the_image() {
+        // A face at the right edge: the square slides left rather than
+        // hanging off the picture.
+        // 200 px wide, 100 tall: the square follows the longer side.
+        let (x, y, side) = rect(0.8, 0.4, 0.2, 0.2).crop_square(1.5, 1000, 500);
+        assert_eq!(side, 300);
+        assert_eq!(x + side, 1000);
+        assert_eq!(y, 100);
+        // A face bigger than the short side: the square is the short side.
+        let (_, _, side) = rect(0.0, 0.0, 1.0, 1.0).crop_square(1.1, 1000, 500);
+        assert_eq!(side, 500);
+    }
+
+    #[test]
+    fn faces_round_trip_with_and_without_embeddings() {
+        let faces = vec![
+            DetectedFace {
+                rect: rect(0.1, 0.2, 0.3, 0.4),
+                embed: Some(vec![0.5, -0.25, 1.0]),
+            },
+            DetectedFace {
+                rect: rect(0.0, 0.0, 0.0, 0.0),
+                embed: None,
+            },
+        ];
+        assert_eq!(decode_faces(&encode_faces(&faces)).unwrap(), faces);
+        assert_eq!(
+            decode_faces(&encode_faces(&[])).unwrap(),
+            Vec::<DetectedFace>::new()
+        );
+        assert!(decode_faces(b"SCHFACE1\x02\x00").is_none(), "torn");
+        assert!(decode_faces(b"nonsense").is_none());
+    }
+
+    #[test]
+    fn a_centroid_is_the_unit_mean_and_matches_clear_a_threshold() {
+        let a = [1.0f32, 0.0];
+        let b = [0.0f32, 1.0];
+        let c = centroid([a.as_slice(), b.as_slice()].into_iter()).unwrap();
+        assert!(
+            (c[0] - c[1]).abs() < 1e-6 && (c[0] - std::f32::consts::FRAC_1_SQRT_2).abs() < 1e-5
+        );
+        assert!(centroid(std::iter::empty()).is_none());
+        let people = [c.clone(), vec![-1.0, 0.0]];
+        let probe = [0.9f32, 0.436]; // near the first
+        let found = best_match(
+            &probe,
+            people.iter().enumerate().map(|(i, v)| (i, v.as_slice())),
+        );
+        assert_eq!(found.map(|(i, _)| i), Some(0));
+        // Straight away from everyone: nothing suggested.
+        assert!(best_match(
+            &[0.0, -1.0],
+            people.iter().enumerate().map(|(i, v)| (i, v.as_slice()))
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn a_query_names_a_person_by_first_name_full_name_or_in_passing() {
+        assert!(name_matches_query("Astrid Example", "astrid"));
+        assert!(name_matches_query("Astrid Example", "Example Astrid"));
+        assert!(name_matches_query(
+            "Astrid Example",
+            "astrid example at the beach"
+        ));
+        assert!(!name_matches_query("Astrid Example", "beach"));
+        assert!(!name_matches_query("Astrid Example", "astridx"));
+        assert!(!name_matches_query("Astrid Example", "astrid beach"));
+        assert!(!name_matches_query("", "astrid"));
+    }
+
+    #[test]
+    fn a_person_lists_each_photo_once() {
+        let p = PersonFile {
+            name: "A".into(),
+            faces: vec![
+                TaggedFace {
+                    photo: "/a.jpg".into(),
+                    rect: rect(0.1, 0.1, 0.1, 0.1),
+                },
+                TaggedFace {
+                    photo: "/b.jpg".into(),
+                    rect: rect(0.1, 0.1, 0.1, 0.1),
+                },
+                TaggedFace {
+                    photo: "/a.jpg".into(),
+                    rect: rect(0.5, 0.5, 0.1, 0.1),
+                },
+            ],
+        };
+        assert_eq!(
+            p.photos(),
+            vec![PathBuf::from("/a.jpg"), PathBuf::from("/b.jpg")]
+        );
+        assert!(p.tagged(Path::new("/a.jpg"), &rect(0.51, 0.5, 0.1, 0.1)));
+        assert!(!p.tagged(Path::new("/c.jpg"), &rect(0.1, 0.1, 0.1, 0.1)));
+    }
+
+    #[test]
+    fn a_face_crop_is_square_and_sized_as_asked() {
+        let (w, h) = (40u32, 20u32);
+        let mut rgba = vec![0u8; (w * h * 4) as usize];
+        // A red block where the face is.
+        for y in 5..15 {
+            for x in 10..20 {
+                let i = ((y * w + x) * 4) as usize;
+                rgba[i] = 255;
+                rgba[i + 3] = 255;
+            }
+        }
+        let face = rect(10.0 / 40.0, 5.0 / 20.0, 10.0 / 40.0, 10.0 / 20.0);
+        let crop = face_crop_rgba(&rgba, w, h, &face, 1.0, 8).unwrap();
+        assert_eq!(crop.len(), 8 * 8 * 4);
+        // The middle of the crop is the middle of the face: red.
+        let mid = ((4 * 8 + 4) * 4) as usize;
+        assert_eq!(crop[mid], 255);
+        let rgb = face_crop_rgb(&rgba, w, h, &face, 1.0, 8).unwrap();
+        assert_eq!(rgb.len(), 8 * 8 * 3);
+        assert!((rgb[(4 * 8 + 4) * 3] - 1.0).abs() < 1e-6);
+    }
+}

--- a/crates/gallery/src/people.rs
+++ b/crates/gallery/src/people.rs
@@ -283,6 +283,35 @@ pub fn name_matches_query(name: &str, query: &str) -> bool {
         })
 }
 
+/// The People sidebar's whole-library numbers as last computed, kept in
+/// the state directory so a launch can show them at once. Counts are by
+/// name, so people reordered or renamed since still line up (a renamed
+/// person simply shows nothing until the live count arrives).
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct PeopleSummaryFile {
+    pub unnamed_faces: usize,
+    #[serde(default)]
+    pub photo_counts: Vec<(String, usize)>,
+}
+
+impl PeopleSummaryFile {
+    pub fn load() -> Option<PeopleSummaryFile> {
+        let text = std::fs::read_to_string(crate::paths::people_summary_path()?).ok()?;
+        serde_json::from_str(&text).ok()
+    }
+
+    pub fn save(&self) -> anyhow::Result<()> {
+        let Some(path) = crate::paths::people_summary_path() else {
+            return Ok(());
+        };
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir)?;
+        }
+        std::fs::write(path, serde_json::to_string(self)?)?;
+        Ok(())
+    }
+}
+
 const FACES_MAGIC: &[u8; 8] = b"SCHFACE1";
 
 /// The detected faces as bytes: magic, a count, then per face the box
@@ -527,6 +556,23 @@ mod tests {
         assert!(!name_matches_query("Astrid Example", "astridx"));
         assert!(!name_matches_query("Astrid Example", "astrid beach"));
         assert!(!name_matches_query("", "astrid"));
+    }
+
+    #[test]
+    fn the_summary_file_round_trips_through_json() {
+        let file = PeopleSummaryFile {
+            unnamed_faces: 7,
+            photo_counts: vec![("Ann".into(), 3), ("Bob".into(), 1)],
+        };
+        let text = serde_json::to_string(&file).unwrap();
+        assert_eq!(
+            serde_json::from_str::<PeopleSummaryFile>(&text).unwrap(),
+            file
+        );
+        // An older file without counts still reads.
+        let bare: PeopleSummaryFile = serde_json::from_str(r#"{"unnamed_faces": 2}"#).unwrap();
+        assert_eq!(bare.unnamed_faces, 2);
+        assert!(bare.photo_counts.is_empty());
     }
 
     #[test]

--- a/crates/gallery/src/persist.rs
+++ b/crates/gallery/src/persist.rs
@@ -2,6 +2,7 @@
 
 use crate::geo::GeoBounds;
 use crate::paths::library_path;
+use crate::people::{PersonFile, TaggedFace};
 use std::path::PathBuf;
 
 /// A bucket as `library.json` holds it. Untagged so the shape saved
@@ -48,8 +49,10 @@ impl BucketFile {
 }
 
 /// What `library.json` persists: the watched folders, the recents, the
-/// grid's preferences and the buckets. Everything else — sections,
-/// thumbnails, the index — is derived from the disk.
+/// grid's preferences, the buckets, and the people — every name given
+/// to a face, and every detected face waved away as not one. Everything
+/// else — sections, thumbnails, the index, the detections themselves —
+/// is derived from the disk.
 #[derive(Default, serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct LibraryFile {
     pub folders: Vec<PathBuf>,
@@ -61,6 +64,10 @@ pub struct LibraryFile {
     pub group_by: Option<String>,
     #[serde(default)]
     pub buckets: Vec<BucketFile>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub people: Vec<PersonFile>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ignored_faces: Vec<TaggedFace>,
 }
 
 impl LibraryFile {

--- a/crates/gallery/src/persist.rs
+++ b/crates/gallery/src/persist.rs
@@ -2,7 +2,7 @@
 
 use crate::geo::GeoBounds;
 use crate::paths::library_path;
-use crate::people::{PersonFile, TaggedFace};
+use crate::people::{DeniedFace, PersonFile, TaggedFace};
 use std::path::PathBuf;
 
 /// A bucket as `library.json` holds it. Untagged so the shape saved
@@ -68,6 +68,8 @@ pub struct LibraryFile {
     pub people: Vec<PersonFile>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ignored_faces: Vec<TaggedFace>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub denied_faces: Vec<DeniedFace>,
 }
 
 impl LibraryFile {

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -76,6 +76,14 @@ mod gallery {
                  matching once it runs. The app reads the file at launch.",
                 json!({"name": {"type": "string"}, "query": {"type": "string"}, "paths": paths}),
                 &["name"]),
+            def("gallery_people",
+                "The People album: every named person with their photo and face counts, and how \
+                 many detected faces are still unnamed. Given a name, lists that person's photos \
+                 instead. Names are given in the app by clicking a face in a photo.",
+                json!({"person": {"type": "string", "description": "A person's name, for their photos."},
+                       "offset": {"type": "integer", "minimum": 0, "default": 0},
+                       "limit": {"type": "integer", "minimum": 1, "maximum": 500, "default": 50}}),
+                &[]),
             def("gallery_bucket_add",
                 "Add photos to a bucket by name, in the library file.",
                 json!({"bucket": {"type": "string"}, "paths": paths}), &["bucket", "paths"]),
@@ -236,6 +244,24 @@ mod gallery {
                 let count = gallery.add_to_bucket(name, &paths_arg(args, "paths"))?;
                 text(json!({"bucket": name, "photos": count}))
             }
+            "gallery_people" => match args.get("person").and_then(|v| v.as_str()) {
+                Some(person) => {
+                    let (offset, limit) = page(args);
+                    let entries = gallery
+                        .person_photos(person)
+                        .ok_or_else(|| anyhow!("nobody named {person:?}"))?;
+                    let rows: Vec<Value> = entries
+                        .iter()
+                        .skip(offset)
+                        .take(limit)
+                        .map(|e| gallery.entry_json(e))
+                        .collect();
+                    text(
+                        json!({"person": person, "total": entries.len(), "offset": offset, "photos": rows}),
+                    )
+                }
+                None => text(gallery.people_json()),
+            },
             other => bail!("unknown gallery tool {other:?}"),
         }
     }

--- a/crates/neural/examples/faces.rs
+++ b/crates/neural/examples/faces.rs
@@ -1,0 +1,66 @@
+//! Detect the faces in photographs and compare them, through the same
+//! models and preprocessing the gallery's People feature uses:
+//!
+//! ```sh
+//! SCHIST_MODEL_DIR=/path/with/face.onnx,face-embed.onnx \
+//!     cargo run -p schist-neural --example faces -- a.jpg b.jpg …
+//! ```
+//!
+//! Prints each face found with its box, then the cosine between every
+//! pair of faces — same person should land above ~0.36.
+
+fn main() -> anyhow::Result<()> {
+    let detector =
+        schist_neural::get("face").ok_or_else(|| anyhow::anyhow!("face is not installed"))?;
+    let recogniser = schist_neural::get("face-embed");
+    if recogniser.is_none() {
+        eprintln!("face-embed is not installed: detecting only");
+    }
+    let mut found: Vec<(String, Vec<f32>)> = Vec::new();
+    for path in std::env::args().skip(1) {
+        let img = image::open(&path)?.into_rgb8();
+        let (w, h) = (img.width() as usize, img.height() as usize);
+        let rgb: Vec<f32> = img.as_raw().iter().map(|v| *v as f32 / 255.0).collect();
+        let started = std::time::Instant::now();
+        let faces = schist_neural::faces(&detector, &rgb, w, h)?;
+        println!("{path}: {} face(s) in {:?}", faces.len(), started.elapsed());
+        for (i, face) in faces.iter().enumerate() {
+            println!(
+                "  #{i} at ({:.0},{:.0}) {:.0}x{:.0} score {:.2}",
+                face.x, face.y, face.width, face.height, face.score
+            );
+            let Some(model) = &recogniser else { continue };
+            // A square round the box, a touch larger, resized to the
+            // recogniser's frame — the gallery's own crop.
+            let side = face.width.max(face.height) * 1.1;
+            let cx = face.x + face.width / 2.0;
+            let cy = face.y + face.height / 2.0;
+            let x0 = (cx - side / 2.0).round().max(0.0) as u32;
+            let y0 = (cy - side / 2.0).round().max(0.0) as u32;
+            let x1 = ((cx + side / 2.0).round() as u32).min(w as u32);
+            let y1 = ((cy + side / 2.0).round() as u32).min(h as u32);
+            let crop = image::imageops::crop_imm(&img, x0, y0, x1 - x0, y1 - y0).to_image();
+            let (mw, mh) = model.spec.input.dims();
+            let crop = image::imageops::resize(
+                &crop,
+                mw as u32,
+                mh as u32,
+                image::imageops::FilterType::Triangle,
+            );
+            let crop_rgb: Vec<f32> = crop.as_raw().iter().map(|v| *v as f32 / 255.0).collect();
+            let started = std::time::Instant::now();
+            let vector = schist_neural::embed_face(model, &crop_rgb)?;
+            println!("     embedded in {:?}", started.elapsed());
+            found.push((format!("{path}#{i}"), vector));
+        }
+    }
+    for (a, va) in &found {
+        for (b, vb) in &found {
+            if a < b {
+                let cos: f32 = va.iter().zip(vb).map(|(x, y)| x * y).sum();
+                println!("{cos:+.3}  {a}  {b}");
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/neural/examples/rss.rs
+++ b/crates/neural/examples/rss.rs
@@ -15,7 +15,7 @@ fn rss_mb() -> f64 {
 fn main() {
     let mut last = rss_mb();
     println!("baseline: {last:.0} MB");
-    for id in ["nsfw", "embed-image", "embed-text"] {
+    for id in ["nsfw", "embed-image", "embed-text", "face", "face-embed"] {
         let started = std::time::Instant::now();
         let loaded = schist_neural::get(id).is_some();
         let now = rss_mb();

--- a/crates/neural/src/faces.rs
+++ b/crates/neural/src/faces.rs
@@ -1,4 +1,5 @@
-//! Face detection, for Skin Smoothing.
+//! Face detection, for Skin Smoothing and the gallery's People — and
+//! face recognition, for telling the gallery's people apart.
 //!
 //! UltraFace is a single-shot detector: it scores a few thousand fixed
 //! boxes at once and hands back all of them, so the work here is choosing
@@ -14,6 +15,9 @@
 use anyhow::{bail, Context as _, Result};
 
 use crate::{frame, Model};
+
+/// Length of the vector [`embed_face`] hands back.
+pub const FACE_EMBED_DIM: usize = 128;
 
 /// A detected face, in image pixels.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -119,6 +123,38 @@ pub fn faces(model: &Model, rgb: &[f32], width: usize, height: usize) -> Result<
         }
     }
     Ok(kept)
+}
+
+/// Describe a face so it can be compared with others: `rgb` is one
+/// crop, interleaved RGB in 0..=1, sized exactly as the recogniser's
+/// spec says (112x112). The result is unit length, so the dot product
+/// of two is their cosine — above ~0.36 they are the same person, by
+/// the threshold the model's own authors use.
+///
+/// The model was trained on OpenCV images, which are BGR, so the
+/// channels swap on the way in; the caller need not know.
+pub fn embed_face(model: &Model, rgb: &[f32]) -> Result<Vec<f32>> {
+    let (w, h) = model.spec.input.dims();
+    if rgb.len() != w * h * 3 {
+        bail!("expected a {w}x{h} crop, got {} floats", rgb.len());
+    }
+    let bgr: Vec<f32> = rgb
+        .as_chunks::<3>()
+        .0
+        .iter()
+        .flat_map(|px| [px[2], px[1], px[0]])
+        .collect();
+    let mut out = model.run_scores(&bgr)?;
+    if out.len() != FACE_EMBED_DIM {
+        bail!("expected {FACE_EMBED_DIM} numbers, got {}", out.len());
+    }
+    let norm = out.iter().map(|v| v * v).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for v in &mut out {
+            *v /= norm;
+        }
+    }
+    Ok(out)
 }
 
 #[cfg(test)]

--- a/crates/neural/src/lib.rs
+++ b/crates/neural/src/lib.rs
@@ -50,7 +50,7 @@ mod segment;
 mod tile;
 pub use colour::{chroma, recolour};
 pub use depth::depth_map;
-pub use faces::{faces, Face};
+pub use faces::{embed_face, faces, Face, FACE_EMBED_DIM};
 pub use framed::run_framed;
 pub use inpaint::inpaint;
 pub use segment::segment;
@@ -405,7 +405,7 @@ pub const CATALOG: &[ModelSpec] = &[
     },
     ModelSpec {
         id: "face",
-        name: "Faces (Skin Smoothing)",
+        name: "Faces (Detection)",
         file: "face.onnx",
         url: Some("https://github.com/onnx/models/raw/main/validated/vision/body_analysis/ultraface/models/version-RFB-320.onnx"),
         sha256: Some("34cd7e60aeff28744c657de7a3dc64e872d506741de66987f3426f2b79f88017"),
@@ -414,7 +414,28 @@ pub const CATALOG: &[ModelSpec] = &[
         range: Range::Standard { mean: [0.498_039_2; 3], sd: [0.501_960_8; 3] },
         license: "ONNX Model Zoo, MIT",
         note: "Finds faces, so Skin Smoothing can work on skin that is on \
-               one rather than on anything skin-coloured.",
+               one rather than on anything skin-coloured — and so the \
+               gallery can find the people in a photo.",
+    },
+    // Who a face belongs to: SFace (a MobileFaceNet trained with the
+    // SFace loss, from the OpenCV Zoo) maps a 112x112 face crop to 128
+    // numbers whose cosine says whether two crops are the same person.
+    // The gallery's People feature compares every detected face against
+    // the faces already named, and suggests. OpenCV feeds it BGR in
+    // 0..=255; the caller swaps the channels, the range does the scale.
+    ModelSpec {
+        id: "face-embed",
+        name: "Faces (Recognition)",
+        file: "face-embed.onnx",
+        url: Some("https://github.com/opencv/opencv_zoo/raw/47534e27c9851bb1128ccc0102f1145e27f23f98/models/face_recognition_sface/face_recognition_sface_2021dec.onnx"),
+        sha256: Some("0ba9fbfa01b5270c96627c4ef784da859931e02f04419c829e83484087c34e79"),
+        bytes: 38_696_353,
+        input: Input::Frame { width: 112, height: 112, fit: Fit::Stretch },
+        range: Range::Byte,
+        license: "OpenCV Zoo SFace (Zhong & Deng), Apache-2.0",
+        note: "Tells faces apart, so the gallery can suggest who a face \
+               is once you have named them elsewhere. Runs on each face \
+               the detector finds, in the background.",
     },
     ModelSpec {
         id: "nsfw",

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -482,7 +482,11 @@ the grid. Double-click on a thumbnail still goes straight to the
 editor.
 
 The sidebar lists each person with an avatar, their name and photo
-count; clicking one shows their photos under a "People · Ann" header,
+count; clicking one shows their photos under a "People · Ann" header.
+With a bucket (or folder) on show the People rows work inside it: the
+counts are the person's photos in that bucket, the grid shows only
+those, and the header says so ("People · Ann · in Trip"). Clicking the
+person again lifts the person filter and the bucket is back as it was;
 right-click offers Rename… (renaming to a name somebody else already
 has merges the two) and Forget person (the faces go back to unnamed;
 nothing is deleted). An "Unnamed faces" row gathers every photo with a

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -198,9 +198,10 @@ can look), `gallery_select`, `gallery_bucket_create` (optionally with
 a smart query), `gallery_bucket_add`, `gallery_group_by`,
 `gallery_content_filter` (read or switch the content filter, with
 counts of flagged, clean and not-yet-scored photos; switching it on
-needs the model), `gallery_flagged` (photos by verdict, paged), and
-`gallery_open`, which takes a photo into the editor where the document
-tools then apply.
+needs the model), `gallery_flagged` (photos by verdict, paged),
+`gallery_people` (the People album, or one person's photos by name —
+which also shows them in the grid), and `gallery_open`, which takes a
+photo into the editor where the document tools then apply.
 
 The headless server has the gallery too. `schist-mcp`, the stdio
 server other agents drive, publishes the same `gallery_*` family over
@@ -432,9 +433,63 @@ optional `bucket` — the in-app one views the bucket as it searches,
 so the user sees what the agent saw; the headless one sees only the
 hand-added photos, as its `gallery_list` does.
 
+## People
+
+The People album, the way Picasa did it. Two models under Manage
+Models do the work, both downloaded once and run locally: **Faces
+(Detection)** — UltraFace, the same 1.2 MB detector Skin Smoothing
+uses — finds the faces in each photo as its thumbnail goes through the
+loader, and **Faces (Recognition)** — SFace from the OpenCV Zoo,
+38.7 MB, Apache-2.0 — turns each one into 128 numbers whose cosine says
+whether two faces are the same person. Detection runs on the thumbnail
+(the detector's own frame is 320×240, so a thumbnail is already more
+than it looks at); the recogniser crops its faces from a 1024 px
+re-decode, because a face in a 256 px thumbnail is a smudge. Until the
+models are installed the sidebar's PEOPLE section offers "+ Find
+faces…", which opens one licence dialog for both.
+
+Boxes are stored as fractions of the photo, not pixels, so a tag is the
+same box in the thumbnail, the viewer and the original. Detections are
+cached beside the thumbnail (`.faces`, with the vectors) and ride in
+the index snapshot; the names are the user's and live in
+`library.json`.
+
+Naming happens in the **viewer**: Space on a selected photo, the tray's
+**View** button, or "View & name people" in the right-click menu shows
+the photo big with every face boxed, and a PEOPLE IN THIS PHOTO panel
+beside it with a crop per face. Click a face (in either place), type a
+name, Enter. Names already known complete as you type; a face the
+detector missed is added by dragging a box round it on the photo; a
+detection that is not a face — or not anyone worth naming — is waved
+away with "Not a face". Once someone has a few named faces the
+recogniser starts offering "Is this Ann?" on unnamed faces that land
+above a 0.45 cosine of the person's mean vector (SFace's authors use
+0.363 on aligned crops; ours are plain squares round the detector's
+box, which spreads the scores, so the bar sits above where different
+people landed in testing). Yes tags it; a face drawn by hand gets its
+vector from the viewer's decode on the spot, so it counts too. Arrows
+walk to the next photo, Escape leaves the name field, then the viewer;
+Enter with nothing focused opens the photo in the editor, as it does in
+the grid. Double-click on a thumbnail still goes straight to the
+editor.
+
+The sidebar lists each person with an avatar, their name and photo
+count; clicking one shows their photos under a "People · Ann" header,
+right-click offers Rename… (renaming to a name somebody else already
+has merges the two) and Forget person (the faces go back to unnamed;
+nothing is deleted). An "Unnamed faces" row gathers every photo with a
+detected face nobody has named or dismissed — Picasa's Unnamed album,
+where the naming gets done. A person's name in the search box pulls
+their photos in ahead of anything the towers rank ("ann at the beach"
+finds Ann's beach photos first), and the results header says "· with
+Ann"; a name alone needs no search models at all. The `gallery_people`
+tool lists the album for the AI panel and the headless server, or one
+person's photos by name.
+
 ## What is persisted
 
 `~/.config/schist/library.json`: the watched folders, the recent-files
-list the start screen shows, and the thumbnail size. Thumbnail caches
+list the start screen shows, the thumbnail size, the buckets, and the
+people — every named face and every detected face waved away. Thumbnail caches
 live under the state directory (`~/.local/state/schist/thumbs`) and can
 be deleted freely.

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -443,8 +443,13 @@ loader, and **Faces (Recognition)** — SFace from the OpenCV Zoo,
 38.7 MB, Apache-2.0 — turns each one into 128 numbers whose cosine says
 whether two faces are the same person. Detection runs on the thumbnail
 (the detector's own frame is 320×240, so a thumbnail is already more
-than it looks at); the recogniser crops its faces from a 1024 px
-re-decode, because a face in a 256 px thumbnail is a smudge. Until the
+than it looks at); the recogniser crops big faces from the thumbnail
+and small ones — a group photo's — from a 1024 px decode: the one kept
+from rendering the thumbnail when the models were already installed,
+otherwise one more decode of the original, once. A face the recogniser
+cannot embed is recorded as tried, so no photo is asked again on every
+pass; a recogniser file that is installed but will not load switches
+recognition off for the session rather than leaving every face owed. Until the
 models are installed the sidebar's PEOPLE section offers "+ Find
 faces…", which opens one licence dialog for both.
 

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -461,13 +461,21 @@ beside it with a crop per face. Click a face (in either place), type a
 name, Enter. Names already known complete as you type; a face the
 detector missed is added by dragging a box round it on the photo; a
 detection that is not a face — or not anyone worth naming — is waved
-away with "Not a face". Once someone has a few named faces the
-recogniser starts offering "Is this Ann?" on unnamed faces that land
-above a 0.45 cosine of the person's mean vector (SFace's authors use
-0.363 on aligned crops; ours are plain squares round the detector's
-box, which spreads the scores, so the bar sits above where different
-people landed in testing). Yes tags it; a face drawn by hand gets its
-vector from the viewer's decode on the spot, so it counts too. Arrows
+away with "Not a face". Naming a face teaches the recogniser: every
+unnamed face in the library that lands above a 0.5 cosine of the
+person's mean vector is put with them at once, as an *automatic* tag
+(the tray says how many followed), and photos indexed later get the
+same treatment as their faces arrive. Between 0.45 and 0.5 a face is
+only offered — "Is this Ann?" with a Yes button — rather than taken
+(SFace's authors use 0.363 on aligned crops; ours are plain squares
+round the detector's box, which spreads the scores, so the bars sit
+above where different people landed in testing). Automatic tags are
+marked "auto" in the panel and on their box, with a "Not them" button;
+saying no remembers that this face is not that person, so the
+recogniser does not put it back — and only hand-named faces feed a
+person's mean vector, so one wrong guess cannot steer the next. A
+face drawn by hand gets its vector from the viewer's decode on the
+spot, so it counts too. Arrows
 walk to the next photo, Escape leaves the name field, then the viewer;
 Enter with nothing focused opens the photo in the editor, as it does in
 the grid. Double-click on a thumbnail still goes straight to the
@@ -490,6 +498,7 @@ person's photos by name.
 
 `~/.config/schist/library.json`: the watched folders, the recent-files
 list the start screen shows, the thumbnail size, the buckets, and the
-people — every named face and every detected face waved away. Thumbnail caches
+people — every named face (hand-made or automatic), every detected
+face waved away, and every "not them". Thumbnail caches
 live under the state directory (`~/.local/state/schist/thumbs`) and can
 be deleted freely.

--- a/docs/gallery.md
+++ b/docs/gallery.md
@@ -488,6 +488,11 @@ editor.
 
 The sidebar lists each person with an avatar, their name and photo
 count; clicking one shows their photos under a "People · Ann" header.
+The counts are right from the first frame: last launch's numbers are
+kept in the state directory (`people.json`) and shown until the index
+snapshot has been read back, and the idle indexer waits for that
+snapshot rather than re-reading per-photo caches it is about to be
+handed — so the unnamed tally no longer creeps up on load.
 With a bucket (or folder) on show the People rows work inside it: the
 counts are the person's photos in that bucket, the grid shows only
 those, and the header says so ("People · Ann · in Trip"). Clicking the


### PR DESCRIPTION
## What

A People album for the gallery, the way Picasa did it: faces are found as photos index, you name them in a viewer, and each person becomes a sidebar album you can browse and search.

- **Detection** runs on every thumbnail through the loader, using the existing UltraFace `face` model (renamed "Faces (Detection)" in Manage Models). Detections are cached beside thumbnails (`.faces`) and carried in the index snapshot, now `SCHIDX2` (v1 still reads).
- **Recognition** is a new catalogue model, `face-embed`: SFace from the OpenCV Zoo (38.7 MB, Apache-2.0, commit-pinned, hash-checked). Big faces are cropped from the thumbnail; small ones from a 1024 px decode kept from rendering the thumbnail (a thumbnail cached before the models arrived earns one more decode of the original, once). Embedding failures are recorded as tried so no photo is re-queued forever, and both models are released when indexing goes idle. Naming a face teaches it: every unnamed face in the library above a 0.5 cosine of the person's mean vector is put with them at once as an *automatic* tag (marked "auto", one-click "Not them"), and faces indexed later get the same pass. Between 0.45 and 0.5 a face is only offered with an "Is this …?" prompt. Only hand-named faces feed the mean, and a "not them" is remembered per name so the face is never put back.
- **Viewer**: Space on a selected photo, the tray's View button, or "View & name people" in the photo menu. Faces are boxed; click one, type a name, Enter. Names autocomplete. Drag a box for a face the detector missed; "Not a face" dismisses a detection. Arrows step between photos, Escape backs out. Double-click still goes to the editor.
- **Sidebar PEOPLE section**: a row per person (avatar, count) plus "Unnamed faces". Click to view their photos; right-click to rename (renaming to an existing name merges) or forget. With a bucket or folder on show, the rows work inside it: counts are the person's photos in that bucket, the grid shows only those, and the header reads "People · Ann · in Trip".
- **Search**: a person's name in the search box pulls their photos in ahead of the CLIP ranking, labelled "· with Name". The box now appears once anyone is named, even without the search models, since names and places need none.
- `gallery_people` MCP tool on both the in-app and stdio servers; docs/gallery.md has a People section.
- While the two models download, the PEOPLE section (and the viewer's panel) show a progress bar in place of the "Find faces…" link.
- Also fixes three clippy lints in the telemetry module that `main` currently fails on.

## Verified

- Unit tests in `schist-gallery`, `schist-neural` and the app's library module; clippy `-D warnings` and rustfmt clean on the touched crates.
- Auto-tagging verified live: naming one Biden portrait "joe" put the other portrait with him automatically (tray: "Named joe · 1 more face matched automatically").
- Headless GUI run on a 135-photo test library: 10 faces found across 7 public-domain portraits, none on 128 synthetic images; naming, suggestion (second Biden portrait suggested "joe" after one tag), person filter, name search and persistence all confirmed by screenshot.
- Model under tract: detection ~21 ms per thumbnail, embedding ~60 ms per face. On the test portraits the same person scored 0.48–0.79 and different people at most 0.44, hence the 0.45 bar.

## Performance

The sidebar's People counts are a cached summary recomputed only when the index, the people, or the bucket/folder/map filter change; scanned entries are indexed by path; a loader batch auto-tags only its own photos. Nothing in the gallery's render path walks all photos or all tags per frame. Last launch's counts are persisted (`people.json` in the state dir) and shown from the first frame until the indexer has caught up, so the unnamed tally does not creep up on load; the idle indexer waits for the snapshot restore instead of re-reading per-photo caches.

## Notes for review

- `Library::save()` is a no-op under `cfg!(test)` so unit tests cannot write the developer's `library.json`.
- gpui gotcha that cost a rebuild: an `.absolute().size_full()` canvas with no offsets lands at its static position; the viewer's bounds probe needed `.top_0().left_0()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

