### PR TITLE
Widget kit crate: buttons commit on release (fixes #119)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6187,6 +6187,7 @@ dependencies = [
  "schist-tools-type",
  "schist-tools-vector",
  "schist-tools-warp",
+ "schist-ui",
  "schist-vector",
  "sentry",
  "serde",
@@ -6652,6 +6653,13 @@ dependencies = [
  "schist-core",
  "schist-fx",
  "schist-plugin-api",
+]
+
+[[package]]
+name = "schist-ui"
+version = "0.12.0"
+dependencies = [
+ "gpui",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/colormgmt",
     "crates/mcp",
     "crates/gallery",
+    "crates/ui",
     "plugins/codecs-common",
     "plugins/tools-basic",
     "plugins/tools-paint",
@@ -65,6 +66,7 @@ schist-layer-fx = { path = "crates/layer-fx" }
 schist-neural = { path = "crates/neural" }
 schist-psd-descriptor = { path = "crates/psd-descriptor" }
 schist-preview = { path = "crates/preview" }
+schist-ui = { path = "crates/ui" }
 
 # zlib for PSD's zip-compressed channels; pure Rust, no C toolchain.
 miniz_oxide = "0.8"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -21,6 +21,8 @@ futures.workspace = true
 smallvec.workspace = true
 rustc-hash.workspace = true
 
+# The widget kit: palette, buttons, rows, checkboxes.
+schist-ui.workspace = true
 schist-core.workspace = true
 schist-color.workspace = true
 schist-plugin-api.workspace = true

--- a/crates/app/src/dialogs/edit.rs
+++ b/crates/app/src/dialogs/edit.rs
@@ -369,24 +369,13 @@ pub(super) fn color_range_dialog(
                 .items_center()
                 .gap_2()
                 .child(
-                    div()
-                        .id("color-range-swatch")
-                        .size(px(18.0))
-                        .flex_none()
-                        .rounded_sm()
-                        .border_1()
-                        .border_color(gpui::rgb(ui::palette().edge))
-                        .bg(gpui::rgb(swatch))
-                        .cursor_pointer()
-                        .hover(|s| s.border_color(gpui::rgb(ui::palette().text)))
-                        .on_mouse_down(
-                            gpui::MouseButton::Left,
-                            cx.listener(move |ws, _e, _w, cx| {
-                                // This dialog stays open underneath the
-                                // picker and takes the colour on OK.
-                                ws.open_color_picker_on(ColorTarget::ColorRange, target, cx);
-                            }),
-                        ),
+                    Swatch::new("color-range-swatch", gpui::rgb(swatch)).on_click(cx.listener(
+                        move |ws, _e, _w, cx| {
+                            // This dialog stays open underneath the
+                            // picker and takes the colour on OK.
+                            ws.open_color_picker_on(ColorTarget::ColorRange, target, cx);
+                        },
+                    )),
                 )
                 .child(ui::button(
                     "Use Foreground",

--- a/crates/app/src/dialogs/mod.rs
+++ b/crates/app/src/dialogs/mod.rs
@@ -12,6 +12,7 @@ use gpui::{
 use schist_color::{ColorMode, Depth};
 use schist_core::Filter;
 use schist_tools_transform::Resample;
+use schist_ui::{Checkbox, Link, Swatch};
 
 mod adjust;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/app/src/dialogs/new_doc.rs
+++ b/crates/app/src/dialogs/new_doc.rs
@@ -33,14 +33,12 @@ pub(super) fn new_file_picker(cx: &mut Context<Workspace>) -> impl IntoElement {
             .border_color(gpui::rgb(ui::palette().edge))
             .text_size(px(12.0))
             .text_color(gpui::rgb(ui::palette().text_dim))
+            .id("new-doc-custom")
             .cursor_pointer()
             .hover(|s| s.border_color(gpui::rgb(ui::palette().accent)))
-            .on_mouse_down(
-                gpui::MouseButton::Left,
-                cx.listener(|ws, _e, _w, cx| {
-                    ws.open_new_document_dialog(cx);
-                }),
-            )
+            .on_click(cx.listener(|ws, _e, _w, cx| {
+                ws.open_new_document_dialog(cx);
+            }))
             .child("Custom…"),
     );
     let actions = div().flex().flex_row().gap_2().child(ui::button(
@@ -71,24 +69,22 @@ fn preset_card(
         .bg(gpui::rgb(ui::palette().control_bg))
         .border_1()
         .border_color(gpui::rgb(ui::palette().edge))
+        .id(label)
         .cursor_pointer()
         .hover(|s| s.border_color(gpui::rgb(ui::palette().accent)))
-        .on_mouse_down(
-            gpui::MouseButton::Left,
-            cx.listener(move |ws, _e, _w, cx| {
-                ws.close_modal(cx);
-                ws.create_document(
-                    "",
-                    width,
-                    height,
-                    ppi,
-                    ColorMode::Rgb,
-                    Depth::Eight,
-                    crate::workspace::NewDocBackground::White,
-                );
-                cx.notify();
-            }),
-        )
+        .on_click(cx.listener(move |ws, _e, _w, cx| {
+            ws.close_modal(cx);
+            ws.create_document(
+                "",
+                width,
+                height,
+                ppi,
+                ColorMode::Rgb,
+                Depth::Eight,
+                crate::workspace::NewDocBackground::White,
+            );
+            cx.notify();
+        }))
         .child(div().text_size(px(12.0)).child(label))
         .child(
             div()

--- a/crates/app/src/dialogs/prefs.rs
+++ b/crates/app/src/dialogs/prefs.rs
@@ -259,19 +259,14 @@ fn gallery_filter_row(
                 .text_color(gpui::rgb(ui::palette().text_dim))
                 .child("Needs the Content (NSFW Filter) model —")
                 .child(
-                    div()
-                        .text_color(gpui::rgb(ui::palette().accent))
-                        .cursor_pointer()
-                        .on_mouse_down(
-                            gpui::MouseButton::Left,
-                            cx.listener(|ws, _e, _w, cx| {
-                                // Leaving Preferences for the model
-                                // manager keeps what was changed.
-                                ws.keep_preferences();
-                                ws.open_modal(Modal::ModelManager, cx);
-                            }),
-                        )
-                        .child("download it in Manage Models…"),
+                    Link::new("prefs-manage-models", "download it in Manage Models…").on_click(
+                        cx.listener(|ws, _e, _w, cx| {
+                            // Leaving Preferences for the model
+                            // manager keeps what was changed.
+                            ws.keep_preferences();
+                            ws.open_modal(Modal::ModelManager, cx);
+                        }),
+                    ),
                 ),
         );
     }
@@ -287,34 +282,16 @@ fn gallery_filter_row(
         )
         .into_any_element()
     } else {
-        // The disabled twin of `ui::checkbox`: same shape, faint, and
-        // listening to nothing.
-        div()
-            .flex()
-            .flex_row()
-            .items_center()
-            .gap_2()
-            .text_size(px(12.0))
-            .text_color(gpui::rgb(ui::palette().text_faint))
-            .child(
-                div()
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .size(px(14.0))
-                    .rounded_sm()
-                    .bg(gpui::rgb(ui::palette().deep_bg))
-                    .border_1()
-                    .border_color(gpui::rgb(ui::palette().divider))
-                    // Still honest about the stored preference, even
-                    // while it cannot be changed from here.
-                    .children(
-                        view.gallery_hide_nsfw
-                            .then(|| crate::panels::icon("check", 10.0, ui::palette().text_faint)),
-                    ),
-            )
-            .child("Hide flagged photos")
-            .into_any_element()
+        // The same box, faint and listening to nothing -- still honest
+        // about the stored preference, even while it cannot be changed
+        // from here.
+        Checkbox::new(
+            "checkbox-Hide flagged photos",
+            "Hide flagged photos",
+            view.gallery_hide_nsfw,
+        )
+        .disabled(true)
+        .into_any_element()
     });
     div()
         .flex()

--- a/crates/app/src/dialogs/size.rs
+++ b/crates/app/src/dialogs/size.rs
@@ -192,17 +192,16 @@ pub(super) fn anchor_grid(anchor: (f32, f32), cx: &mut Context<Workspace>) -> im
                     }))
                     .border_1()
                     .border_color(gpui::rgb(ui::palette().edge))
-                    .on_mouse_down(
-                        gpui::MouseButton::Left,
-                        cx.listener(move |ws, _e, _w, cx| {
-                            ws.update_modal(|m| {
-                                if let Modal::CanvasSize { anchor, .. } = m {
-                                    *anchor = value;
-                                }
-                            });
-                            cx.notify();
-                        }),
-                    ),
+                    .id(("anchor", (row * 3 + col) as usize))
+                    .cursor_pointer()
+                    .on_click(cx.listener(move |ws, _e, _w, cx| {
+                        ws.update_modal(|m| {
+                            if let Modal::CanvasSize { anchor, .. } = m {
+                                *anchor = value;
+                            }
+                        });
+                        cx.notify();
+                    })),
             );
         }
         grid = grid.child(line);

--- a/crates/app/src/gallery.rs
+++ b/crates/app/src/gallery.rs
@@ -10,9 +10,10 @@ use crate::dialogs::{param_slider, SliderSpec};
 use crate::ui;
 use crate::workspace::{GalleryEntry, Modal, Workspace};
 use gpui::{
-    div, px, Context, InteractiveElement as _, IntoElement, MouseButton, MouseDownEvent,
-    ParentElement as _, SharedString, StatefulInteractiveElement as _, Styled,
+    div, px, Context, InteractiveElement as _, IntoElement, ParentElement as _, SharedString,
+    StatefulInteractiveElement as _, Styled,
 };
+use schist_ui::{Checkbox, IconButton, ListItem};
 
 /// Mutate the open gallery and re-run its preview.
 fn edit(
@@ -83,34 +84,28 @@ pub fn render(
                         .child(SharedString::from(name)),
                 )
                 .children(list.into_iter().map(|(id, label)| {
-                    div()
-                        .px_2()
+                    ListItem::new(id)
                         .h(px(20.0))
                         .rounded_sm()
-                        .text_size(px(12.0))
-                        .hover(|s| s.bg(gpui::rgb(ui::palette().hover)))
                         .child(SharedString::from(label))
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
-                                // Adding puts the new filter on top of the
-                                // stack and selects it, as Photoshop does.
-                                let values = ws
-                                    .registry
-                                    .filters()
-                                    .find(|f| f.id() == id)
-                                    .map(|f| schist_plugin_api::FilterValues::defaults(&f.params()))
-                                    .unwrap_or_default();
-                                edit(ws, cx, |stack, selected| {
-                                    stack.push(GalleryEntry {
-                                        id,
-                                        values,
-                                        enabled: true,
-                                    });
-                                    *selected = stack.len() - 1;
+                        .on_click(cx.listener(move |ws, _e, _w, cx| {
+                            // Adding puts the new filter on top of the
+                            // stack and selects it, as Photoshop does.
+                            let values = ws
+                                .registry
+                                .filters()
+                                .find(|f| f.id() == id)
+                                .map(|f| schist_plugin_api::FilterValues::defaults(&f.params()))
+                                .unwrap_or_default();
+                            edit(ws, cx, |stack, selected| {
+                                stack.push(GalleryEntry {
+                                    id,
+                                    values,
+                                    enabled: true,
                                 });
-                            }),
-                        )
+                                *selected = stack.len() - 1;
+                            });
+                        }))
                 }))
         }));
 
@@ -134,56 +129,44 @@ pub fn render(
         .gap(px(1.0))
         .children(names.into_iter().rev().map(|(i, name, on)| {
             let is_selected = i == selected;
-            div()
-                .flex()
-                .flex_row()
-                .items_center()
+            ListItem::new(("gallery-entry", i))
                 .gap_2()
-                .px_2()
                 .h(px(22.0))
                 .rounded_sm()
-                .text_size(px(12.0))
                 .bg(gpui::rgb(if is_selected {
                     ui::palette().selection_bg
                 } else {
                     ui::palette().window_bg
                 }))
-                .child(ui::checkbox(
-                    "",
-                    on,
-                    move |ws, cx| {
-                        edit(ws, cx, |stack, _| {
-                            if let Some(e) = stack.get_mut(i) {
-                                e.enabled = !on;
-                            }
-                        });
-                    },
-                    cx,
-                ))
+                .child(
+                    Checkbox::new(("gallery-entry-on", i), "", on).on_change(cx.listener(
+                        move |ws, _on, _w, cx| {
+                            edit(ws, cx, |stack, _| {
+                                if let Some(e) = stack.get_mut(i) {
+                                    e.enabled = !on;
+                                }
+                            });
+                        },
+                    )),
+                )
                 .child(div().flex_grow().child(SharedString::from(name)))
                 .child(
-                    div()
-                        .px_1()
-                        .text_size(px(11.0))
-                        .text_color(gpui::rgb(ui::palette().text_dim))
-                        .child("\u{2715}")
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
-                                edit(ws, cx, |stack, _| {
-                                    if i < stack.len() {
-                                        stack.remove(i);
-                                    }
-                                });
-                            }),
-                        ),
+                    IconButton::new(("gallery-entry-remove", i), "close")
+                        .size(16.0)
+                        .icon_size(9.0)
+                        .color(ui::palette().text_dim)
+                        .consume_press()
+                        .on_click(cx.listener(move |ws, _e, _w, cx| {
+                            edit(ws, cx, |stack, _| {
+                                if i < stack.len() {
+                                    stack.remove(i);
+                                }
+                            });
+                        })),
                 )
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
-                        edit(ws, cx, |_, selected| *selected = i);
-                    }),
-                )
+                .on_click(cx.listener(move |ws, _e, _w, cx| {
+                    edit(ws, cx, |_, selected| *selected = i);
+                }))
         }));
 
     // Parameters of whichever entry is selected.

--- a/crates/app/src/panels/ai.rs
+++ b/crates/app/src/panels/ai.rs
@@ -50,38 +50,20 @@ fn header(cx: &mut Context<Workspace>) -> impl IntoElement {
                 .items_center()
                 .gap_1()
                 .child(
-                    div()
-                        .id("ai-clear")
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .size(px(20.0))
-                        .rounded_sm()
-                        .cursor_pointer()
-                        .hover(|s| s.bg(gpui::rgb(palette().hover)))
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(|ws, _e, _w, cx| ws.ai_new_conversation(cx)),
-                        )
-                        .child(icon("trash", 13.0, palette().text_dim)),
+                    IconButton::new("ai-clear", "trash")
+                        .size(20.0)
+                        .icon_size(13.0)
+                        .color(palette().text_dim)
+                        .on_click(cx.listener(|ws, _e, _w, cx| ws.ai_new_conversation(cx))),
                 )
                 // Closes the sidebar; whether it was open is a saved
                 // preference, so it comes back on the next launch.
                 .child(
-                    div()
-                        .id("ai-close")
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .size(px(20.0))
-                        .rounded_sm()
-                        .cursor_pointer()
-                        .hover(|s| s.bg(gpui::rgb(palette().hover)))
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(|ws, _e, _w, cx| ws.toggle_ai_panel(cx)),
-                        )
-                        .child(icon("close", 13.0, palette().text_dim)),
+                    IconButton::new("ai-close", "close")
+                        .size(20.0)
+                        .icon_size(13.0)
+                        .color(palette().text_dim)
+                        .on_click(cx.listener(|ws, _e, _w, cx| ws.toggle_ai_panel(cx))),
                 ),
         )
 }
@@ -309,7 +291,8 @@ fn model_menu(ws: &Workspace, cx: &mut Context<Workspace>) -> AnyElement {
     } else {
         entries
             .into_iter()
-            .map(|(backend, entry)| {
+            .enumerate()
+            .map(|(ix, (backend, entry))| {
                 let picked = backend == current_backend && entry.slug == current_slug;
                 let slug = entry.slug.clone();
                 let sub = if entry.detail.is_empty() {
@@ -322,22 +305,17 @@ fn model_menu(ws: &Workspace, cx: &mut Context<Workspace>) -> AnyElement {
                 // how the rest of the chrome truncates.
                 let name = ellipsize(&entry.name, if picked { 27 } else { 31 });
                 let sub = ellipsize(&sub, 41);
-                div()
-                    .px_2()
+                ListItem::new(("ai-model", ix))
+                    .h_auto()
                     .py_1()
-                    .flex_none()
-                    .flex()
                     .flex_col()
-                    .cursor_pointer()
-                    .hover(|s| s.bg(gpui::rgb(palette().hover)))
-                    .on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(move |ws, _e, _w, cx| {
-                            ws.ai_pick_model(backend, slug.clone(), cx);
-                        }),
-                    )
+                    .items_start()
+                    .on_click(cx.listener(move |ws, _e, _w, cx| {
+                        ws.ai_pick_model(backend, slug.clone(), cx);
+                    }))
                     .child(
                         div()
+                            .w_full()
                             .flex()
                             .flex_row()
                             .items_center()
@@ -360,6 +338,7 @@ fn model_menu(ws: &Workspace, cx: &mut Context<Workspace>) -> AnyElement {
                     )
                     .child(
                         div()
+                            .w_full()
                             .flex()
                             .flex_row()
                             .items_center()
@@ -406,34 +385,21 @@ fn model_menu(ws: &Workspace, cx: &mut Context<Workspace>) -> AnyElement {
         // A search spans every harness, so the rail stands down.
         let selected = !searching && ws.ai.menu_backend == backend;
         rail = rail.child(
-            div()
-                .id(backend.icon())
-                .flex()
-                .items_center()
-                .justify_center()
-                .size(px(24.0))
-                .rounded_sm()
-                .cursor_pointer()
-                .when(selected, |d| d.bg(gpui::rgb(palette().selection_bg)))
-                .hover(|s| s.bg(gpui::rgb(palette().hover)))
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |ws, _e, _w, cx| {
-                        ws.ai.menu_backend = backend;
-                        ws.ai.model_search.clear();
-                        ws.ensure_ai_models(cx);
-                        cx.notify();
-                    }),
-                )
-                .child(icon(
-                    backend.icon(),
-                    13.0,
-                    if selected {
-                        palette().text
-                    } else {
-                        palette().text_dim
-                    },
-                )),
+            IconButton::new(backend.icon(), backend.icon())
+                .size(24.0)
+                .icon_size(13.0)
+                .color(if selected {
+                    palette().text
+                } else {
+                    palette().text_dim
+                })
+                .when(selected, |b| b.bg(gpui::rgb(palette().selection_bg)))
+                .on_click(cx.listener(move |ws, _e, _w, cx| {
+                    ws.ai.menu_backend = backend;
+                    ws.ai.model_search.clear();
+                    ws.ensure_ai_models(cx);
+                    cx.notify();
+                })),
         );
     }
 

--- a/crates/app/src/panels/color.rs
+++ b/crates/app/src/panels/color.rs
@@ -8,53 +8,41 @@ pub(super) fn color_wells(ws: &Workspace, cx: &mut Context<Workspace>) -> impl I
         .size(px(30.0))
         .mt_2()
         .child(
-            div()
+            Swatch::new("background-well", swatch_hex(ws.editor.background))
                 .absolute()
                 .bottom_0()
                 .right_0()
-                .size(px(18.0))
-                .bg(swatch_hex(ws.editor.background))
-                .border_1()
+                .rounded_none()
                 .border_color(gpui::rgb(palette().text_faint))
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(|ws, _ev, _w, cx| {
-                        ws.open_color_picker(ColorTarget::Background, cx)
-                    }),
+                .on_click(
+                    cx.listener(|ws, _e, _w, cx| ws.open_color_picker(ColorTarget::Background, cx)),
                 ),
         )
         .child(
-            div()
+            Swatch::new("foreground-well", swatch_hex(ws.editor.foreground))
                 .absolute()
                 .top_0()
                 .left_0()
-                .size(px(18.0))
-                .bg(swatch_hex(ws.editor.foreground))
-                .border_1()
+                .rounded_none()
                 .border_color(gpui::rgb(palette().text))
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(|ws, _ev, _w, cx| {
-                        ws.open_color_picker(ColorTarget::Foreground, cx)
-                    }),
+                .on_click(
+                    cx.listener(|ws, _e, _w, cx| ws.open_color_picker(ColorTarget::Foreground, cx)),
                 ),
         )
         // The empty corner between the two wells, which is where
         // Photoshop puts the swap arrows too.
         .child(
-            div()
+            IconButton::new("swap-colors", "swap")
+                .size(11.0)
+                .icon_size(11.0)
+                .color(palette().text_dim)
                 .absolute()
                 .top(px(-1.0))
                 .right(px(-1.0))
-                .size(px(11.0))
-                .child(icon("swap", 11.0, palette().text_dim))
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(|ws, _ev, _w, cx| {
-                        std::mem::swap(&mut ws.editor.foreground, &mut ws.editor.background);
-                        cx.notify();
-                    }),
-                ),
+                .on_click(cx.listener(|ws, _e, _w, cx| {
+                    std::mem::swap(&mut ws.editor.foreground, &mut ws.editor.background);
+                    cx.notify();
+                })),
         )
 }
 
@@ -79,37 +67,27 @@ pub(super) fn color_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> im
                 ws.open_context_menu(ContextTarget::Color, ev.position, cx);
             }),
         )
-        .child(
-            div()
-                .flex()
-                .flex_row()
-                .flex_wrap()
-                .gap_1()
-                .children(PALETTE.map(|hex| {
-                    div()
-                        .size(px(18.0))
-                        .bg(gpui::rgb(hex))
-                        .border_1()
-                        .border_color(gpui::rgb(palette().divider))
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(move |ws, ev: &MouseDownEvent, _w, cx| {
-                                let color = Rgba::from_u8(
-                                    ((hex >> 16) & 0xFF) as u8,
-                                    ((hex >> 8) & 0xFF) as u8,
-                                    (hex & 0xFF) as u8,
-                                    255,
-                                );
-                                if ev.modifiers.alt {
-                                    ws.editor.background = color;
-                                } else {
-                                    ws.editor.foreground = color;
-                                }
-                                cx.notify();
-                            }),
-                        )
-                })),
-        )
+        .child(div().flex().flex_row().flex_wrap().gap_1().children(
+            PALETTE.iter().enumerate().map(|(i, &hex)| {
+                Swatch::new(("palette-swatch", i), gpui::rgb(hex))
+                    .rounded_none()
+                    .border_color(gpui::rgb(palette().divider))
+                    .on_click(cx.listener(move |ws, ev: &gpui::ClickEvent, _w, cx| {
+                        let color = Rgba::from_u8(
+                            ((hex >> 16) & 0xFF) as u8,
+                            ((hex >> 8) & 0xFF) as u8,
+                            (hex & 0xFF) as u8,
+                            255,
+                        );
+                        if ev.modifiers().alt {
+                            ws.editor.background = color;
+                        } else {
+                            ws.editor.foreground = color;
+                        }
+                        cx.notify();
+                    }))
+            }),
+        ))
         .child(slider(
             "col-r",
             "R",
@@ -147,17 +125,12 @@ pub(super) fn color_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> im
                         .child(format!("#{:02X}{:02X}{:02X}", fg[0], fg[1], fg[2])),
                 )
                 .child(
-                    div()
+                    Link::new("open-color-picker", "Picker\u{2026}")
                         .text_size(px(10.0))
                         .text_color(gpui::rgb(palette().text_dim))
-                        .hover(|s| s.text_color(gpui::rgb(palette().text)))
-                        .child("Picker\u{2026}")
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(|ws, _e, _w, cx| {
-                                ws.open_color_picker(ColorTarget::Foreground, cx)
-                            }),
-                        ),
+                        .on_click(cx.listener(|ws, _e, _w, cx| {
+                            ws.open_color_picker(ColorTarget::Foreground, cx)
+                        })),
                 ),
         )
         // Photoshop's spectrum bar: drag along it to take a hue directly.

--- a/crates/app/src/panels/history.rs
+++ b/crates/app/src/panels/history.rs
@@ -68,67 +68,38 @@ pub(super) fn history_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> 
                 // Photoshop's panel has this row too.
                 .child({
                     let is_current = n_undo == 0;
-                    div()
+                    ListItem::new("history-opened")
                         .px_1()
                         .h(px(19.0))
-                        .flex_none()
                         .text_size(px(11.0))
                         .rounded_sm()
-                        .cursor_pointer()
-                        .when_active(is_current)
-                        .hover(move |s| {
-                            if is_current {
-                                s
-                            } else {
-                                s.bg(gpui::rgb(palette().hover))
-                            }
-                        })
+                        .selected(is_current)
                         .text_color(gpui::rgb(palette().text_dim))
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(move |ws, _e, _w, cx| ws.history_jump(-n_undo, cx)),
-                        )
+                        .on_click(cx.listener(move |ws, _e, _w, cx| ws.history_jump(-n_undo, cx)))
                         .child("Opened")
                 })
                 .children(undo_entries.into_iter().enumerate().map(|(i, name)| {
                     // Jump so entry i becomes the last applied edit.
                     let steps = (i as i32 + 1) - n_undo;
                     let is_current = i as i32 + 1 == n_undo;
-                    div()
+                    ListItem::new(("history-undo", i))
                         .px_1()
                         .h(px(19.0))
-                        .flex_none()
                         .text_size(px(11.0))
                         .rounded_sm()
-                        .cursor_pointer()
-                        .when_active(is_current)
-                        .hover(move |s| {
-                            if is_current {
-                                s
-                            } else {
-                                s.bg(gpui::rgb(palette().hover))
-                            }
-                        })
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(move |ws, _e, _w, cx| ws.history_jump(steps, cx)),
-                        )
+                        .selected(is_current)
+                        .on_click(cx.listener(move |ws, _e, _w, cx| ws.history_jump(steps, cx)))
                         .child(name)
                 }))
                 .children(redo_entries.into_iter().enumerate().map(|(j, name)| {
                     let steps = j as i32 + 1;
-                    div()
+                    ListItem::new(("history-redo", j))
                         .px_1()
                         .h(px(19.0))
-                        .flex_none()
                         .text_size(px(11.0))
                         .rounded_sm()
                         .text_color(gpui::rgb(palette().text_faint))
-                        .hover(|s| s.bg(gpui::rgb(palette().hover)))
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(move |ws, _e, _w, cx| ws.history_jump(steps, cx)),
-                        )
+                        .on_click(cx.listener(move |ws, _e, _w, cx| ws.history_jump(steps, cx)))
                         .child(name)
                 })),
         )

--- a/crates/app/src/panels/info.rs
+++ b/crates/app/src/panels/info.rs
@@ -34,31 +34,21 @@ pub(super) fn top_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> gpui
     };
     let tab_chip = |label: &'static str, which: SideTab, cx: &mut Context<Workspace>| {
         let on = tab == which;
-        div()
+        Button::new(label, label)
+            .ghost()
+            .h(px(22.0))
             .px_2()
-            .py(px(3.0))
-            .rounded_sm()
             .text_size(px(11.0))
-            .cursor_pointer()
-            .bg(gpui::rgb(if on {
-                palette().hover
-            } else {
-                palette().panel_bg
-            }))
+            .when(on, |b| b.bg(gpui::rgb(palette().hover)))
             .text_color(gpui::rgb(if on {
                 palette().text
             } else {
                 palette().text_dim
             }))
-            .hover(|s| s.bg(gpui::rgb(palette().hover)))
-            .on_mouse_down(
-                MouseButton::Left,
-                cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
-                    ws.side_tab = Some(which);
-                    cx.notify();
-                }),
-            )
-            .child(label)
+            .on_click(cx.listener(move |ws, _e, _w, cx| {
+                ws.side_tab = Some(which);
+                cx.notify();
+            }))
     };
     let tabs = div()
         .flex()

--- a/crates/app/src/panels/layers.rs
+++ b/crates/app/src/panels/layers.rs
@@ -217,60 +217,45 @@ pub(super) fn layers_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> i
                         .size_full(),
                     )
                     .child(
-                        // Visibility eye.
-                        div()
-                            .flex()
-                            .items_center()
-                            .justify_center()
-                            .size(px(20.0))
-                            .flex_none()
-                            .on_mouse_down(
-                                MouseButton::Left,
-                                cx.listener(move |ws, _e, _w, cx| {
-                                    if let Some(doc) = &mut ws.doc {
-                                        let mut edit = doc.begin_edit("Toggle Visibility");
-                                        edit.change_props(id, |l| l.visible = !l.visible);
-                                        edit.commit();
-                                    }
-                                    ws.after_change(cx);
-                                    cx.stop_propagation();
-                                }),
-                            )
-                            .child(icon(
-                                if row.visible { "eye" } else { "eye-off" },
-                                13.0,
-                                if row.visible {
-                                    palette().text
-                                } else {
-                                    palette().text_dim
-                                },
-                            )),
+                        // Visibility eye. It swallows its press so the
+                        // row beneath neither selects nor starts a drag.
+                        IconButton::new(
+                            ("layer-eye", id.0),
+                            if row.visible { "eye" } else { "eye-off" },
+                        )
+                        .size(20.0)
+                        .icon_size(13.0)
+                        .color(if row.visible {
+                            palette().text
+                        } else {
+                            palette().text_dim
+                        })
+                        .consume_press()
+                        .on_click(cx.listener(move |ws, _e, _w, cx| {
+                            if let Some(doc) = &mut ws.doc {
+                                let mut edit = doc.begin_edit("Toggle Visibility");
+                                edit.change_props(id, |l| l.visible = !l.visible);
+                                edit.commit();
+                            }
+                            ws.after_change(cx);
+                        })),
                     )
                     .child(div().w(px(row.depth as f32 * 12.0)).flex_none())
                     .child(match &row.kind {
-                        RowKind::Group => div()
-                            .flex()
-                            .items_center()
-                            .justify_center()
-                            .size(px(16.0))
-                            .flex_none()
-                            .on_mouse_down(
-                                MouseButton::Left,
-                                cx.listener(move |ws, _e, _w, cx| {
-                                    ws.toggle_group_open(id, cx);
-                                    cx.stop_propagation();
-                                }),
-                            )
-                            .child(icon(
-                                if row.open {
-                                    "chevron-down"
-                                } else {
-                                    "chevron-right"
-                                },
-                                11.0,
-                                palette().text_dim,
-                            ))
-                            .into_any_element(),
+                        RowKind::Group => IconButton::new(
+                            ("layer-fold", id.0),
+                            if row.open {
+                                "chevron-down"
+                            } else {
+                                "chevron-right"
+                            },
+                        )
+                        .size(16.0)
+                        .icon_size(11.0)
+                        .color(palette().text_dim)
+                        .consume_press()
+                        .on_click(cx.listener(move |ws, _e, _w, cx| ws.toggle_group_open(id, cx)))
+                        .into_any_element(),
                         _ => div().w(px(0.0)).into_any_element(),
                     })
                     .child(
@@ -284,12 +269,10 @@ pub(super) fn layers_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -> i
                             .flex_none()
                             .bg(gpui::rgb(palette().field_bg))
                             .rounded_sm()
+                            .id(("layer-thumb", id.0))
                             // Adjustment layers open their settings
                             // from the thumbnail, like Photoshop.
-                            .on_mouse_down(
-                                MouseButton::Left,
-                                cx.listener(move |ws, _e, _w, cx| ws.edit_adjustment(id, cx)),
-                            )
+                            .on_click(cx.listener(move |ws, _e, _w, cx| ws.edit_adjustment(id, cx)))
                             .child(match (&row.kind, thumb) {
                                 (RowKind::Raster, Some(t)) => {
                                     img(t).max_w(px(36.0)).max_h(px(28.0)).into_any_element()

--- a/crates/app/src/panels/menu_bar.rs
+++ b/crates/app/src/panels/menu_bar.rs
@@ -319,21 +319,13 @@ pub(super) fn menu_row_checked(
     label: String,
     hint: String,
     checked: Option<bool>,
-    on_click: impl Fn(&mut Workspace, &MouseDownEvent, &mut Window, &mut Context<Workspace>) + 'static,
+    on_click: impl Fn(&mut Workspace, &gpui::ClickEvent, &mut Window, &mut Context<Workspace>) + 'static,
     cx: &mut Context<Workspace>,
 ) -> impl IntoElement {
-    div()
-        .flex()
-        .flex_row()
-        .items_center()
+    ListItem::new(SharedString::from(label.clone()))
         .justify_between()
-        .px_2()
-        .h(px(24.0))
-        .hover(|s| {
-            s.bg(gpui::rgb(palette().accent))
-                .text_color(gpui::rgb(palette().accent_text))
-        })
-        .on_mouse_down(MouseButton::Left, cx.listener(on_click))
+        .accent_hover()
+        .on_click(cx.listener(on_click))
         .child(
             div()
                 .flex()
@@ -362,22 +354,13 @@ pub(super) fn menu_row_checked(
 pub(super) fn menu_row(
     label: String,
     hint: String,
-    on_click: impl Fn(&mut Workspace, &MouseDownEvent, &mut Window, &mut Context<Workspace>) + 'static,
+    on_click: impl Fn(&mut Workspace, &gpui::ClickEvent, &mut Window, &mut Context<Workspace>) + 'static,
     cx: &mut Context<Workspace>,
 ) -> impl IntoElement {
-    div()
-        .flex()
-        .flex_row()
-        .items_center()
+    ListItem::new(SharedString::from(label.clone()))
         .justify_between()
-        .px_2()
-        .h(px(24.0))
-        .cursor_pointer()
-        .hover(|s| {
-            s.bg(gpui::rgb(palette().accent))
-                .text_color(gpui::rgb(palette().accent_text))
-        })
-        .on_mouse_down(MouseButton::Left, cx.listener(on_click))
+        .accent_hover()
+        .on_click(cx.listener(on_click))
         .child(div().text_size(px(12.0)).child(label))
         .child(
             div()

--- a/crates/app/src/panels/mod.rs
+++ b/crates/app/src/panels/mod.rs
@@ -12,12 +12,13 @@ use crate::ui::palette;
 use crate::workspace::{ColorTarget, ContextTarget, LayerDrop, Modal, NoteField, Popup, Workspace};
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
-    canvas, deferred, div, img, px, svg, Context, InteractiveElement as _, IntoElement,
-    MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement as _, RenderImage,
-    SharedString, StatefulInteractiveElement as _, Styled, Window,
+    canvas, deferred, div, img, px, Context, InteractiveElement as _, IntoElement, MouseButton,
+    MouseDownEvent, MouseMoveEvent, MouseUpEvent, ParentElement as _, RenderImage, SharedString,
+    StatefulInteractiveElement as _, Styled, Window,
 };
 use schist_color::Rgba;
 use schist_core::{BlendMode, Layer, LayerId, LayerKind};
+use schist_ui::{Button, ButtonColors, IconButton, Link, ListItem, Swatch, Tab};
 use std::sync::Arc;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -69,12 +70,7 @@ fn swatch_hex(c: Rgba) -> gpui::Rgba {
     gpui::rgb(((r as u32) << 16) | ((g as u32) << 8) | b as u32)
 }
 
-pub fn icon(name: &str, size: f32, color: u32) -> impl IntoElement {
-    svg()
-        .path(format!("icons/{name}.svg"))
-        .size(px(size))
-        .text_color(gpui::rgb(color))
-}
+pub use schist_ui::icon;
 
 trait ActiveExt: Styled + Sized {
     fn when_active(self, active: bool) -> Self {
@@ -155,17 +151,6 @@ fn icon_button(
     command: &'static str,
     cx: &mut Context<Workspace>,
 ) -> impl IntoElement {
-    div()
-        .flex()
-        .items_center()
-        .justify_center()
-        .size(px(22.0))
-        .rounded_sm()
-        .cursor_pointer()
-        .hover(|s| s.bg(gpui::rgb(palette().hover)))
-        .on_mouse_down(
-            MouseButton::Left,
-            cx.listener(move |ws, _e, _w, cx| ws.run_command(command, cx)),
-        )
-        .child(icon(icon_name, 14.0, palette().text))
+    IconButton::new(icon_name, icon_name)
+        .on_click(cx.listener(move |ws, _e, _w, cx| ws.run_command(command, cx)))
 }

--- a/crates/app/src/panels/notes.rs
+++ b/crates/app/src/panels/notes.rs
@@ -53,15 +53,9 @@ pub(super) fn note_options(ws: &Workspace, cx: &mut Context<Workspace>) -> impl 
                 .child(author),
         )
         .child(
-            div()
-                .size(px(18.0))
-                .rounded_sm()
-                .bg(swatch_hex(ws.editor.note_color))
-                .border_1()
+            Swatch::new("note-color", swatch_hex(ws.editor.note_color))
                 .border_color(gpui::rgb(palette().text_faint))
-                .cursor_pointer()
-                .on_mouse_down(
-                    MouseButton::Left,
+                .on_click(
                     cx.listener(|ws, _e, _w, cx| ws.open_color_picker(ColorTarget::Note, cx)),
                 ),
         )
@@ -81,28 +75,13 @@ pub(super) fn note_button(
     on_click: impl Fn(&mut Workspace, &mut Context<Workspace>) + 'static,
     cx: &mut Context<Workspace>,
 ) -> impl IntoElement {
-    let colour = if enabled {
-        palette().text
-    } else {
-        palette().text_faint
-    };
-    div()
-        .id(id)
-        .flex()
-        .items_center()
-        .justify_center()
+    Button::bare(id)
+        .ghost()
+        .disabled(!enabled)
         .size(px(20.0))
-        .rounded_sm()
+        .px_0()
         .text_size(px(13.0))
-        .text_color(gpui::rgb(colour))
-        .when(enabled, |d| {
-            d.cursor_pointer()
-                .hover(|s| s.bg(gpui::rgb(palette().hover)))
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |ws, _e, _w, cx| on_click(ws, cx)),
-                )
-        })
+        .on_click(cx.listener(move |ws, _e, _w, cx| on_click(ws, cx)))
         .child(label)
 }
 
@@ -175,30 +154,11 @@ pub(super) fn notes_panel(ws: &Workspace, cx: &mut Context<Workspace>) -> Option
                     cx,
                 ))
                 .child(
-                    div()
-                        .id("note-delete")
-                        .flex()
-                        .items_center()
-                        .justify_center()
-                        .size(px(20.0))
-                        .rounded_sm()
-                        .when(count > 0, |d| {
-                            d.cursor_pointer()
-                                .hover(|s| s.bg(gpui::rgb(palette().hover)))
-                                .on_mouse_down(
-                                    MouseButton::Left,
-                                    cx.listener(move |ws, _e, _w, cx| ws.delete_note(index, cx)),
-                                )
-                        })
-                        .child(icon(
-                            "trash",
-                            13.0,
-                            if count > 0 {
-                                palette().text
-                            } else {
-                                palette().text_faint
-                            },
-                        )),
+                    IconButton::new("note-delete", "trash")
+                        .size(20.0)
+                        .icon_size(13.0)
+                        .disabled(count == 0)
+                        .on_click(cx.listener(move |ws, _e, _w, cx| ws.delete_note(index, cx))),
                 ),
         );
 

--- a/crates/app/src/panels/tabs.rs
+++ b/crates/app/src/panels/tabs.rs
@@ -25,59 +25,12 @@ pub fn tab_bar(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElem
             } else {
                 title
             };
-            let mut tab = div()
-                .flex()
-                .flex_row()
-                .items_center()
-                .gap_1()
-                .h(px(25.0))
-                .pl_2()
-                .pr_1()
-                .max_w(px(180.0))
-                .border_r_1()
-                .border_color(gpui::rgb(palette().panel_edge))
-                .text_size(px(11.0));
-            tab = if is_active {
-                tab.bg(gpui::rgb(palette().control_bg))
-                    .text_color(gpui::rgb(palette().text))
-            } else {
-                tab.bg(gpui::rgb(palette().panel_bg))
-                    .text_color(gpui::rgb(palette().text_dim))
-                    .hover(|s| s.bg(gpui::rgb(palette().hover)))
-            };
-            tab.on_mouse_down(
-                MouseButton::Left,
-                cx.listener(move |ws, _e, _w, cx| ws.select_tab(i, cx)),
-            )
-            .on_mouse_down(
-                MouseButton::Middle,
-                cx.listener(move |ws, _e, _w, cx| ws.request_close_tab(i, cx)),
-            )
-            .child(
-                div()
-                    .overflow_hidden()
-                    .whitespace_nowrap()
-                    .text_ellipsis()
-                    .child(label),
-            )
-            .child(
-                div()
-                    .flex()
-                    .flex_none()
-                    .items_center()
-                    .justify_center()
-                    .size(px(16.0))
-                    .rounded_sm()
-                    .hover(|s| s.bg(gpui::rgb(palette().button_hover)))
-                    .on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(move |ws, _e, _w, cx| {
-                            cx.stop_propagation();
-                            ws.request_close_tab(i, cx);
-                        }),
-                    )
-                    .child(icon("close", 9.0, palette().text_dim)),
-            )
+            let select = cx.entity();
+            let close = cx.entity();
+            Tab::new(("doc-tab", i), label)
+                .active(is_active)
+                .on_select(move |_w, cx| select.update(cx, |ws, cx| ws.select_tab(i, cx)))
+                .on_close(move |_w, cx| close.update(cx, |ws, cx| ws.request_close_tab(i, cx)))
         }))
 }
 

--- a/crates/app/src/panels/toolbar.rs
+++ b/crates/app/src/panels/toolbar.rs
@@ -319,28 +319,13 @@ pub fn tool_flyout(ws: &mut Workspace, cx: &mut Context<Workspace>) -> Option<gp
                 .unwrap_or((id, "move"));
             let selected = id == active;
             let shortcut = shortcut.clone();
-            div()
-                .flex()
-                .flex_row()
-                .items_center()
+            ListItem::new(id)
                 .gap_2()
-                .px_2()
-                .h(px(24.0))
-                .when_active(selected)
-                .hover(move |s| {
-                    if selected {
-                        s
-                    } else {
-                        s.bg(gpui::rgb(palette().hover))
-                    }
-                })
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |ws, _e, _w, cx| {
-                        ws.close_tool_flyout(cx);
-                        ws.activate_tool(id, cx);
-                    }),
-                )
+                .selected(selected)
+                .on_click(cx.listener(move |ws, _e, _w, cx| {
+                    ws.close_tool_flyout(cx);
+                    ws.activate_tool(id, cx);
+                }))
                 .child(icon(icon_name, 14.0, palette().text))
                 .child(div().flex_grow().text_size(px(12.0)).child(name))
                 .child(

--- a/crates/app/src/panels/typography.rs
+++ b/crates/app/src/panels/typography.rs
@@ -29,34 +29,18 @@ fn separator() -> gpui::Div {
         .bg(gpui::rgb(palette().divider))
 }
 
-fn compact_button(
-    id: &'static str,
-    label: &'static str,
-    active: bool,
-) -> gpui::Stateful<gpui::Div> {
-    div()
-        .id(id)
-        .flex()
-        .items_center()
-        .justify_center()
-        .h(px(24.0))
+fn compact_button(id: &'static str, label: &'static str, active: bool) -> Button {
+    let p = palette();
+    Button::bare(id)
+        .colors(ButtonColors {
+            bg: Some(if active { p.control_bg } else { p.panel_bg }),
+            hover: p.hover,
+            text: p.text,
+            border: Some(if active { p.edge } else { p.panel_bg }),
+        })
+        .tooltip(label, None)
         .min_w(px(26.0))
-        .flex_none()
-        .rounded_sm()
-        .border_1()
-        .border_color(gpui::rgb(if active {
-            palette().edge
-        } else {
-            palette().panel_bg
-        }))
-        .bg(gpui::rgb(if active {
-            palette().control_bg
-        } else {
-            palette().panel_bg
-        }))
-        .cursor_pointer()
-        .hover(|style| style.bg(gpui::rgb(palette().hover)))
-        .tooltip(ui::tip(label, None))
+        .px_0()
 }
 
 fn choice(
@@ -197,13 +181,10 @@ fn align_buttons(current: usize, panel: bool, cx: &mut Context<Workspace>) -> gp
                 label,
                 current == i,
             )
-            .on_mouse_down(
-                MouseButton::Left,
-                cx.listener(move |ws, _e, _w, cx| {
-                    ws.commit_focused_field();
-                    ws.set_tool_option("type-align", OptionValue::Choice(i), cx);
-                }),
-            )
+            .on_click(cx.listener(move |ws, _e, _w, cx| {
+                ws.commit_focused_field();
+                ws.set_tool_option("type-align", OptionValue::Choice(i), cx);
+            }))
             .child(icon(name, 16.0, palette().text))
         }),
     )
@@ -229,9 +210,11 @@ pub(super) fn type_options_bar(
         .border_b_1()
         .border_color(gpui::rgb(palette().panel_edge))
         .child(
-            compact_button("type-tool-indicator", "Type tool (T)", false)
-                .cursor_default()
-                .child(icon("type", 17.0, palette().text)),
+            compact_button("type-tool-indicator", "Type tool (T)", false).child(icon(
+                "type",
+                17.0,
+                palette().text,
+            )),
         )
         .child(separator())
         .child(choice(
@@ -264,13 +247,10 @@ pub(super) fn type_options_bar(
         .child(separator())
         .child(
             compact_button("type-color", "Text color", false)
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(|ws, _e, _w, cx| {
-                        ws.commit_focused_field();
-                        ws.open_color_picker(ColorTarget::Foreground, cx);
-                    }),
-                )
+                .on_click(cx.listener(|ws, _e, _w, cx| {
+                    ws.commit_focused_field();
+                    ws.open_color_picker(ColorTarget::Foreground, cx);
+                }))
                 .child(
                     div()
                         .w(px(22.0))
@@ -288,49 +268,40 @@ pub(super) fn type_options_bar(
                 "Character panel",
                 ws.side_tab.unwrap_or(SideTab::Character) == SideTab::Character,
             )
-            .on_mouse_down(
-                MouseButton::Left,
-                cx.listener(|ws, _e, _w, cx| {
-                    ws.commit_focused_field();
-                    ws.side_tab = Some(
-                        if ws.side_tab.unwrap_or(SideTab::Character) == SideTab::Character {
-                            SideTab::Color
-                        } else {
-                            SideTab::Character
-                        },
-                    );
-                    cx.notify();
-                }),
-            )
+            .on_click(cx.listener(|ws, _e, _w, cx| {
+                ws.commit_focused_field();
+                ws.side_tab = Some(
+                    if ws.side_tab.unwrap_or(SideTab::Character) == SideTab::Character {
+                        SideTab::Color
+                    } else {
+                        SideTab::Character
+                    },
+                );
+                cx.notify();
+            }))
             .child(icon("character", 16.0, palette().text)),
         )
         .child(separator())
         .child(
             compact_button("type-cancel", "Cancel text edit", false)
-                .when(!editing, |d| d.opacity(0.3).cursor_default())
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |ws, _e, _w, cx| {
-                        if editing {
-                            ws.commit_focused_field();
-                            ws.cancel_gesture(cx);
-                        }
-                    }),
-                )
+                .disabled(!editing)
+                .on_click(cx.listener(move |ws, _e, _w, cx| {
+                    if editing {
+                        ws.commit_focused_field();
+                        ws.cancel_gesture(cx);
+                    }
+                }))
                 .child(icon("close", 16.0, palette().text)),
         )
         .child(
             compact_button("type-commit", "Commit text edit", false)
-                .when(!editing, |d| d.opacity(0.3).cursor_default())
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |ws, _e, _w, cx| {
-                        if editing {
-                            ws.commit_focused_field();
-                            ws.commit_gesture(cx);
-                        }
-                    }),
-                )
+                .disabled(!editing)
+                .on_click(cx.listener(move |ws, _e, _w, cx| {
+                    if editing {
+                        ws.commit_focused_field();
+                        ws.commit_gesture(cx);
+                    }
+                }))
                 .child(icon("check", 17.0, palette().text)),
         )
         .into_any_element()
@@ -445,13 +416,10 @@ pub(super) fn character_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -
                         .h(px(28.0))
                         .text_size(px(14.0))
                         .when(on, |d| d.border_color(gpui::rgb(palette().accent)))
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(move |ws, _e, _w, cx| {
-                                ws.commit_focused_field();
-                                ws.set_tool_option(key, OptionValue::Bool(!on), cx);
-                            }),
-                        )
+                        .on_click(cx.listener(move |ws, _e, _w, cx| {
+                            ws.commit_focused_field();
+                            ws.set_tool_option(key, OptionValue::Bool(!on), cx);
+                        }))
                         .child(glyph)
                 }),
             ),
@@ -477,13 +445,10 @@ pub(super) fn character_panel(ws: &mut Workspace, cx: &mut Context<Workspace>) -
                         )
                         .w(px(120.0))
                         .text_size(px(11.0))
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(move |ws, _e, _w, cx| {
-                                ws.commit_focused_field();
-                                ws.set_tool_option("type-path", OptionValue::Bool(on), cx);
-                            }),
-                        )
+                        .on_click(cx.listener(move |ws, _e, _w, cx| {
+                            ws.commit_focused_field();
+                            ws.set_tool_option("type-path", OptionValue::Bool(on), cx);
+                        }))
                         .child(label)
                     }),
             ),

--- a/crates/app/src/style_dialog.rs
+++ b/crates/app/src/style_dialog.rs
@@ -10,13 +10,14 @@ use crate::dialogs::{param_slider, SliderSpec};
 use crate::ui;
 use crate::workspace::{ColorTarget, Modal, Popup, Workspace};
 use gpui::{
-    div, px, Context, InteractiveElement as _, IntoElement, MouseButton, MouseDownEvent,
-    ParentElement as _, SharedString, StatefulInteractiveElement as _, Styled,
+    div, px, Context, InteractiveElement as _, IntoElement, ParentElement as _, SharedString,
+    StatefulInteractiveElement as _, Styled,
 };
 use schist_color::Rgba;
 use schist_core::{
     BevelStyle_, BlendMode, GradientShape, LayerId, LayerStyle, StrokePosition, Technique,
 };
+use schist_ui::{Checkbox, ListItem, Swatch};
 
 /// The effects, in the order Photoshop lists them.
 pub const EFFECTS: &[(&str, &str)] = &[
@@ -318,22 +319,9 @@ fn color_swatch(
     c: Rgba,
     cx: &mut Context<Workspace>,
 ) -> impl IntoElement {
-    div()
-        .id(id)
-        .size(px(18.0))
-        .flex_none()
-        .rounded_sm()
-        .border_1()
-        .border_color(gpui::rgb(ui::palette().edge))
-        .bg(gpui::rgb(rgb_of(c)))
-        .cursor_pointer()
-        .hover(|s| s.border_color(gpui::rgb(ui::palette().text)))
-        .on_mouse_down(
-            MouseButton::Left,
-            cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
-                ws.open_color_picker_on(ColorTarget::StyleEffect(key), c, cx);
-            }),
-        )
+    Swatch::new(id, gpui::rgb(rgb_of(c))).on_click(cx.listener(move |ws, _e, _w, cx| {
+        ws.open_color_picker_on(ColorTarget::StyleEffect(key), c, cx);
+    }))
 }
 
 fn blend_of(style: &LayerStyle, effect: &str) -> Option<BlendMode> {
@@ -397,36 +385,25 @@ pub fn render(
             let key = *key;
             let on = enabled(&style, key);
             let selected = key == active;
-            div()
-                .flex()
-                .flex_row()
-                .items_center()
+            ListItem::new(key)
                 .gap_2()
-                .px_2()
                 .h(px(22.0))
                 .rounded_sm()
-                .text_size(px(12.0))
                 .when_selected(selected)
-                .child(ui::checkbox(
-                    "",
-                    on,
-                    move |ws, cx| {
+                .child(
+                    Checkbox::new(key, "", on).on_change(cx.listener(move |ws, _on, _w, cx| {
                         edit(ws, cx, |s| set_enabled(s, key, !on));
-                    },
-                    cx,
-                ))
-                .child(div().flex_grow().child(SharedString::from(*label)))
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
-                        ws.update_modal(|m| {
-                            if let Modal::LayerStyle { active, .. } = m {
-                                *active = key;
-                            }
-                        });
-                        cx.notify();
-                    }),
+                    })),
                 )
+                .child(div().flex_grow().child(SharedString::from(*label)))
+                .on_click(cx.listener(move |ws, _e, _w, cx| {
+                    ws.update_modal(|m| {
+                        if let Modal::LayerStyle { active, .. } = m {
+                            *active = key;
+                        }
+                    });
+                    cx.notify();
+                }))
         }));
 
     let mut settings = div().flex().flex_col().gap_1().flex_grow();

--- a/crates/app/src/ui.rs
+++ b/crates/app/src/ui.rs
@@ -7,127 +7,15 @@
 
 use crate::workspace::{Popup, Workspace};
 use gpui::{
-    div, px, AppContext as _, Context, InteractiveElement as _, IntoElement, MouseButton,
-    ParentElement as _, SharedString, StatefulInteractiveElement as _, Styled as _,
+    div, px, Context, InteractiveElement as _, IntoElement, MouseButton, ParentElement as _,
+    SharedString, StatefulInteractiveElement as _, Styled as _,
 };
+use schist_ui::{Button, Checkbox, IconButton, ListItem};
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-/// The chrome colours for one theme. Everything that isn't document
-/// content draws from here; the active set is swapped by [`set_light`].
-pub struct Palette {
-    /// The window shell behind the panels.
-    pub window_bg: u32,
-    /// The area surrounding the document canvas.
-    pub canvas_bg: u32,
-    pub panel_bg: u32,
-    /// Recessed strips: the document tab bar, the curve editor well.
-    pub deep_bg: u32,
-    pub status_bg: u32,
-    pub ruler_bg: u32,
-    pub field_bg: u32,
-    pub popup_bg: u32,
-    /// Small inline controls: step buttons, the active tab, badges.
-    pub control_bg: u32,
-    pub button_bg: u32,
-    pub button_hover: u32,
-    /// Row hover inside menus, popups and panels.
-    pub hover: u32,
-    /// Hairlines inside a panel (separators, section borders).
-    pub divider: u32,
-    /// Borders around fields, popups and modals.
-    pub edge: u32,
-    /// The border between panels and the shell.
-    pub panel_edge: u32,
-    /// Grid lines drawn on `deep_bg` (curve editor).
-    pub grid: u32,
-    pub text: u32,
-    pub text_dim: u32,
-    pub text_faint: u32,
-    pub accent: u32,
-    pub accent_hover: u32,
-    /// Text and icons drawn on top of `accent`.
-    pub accent_text: u32,
-    /// Selected rows that keep their own text colour (lists, tiles).
-    pub selection_bg: u32,
-}
+pub use schist_ui::{is_light, palette, set_light, tip};
 
-pub const DARK: Palette = Palette {
-    window_bg: 0x1E1E1E,
-    canvas_bg: 0x262626,
-    panel_bg: 0x1A1A1A,
-    deep_bg: 0x141414,
-    status_bg: 0x161616,
-    ruler_bg: 0x202020,
-    field_bg: 0x0E0E0E,
-    popup_bg: 0x242424,
-    control_bg: 0x2A2A2A,
-    button_bg: 0x333333,
-    button_hover: 0x3E3E3E,
-    hover: 0x2E2E2E,
-    divider: 0x2A2A2A,
-    edge: 0x3A3A3A,
-    panel_edge: 0x111111,
-    grid: 0x262626,
-    text: 0xD8D8D8,
-    text_dim: 0x9A9A9A,
-    text_faint: 0x666666,
-    accent: 0x3A6EA5,
-    accent_hover: 0x4A80BC,
-    accent_text: 0xFFFFFF,
-    selection_bg: 0x2F5B8C,
-};
-
-pub const LIGHT: Palette = Palette {
-    window_bg: 0xE8E8E8,
-    canvas_bg: 0xB4B4B4,
-    panel_bg: 0xF0F0F0,
-    deep_bg: 0xE0E0E0,
-    status_bg: 0xE4E4E4,
-    ruler_bg: 0xE6E6E6,
-    field_bg: 0xFFFFFF,
-    popup_bg: 0xFAFAFA,
-    control_bg: 0xD6D6D6,
-    button_bg: 0xD0D0D0,
-    button_hover: 0xC2C2C2,
-    hover: 0xDCDCDC,
-    divider: 0xD4D4D4,
-    edge: 0xB8B8B8,
-    panel_edge: 0xC4C4C4,
-    grid: 0xC8C8C8,
-    text: 0x1C1C1C,
-    text_dim: 0x5A5A5A,
-    text_faint: 0x9E9E9E,
-    accent: 0x3A6EA5,
-    accent_hover: 0x2E5E95,
-    accent_text: 0xFFFFFF,
-    selection_bg: 0xB8D2EE,
-};
-
-static LIGHT_THEME: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
-/// Select the palette that [`palette`] returns. `Workspace::render` calls
-/// this every frame from the persisted preference, so widgets built during
-/// that render (and canvas paint callbacks after it) all agree.
-pub fn set_light(light: bool) {
-    LIGHT_THEME.store(light, std::sync::atomic::Ordering::Relaxed);
-}
-
-pub fn palette() -> &'static Palette {
-    if is_light() {
-        &LIGHT
-    } else {
-        &DARK
-    }
-}
-
-/// Whether the light theme is active this frame, for chrome that keeps
-/// its own palette (the gallery) but still follows the theme choice.
-pub fn is_light() -> bool {
-    LIGHT_THEME.load(std::sync::atomic::Ordering::Relaxed)
-}
-
-/// A labelled push button.
 /// What a dialog does when the user presses Enter.
 pub type DialogAction = Rc<dyn Fn(&mut Workspace, &mut gpui::Window, &mut Context<Workspace>)>;
 
@@ -155,56 +43,7 @@ pub fn take_default_action() -> Option<DialogAction> {
     DEFAULT_ACTION.with(|slot| slot.borrow_mut().take())
 }
 
-/// A hover label for an icon-only control.
-///
-/// `grep -rn "tooltip" crates/app/` returned nothing: every icon in the
-/// window was a bare SVG with no hover label and no shortcut hint, and
-/// the only place a tool's name and key appeared was inside the flyout,
-/// which most slots do not have. The toolbar slots use this; the panel
-/// buttons, visibility eyes and tab close are still unlabelled, and want
-/// an `id` each before they can be.
-pub struct Tooltip {
-    label: SharedString,
-    /// A keyboard shortcut, shown dimmed after the label.
-    hint: Option<SharedString>,
-}
-
-impl gpui::Render for Tooltip {
-    fn render(&mut self, _window: &mut gpui::Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        let mut row = div()
-            .flex()
-            .flex_row()
-            .items_center()
-            .gap_2()
-            .px_2()
-            .py_1()
-            .rounded_sm()
-            .bg(gpui::rgb(palette().popup_bg))
-            .border_1()
-            .border_color(gpui::rgb(palette().panel_edge))
-            .text_size(px(11.0))
-            .text_color(gpui::rgb(palette().text))
-            .child(self.label.clone());
-        if let Some(hint) = self.hint.clone() {
-            row = row.child(div().text_color(gpui::rgb(palette().text_dim)).child(hint));
-        }
-        row
-    }
-}
-
-/// Build a tooltip callback for [`StatefulInteractiveElement::tooltip`].
-pub fn tip(
-    label: impl Into<SharedString>,
-    hint: Option<SharedString>,
-) -> impl Fn(&mut gpui::Window, &mut gpui::App) -> gpui::AnyView + 'static {
-    let label = label.into();
-    move |_window, cx| {
-        let label = label.clone();
-        let hint = hint.clone();
-        cx.new(|_| Tooltip { label, hint }).into()
-    }
-}
-
+/// A labelled push button, wired to the workspace.
 pub fn button(
     label: impl Into<SharedString>,
     primary: bool,
@@ -216,37 +55,10 @@ pub fn button(
         let action = on_click.clone();
         DEFAULT_ACTION.with(|slot| *slot.borrow_mut() = Some(action));
     }
-    div()
-        .flex()
-        .items_center()
-        .justify_center()
-        .h(px(24.0))
-        .px_3()
-        .rounded_sm()
-        .text_size(px(12.0))
-        .cursor_pointer()
-        .bg(gpui::rgb(if primary {
-            palette().accent
-        } else {
-            palette().button_bg
-        }))
-        .text_color(gpui::rgb(if primary {
-            palette().accent_text
-        } else {
-            palette().text
-        }))
-        .hover(|s| {
-            s.bg(gpui::rgb(if primary {
-                palette().accent_hover
-            } else {
-                palette().button_hover
-            }))
-        })
-        .on_mouse_down(
-            MouseButton::Left,
-            cx.listener(move |ws, _e, window, cx| on_click(ws, window, cx)),
-        )
-        .child(label.into())
+    let label = label.into();
+    Button::new(label.clone(), label)
+        .when(primary, Button::primary)
+        .on_click(cx.listener(move |ws, _e, window, cx| on_click(ws, window, cx)))
 }
 
 /// Everything a [`num_field`] needs to draw itself.
@@ -320,72 +132,46 @@ pub fn num_field(
                 )
                 .child(format!("{shown}{suffix}")),
         )
-        .child(step_button("minus", move |ws| dec(ws, -step), cx))
-        .child(step_button("plus", move |ws| inc(ws, step), cx))
+        .child(step_button(id, "minus", move |ws| dec(ws, -step), cx))
+        .child(step_button(id, "plus", move |ws| inc(ws, step), cx))
 }
 
 fn step_button(
+    field: &'static str,
     icon_name: &'static str,
     on_click: impl Fn(&mut Workspace) + 'static,
     cx: &mut Context<Workspace>,
 ) -> impl IntoElement {
-    div()
-        .flex()
-        .items_center()
-        .justify_center()
-        .size(px(18.0))
-        .rounded_sm()
-        .bg(gpui::rgb(palette().control_bg))
-        .hover(|s| s.bg(gpui::rgb(palette().button_hover)))
-        .on_mouse_down(
-            MouseButton::Left,
-            cx.listener(move |ws, _e, _w, cx| {
-                on_click(ws);
-                cx.notify();
-            }),
-        )
-        .child(crate::panels::icon(icon_name, 11.0, palette().text))
+    IconButton::new(
+        SharedString::from(format!("{field}-{icon_name}")),
+        icon_name,
+    )
+    .filled()
+    .size(18.0)
+    .icon_size(11.0)
+    .on_click(cx.listener(move |ws, _e, _w, cx| {
+        on_click(ws);
+        cx.notify();
+    }))
 }
 
-/// A checkbox with a label to its right.
+/// A checkbox with a label to its right, keyed by that label.
 pub fn checkbox(
     label: impl Into<SharedString>,
     checked: bool,
     on_toggle: impl Fn(&mut Workspace, &mut Context<Workspace>) + 'static,
     cx: &mut Context<Workspace>,
 ) -> impl IntoElement {
-    div()
-        .flex()
-        .flex_row()
-        .items_center()
-        .gap_2()
-        .text_size(px(12.0))
-        .on_mouse_down(
-            MouseButton::Left,
-            cx.listener(move |ws, _e, _w, cx| {
-                on_toggle(ws, cx);
-                cx.notify();
-            }),
-        )
-        .child(
-            div()
-                .flex()
-                .items_center()
-                .justify_center()
-                .size(px(14.0))
-                .rounded_sm()
-                .bg(gpui::rgb(if checked {
-                    palette().accent
-                } else {
-                    palette().field_bg
-                }))
-                .border_1()
-                .border_color(gpui::rgb(palette().edge))
-                .when_some(checked.then_some(()), |d, _| {
-                    d.child(crate::panels::icon("check", 10.0, palette().accent_text))
-                }),
-        )
-        .child(label.into())
+    let label = label.into();
+    Checkbox::new(
+        SharedString::from(format!("checkbox-{label}")),
+        label,
+        checked,
+    )
+    .on_change(cx.listener(move |ws, _checked, _w, cx| {
+        on_toggle(ws, cx);
+        cx.notify();
+    }))
 }
 
 /// State of the open dropdown's option list: its scroll, the row the
@@ -647,43 +433,19 @@ fn dropdown_impl<T: Clone + PartialEq + 'static>(
                 let selected = value == *current;
                 let keyed = highlight == Some(ix) && !selected;
                 let on_select = on_select.clone();
-                div()
-                    .px_2()
+                ListItem::new(("dropdown-row", ix))
                     .h(px(20.0))
-                    .flex_none()
-                    .flex()
-                    .items_center()
                     .text_size(px(11.0))
                     // Each family's name set in itself is what tells you
                     // what you are choosing; the label alone does not.
                     .when(preview_fonts, |d| d.font_family(text.clone()))
-                    .bg(gpui::rgb(if selected {
-                        palette().accent
-                    } else if keyed {
-                        palette().hover
-                    } else {
-                        palette().popup_bg
+                    .selected(selected)
+                    .highlighted(keyed)
+                    .on_click(cx.listener(move |ws, _e, _w, cx| {
+                        ws.close_popup(cx);
+                        on_select(ws, value.clone(), cx);
+                        cx.notify();
                     }))
-                    .text_color(gpui::rgb(if selected {
-                        palette().accent_text
-                    } else {
-                        palette().text
-                    }))
-                    .hover(move |s| {
-                        if selected {
-                            s
-                        } else {
-                            s.bg(gpui::rgb(palette().hover))
-                        }
-                    })
-                    .on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(move |ws, _e, _w, cx| {
-                            ws.close_popup(cx);
-                            on_select(ws, value.clone(), cx);
-                            cx.notify();
-                        }),
-                    )
                     .child(text)
                     .into_any_element()
             })

--- a/crates/app/src/workspace/library_people_view.rs
+++ b/crates/app/src/workspace/library_people_view.rs
@@ -9,6 +9,7 @@ use super::library_view::{bucket_field, gallery_button, pal};
 use super::*;
 use gpui::{img, StatefulInteractiveElement as _};
 use schist_gallery::FaceRect;
+use schist_ui::{Button, ButtonColors, Link};
 use std::path::Path;
 
 /// The colour of a face box by its state: named, picked, guessed, or
@@ -194,6 +195,7 @@ pub(super) fn people_rows(
     }
     let link = |label: &'static str, cx: &mut Context<Workspace>| {
         div()
+            .id(label)
             .px_2()
             .h(px(24.0))
             .flex()
@@ -202,10 +204,7 @@ pub(super) fn people_rows(
             .text_color(gpui::rgb(pal().header))
             .cursor_pointer()
             .hover(|s| s.bg(gpui::rgb(pal().sidebar_selected)))
-            .on_mouse_down(
-                MouseButton::Left,
-                cx.listener(|ws, _e: &MouseDownEvent, _w, cx| ws.open_people_models(cx)),
-            )
+            .on_click(cx.listener(|ws, _e, _w, cx| ws.open_people_models(cx)))
             .child(label)
             .into_any_element()
     };
@@ -652,9 +651,9 @@ fn people_panel(
                 .child("No faces found. Drag a box round one to add a person by hand."),
         );
     }
-    for face in faces {
+    for (index, face) in faces.iter().enumerate() {
         let picked = pick.is_some_and(|p| p.same_face(&face.rect));
-        col = col.child(face_row(ws, face, picked, cx));
+        col = col.child(face_row(ws, index, face, picked, cx));
     }
     // A box just drawn, not yet a face anyone knows.
     if let Some(rect) = pick.filter(|p| !faces.iter().any(|f| f.rect.same_face(p))) {
@@ -665,7 +664,7 @@ fn people_panel(
             suggestion: None,
             detected: false,
         };
-        col = col.child(face_row(ws, &fresh, true, cx));
+        col = col.child(face_row(ws, faces.len(), &fresh, true, cx));
     }
     col = col.child(
         div()
@@ -680,47 +679,44 @@ fn people_panel(
     col.into_any_element()
 }
 
-/// A small text button on the gallery palette.
+/// A small text button on the gallery palette. It swallows its press,
+/// so one inside a face row does not also pick the face; it fires on
+/// release. Its label is its id, so a row must not hold two alike.
 fn small_button(
     label: impl Into<SharedString>,
     primary: bool,
     on_click: impl Fn(&mut Workspace, &mut Context<Workspace>) + 'static,
     cx: &mut Context<Workspace>,
 ) -> impl IntoElement {
-    div()
-        .px_2()
-        .h(px(20.0))
-        .flex()
-        .items_center()
-        .rounded_sm()
-        .text_size(px(11.0))
-        .cursor_pointer()
-        .bg(gpui::rgb(if primary {
-            pal().green
-        } else {
-            pal().button_bg
-        }))
-        .text_color(gpui::rgb(if primary { 0xFFFFFF } else { pal().text }))
-        .hover(move |s| {
-            s.bg(gpui::rgb(if primary {
+    let label = label.into();
+    Button::new(label.clone(), label)
+        .colors(ButtonColors {
+            bg: Some(if primary {
+                pal().green
+            } else {
+                pal().button_bg
+            }),
+            hover: if primary {
                 pal().green_hover
             } else {
                 pal().button_hover
-            }))
+            },
+            text: if primary { 0xFFFFFF } else { pal().text },
+            border: None,
         })
-        .on_mouse_down(
-            MouseButton::Left,
-            cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
-                cx.stop_propagation();
-                on_click(ws, cx)
-            }),
-        )
-        .child(label.into())
+        .h(px(20.0))
+        .px_2()
+        .text_size(px(11.0))
+        .consume_press()
+        .on_click(cx.listener(move |ws, _e, _w, cx| on_click(ws, cx)))
 }
 
 /// One face in the panel: its crop, and its name, guess, or field.
+/// `index` is its place in the panel, which scopes its buttons' ids:
+/// every row has a Save and a Cancel.
 fn face_row(
     ws: &mut Workspace,
+    index: usize,
     face: &FaceView,
     picked: bool,
     cx: &mut Context<Workspace>,
@@ -735,6 +731,7 @@ fn face_row(
         .suggestion
         .and_then(|(i, _)| ws.library.people.get(i).map(|p| (i, p.name.clone())));
     let mut row = div()
+        .id(("face-row", index))
         .flex()
         .flex_col()
         .gap_1()
@@ -775,23 +772,22 @@ fn face_row(
             .collect();
         for (index, name) in completions {
             row = row.child(
-                div()
-                    .pl(px(56.0))
+                Button::new(("completion", index), name)
+                    .colors(ButtonColors {
+                        bg: None,
+                        hover: pal().button_hover,
+                        text: pal().header,
+                        border: None,
+                    })
                     .h(px(20.0))
-                    .flex()
-                    .items_center()
-                    .text_size(px(12.0))
-                    .text_color(gpui::rgb(pal().header))
-                    .cursor_pointer()
-                    .hover(|s| s.bg(gpui::rgb(pal().button_hover)))
-                    .on_mouse_down(
-                        MouseButton::Left,
-                        cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
-                            cx.stop_propagation();
-                            ws.viewer_name_as(rect, index, cx);
-                        }),
-                    )
-                    .child(SharedString::from(name)),
+                    .pl(px(56.0))
+                    .pr_0()
+                    .justify_start()
+                    .rounded_none()
+                    .consume_press()
+                    .on_click(cx.listener(move |ws, _e, _w, cx| {
+                        ws.viewer_name_as(rect, index, cx);
+                    })),
             );
         }
         let mut actions = div()
@@ -983,22 +979,8 @@ fn name_field(ws: &Workspace, cx: &mut Context<Workspace>) -> impl IntoElement {
         })
 }
 
-fn model_link(
-    id: &'static str,
-    label: &'static str,
-    url: &'static str,
-    cx: &mut Context<Workspace>,
-) -> impl IntoElement {
-    div()
-        .id(id)
-        .cursor_pointer()
-        .text_color(gpui::rgb(crate::ui::palette().accent))
-        .hover(|style| style.text_color(gpui::rgb(crate::ui::palette().accent_hover)))
-        .on_mouse_down(
-            MouseButton::Left,
-            cx.listener(move |_ws, _event, _window, cx| cx.open_url(url)),
-        )
-        .child(label)
+fn model_link(id: &'static str, label: &'static str, url: &'static str) -> Link {
+    Link::new(id, label).url(url)
 }
 
 /// The licences behind the People album, and the button that accepts
@@ -1042,14 +1024,12 @@ pub(crate) fn people_models_dialog(cx: &mut Context<Workspace>) -> impl IntoElem
                 "ultraface-source",
                 "UltraFace (ONNX Model Zoo)",
                 "https://github.com/onnx/models/tree/main/validated/vision/body_analysis/ultraface",
-                cx,
             ))
             .child("\u{b7}")
             .child(model_link(
                 "sface-source",
                 "SFace (OpenCV Zoo)",
                 "https://github.com/opencv/opencv_zoo/tree/main/models/face_recognition_sface",
-                cx,
             )),
     );
     body = body.child(

--- a/crates/app/src/workspace/library_view.rs
+++ b/crates/app/src/workspace/library_view.rs
@@ -14,6 +14,7 @@ use gpui::{
     img, prelude::FluentBuilder as _, AppContext as _, StatefulInteractiveElement as _,
     StyledImage as _,
 };
+use schist_ui::{Button, ButtonColors, Link, ListItem};
 
 /// The gallery's chrome colours for one theme.
 pub(super) struct GalleryPalette {
@@ -229,35 +230,27 @@ pub(super) fn gallery_button(
     on_click: impl Fn(&mut Workspace, &mut Window, &mut Context<Workspace>) + 'static,
     cx: &mut Context<Workspace>,
 ) -> impl IntoElement {
-    div()
-        .flex()
-        .items_center()
-        .justify_center()
-        .h(px(24.0))
-        .px_3()
+    // The kit's button on the gallery's own palette: it fires on
+    // release, like every other button in the app (issue #119).
+    let colors = if green {
+        ButtonColors {
+            bg: Some(pal().green),
+            hover: pal().green_hover,
+            text: 0xFFFFFF,
+            border: Some(pal().green),
+        }
+    } else {
+        ButtonColors {
+            bg: Some(pal().button_bg),
+            hover: pal().button_hover,
+            text: pal().text,
+            border: Some(pal().chrome_edge),
+        }
+    };
+    Button::new(label, label)
+        .colors(colors)
         .rounded_md()
-        .text_size(px(12.0))
-        .cursor_pointer()
-        .bg(gpui::rgb(if green { pal().green } else { pal().button_bg }))
-        .text_color(gpui::rgb(if green { 0xFFFFFF } else { pal().text }))
-        .border_1()
-        .border_color(gpui::rgb(if green {
-            pal().green
-        } else {
-            pal().chrome_edge
-        }))
-        .hover(move |s| {
-            s.bg(gpui::rgb(if green {
-                pal().green_hover
-            } else {
-                pal().button_hover
-            }))
-        })
-        .on_mouse_down(
-            MouseButton::Left,
-            cx.listener(move |ws, _e: &MouseDownEvent, window, cx| on_click(ws, window, cx)),
-        )
-        .child(label)
+        .on_click(cx.listener(move |ws, _e, window, cx| on_click(ws, window, cx)))
 }
 
 /// The strip under the menu bar: import and folder buttons on the left,
@@ -304,35 +297,31 @@ fn top_strip(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElemen
             // While the map filter is on it wears the least
             // ignorable thing in the strip — a filter you forgot is a
             // gallery that looks mysteriously empty.
-            div()
-                .flex()
-                .flex_row()
-                .items_center()
-                .gap_1()
-                .h(px(24.0))
+            Button::bare("map-filter-chip")
+                .colors(ButtonColors {
+                    bg: Some(pal().select_border),
+                    hover: pal().select_border,
+                    text: 0xFFFFFF,
+                    border: None,
+                })
                 .px_2()
                 .rounded_md()
-                .bg(gpui::rgb(pal().select_border))
-                .text_color(gpui::rgb(0xFFFFFF))
-                .text_size(px(12.0))
-                .cursor_pointer()
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(|ws, _e: &MouseDownEvent, _w, cx| ws.open_map_filter(cx)),
-                )
+                .on_click(cx.listener(|ws, _e, _w, cx| ws.open_map_filter(cx)))
                 .child(format!("Map filter: {label}"))
                 .child(
-                    div()
+                    // The × swallows its press so it does not also
+                    // open the filter it is clearing.
+                    Button::new("map-filter-clear", "\u{2715}")
+                        .colors(ButtonColors {
+                            bg: None,
+                            hover: 0xFFFFFF30,
+                            text: 0xFFFFFF,
+                            border: None,
+                        })
+                        .h_auto()
                         .px_1()
-                        .hover(|s| s.bg(gpui::rgb(0xFFFFFF30)).rounded_sm())
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(|ws, _e: &MouseDownEvent, _w, cx| {
-                                cx.stop_propagation();
-                                ws.clear_map_filter(cx);
-                            }),
-                        )
-                        .child("\u{2715}"),
+                        .consume_press()
+                        .on_click(cx.listener(|ws, _e, _w, cx| ws.clear_map_filter(cx))),
                 )
         }))
         .child(search_slot(ws, cx))
@@ -557,18 +546,21 @@ fn search_box(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoEleme
             },
         ))
         .children((!text.is_empty()).then(|| {
-            div()
+            // Swallows its press, so clearing does not also focus the
+            // box it just emptied.
+            Button::new("search-clear", "\u{2715}")
+                .colors(ButtonColors {
+                    bg: None,
+                    hover: pal().button_hover,
+                    text: pal().text_dim,
+                    border: None,
+                })
+                .h_auto()
                 .px_1()
-                .text_color(gpui::rgb(pal().text_dim))
-                .hover(|s| s.text_color(gpui::rgb(pal().text)))
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(|ws, _e: &MouseDownEvent, _w, cx| {
-                        cx.stop_propagation();
-                        ws.gallery_search_clear(cx);
-                    }),
-                )
-                .child("\u{2715}")
+                .consume_press()
+                .on_click(cx.listener(|ws, _e, _w, cx| {
+                    ws.gallery_search_clear(cx);
+                }))
         }))
 }
 
@@ -657,6 +649,9 @@ fn gallery_empty_state(cx: &mut Context<Workspace>) -> impl IntoElement {
             "The gallery is always Ctrl+Shift+G away, whatever you are editing."
         }));
     div()
+        // Its own id scope: the buttons here share labels (and so
+        // element ids) with the top strip's.
+        .id("gallery-empty-state")
         .flex()
         .flex_col()
         .flex_grow()
@@ -753,76 +748,68 @@ fn sidebar(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElement 
         .child({
             let current = ws.library.group_by;
             let mut row = div().flex().flex_row().gap_1().px_2().pb_2();
-            for group in super::library::GroupBy::ALL {
+            for (i, group) in super::library::GroupBy::ALL.into_iter().enumerate() {
                 let active = group == current;
                 row = row.child(
-                    div()
-                        .px_2()
+                    Button::new(("group-by", i), group.label())
+                        .colors(ButtonColors {
+                            bg: Some(if active {
+                                pal().sidebar_selected
+                            } else {
+                                pal().button_bg
+                            }),
+                            hover: if active {
+                                pal().sidebar_selected
+                            } else {
+                                pal().button_hover
+                            },
+                            text: pal().text,
+                            border: None,
+                        })
                         .h(px(20.0))
-                        .flex()
-                        .items_center()
+                        .px_2()
                         .rounded_md()
                         .text_size(px(11.0))
-                        .cursor_pointer()
-                        .bg(gpui::rgb(if active {
-                            pal().sidebar_selected
-                        } else {
-                            pal().button_bg
-                        }))
-                        .hover(move |s| {
-                            if active {
-                                s
-                            } else {
-                                s.bg(gpui::rgb(pal().button_hover))
-                            }
-                        })
-                        .on_mouse_down(
-                            MouseButton::Left,
-                            cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
-                                ws.set_gallery_group(group, cx);
-                            }),
-                        )
-                        .child(group.label()),
+                        .on_click(cx.listener(move |ws, _e, _w, cx| {
+                            ws.set_gallery_group(group, cx);
+                        })),
                 );
             }
             row
         })
         .child({
             let active = ws.library.map_filter.is_some();
-            div()
-                .mx_2()
-                .mb_1()
-                .px_2()
-                .h(px(22.0))
-                .flex()
-                .items_center()
-                .justify_between()
-                .rounded_md()
-                .text_size(px(11.0))
-                .cursor_pointer()
-                .bg(gpui::rgb(if active {
-                    pal().select_border
-                } else {
-                    pal().button_bg
-                }))
-                .text_color(gpui::rgb(if active { 0xFFFFFF } else { pal().text }))
-                .hover(move |s| {
-                    if active {
-                        s
-                    } else {
-                        s.bg(gpui::rgb(pal().button_hover))
-                    }
-                })
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(|ws, _e: &MouseDownEvent, _w, cx| ws.open_map_filter(cx)),
-                )
-                .child(if active {
+            Button::new(
+                "map-filter",
+                if active {
                     "Map filter on"
                 } else {
                     "Map filter…"
-                })
-                .children(active.then(|| div().child("\u{25cf}")))
+                },
+            )
+            .colors(ButtonColors {
+                bg: Some(if active {
+                    pal().select_border
+                } else {
+                    pal().button_bg
+                }),
+                hover: if active {
+                    pal().select_border
+                } else {
+                    pal().button_hover
+                },
+                text: if active { 0xFFFFFF } else { pal().text },
+                border: None,
+            })
+            .mx_2()
+            .mb_1()
+            .px_2()
+            .h(px(22.0))
+            .justify_between()
+            .rounded_md()
+            .text_size(px(11.0))
+            .on_click(cx.listener(|ws, _e, _w, cx| ws.open_map_filter(cx)))
+            .children(active.then(|| div().child("\u{25cf}")))
         })
         .child(
             div()
@@ -836,6 +823,7 @@ fn sidebar(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElement 
         .children(rows)
         .child(
             div()
+                .id("add-folder")
                 .px_2()
                 .h(px(24.0))
                 .flex()
@@ -844,12 +832,7 @@ fn sidebar(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElement 
                 .text_color(gpui::rgb(pal().header))
                 .cursor_pointer()
                 .hover(|s| s.bg(gpui::rgb(pal().sidebar_selected)))
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(|ws, _e: &MouseDownEvent, window, cx| {
-                        ws.gallery_add_folder(window, cx)
-                    }),
-                )
+                .on_click(cx.listener(|ws, _e, window, cx| ws.gallery_add_folder(window, cx)))
                 .child("+ Add folder…"),
         )
         .child(
@@ -880,6 +863,7 @@ fn sidebar(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElement 
         })
         .child(
             div()
+                .id("new-bucket")
                 .px_2()
                 .h(px(24.0))
                 .flex()
@@ -888,15 +872,12 @@ fn sidebar(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElement 
                 .text_color(gpui::rgb(pal().header))
                 .cursor_pointer()
                 .hover(|s| s.bg(gpui::rgb(pal().sidebar_selected)))
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(|ws, _e: &MouseDownEvent, _w, cx| {
-                        // Born holding the selection, so "new bucket
-                        // from these" is the dialog's Create away.
-                        let selected = ws.library.selected.clone();
-                        ws.gallery_new_bucket(selected, cx);
-                    }),
-                )
+                .on_click(cx.listener(|ws, _e, _w, cx| {
+                    // Born holding the selection, so "new bucket
+                    // from these" is the dialog's Create away.
+                    let selected = ws.library.selected.clone();
+                    ws.gallery_new_bucket(selected, cx);
+                }))
                 .child("+ New bucket"),
         )
         .children(super::library_people_view::people_rows(ws, cx))
@@ -1025,22 +1006,28 @@ fn sidebar_row(
     if let Some(root) = root {
         // The quiet way out, matching Picasa's "Remove from Picasa":
         // stop watching, never delete.
+        // A ghost button that swallows its press, so it does not
+        // also select the row it sits in.
         row = row.child(
-            div()
-                .id(SharedString::from(format!("unwatch-{}", root.display())))
-                .pl_1()
-                .text_size(px(11.0))
-                .text_color(gpui::rgb(pal().text_dim))
-                .hover(|s| s.text_color(gpui::rgb(pal().text)))
-                .tooltip(crate::ui::tip("Stop watching this folder", None))
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
-                        cx.stop_propagation();
-                        ws.gallery_remove_folder(&root.clone(), cx);
-                    }),
-                )
-                .child("\u{2715}"),
+            Button::new(
+                SharedString::from(format!("unwatch-{}", root.display())),
+                "\u{2715}",
+            )
+            .colors(ButtonColors {
+                bg: None,
+                hover: pal().button_hover,
+                text: pal().text_dim,
+                border: None,
+            })
+            .h_auto()
+            .px_1()
+            .ml_1()
+            .text_size(px(11.0))
+            .tooltip("Stop watching this folder", None)
+            .consume_press()
+            .on_click(cx.listener(move |ws, _e, _w, cx| {
+                ws.gallery_remove_folder(&root.clone(), cx);
+            })),
         );
     }
     row
@@ -1127,13 +1114,13 @@ fn world_map(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElemen
     let mut view = div().flex().flex_col().flex_grow().min_w(px(0.0)).min_h(px(0.0))
         .child(div().flex().items_center().gap_2().p_2().flex_wrap()
             .child(div().text_size(px(12.0)).child("World Map"))
-            .child(map_tool_button("−", false, |ws, cx| {
+            .child(map_tool_button("world-zoom-out", "−", false, |ws, cx| {
                 ws.library.world_map.zoom_center(-1); cx.notify();
             }, cx))
-            .child(map_tool_button("+", false, |ws, cx| {
+            .child(map_tool_button("world-zoom-in", "+", false, |ws, cx| {
                 ws.library.world_map.zoom_center(1); cx.notify();
             }, cx))
-            .child(map_tool_button("Reset view", false, |ws, cx| {
+            .child(map_tool_button("world-reset", "Reset view", false, |ws, cx| {
                 ws.library.world_map.show_world(); cx.notify();
             }, cx))
             .child(div().text_size(px(11.0)).text_color(gpui::rgb(pal().text_dim)).child(status)))
@@ -1209,6 +1196,7 @@ fn world_map(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElemen
                             .child(format!("{count} photos at this marker")),
                     )
                     .child(map_tool_button(
+                        "world-strip-close",
                         "Close",
                         false,
                         |ws, cx| {
@@ -1940,6 +1928,8 @@ fn tray(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl IntoElement {
         .and_then(|e| e.path.file_name())
         .map(|n| n.to_string_lossy().into_owned());
     div()
+        // Its own id scope: the viewer's header has an Edit button too.
+        .id("gallery-tray")
         .flex()
         .flex_row()
         .items_center()
@@ -2136,7 +2126,7 @@ pub(crate) fn camera_import_dialog(
             .text_size(px(12.0))
             .child("More than one camera is reachable. Import from:"),
     );
-    for source in sources {
+    for (i, source) in sources.iter().enumerate() {
         let pick = source.clone();
         let label = super::library::source_label(source);
         let detail = match source {
@@ -2144,29 +2134,20 @@ pub(crate) fn camera_import_dialog(
             ImportSource::Device { .. } => "via Image Capture".to_string(),
         };
         body = body.child(
-            div()
-                .flex()
-                .flex_row()
-                .items_center()
+            ListItem::new(("camera-source", i))
                 .justify_between()
-                .px_2()
                 .h(px(26.0))
                 .rounded_sm()
-                .text_size(px(12.0))
-                .hover(|s| s.bg(gpui::rgb(crate::ui::palette().hover)))
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
-                        ws.close_modal(cx);
-                        // On to the options: the map, the destination.
-                        ws.open_modal(
-                            Modal::CameraImportOptions {
-                                source: pick.clone(),
-                            },
-                            cx,
-                        );
-                    }),
-                )
+                .on_click(cx.listener(move |ws, _e, _w, cx| {
+                    ws.close_modal(cx);
+                    // On to the options: the map, the destination.
+                    ws.open_modal(
+                        Modal::CameraImportOptions {
+                            source: pick.clone(),
+                        },
+                        cx,
+                    );
+                }))
                 .child(label)
                 .child(
                     div()
@@ -2204,34 +2185,29 @@ fn boundary_editor(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl Into
     for place in PLACES {
         let active = selection_name.as_deref() == Some(place.name);
         chips = chips.child(
-            div()
-                .px_2()
+            Button::new(place.name, place.name)
+                .colors(ButtonColors {
+                    bg: Some(if active {
+                        crate::ui::palette().selection_bg
+                    } else {
+                        crate::ui::palette().control_bg
+                    }),
+                    hover: if active {
+                        crate::ui::palette().selection_bg
+                    } else {
+                        crate::ui::palette().hover
+                    },
+                    text: crate::ui::palette().text,
+                    border: None,
+                })
                 .h(px(20.0))
-                .flex()
-                .items_center()
+                .px_2()
                 .rounded_md()
                 .text_size(px(11.0))
-                .cursor_pointer()
-                .bg(gpui::rgb(if active {
-                    crate::ui::palette().selection_bg
-                } else {
-                    crate::ui::palette().control_bg
-                }))
-                .hover(move |s| {
-                    if active {
-                        s
-                    } else {
-                        s.bg(gpui::rgb(crate::ui::palette().hover))
-                    }
-                })
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| {
-                        ws.library.map.jump_to(place.name, place.bounds);
-                        cx.notify();
-                    }),
-                )
-                .child(place.name),
+                .on_click(cx.listener(move |ws, _e, _w, cx| {
+                    ws.library.map.jump_to(place.name, place.bounds);
+                    cx.notify();
+                })),
         );
     }
 
@@ -2241,6 +2217,7 @@ fn boundary_editor(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl Into
         .items_center()
         .gap_2()
         .child(map_tool_button(
+            "map-draw",
             if draw_mode { "Drawing…" } else { "Draw area" },
             draw_mode,
             |ws, cx| {
@@ -2251,6 +2228,7 @@ fn boundary_editor(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl Into
         ));
     if selection.is_some() {
         tools = tools.child(map_tool_button(
+            "map-clear",
             "Clear boundary",
             false,
             |ws, cx| {
@@ -2270,6 +2248,7 @@ fn boundary_editor(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl Into
         )
         .child(div().flex_grow())
         .child(map_tool_button(
+            "map-zoom-out",
             "−",
             false,
             |ws, cx| {
@@ -2285,6 +2264,7 @@ fn boundary_editor(ws: &mut Workspace, cx: &mut Context<Workspace>) -> impl Into
                 .child(format!("z{zoom}")),
         )
         .child(map_tool_button(
+            "map-zoom-in",
             "+",
             false,
             |ws, cx| {
@@ -2383,42 +2363,25 @@ pub(crate) fn camera_import_options_dialog(
     crate::ui::modal_frame(format!("Import from {label}"), 580.0, body, actions)
 }
 
+/// The small buttons around a map. Explicitly identified, because the
+/// world map's zoom controls and the map filter's can be on screen at
+/// once and wear the same labels.
 fn map_tool_button(
+    id: &'static str,
     label: impl Into<SharedString>,
     active: bool,
     on_click: impl Fn(&mut Workspace, &mut Context<Workspace>) + 'static,
     cx: &mut Context<Workspace>,
 ) -> impl IntoElement {
-    div()
-        .px_2()
+    // The kit's secondary fill is the editor palette's button_bg /
+    // button_hover, and `active` lights it in the accent — what this
+    // drew by hand before.
+    Button::new(id, label)
+        .active(active)
         .h(px(20.0))
-        .flex()
-        .items_center()
-        .rounded_sm()
+        .px_2()
         .text_size(px(11.0))
-        .cursor_pointer()
-        .bg(gpui::rgb(if active {
-            crate::ui::palette().accent
-        } else {
-            crate::ui::palette().button_bg
-        }))
-        .text_color(gpui::rgb(if active {
-            crate::ui::palette().accent_text
-        } else {
-            crate::ui::palette().text
-        }))
-        .hover(move |s| {
-            if active {
-                s
-            } else {
-                s.bg(gpui::rgb(crate::ui::palette().button_hover))
-            }
-        })
-        .on_mouse_down(
-            MouseButton::Left,
-            cx.listener(move |ws, _e: &MouseDownEvent, _w, cx| on_click(ws, cx)),
-        )
-        .child(label.into())
+        .on_click(cx.listener(move |ws, _e, _w, cx| on_click(ws, cx)))
 }
 
 /// The navigable map itself: tiles painted like the document canvas —
@@ -2741,22 +2704,8 @@ fn search_models_downloading(ws: &Workspace) -> bool {
         .any(|d| SEARCH_MODELS.contains(&d.id))
 }
 
-fn search_model_link(
-    id: &'static str,
-    label: &'static str,
-    url: &'static str,
-    cx: &mut Context<Workspace>,
-) -> impl IntoElement {
-    div()
-        .id(id)
-        .cursor_pointer()
-        .text_color(gpui::rgb(crate::ui::palette().accent))
-        .hover(|style| style.text_color(gpui::rgb(crate::ui::palette().accent_hover)))
-        .on_mouse_down(
-            MouseButton::Left,
-            cx.listener(move |_ws, _event, _window, cx| cx.open_url(url)),
-        )
-        .child(label)
+fn search_model_link(id: &'static str, label: &'static str, url: &'static str) -> Link {
+    Link::new(id, label).url(url)
 }
 
 /// The licences behind photo search, and the button that accepts them.
@@ -2801,21 +2750,18 @@ pub(crate) fn search_models_dialog(cx: &mut Context<Workspace>) -> impl IntoElem
                 "mobileclip-source",
                 "MobileCLIP by Apple",
                 "https://github.com/apple/ml-mobileclip",
-                cx,
             ))
             .child("\u{b7}")
             .child(search_model_link(
                 "mobileclip-export",
                 "ONNX export by Xenova",
                 "https://huggingface.co/Xenova/mobileclip_s0",
-                cx,
             ))
             .child("\u{b7}")
             .child(search_model_link(
                 "mobileclip-license",
                 "License",
                 "https://github.com/apple/ml-mobileclip/blob/main/LICENSE",
-                cx,
             )),
     );
     body = body.child(
@@ -3083,25 +3029,13 @@ fn gallery_context_menu(
                cx: &mut Context<Workspace>,
                act: RowAction| {
         rows.push(
-            div()
-                .px_2()
-                .h(px(24.0))
-                .flex()
-                .items_center()
-                .text_size(px(12.0))
-                .cursor_pointer()
-                .hover(|s| {
-                    s.bg(gpui::rgb(crate::ui::palette().accent))
-                        .text_color(gpui::rgb(crate::ui::palette().accent_text))
-                })
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |ws, _e: &MouseDownEvent, window, cx| {
-                        ws.library.context = None;
-                        act(ws, window, cx);
-                        cx.notify();
-                    }),
-                )
+            ListItem::new(("gallery-menu-row", rows.len()))
+                .accent_hover()
+                .on_click(cx.listener(move |ws, _e, window, cx| {
+                    ws.library.context = None;
+                    act(ws, window, cx);
+                    cx.notify();
+                }))
                 .child(SharedString::from(label))
                 .into_any_element(),
         );

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "schist-ui"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Schist's widget kit: the chrome components the panels and dialogs build from, and the palette they draw with"
+
+[dependencies]
+gpui.workspace = true

--- a/crates/ui/src/button.rs
+++ b/crates/ui/src/button.rs
@@ -1,0 +1,374 @@
+//! Push buttons: labelled, icon-only, or carrying whatever the caller
+//! puts in them.
+
+use crate::{icon, palette, tip, ClickHandler};
+use gpui::prelude::FluentBuilder as _;
+use gpui::{
+    div, px, AnyElement, App, ClickEvent, ElementId, InteractiveElement as _, IntoElement,
+    MouseButton, ParentElement, Refineable as _, RenderOnce, SharedString,
+    StatefulInteractiveElement as _, StyleRefinement, Styled, Window,
+};
+
+/// How a [`Button`] is filled.
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default)]
+pub enum ButtonVariant {
+    /// The accent fill: a dialog's default action, Send, OK.
+    Primary,
+    /// The plain grey fill most buttons wear.
+    #[default]
+    Secondary,
+    /// No fill until hovered: toolbar and panel-header controls.
+    Ghost,
+}
+
+/// Explicit colours for a [`Button`], for chrome that keeps its own
+/// palette (the gallery's green import button).
+#[derive(Clone, Copy, Debug)]
+pub struct ButtonColors {
+    /// The fill, or none for a transparent button.
+    pub bg: Option<u32>,
+    /// The fill while the pointer is over it.
+    pub hover: u32,
+    pub text: u32,
+    /// A one-pixel border, if any.
+    pub border: Option<u32>,
+}
+
+impl ButtonColors {
+    fn of(variant: ButtonVariant) -> Self {
+        let p = palette();
+        match variant {
+            ButtonVariant::Primary => ButtonColors {
+                bg: Some(p.accent),
+                hover: p.accent_hover,
+                text: p.accent_text,
+                border: None,
+            },
+            ButtonVariant::Secondary => ButtonColors {
+                bg: Some(p.button_bg),
+                hover: p.button_hover,
+                text: p.text,
+                border: None,
+            },
+            ButtonVariant::Ghost => ButtonColors {
+                bg: None,
+                hover: p.hover,
+                text: p.text,
+                border: None,
+            },
+        }
+    }
+}
+
+/// A push button. Fires [`Button::on_click`] when the mouse is released
+/// over it (or on Enter/Space while focused), never on the press.
+///
+/// Defaults to 24 px high with a 12 px label and the secondary fill;
+/// every one of those is a [`Styled`] call away from something else.
+/// Children added through [`ParentElement`] go after the label, so an
+/// icon-and-text button is `Button::new(id, "Save").child(icon(..))`,
+/// and a button with no label at all is [`Button::bare`].
+#[derive(gpui::IntoElement)]
+pub struct Button {
+    id: ElementId,
+    label: Option<SharedString>,
+    variant: ButtonVariant,
+    colors: Option<ButtonColors>,
+    active: bool,
+    disabled: bool,
+    consume_press: bool,
+    tooltip: Option<(SharedString, Option<SharedString>)>,
+    style: StyleRefinement,
+    children: Vec<AnyElement>,
+    on_click: Option<ClickHandler>,
+}
+
+impl Button {
+    /// A labelled button with the secondary fill.
+    pub fn new(id: impl Into<ElementId>, label: impl Into<SharedString>) -> Self {
+        Self::bare(id).label(label)
+    }
+
+    /// A button with nothing in it yet: add children for its content.
+    pub fn bare(id: impl Into<ElementId>) -> Self {
+        Button {
+            id: id.into(),
+            label: None,
+            variant: ButtonVariant::Secondary,
+            colors: None,
+            active: false,
+            disabled: false,
+            consume_press: false,
+            tooltip: None,
+            style: StyleRefinement::default(),
+            children: Vec::new(),
+            on_click: None,
+        }
+    }
+
+    pub fn label(mut self, label: impl Into<SharedString>) -> Self {
+        let label = label.into();
+        self.label = (!label.is_empty()).then_some(label);
+        self
+    }
+
+    pub fn variant(mut self, variant: ButtonVariant) -> Self {
+        self.variant = variant;
+        self
+    }
+
+    /// The accent fill.
+    pub fn primary(self) -> Self {
+        self.variant(ButtonVariant::Primary)
+    }
+
+    /// No fill until hovered.
+    pub fn ghost(self) -> Self {
+        self.variant(ButtonVariant::Ghost)
+    }
+
+    /// Colours of the caller's own choosing, in place of the variant's.
+    pub fn colors(mut self, colors: ButtonColors) -> Self {
+        self.colors = Some(colors);
+        self
+    }
+
+    /// Lit in the accent, for a toggle that is on or a tool that is the
+    /// current one. Hovering an active button does not change it.
+    pub fn active(mut self, active: bool) -> Self {
+        self.active = active;
+        self
+    }
+
+    /// Dimmed, and deaf to the pointer.
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// Swallow the press so whatever the button sits in (a selectable
+    /// row, a draggable tile) does not also react to it. The click still
+    /// fires on release.
+    pub fn consume_press(mut self) -> Self {
+        self.consume_press = true;
+        self
+    }
+
+    /// A hover label, with an optional shortcut hint after it.
+    pub fn tooltip(mut self, label: impl Into<SharedString>, hint: Option<SharedString>) -> Self {
+        self.tooltip = Some((label.into(), hint));
+        self
+    }
+
+    pub fn on_click(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_click = Some(Box::new(handler));
+        self
+    }
+}
+
+impl Styled for Button {
+    fn style(&mut self) -> &mut StyleRefinement {
+        &mut self.style
+    }
+}
+
+impl ParentElement for Button {
+    fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
+        self.children.extend(elements);
+    }
+}
+
+impl RenderOnce for Button {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let p = palette();
+        let colors = self
+            .colors
+            .unwrap_or_else(|| ButtonColors::of(self.variant));
+        let (bg, hover, text) = if self.active {
+            (Some(p.accent), p.accent, p.accent_text)
+        } else if self.disabled && colors.bg.is_none() {
+            (None, colors.hover, p.text_faint)
+        } else {
+            (colors.bg, colors.hover, colors.text)
+        };
+        let mut el = div()
+            .flex()
+            .flex_none()
+            .items_center()
+            .justify_center()
+            .gap_1()
+            .h(px(24.0))
+            .px_3()
+            .rounded_sm()
+            .text_size(px(12.0))
+            .text_color(gpui::rgb(text))
+            .when_some(bg, |d, bg| d.bg(gpui::rgb(bg)))
+            .when_some(colors.border, |d, b| {
+                d.border_1().border_color(gpui::rgb(b))
+            });
+        // The caller's own refinements win over the defaults above.
+        el.style().refine(&self.style);
+        let mut el = el.id(self.id);
+        if self.disabled {
+            // A filled button fades as a whole; a ghost one has nothing
+            // to fade but its text, handled above.
+            if bg.is_some() {
+                el = el.opacity(0.4);
+            }
+        } else {
+            el = el.hover(move |s| s.bg(gpui::rgb(hover)));
+            if let Some(on_click) = self.on_click {
+                el = el
+                    .cursor_pointer()
+                    // Pressed: a touch dimmer, so the press reads before
+                    // the release commits it.
+                    .active(|s| s.opacity(0.8))
+                    .on_click(on_click);
+            }
+            if self.consume_press {
+                el = el.on_mouse_down(MouseButton::Left, |_e, _window, cx| cx.stop_propagation());
+            }
+        }
+        if let Some((label, hint)) = self.tooltip {
+            el = el.tooltip(tip(label, hint));
+        }
+        el.children(self.label).children(self.children)
+    }
+}
+
+/// A square button holding one icon: the panel headers' new/delete
+/// controls, the ± steppers, a tab's close.
+///
+/// 22 px square with a 14 px icon by default, no fill until hovered.
+#[derive(gpui::IntoElement)]
+pub struct IconButton {
+    id: ElementId,
+    icon: SharedString,
+    size: f32,
+    icon_size: f32,
+    color: Option<u32>,
+    active: bool,
+    disabled: bool,
+    consume_press: bool,
+    filled: bool,
+    tooltip: Option<(SharedString, Option<SharedString>)>,
+    style: StyleRefinement,
+    on_click: Option<ClickHandler>,
+}
+
+impl IconButton {
+    pub fn new(id: impl Into<ElementId>, icon: impl Into<SharedString>) -> Self {
+        IconButton {
+            id: id.into(),
+            icon: icon.into(),
+            size: 22.0,
+            icon_size: 14.0,
+            color: None,
+            active: false,
+            disabled: false,
+            consume_press: false,
+            filled: false,
+            tooltip: None,
+            style: StyleRefinement::default(),
+            on_click: None,
+        }
+    }
+
+    /// The button's side, in pixels.
+    pub fn size(mut self, size: f32) -> Self {
+        self.size = size;
+        self
+    }
+
+    /// The icon's side, in pixels.
+    pub fn icon_size(mut self, size: f32) -> Self {
+        self.icon_size = size;
+        self
+    }
+
+    /// The icon's tint; the text colour unless told otherwise.
+    pub fn color(mut self, color: u32) -> Self {
+        self.color = Some(color);
+        self
+    }
+
+    /// The control fill even at rest, as the ± steppers beside a field
+    /// have, instead of appearing only under the pointer.
+    pub fn filled(mut self) -> Self {
+        self.filled = true;
+        self
+    }
+
+    /// Lit in the accent.
+    pub fn active(mut self, active: bool) -> Self {
+        self.active = active;
+        self
+    }
+
+    /// Faint, and deaf to the pointer.
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// See [`Button::consume_press`].
+    pub fn consume_press(mut self) -> Self {
+        self.consume_press = true;
+        self
+    }
+
+    pub fn tooltip(mut self, label: impl Into<SharedString>, hint: Option<SharedString>) -> Self {
+        self.tooltip = Some((label.into(), hint));
+        self
+    }
+
+    pub fn on_click(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_click = Some(Box::new(handler));
+        self
+    }
+}
+
+impl Styled for IconButton {
+    fn style(&mut self) -> &mut StyleRefinement {
+        &mut self.style
+    }
+}
+
+impl RenderOnce for IconButton {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        let p = palette();
+        let color = if self.active {
+            p.accent_text
+        } else if self.disabled {
+            p.text_faint
+        } else {
+            self.color.unwrap_or(p.text)
+        };
+        let mut button = Button::bare(self.id)
+            .ghost()
+            .when(self.filled, |b| {
+                b.colors(ButtonColors {
+                    bg: Some(p.control_bg),
+                    hover: p.button_hover,
+                    text: p.text,
+                    border: None,
+                })
+            })
+            .active(self.active)
+            .disabled(self.disabled)
+            .when(self.consume_press, Button::consume_press)
+            .when_some(self.tooltip, |b, (label, hint)| b.tooltip(label, hint))
+            .when_some(self.on_click, |b, handler| b.on_click(handler))
+            .size(px(self.size))
+            .px_0()
+            .child(icon(&self.icon, self.icon_size, color));
+        button.style().refine(&self.style);
+        button.render(window, cx)
+    }
+}

--- a/crates/ui/src/checkbox.rs
+++ b/crates/ui/src/checkbox.rs
@@ -1,0 +1,87 @@
+//! A checkbox with a label to its right.
+
+use crate::{icon, palette, BoolHandler};
+use gpui::prelude::FluentBuilder as _;
+use gpui::{
+    div, px, App, ElementId, InteractiveElement as _, IntoElement, ParentElement as _,
+    Refineable as _, RenderOnce, SharedString, StatefulInteractiveElement as _, StyleRefinement,
+    Styled, Window,
+};
+
+/// A 14 px box with a label after it; clicking either toggles. The
+/// handler is given the *new* state, on release. It takes the state by
+/// reference so a `Context::listener` closure fits it directly.
+#[derive(gpui::IntoElement)]
+pub struct Checkbox {
+    id: ElementId,
+    label: SharedString,
+    checked: bool,
+    disabled: bool,
+    style: StyleRefinement,
+    on_change: Option<BoolHandler>,
+}
+
+impl Checkbox {
+    pub fn new(id: impl Into<ElementId>, label: impl Into<SharedString>, checked: bool) -> Self {
+        Checkbox {
+            id: id.into(),
+            label: label.into(),
+            checked,
+            disabled: false,
+            style: StyleRefinement::default(),
+            on_change: None,
+        }
+    }
+
+    /// Faint, and deaf to the pointer.
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    pub fn on_change(mut self, handler: impl Fn(&bool, &mut Window, &mut App) + 'static) -> Self {
+        self.on_change = Some(Box::new(handler));
+        self
+    }
+}
+
+impl Styled for Checkbox {
+    fn style(&mut self) -> &mut StyleRefinement {
+        &mut self.style
+    }
+}
+
+impl RenderOnce for Checkbox {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let p = palette();
+        let checked = self.checked;
+        let mut el = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap_2()
+            .text_size(px(12.0))
+            .when(self.disabled, |d| d.text_color(gpui::rgb(p.text_faint)));
+        el.style().refine(&self.style);
+        let mark = div()
+            .flex()
+            .flex_none()
+            .items_center()
+            .justify_center()
+            .size(px(14.0))
+            .rounded_sm()
+            .bg(gpui::rgb(if checked { p.accent } else { p.field_bg }))
+            .border_1()
+            .border_color(gpui::rgb(p.edge))
+            .when(self.disabled, |d| d.opacity(0.4))
+            .when(checked, |d| d.child(icon("check", 10.0, p.accent_text)));
+        let mut el = el.id(self.id).child(mark);
+        if !self.disabled {
+            el = el.cursor_pointer();
+            if let Some(on_change) = self.on_change {
+                el = el.on_click(move |_e, window, cx| on_change(&!checked, window, cx));
+            }
+        }
+        el.when(!self.label.is_empty(), |d| d.child(self.label))
+    }
+}

--- a/crates/ui/src/icon.rs
+++ b/crates/ui/src/icon.rs
@@ -1,0 +1,15 @@
+//! Monochrome line icons, tinted at render time.
+
+use gpui::{px, svg, IntoElement, Styled as _};
+
+/// The icon called `name`, `size` pixels square, tinted `color`.
+///
+/// Icons are SVGs the host application serves from its asset source as
+/// `icons/<name>.svg`; the kit only names them. Their fill is the text
+/// colour, which is why a single set works in both themes.
+pub fn icon(name: &str, size: f32, color: u32) -> impl IntoElement {
+    svg()
+        .path(format!("icons/{name}.svg"))
+        .size(px(size))
+        .text_color(gpui::rgb(color))
+}

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -1,0 +1,62 @@
+//! Schist's widget kit: the chrome components every panel and dialog
+//! builds from, and the palette they draw with.
+//!
+//! GPUI ships no widget library, so before this crate each panel drew
+//! its own buttons from bare `div()`s, and every one of them fired its
+//! action from `on_mouse_down` -- the moment the button went down, not
+//! when it came back up. Native buttons (AppKit, UIKit, Win32, the web)
+//! all commit on *release*, and only if the pointer is still over the
+//! control; pressing, changing your mind and sliding off cancels. That
+//! is what GPUI's `on_click` implements, and it is the one thing every
+//! pressable component here has in common: nothing in this crate acts on
+//! the press alone (issue #119).
+//!
+//! The components know nothing about the workspace. They take plain
+//! `Fn(&ClickEvent, &mut Window, &mut App)` handlers, which is exactly
+//! what `Context::listener` produces, so a panel writes
+//!
+//! ```ignore
+//! Button::new("ok", "OK")
+//!     .primary()
+//!     .on_click(cx.listener(|ws, _e, window, cx| ws.confirm(window, cx)))
+//! ```
+//!
+//! Every component is a [`gpui::RenderOnce`] value that implements
+//! [`gpui::Styled`], so a caller can adjust its size or colours with the
+//! usual fluent methods; those refinements win over the component's own
+//! defaults. The ones that hold content also implement
+//! [`gpui::ParentElement`].
+//!
+//! Icons are monochrome SVGs served by the host application's asset
+//! source under `icons/<name>.svg`; see [`icon`].
+
+mod button;
+mod checkbox;
+mod icon;
+mod link;
+mod list_item;
+mod swatch;
+mod tab;
+mod theme;
+mod tooltip;
+
+pub use button::{Button, ButtonColors, ButtonVariant, IconButton};
+pub use checkbox::Checkbox;
+pub use icon::icon;
+pub use link::Link;
+pub use list_item::ListItem;
+pub use swatch::Swatch;
+pub use tab::Tab;
+pub use theme::{is_light, palette, set_light, Palette, DARK, LIGHT};
+pub use tooltip::{tip, Tooltip};
+
+/// What a component's `on_click` takes: fired on release, over the
+/// control, or from the keyboard (Enter or Space while focused).
+pub type ClickHandler = Box<dyn Fn(&gpui::ClickEvent, &mut gpui::Window, &mut gpui::App) + 'static>;
+
+/// A handler told a yes-or-no: a checkbox's new state, a row's hover.
+pub type BoolHandler = Box<dyn Fn(&bool, &mut gpui::Window, &mut gpui::App) + 'static>;
+
+/// A handler with no event payload, for the secondary gestures a
+/// component offers (a tab's middle-click close, for instance).
+pub type Handler = std::rc::Rc<dyn Fn(&mut gpui::Window, &mut gpui::App) + 'static>;

--- a/crates/ui/src/link.rs
+++ b/crates/ui/src/link.rs
@@ -1,0 +1,65 @@
+//! Inline text that acts when clicked.
+
+use crate::{palette, ClickHandler};
+use gpui::{
+    div, App, ClickEvent, ElementId, InteractiveElement as _, IntoElement, ParentElement as _,
+    Refineable as _, RenderOnce, SharedString, StatefulInteractiveElement as _, StyleRefinement,
+    Styled, Window,
+};
+
+/// A run of accent-coloured text that opens a URL or runs a handler on
+/// release. Inherits its size from the text around it.
+#[derive(gpui::IntoElement)]
+pub struct Link {
+    id: ElementId,
+    label: SharedString,
+    style: StyleRefinement,
+    on_click: Option<ClickHandler>,
+}
+
+impl Link {
+    pub fn new(id: impl Into<ElementId>, label: impl Into<SharedString>) -> Self {
+        Link {
+            id: id.into(),
+            label: label.into(),
+            style: StyleRefinement::default(),
+            on_click: None,
+        }
+    }
+
+    /// Open `url` in the user's browser.
+    pub fn url(self, url: impl Into<String>) -> Self {
+        let url = url.into();
+        self.on_click(move |_e, _window, cx| cx.open_url(&url))
+    }
+
+    pub fn on_click(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_click = Some(Box::new(handler));
+        self
+    }
+}
+
+impl Styled for Link {
+    fn style(&mut self) -> &mut StyleRefinement {
+        &mut self.style
+    }
+}
+
+impl RenderOnce for Link {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let p = palette();
+        let mut el = div().text_color(gpui::rgb(p.accent));
+        el.style().refine(&self.style);
+        let mut el = el
+            .id(self.id)
+            .cursor_pointer()
+            .hover(|s| s.text_color(gpui::rgb(p.accent_hover)));
+        if let Some(on_click) = self.on_click {
+            el = el.on_click(on_click);
+        }
+        el.child(self.label)
+    }
+}

--- a/crates/ui/src/list_item.rs
+++ b/crates/ui/src/list_item.rs
@@ -1,0 +1,152 @@
+//! One row of a menu, a dropdown, a flyout or a panel list.
+
+use crate::{palette, BoolHandler, ClickHandler};
+use gpui::{
+    div, px, AnyElement, App, ClickEvent, ElementId, InteractiveElement as _, IntoElement,
+    MouseButton, ParentElement, Refineable as _, RenderOnce, StatefulInteractiveElement as _,
+    StyleRefinement, Styled, Window,
+};
+
+/// A clickable row. The caller supplies its content through
+/// [`ParentElement`]; the row lays it out as a horizontal strip, 24 px
+/// high with 8 px side padding, lights on hover, and fires
+/// [`ListItem::on_click`] on release.
+#[derive(gpui::IntoElement)]
+pub struct ListItem {
+    id: ElementId,
+    selected: bool,
+    highlighted: bool,
+    accent_hover: bool,
+    disabled: bool,
+    consume_press: bool,
+    style: StyleRefinement,
+    children: Vec<AnyElement>,
+    on_click: Option<ClickHandler>,
+    on_hover: Option<BoolHandler>,
+}
+
+impl ListItem {
+    pub fn new(id: impl Into<ElementId>) -> Self {
+        ListItem {
+            id: id.into(),
+            selected: false,
+            highlighted: false,
+            accent_hover: false,
+            disabled: false,
+            consume_press: false,
+            style: StyleRefinement::default(),
+            children: Vec::new(),
+            on_click: None,
+            on_hover: None,
+        }
+    }
+
+    /// The row that is the current value: accent fill, and unmoved by
+    /// the pointer.
+    pub fn selected(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
+    }
+
+    /// The row the keyboard has walked to: drawn as if hovered.
+    pub fn highlighted(mut self, highlighted: bool) -> Self {
+        self.highlighted = highlighted;
+        self
+    }
+
+    /// Hover in the accent rather than the quiet row hover, the way
+    /// menus do.
+    pub fn accent_hover(mut self) -> Self {
+        self.accent_hover = true;
+        self
+    }
+
+    /// Faint, and deaf to the pointer.
+    pub fn disabled(mut self, disabled: bool) -> Self {
+        self.disabled = disabled;
+        self
+    }
+
+    /// See [`crate::Button::consume_press`].
+    pub fn consume_press(mut self) -> Self {
+        self.consume_press = true;
+        self
+    }
+
+    pub fn on_click(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_click = Some(Box::new(handler));
+        self
+    }
+
+    /// Told `true` as the pointer arrives and `false` as it leaves; a
+    /// menu row opens its submenu from this.
+    pub fn on_hover(mut self, handler: impl Fn(&bool, &mut Window, &mut App) + 'static) -> Self {
+        self.on_hover = Some(Box::new(handler));
+        self
+    }
+}
+
+impl Styled for ListItem {
+    fn style(&mut self) -> &mut StyleRefinement {
+        &mut self.style
+    }
+}
+
+impl ParentElement for ListItem {
+    fn extend(&mut self, elements: impl IntoIterator<Item = AnyElement>) {
+        self.children.extend(elements);
+    }
+}
+
+impl RenderOnce for ListItem {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let p = palette();
+        let mut el = div()
+            .flex()
+            .flex_row()
+            .flex_none()
+            .items_center()
+            .px_2()
+            .h(px(24.0))
+            .text_size(px(12.0));
+        if self.selected {
+            el = el
+                .bg(gpui::rgb(p.accent))
+                .text_color(gpui::rgb(p.accent_text));
+        } else if self.highlighted {
+            el = el.bg(gpui::rgb(p.hover));
+        }
+        if self.disabled {
+            el = el.text_color(gpui::rgb(p.text_faint));
+        }
+        el.style().refine(&self.style);
+        let mut el = el.id(self.id);
+        if !self.disabled {
+            el = el.cursor_pointer();
+            if !self.selected {
+                let accent = self.accent_hover;
+                el = el.hover(move |s| {
+                    if accent {
+                        s.bg(gpui::rgb(p.accent))
+                            .text_color(gpui::rgb(p.accent_text))
+                    } else {
+                        s.bg(gpui::rgb(p.hover))
+                    }
+                });
+            }
+            if let Some(on_click) = self.on_click {
+                el = el.on_click(on_click);
+            }
+            if let Some(on_hover) = self.on_hover {
+                el = el.on_hover(on_hover);
+            }
+            if self.consume_press {
+                el = el.on_mouse_down(MouseButton::Left, |_e, _window, cx| cx.stop_propagation());
+            }
+        }
+        el.children(self.children)
+    }
+}

--- a/crates/ui/src/swatch.rs
+++ b/crates/ui/src/swatch.rs
@@ -1,0 +1,66 @@
+//! A colour well.
+
+use crate::{palette, ClickHandler};
+use gpui::{
+    div, px, App, ClickEvent, ElementId, InteractiveElement as _, IntoElement, Refineable as _,
+    RenderOnce, StatefulInteractiveElement as _, StyleRefinement, Styled, Window,
+};
+
+/// A square of one colour that opens a picker, or takes the colour,
+/// when clicked. 18 px with a hairline edge that brightens under the
+/// pointer; the modifiers held are on the event for "alt sets the
+/// background" conventions.
+#[derive(gpui::IntoElement)]
+pub struct Swatch {
+    id: ElementId,
+    color: gpui::Rgba,
+    style: StyleRefinement,
+    on_click: Option<ClickHandler>,
+}
+
+impl Swatch {
+    pub fn new(id: impl Into<ElementId>, color: impl Into<gpui::Rgba>) -> Self {
+        Swatch {
+            id: id.into(),
+            color: color.into(),
+            style: StyleRefinement::default(),
+            on_click: None,
+        }
+    }
+
+    pub fn on_click(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_click = Some(Box::new(handler));
+        self
+    }
+}
+
+impl Styled for Swatch {
+    fn style(&mut self) -> &mut StyleRefinement {
+        &mut self.style
+    }
+}
+
+impl RenderOnce for Swatch {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let p = palette();
+        let mut el = div()
+            .flex_none()
+            .size(px(18.0))
+            .rounded_sm()
+            .border_1()
+            .border_color(gpui::rgb(p.edge))
+            .bg(self.color);
+        el.style().refine(&self.style);
+        let mut el = el.id(self.id);
+        if let Some(on_click) = self.on_click {
+            el = el
+                .cursor_pointer()
+                .hover(|s| s.border_color(gpui::rgb(p.text)))
+                .on_click(on_click);
+        }
+        el
+    }
+}

--- a/crates/ui/src/tab.rs
+++ b/crates/ui/src/tab.rs
@@ -1,0 +1,109 @@
+//! A document tab.
+
+use crate::{palette, Handler, IconButton};
+use gpui::{
+    div, px, App, ElementId, InteractiveElement as _, IntoElement, MouseButton, ParentElement as _,
+    Refineable as _, RenderOnce, SharedString, StyleRefinement, Styled, Window,
+};
+
+/// One tab in a strip: its title, and a close control on the right.
+///
+/// Selecting switches on the *press*, as every native tab strip does
+/// (a tab is a place to be, not an action to confirm); the close button
+/// is a button, and commits on release. Middle-click closes too.
+#[derive(gpui::IntoElement)]
+pub struct Tab {
+    id: ElementId,
+    label: SharedString,
+    active: bool,
+    style: StyleRefinement,
+    on_select: Option<Handler>,
+    on_close: Option<Handler>,
+}
+
+impl Tab {
+    pub fn new(id: impl Into<ElementId>, label: impl Into<SharedString>) -> Self {
+        Tab {
+            id: id.into(),
+            label: label.into(),
+            active: false,
+            style: StyleRefinement::default(),
+            on_select: None,
+            on_close: None,
+        }
+    }
+
+    /// The tab whose document is showing.
+    pub fn active(mut self, active: bool) -> Self {
+        self.active = active;
+        self
+    }
+
+    pub fn on_select(mut self, handler: impl Fn(&mut Window, &mut App) + 'static) -> Self {
+        self.on_select = Some(std::rc::Rc::new(handler));
+        self
+    }
+
+    pub fn on_close(mut self, handler: impl Fn(&mut Window, &mut App) + 'static) -> Self {
+        self.on_close = Some(std::rc::Rc::new(handler));
+        self
+    }
+}
+
+impl Styled for Tab {
+    fn style(&mut self) -> &mut StyleRefinement {
+        &mut self.style
+    }
+}
+
+impl RenderOnce for Tab {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let p = palette();
+        let mut el = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap_1()
+            .h(px(25.0))
+            .pl_2()
+            .pr_1()
+            .max_w(px(180.0))
+            .border_r_1()
+            .border_color(gpui::rgb(p.panel_edge))
+            .text_size(px(11.0));
+        el = if self.active {
+            el.bg(gpui::rgb(p.control_bg)).text_color(gpui::rgb(p.text))
+        } else {
+            el.bg(gpui::rgb(p.panel_bg))
+                .text_color(gpui::rgb(p.text_dim))
+                .hover(|s| s.bg(gpui::rgb(p.hover)))
+        };
+        el.style().refine(&self.style);
+        let mut el = el.id(self.id);
+        if let Some(on_select) = self.on_select {
+            el = el.on_mouse_down(MouseButton::Left, move |_e, window, cx| {
+                on_select(window, cx)
+            });
+        }
+        let mut close = IconButton::new("close", "close")
+            .size(16.0)
+            .icon_size(9.0)
+            .color(p.text_dim)
+            .consume_press();
+        if let Some(on_close) = self.on_close {
+            let by_middle = on_close.clone();
+            el = el.on_mouse_down(MouseButton::Middle, move |_e, window, cx| {
+                by_middle(window, cx)
+            });
+            close = close.on_click(move |_e, window, cx| on_close(window, cx));
+        }
+        el.child(
+            div()
+                .overflow_hidden()
+                .whitespace_nowrap()
+                .text_ellipsis()
+                .child(self.label),
+        )
+        .child(close)
+    }
+}

--- a/crates/ui/src/theme.rs
+++ b/crates/ui/src/theme.rs
@@ -1,0 +1,115 @@
+//! The chrome palette, and which of its two themes is on.
+
+/// The chrome colours for one theme. Everything that isn't document
+/// content draws from here; the active set is swapped by [`set_light`].
+pub struct Palette {
+    /// The window shell behind the panels.
+    pub window_bg: u32,
+    /// The area surrounding the document canvas.
+    pub canvas_bg: u32,
+    pub panel_bg: u32,
+    /// Recessed strips: the document tab bar, the curve editor well.
+    pub deep_bg: u32,
+    pub status_bg: u32,
+    pub ruler_bg: u32,
+    pub field_bg: u32,
+    pub popup_bg: u32,
+    /// Small inline controls: step buttons, the active tab, badges.
+    pub control_bg: u32,
+    pub button_bg: u32,
+    pub button_hover: u32,
+    /// Row hover inside menus, popups and panels.
+    pub hover: u32,
+    /// Hairlines inside a panel (separators, section borders).
+    pub divider: u32,
+    /// Borders around fields, popups and modals.
+    pub edge: u32,
+    /// The border between panels and the shell.
+    pub panel_edge: u32,
+    /// Grid lines drawn on `deep_bg` (curve editor).
+    pub grid: u32,
+    pub text: u32,
+    pub text_dim: u32,
+    pub text_faint: u32,
+    pub accent: u32,
+    pub accent_hover: u32,
+    /// Text and icons drawn on top of `accent`.
+    pub accent_text: u32,
+    /// Selected rows that keep their own text colour (lists, tiles).
+    pub selection_bg: u32,
+}
+
+pub const DARK: Palette = Palette {
+    window_bg: 0x1E1E1E,
+    canvas_bg: 0x262626,
+    panel_bg: 0x1A1A1A,
+    deep_bg: 0x141414,
+    status_bg: 0x161616,
+    ruler_bg: 0x202020,
+    field_bg: 0x0E0E0E,
+    popup_bg: 0x242424,
+    control_bg: 0x2A2A2A,
+    button_bg: 0x333333,
+    button_hover: 0x3E3E3E,
+    hover: 0x2E2E2E,
+    divider: 0x2A2A2A,
+    edge: 0x3A3A3A,
+    panel_edge: 0x111111,
+    grid: 0x262626,
+    text: 0xD8D8D8,
+    text_dim: 0x9A9A9A,
+    text_faint: 0x666666,
+    accent: 0x3A6EA5,
+    accent_hover: 0x4A80BC,
+    accent_text: 0xFFFFFF,
+    selection_bg: 0x2F5B8C,
+};
+
+pub const LIGHT: Palette = Palette {
+    window_bg: 0xE8E8E8,
+    canvas_bg: 0xB4B4B4,
+    panel_bg: 0xF0F0F0,
+    deep_bg: 0xE0E0E0,
+    status_bg: 0xE4E4E4,
+    ruler_bg: 0xE6E6E6,
+    field_bg: 0xFFFFFF,
+    popup_bg: 0xFAFAFA,
+    control_bg: 0xD6D6D6,
+    button_bg: 0xD0D0D0,
+    button_hover: 0xC2C2C2,
+    hover: 0xDCDCDC,
+    divider: 0xD4D4D4,
+    edge: 0xB8B8B8,
+    panel_edge: 0xC4C4C4,
+    grid: 0xC8C8C8,
+    text: 0x1C1C1C,
+    text_dim: 0x5A5A5A,
+    text_faint: 0x9E9E9E,
+    accent: 0x3A6EA5,
+    accent_hover: 0x2E5E95,
+    accent_text: 0xFFFFFF,
+    selection_bg: 0xB8D2EE,
+};
+
+static LIGHT_THEME: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Select the palette that [`palette`] returns. The application calls
+/// this every frame from the persisted preference, so widgets built
+/// during that render (and canvas paint callbacks after it) all agree.
+pub fn set_light(light: bool) {
+    LIGHT_THEME.store(light, std::sync::atomic::Ordering::Relaxed);
+}
+
+pub fn palette() -> &'static Palette {
+    if is_light() {
+        &LIGHT
+    } else {
+        &DARK
+    }
+}
+
+/// Whether the light theme is active this frame, for chrome that keeps
+/// its own palette (the gallery) but still follows the theme choice.
+pub fn is_light() -> bool {
+    LIGHT_THEME.load(std::sync::atomic::Ordering::Relaxed)
+}

--- a/crates/ui/src/tooltip.rs
+++ b/crates/ui/src/tooltip.rs
@@ -1,0 +1,49 @@
+//! Hover labels for icon-only controls.
+
+use crate::palette;
+use gpui::{
+    div, px, AppContext as _, Context, IntoElement, ParentElement as _, SharedString, Styled as _,
+};
+
+/// A hover label for an icon-only control: the name, and optionally its
+/// keyboard shortcut dimmed after it.
+pub struct Tooltip {
+    label: SharedString,
+    hint: Option<SharedString>,
+}
+
+impl gpui::Render for Tooltip {
+    fn render(&mut self, _window: &mut gpui::Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let mut row = div()
+            .flex()
+            .flex_row()
+            .items_center()
+            .gap_2()
+            .px_2()
+            .py_1()
+            .rounded_sm()
+            .bg(gpui::rgb(palette().popup_bg))
+            .border_1()
+            .border_color(gpui::rgb(palette().panel_edge))
+            .text_size(px(11.0))
+            .text_color(gpui::rgb(palette().text))
+            .child(self.label.clone());
+        if let Some(hint) = self.hint.clone() {
+            row = row.child(div().text_color(gpui::rgb(palette().text_dim)).child(hint));
+        }
+        row
+    }
+}
+
+/// Build a tooltip callback for [`gpui::StatefulInteractiveElement::tooltip`].
+pub fn tip(
+    label: impl Into<SharedString>,
+    hint: Option<SharedString>,
+) -> impl Fn(&mut gpui::Window, &mut gpui::App) -> gpui::AnyView + 'static {
+    let label = label.into();
+    move |_window, cx| {
+        let label = label.clone();
+        let hint = hint.clone();
+        cx.new(|_| Tooltip { label, hint }).into()
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,6 +5,7 @@ contracts*; everything a user can see or click lives in a plugin.
 
 ```
 crates/app              GPUI shell: window, canvas, panels, dialogs, keymap
+├── crates/ui           widget kit: palette, buttons, rows, checkboxes, links
 ├── crates/plugin-api   the trait surface every feature implements
 ├── crates/core         kernel: document, COW tiles, layers, history, selection
 ├── crates/color        pixel/colour primitives, depth conversion
@@ -37,6 +38,19 @@ plugins/                first-party features, each optional at compile time
 ├── codecs-common       PNG/JPEG/WebP/TIFF/HEIC/camera raw
 └── commands-core       menu commands and their keybindings
 ```
+
+## Chrome
+
+GPUI ships no widget library, so `crates/ui` is the one the panels and
+dialogs share: the two palettes, and a small set of components (`Button`,
+`IconButton`, `Checkbox`, `ListItem`, `Tab`, `Link`, `Swatch`). They know
+nothing about the workspace; they take plain handlers, which is what
+`Context::listener` produces. The rule they enforce is *when* a control
+acts: a button, a row in a menu, a checkbox, a link all commit on
+release over the control (GPUI's `on_click`), the way native buttons do,
+and never on the press. What starts a gesture keeps the press: canvas
+tools, sliders, drags, click-to-focus fields, and the openers of menus
+and dropdowns, which native menus also open on press.
 
 ## Why the kernel is small
 


### PR DESCRIPTION
Fixes #119.

## Why
Every control in the app fired its action from gpui's `on_mouse_down`, so a button "clicked" the moment it went down and sliding off could not cancel it. Native buttons (AppKit, UIKit, Win32, the web) commit on release over the control, which is exactly what gpui's `on_click` implements.

## What
- **New crate `crates/ui` (`schist-ui`).** The palette, icons and tooltips move out of the app (which re-exports them), joined by `Button`, `IconButton`, `Checkbox`, `ListItem`, `Tab`, `Link` and `Swatch`. Every one acts on release (or Enter/Space when focused). They take plain `Fn(&ClickEvent, &mut Window, &mut App)` handlers so `cx.listener` fits directly, and implement `Styled` and `ParentElement` so a caller's refinements override the defaults. `consume_press()` covers buttons that sit inside selectable rows, replacing the hand-rolled `stop_propagation` calls.
- **Converted to the kit:** dialog buttons and checkboxes, dropdown rows, menu and context-menu rows, tool flyout rows, history rows, layer eye/fold toggles, tab close buttons, panel header icon buttons, AI panel controls, typography buttons, colour swatches and wells, links, the filter gallery, and the photo gallery views. Mouse-down handlers in the app drop from 124 to 59.
- **Deliberately still on press:** canvas tools, sliders, rulers, curve editor, colour wheel, drags, click-to-focus text fields, right-click context menus, sidebar and layer-row selection, tab switching, and menu/dropdown openers. Native menus open on press, and a popup dismisses on the press outside it, so a release-toggled opener would reopen at once. `docs/architecture.md` gains a short "Chrome" section stating the rule.

## Verification
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` all pass.
- Headless under Xvfb with xdotool on the layer eye and the New File dialog's Cancel: a press without release does nothing, a release off the control cancels, a click acts.

## Worth a glance
- Kit buttons dim slightly while held, and icon buttons that used to be bare now get a hover fill.
- The three small "×" controls in the gallery used to brighten their text on hover; they now show a faint hover pill, since `Button`'s hover only changes the fill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
